### PR TITLE
feat(capabilities): stream http responses with windowed flow control

### DIFF
--- a/crates/aether-capabilities/src/http/kinds.rs
+++ b/crates/aether-capabilities/src/http/kinds.rs
@@ -145,6 +145,68 @@ pub struct HttpServerResponse {
     pub body: Vec<u8>,
 }
 
+// ADR-0128 HTTP server response streaming. A handler opts into streaming by
+// replying `HttpResponseStreamOpen` instead of `HttpServerResponse`, emits its
+// body across many `HttpResponseChunk` mails paced by the cap's
+// `HttpStreamCredit` grants, and terminates with `HttpResponseStreamEnd`.
+//
+// Correlation carries an explicit `stream_id` on the chunk / end / credit
+// kinds rather than riding the transport-envelope correlation the buffered
+// reply uses: the guest reply handle is one-shot, so a handler cannot re-echo
+// the request correlation across many chunks (ADR-0128 reconciles §2's
+// "keyed by correlation id" wording with this payload field). The cap sets
+// `stream_id` to the request's dispatch correlation id `C` — the same key its
+// in-flight table already holds — and the handler learns `C` from the first
+// `HttpStreamCredit`. The `HttpResponseStreamOpen` reply still rides the
+// one-shot correlation-echoed reply path, so the open handshake keys on `C`
+// directly.
+
+/// `aether.http.server.response_stream_open` — a handler's first reply on a
+/// streamed response (ADR-0128). Declares the status line and headers; the
+/// cap writes the response head with `Transfer-Encoding: chunked` (no
+/// `Content-Length`) and begins the stream. Replied like [`HttpServerResponse`]
+/// (correlation-echoed), so the cap keys the new stream by the request's
+/// in-flight correlation id.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.response_stream_open")]
+pub struct HttpResponseStreamOpen {
+    pub status: u16,
+    pub headers: Vec<HttpHeader>,
+}
+
+/// `aether.http.server.stream_credit` — the cap → handler backpressure grant
+/// (ADR-0128). Grants permission to send up to `credit` more
+/// [`HttpResponseChunk`] mails on the stream named by `stream_id`. The handler
+/// learns its `stream_id` from the first credit mail (the cap sets it to the
+/// request's dispatch correlation id) and pauses when its accumulated credit
+/// reaches zero.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.stream_credit")]
+pub struct HttpStreamCredit {
+    pub stream_id: u64,
+    pub credit: u32,
+}
+
+/// `aether.http.server.response_chunk` — handler → cap, one body piece on the
+/// stream named by `stream_id` (ADR-0128). Consumes one unit of credit; the
+/// cap frames it as one chunked-transfer chunk to the peer. `body` is raw
+/// bytes so binary downloads stream without loss.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.response_chunk")]
+pub struct HttpResponseChunk {
+    pub stream_id: u64,
+    pub body: Vec<u8>,
+}
+
+/// `aether.http.server.response_stream_end` — handler → cap terminator on the
+/// stream named by `stream_id` (ADR-0128). The cap writes the terminating
+/// zero-length chunk and closes the connection.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.response_stream_end")]
+pub struct HttpResponseStreamEnd {
+    pub stream_id: u64,
+}
+
 /// `aether.http.server.inbound_ready` — accept / reader sidecar →
 /// `HttpServerCapability` dispatcher wake (ADR-0108, issue 1760).
 /// The HTTP-server analog of `RpcInboundReady`: the sidecar pushes

--- a/crates/aether-capabilities/src/http/server/config.rs
+++ b/crates/aether-capabilities/src/http/server/config.rs
@@ -4,7 +4,7 @@
 
 use super::{
     DEFAULT_BIND_ADDR, DEFAULT_MAX_CONNECTIONS, DEFAULT_MAX_HEADER_BYTES,
-    DEFAULT_MAX_REQUEST_BYTES, DEFAULT_REQUEST_TIMEOUT_MILLIS,
+    DEFAULT_MAX_REQUEST_BYTES, DEFAULT_REQUEST_TIMEOUT_MILLIS, DEFAULT_RESPONSE_STREAM_WINDOW,
 };
 
 /// Init config for [`HttpServerCapability`](super::HttpServerCapability) (ADR-0108).
@@ -65,6 +65,15 @@ pub struct HttpServerConfig {
     /// `503` and closed rather than getting a reader thread.
     #[cfg_attr(feature = "runtime", config(default = 1024))]
     pub max_connections: usize,
+    /// Response-stream credit-window depth ([`DEFAULT_RESPONSE_STREAM_WINDOW`],
+    /// ADR-0128): the count of in-flight [`HttpResponseChunk`] mails a
+    /// streaming handler may hold before the per-connection writer thread
+    /// drains one and the cap replenishes credit. A count, not a byte or time
+    /// quantity, so it carries no unit suffix.
+    ///
+    /// [`HttpResponseChunk`]: crate::http::kinds::HttpResponseChunk
+    #[cfg_attr(feature = "runtime", config(default = 16))]
+    pub response_stream_window: u32,
 }
 
 impl Default for HttpServerConfig {
@@ -77,6 +86,7 @@ impl Default for HttpServerConfig {
             max_header_bytes: DEFAULT_MAX_HEADER_BYTES,
             request_timeout_millis: DEFAULT_REQUEST_TIMEOUT_MILLIS,
             max_connections: DEFAULT_MAX_CONNECTIONS,
+            response_stream_window: DEFAULT_RESPONSE_STREAM_WINDOW,
         }
     }
 }

--- a/crates/aether-capabilities/src/http/server/mod.rs
+++ b/crates/aether-capabilities/src/http/server/mod.rs
@@ -37,8 +37,10 @@
 
 // Handler-signature kinds resolve at file root through these imports —
 // `#[actor]` emits the `HandlesKind<K>` markers always-on against the
-// identity, and the `init` / handler bodies name these kinds.
-use crate::http::kinds::HttpInboundReady;
+// identity, and the `init` / handler bodies name these kinds. The two
+// stream-inbound kinds (ADR-0128) are `#[handler]` kinds so a streaming
+// handler can address them at `HttpServerCapability` type-safely.
+use crate::http::kinds::{HttpInboundReady, HttpResponseChunk, HttpResponseStreamEnd};
 use aether_kinds::trace::Settled;
 
 // Default bind address. Loopback per ADR-0108 §6 — binding a public
@@ -56,6 +58,10 @@ pub const DEFAULT_REQUEST_TIMEOUT_MILLIS: u64 = 30_000;
 /// without tripping legitimate loopback use. Operator-tunable; each unit
 /// costs roughly one reader-thread stack.
 pub const DEFAULT_MAX_CONNECTIONS: usize = 1024;
+/// Default `response_stream_window` (ADR-0128): the credit-window depth, a
+/// count of in-flight response chunks a streaming handler may hold before the
+/// cap's per-connection writer thread drains one and replenishes credit.
+pub const DEFAULT_RESPONSE_STREAM_WINDOW: u32 = 16;
 
 mod config;
 

--- a/crates/aether-capabilities/src/http/server/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/runtime.rs
@@ -43,7 +43,10 @@ pub use aether_substrate::mail::mailer::Mailer;
 // The parent `#[actor] impl` writes the `502` reply path, so it names
 // `HttpServerResponse`; the rest of the kind vocabulary is used only here.
 pub use crate::http::kinds::HttpServerResponse;
-use crate::http::kinds::{HttpHeader, HttpMethod, HttpServerRequest};
+use crate::http::kinds::{
+    HttpHeader, HttpMethod, HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen,
+    HttpServerRequest, HttpStreamCredit,
+};
 
 use aether_substrate::Mail;
 use std::io::{self, Read, Write};
@@ -96,6 +99,23 @@ pub enum InboundEvent {
     /// The handler didn't reply within `request_timeout`; the
     /// dispatcher writes `504` if the request is still in-flight.
     RequestTimedOut { conn_id: ConnId },
+    /// A response-stream writer thread drained one chunk to the socket,
+    /// freeing a window slot (ADR-0128) — the dispatcher replenishes the
+    /// handler's credit.
+    StreamSlotFreed { stream_id: u64 },
+    /// A response-stream writer thread finished — the terminating chunk was
+    /// written, the peer disconnected, an idle-write deadline fired, or a
+    /// socket error occurred — so the dispatcher tears the stream +
+    /// connection down (ADR-0128).
+    StreamFinished { stream_id: u64 },
+}
+
+/// One frame handed to a per-connection response-stream writer thread over
+/// the bounded hand-off channel (ADR-0128). `Chunk` frames one body piece as
+/// chunked transfer-encoding; `End` writes the terminating zero-length chunk.
+enum WriterMsg {
+    Chunk(Vec<u8>),
+    End,
 }
 
 /// Per-connection state owned by the cap dispatcher. The reader sidecar
@@ -122,6 +142,34 @@ pub struct PendingRequest {
     /// The request's method, carried so the reply path can suppress the
     /// body on a HEAD response (message-body semantics forbid one).
     pub method: HttpMethod,
+}
+
+/// Per-connection response-stream state (ADR-0128), keyed in
+/// [`HttpServerCapabilityState::streams`] by `stream_id` (== the request's
+/// dispatch correlation id `C`). The dispatcher owns all of this
+/// single-threaded, exactly like [`PendingRequest`]; the writer thread owns
+/// only the socket write.
+pub struct StreamState {
+    /// The connection this stream writes to. Teardown paths locate a stream
+    /// by connection through this field.
+    conn_id: ConnId,
+    /// Bounded hand-off to the writer thread. `try_send` never blocks the
+    /// dispatcher: the credit accounting keeps the invariant
+    /// `credit_outstanding + queued <= window`, so a slot is always free when
+    /// a within-credit chunk arrives.
+    tx: mpsc::SyncSender<WriterMsg>,
+    /// Writer thread handle. Detached on teardown / close (the dispatcher
+    /// must never block joining a slow-peer write); joined in `unwire` after
+    /// the sender is dropped.
+    writer_thread: Option<JoinHandle<()>>,
+    /// Credits granted to the handler it has not yet spent, bounded by the
+    /// window. A chunk arriving with this at zero is an over-window flood
+    /// (ADR-0128 §Consequences trust boundary) → the stream is torn down.
+    credit_outstanding: u32,
+    /// The handler sent `HttpResponseStreamEnd` but the terminator did not
+    /// fit the bounded channel yet (chunks still queued). Flushed as slots
+    /// free so the terminating chunk always follows the body in order.
+    pending_end: bool,
 }
 
 /// Wake sink shared with the accept + reader sidecar threads: push an
@@ -181,6 +229,15 @@ pub struct HttpServerCapabilityState {
     /// Dispatch-correlation → open response socket. Populated on
     /// dispatch; cleared on reply, settlement, timeout, or close.
     pub in_flight: HashMap<u64, PendingRequest>,
+    /// Credit-window depth (ADR-0128): the count of in-flight response
+    /// chunks a stream may hold; also the bounded hand-off channel's
+    /// capacity and the initial credit grant.
+    pub response_stream_window: u32,
+    /// Active response streams (ADR-0128), keyed by `stream_id` (== the
+    /// request's dispatch correlation id). Promoted from `in_flight` on
+    /// `HttpResponseStreamOpen`; torn down on stream end, flood, timeout, or
+    /// connection close.
+    pub streams: HashMap<u64, StreamState>,
 }
 
 impl HttpServerCapabilityState {
@@ -390,6 +447,18 @@ impl HttpServerCapabilityState {
         // not block on it. The thread sees the shutdown (or its own EOF)
         // and exits; the JoinHandle drop detaches.
         drop(conn.reader_thread.take());
+        // Tear down any response stream bound to this connection (ADR-0128).
+        // The socket shutdown above unblocks a write-blocked writer; dropping
+        // the sender (in `teardown_stream`) unblocks a recv-blocked one.
+        let stream_ids: Vec<u64> = self
+            .streams
+            .iter()
+            .filter(|(_, stream)| stream.conn_id == conn_id)
+            .map(|(id, _)| *id)
+            .collect();
+        for stream_id in stream_ids {
+            self.teardown_stream(stream_id);
+        }
         // Drop any in-flight entry pinned to this connection so we don't
         // write to a dead socket.
         self.in_flight
@@ -401,6 +470,201 @@ impl HttpServerCapabilityState {
             reason,
             "http conn closed",
         );
+    }
+
+    /// Promote a buffered request to a response stream (ADR-0128): drop its
+    /// in-flight entry so the settlement safety net no longer trips `502` on
+    /// this chain, write the chunked response head, spawn the per-connection
+    /// writer thread, and grant the handler its initial credit window.
+    /// `stream_id` == the request's dispatch correlation id `C`.
+    pub fn open_stream(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        stream_id: u64,
+        conn_id: ConnId,
+        open: &HttpResponseStreamOpen,
+    ) {
+        // The stream chain settles here; the request is no longer in-flight
+        // (ADR-0128 §4), so `on_settled` won't `502` it.
+        self.in_flight.remove(&stream_id);
+        let head = render_stream_head(open);
+        self.write_raw_to(conn_id, &head);
+
+        let Some(conn) = self.connections.get(&conn_id) else {
+            // Connection already gone — nothing to stream to.
+            return;
+        };
+        let write_half = match conn.write_half.try_clone() {
+            Ok(half) => half,
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::http_server",
+                    conn = conn_id,
+                    error = %e,
+                    "http stream: writer clone failed; closing",
+                );
+                self.close_connection(conn_id, "stream writer clone failed");
+                return;
+            }
+        };
+
+        let window = self.response_stream_window.max(1);
+        let (tx, rx) = mpsc::sync_channel::<WriterMsg>(window as usize);
+        let sink = WakeSink {
+            inbound_tx: self.inbound_tx.clone(),
+            mailer: Arc::clone(&self.mailer),
+            self_id: self.self_mailbox,
+            wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
+        };
+        let idle_deadline = self.request_timeout;
+
+        // Per-connection writer below the mail layer, mirroring the reader
+        // sidecar — it owns only the socket write, never the cap state.
+        #[allow(clippy::disallowed_methods)]
+        let writer_thread = match thread::Builder::new()
+            .name(format!("aether-http-writer-{conn_id}"))
+            .spawn(move || {
+                run_writer_loop(write_half, stream_id, &rx, &sink, idle_deadline);
+            }) {
+            Ok(thread) => thread,
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::http_server",
+                    conn = conn_id,
+                    error = %e,
+                    "http stream: writer thread spawn failed; closing",
+                );
+                self.close_connection(conn_id, "stream writer spawn failed");
+                return;
+            }
+        };
+
+        self.streams.insert(
+            stream_id,
+            StreamState {
+                conn_id,
+                tx,
+                writer_thread: Some(writer_thread),
+                credit_outstanding: window,
+                pending_end: false,
+            },
+        );
+        // Grant the initial credit window — the handler learns its
+        // `stream_id` from this first credit mail.
+        self.send_stream_credit(ctx, stream_id, window);
+        tracing::debug!(
+            target: "aether_substrate::http_server",
+            conn = conn_id,
+            stream = stream_id,
+            window,
+            "http response stream opened",
+        );
+    }
+
+    /// Accept one body chunk from the handler (ADR-0128): a chunk arriving
+    /// with zero outstanding credit is an over-window flood and tears the
+    /// stream down; otherwise it spends one credit and hands the bytes to the
+    /// writer thread over the bounded channel.
+    pub fn push_chunk(&mut self, stream_id: u64, body: Vec<u8>) {
+        let Some((conn_id, has_credit)) = self
+            .streams
+            .get(&stream_id)
+            .map(|stream| (stream.conn_id, stream.credit_outstanding > 0))
+        else {
+            // No such stream — already ended / torn down, or never opened.
+            return;
+        };
+        if !has_credit {
+            // Over-window flood (ADR-0128 §Consequences trust boundary).
+            self.teardown_stream(stream_id);
+            self.close_connection(conn_id, "stream credit exceeded");
+            return;
+        }
+        let send_result = {
+            let stream = self
+                .streams
+                .get_mut(&stream_id)
+                .expect("stream present under the same borrow");
+            stream.credit_outstanding -= 1;
+            stream.tx.try_send(WriterMsg::Chunk(body))
+        };
+        if send_result.is_err() {
+            // Writer gone, or (defensively) the channel was full despite the
+            // credit invariant — tear the stream down rather than block.
+            self.teardown_stream(stream_id);
+            self.close_connection(conn_id, "stream writer unavailable");
+        }
+    }
+
+    /// The handler terminated the stream (ADR-0128): hand the terminator to
+    /// the writer. If the bounded channel is full it is deferred and flushed
+    /// as slots free ([`Self::try_flush_end`]), so the terminating chunk
+    /// always follows the body in order.
+    pub fn end_stream(&mut self, stream_id: u64) {
+        if let Some(stream) = self.streams.get_mut(&stream_id) {
+            stream.pending_end = true;
+        }
+        self.try_flush_end(stream_id);
+    }
+
+    /// A writer slot freed (ADR-0128): grant one more credit to the handler
+    /// (unless the stream is ending, when no more chunks are expected) and
+    /// try to flush a deferred terminator.
+    pub fn replenish_credit(&mut self, ctx: &mut NativeCtx<'_>, stream_id: u64) {
+        let grant = match self.streams.get_mut(&stream_id) {
+            Some(stream) if !stream.pending_end => {
+                stream.credit_outstanding += 1;
+                true
+            }
+            Some(_) => false,
+            None => return,
+        };
+        if grant {
+            self.send_stream_credit(ctx, stream_id, 1);
+        }
+        self.try_flush_end(stream_id);
+    }
+
+    /// A writer thread finished (ADR-0128) — tear the stream down and close
+    /// its connection.
+    pub fn finish_stream(&mut self, stream_id: u64) {
+        let Some(conn_id) = self.streams.get(&stream_id).map(|stream| stream.conn_id) else {
+            return;
+        };
+        self.teardown_stream(stream_id);
+        self.close_connection(conn_id, "stream finished");
+    }
+
+    /// Try to hand a deferred terminator to the writer; on success clear the
+    /// pending flag so it is sent exactly once.
+    fn try_flush_end(&mut self, stream_id: u64) {
+        if let Some(stream) = self.streams.get_mut(&stream_id)
+            && stream.pending_end
+            && stream.tx.try_send(WriterMsg::End).is_ok()
+        {
+            stream.pending_end = false;
+        }
+    }
+
+    /// Resolve the handler mailbox and send it a credit grant on `stream_id`.
+    /// A fresh causal root per grant keeps credit mails settling per-chunk,
+    /// never holding one chain open across the stream (ADR-0128 §4).
+    fn send_stream_credit(&self, ctx: &mut NativeCtx<'_>, stream_id: u64, credit: u32) {
+        let Some(handler) = self.mailer.registry().lookup(&self.handler_mailbox) else {
+            return;
+        };
+        let payload = HttpStreamCredit { stream_id, credit }.encode_into_bytes();
+        let _ = ctx.send_envelope_as_root(handler, <HttpStreamCredit as Kind>::ID, &payload);
+    }
+
+    /// Remove a stream and detach its writer thread without joining inline —
+    /// the dispatcher must never block on a slow-peer write. Dropping the
+    /// sender unblocks a recv-waiting writer; a socket shutdown by the caller
+    /// unblocks a write-blocked one.
+    fn teardown_stream(&mut self, stream_id: u64) {
+        if let Some(mut stream) = self.streams.remove(&stream_id) {
+            drop(stream.writer_thread.take());
+        }
     }
 }
 
@@ -756,6 +1020,94 @@ fn render_status_response(status: u16, message: &str) -> Vec<u8> {
     out
 }
 
+/// Render the response head for a streamed response (ADR-0128): the status
+/// line, the handler's headers (cap-owned ones stripped), `Transfer-Encoding:
+/// chunked` in place of `Content-Length`, and `Date` / `Connection`.
+fn render_stream_head(open: &HttpResponseStreamOpen) -> Vec<u8> {
+    use std::fmt::Write as _;
+    let mut head = format!(
+        "HTTP/1.1 {} {}\r\n",
+        open.status,
+        reason_phrase(open.status)
+    );
+    for header in &open.headers {
+        if is_cap_owned_header(&header.name) {
+            continue;
+        }
+        let _ = write!(head, "{}: {}\r\n", header.name, header.value);
+    }
+    head.push_str("Transfer-Encoding: chunked\r\n");
+    let _ = write!(head, "Date: {}\r\n", http_date(SystemTime::now()));
+    head.push_str("Connection: close\r\n\r\n");
+    head.into_bytes()
+}
+
+/// Per-connection response-stream writer thread body (ADR-0128). Drains the
+/// bounded hand-off channel, framing each chunk as chunked transfer-encoding
+/// and writing the terminating chunk on `End`. TCP backpressure blocks this
+/// thread on the socket write, never the dispatcher. A `recv_timeout` past
+/// `idle_deadline` is the idle-write / no-progress deadline: a handler that
+/// stalled mid-stream tears the stream down.
+fn run_writer_loop(
+    write_half: TcpStream,
+    stream_id: u64,
+    rx: &mpsc::Receiver<WriterMsg>,
+    sink: &WakeSink,
+    idle_deadline: Duration,
+) {
+    let mut write_half = write_half;
+    loop {
+        match rx.recv_timeout(idle_deadline) {
+            Ok(WriterMsg::Chunk(body)) => {
+                if write_chunk(&mut write_half, &body).is_err() {
+                    // Peer disconnected / socket error mid-stream.
+                    sink.post(InboundEvent::StreamFinished { stream_id });
+                    return;
+                }
+                // One window slot freed — let the dispatcher replenish credit.
+                if !sink.post(InboundEvent::StreamSlotFreed { stream_id }) {
+                    return;
+                }
+            }
+            Ok(WriterMsg::End) => {
+                let _ = write_terminator(&mut write_half);
+                sink.post(InboundEvent::StreamFinished { stream_id });
+                return;
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                // Idle-write deadline (ADR-0128 §4): the handler stalled.
+                sink.post(InboundEvent::StreamFinished { stream_id });
+                return;
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                // The dispatcher dropped the sender (stream torn down
+                // elsewhere) — nothing more to write.
+                return;
+            }
+        }
+    }
+}
+
+/// Frame one body piece as a chunked transfer-encoding chunk (`hexlen CRLF
+/// body CRLF`) and flush it. An empty body is skipped rather than framed — a
+/// zero-length chunk is the transfer terminator, which only `End` may write.
+fn write_chunk(write_half: &mut TcpStream, body: &[u8]) -> io::Result<()> {
+    if body.is_empty() {
+        return Ok(());
+    }
+    let header = format!("{:x}\r\n", body.len());
+    write_half.write_all(header.as_bytes())?;
+    write_half.write_all(body)?;
+    write_half.write_all(b"\r\n")?;
+    write_half.flush()
+}
+
+/// Write the chunked transfer terminator (the zero-length chunk) and flush.
+fn write_terminator(write_half: &mut TcpStream) -> io::Result<()> {
+    write_half.write_all(b"0\r\n\r\n")?;
+    write_half.flush()
+}
+
 /// Map a raw HTTP method token to the typed [`HttpMethod`]; `None` for a
 /// non-enumerated verb (answered `501` before any dispatch).
 fn parse_http_method(method: &str) -> Option<HttpMethod> {
@@ -918,6 +1270,8 @@ impl NativeActor for HttpServerCapability {
             connections: HashMap::new(),
             next_conn_id: 0,
             in_flight: HashMap::new(),
+            response_stream_window: config.response_stream_window,
+            streams: HashMap::new(),
         })
     }
 
@@ -937,6 +1291,17 @@ impl NativeActor for HttpServerCapability {
             conn.shutdown.store(true, Ordering::Release);
             let _ = conn.write_half.shutdown(Shutdown::Both);
             if let Some(thread) = conn.reader_thread.take() {
+                let _ = thread.join();
+            }
+        }
+        // Stop every response-stream writer (ADR-0128). The socket shutdown
+        // above unblocks a write-blocked writer; dropping the sender unblocks
+        // a recv-blocked one, so drop it before joining to keep `unwire`
+        // prompt (never waiting out the idle-write deadline).
+        for (_, mut stream) in state.streams.drain() {
+            let writer = stream.writer_thread.take();
+            drop(stream);
+            if let Some(thread) = writer {
                 let _ = thread.join();
             }
         }
@@ -975,13 +1340,59 @@ impl NativeActor for HttpServerCapability {
                     state.close_connection(conn_id, &reason);
                 }
                 InboundEvent::RequestTimedOut { conn_id } => {
-                    if state.in_flight.values().any(|p| p.conn_id == conn_id) {
-                        state.write_status_response(conn_id, 504, "gateway timeout");
+                    // A streaming connection's writer thread owns the
+                    // idle-write deadline (ADR-0128 §4), so the reader's
+                    // response-deadline timeout must not tear an active
+                    // stream down — a stream making progress isn't stalled.
+                    let streaming = state.streams.values().any(|s| s.conn_id == conn_id);
+                    if !streaming {
+                        if state.in_flight.values().any(|p| p.conn_id == conn_id) {
+                            state.write_status_response(conn_id, 504, "gateway timeout");
+                        }
+                        state.close_connection(conn_id, "request timeout");
                     }
-                    state.close_connection(conn_id, "request timeout");
+                }
+                InboundEvent::StreamSlotFreed { stream_id } => {
+                    state.replenish_credit(ctx, stream_id);
+                }
+                InboundEvent::StreamFinished { stream_id } => {
+                    state.finish_stream(stream_id);
                 }
             }
         }
+    }
+
+    /// One streamed response body chunk from the handler (ADR-0128).
+    /// Matched by the payload's `stream_id` against the `streams` table —
+    /// not by envelope correlation, since a handler's `ctx.send` mints a
+    /// fresh correlation the request's in-flight key would not match.
+    ///
+    /// # Agent
+    /// Not user-callable — a streaming handler sends this after replying
+    /// [`HttpResponseStreamOpen`], paced by the cap's
+    /// [`HttpStreamCredit`](crate::http::kinds::HttpStreamCredit) grants.
+    #[handler]
+    fn on_response_chunk(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        chunk: HttpResponseChunk,
+    ) {
+        state.push_chunk(chunk.stream_id, chunk.body);
+    }
+
+    /// The handler's stream terminator (ADR-0128). Matched by the payload's
+    /// `stream_id` like [`Self::on_response_chunk`].
+    ///
+    /// # Agent
+    /// Not user-callable — a streaming handler sends this once after its
+    /// final [`HttpResponseChunk`] to close the stream.
+    #[handler]
+    fn on_response_stream_end(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        end: HttpResponseStreamEnd,
+    ) {
+        state.end_stream(end.stream_id);
     }
 
     /// Settlement notice. The root corresponds to a dispatched request
@@ -1011,13 +1422,30 @@ impl NativeActor for HttpServerCapability {
     /// Not user-callable — this is the cap's reply-interception path. A
     /// by-value `#[handler]` can't read the inbound `sender.correlation_id`,
     /// so reply correlation goes through this envelope fallback
-    /// (ADR-0108 §5).
+    /// (ADR-0108 §5). The handler's one-shot reply is either an
+    /// [`HttpServerResponse`] (buffered, ADR-0108) or an
+    /// [`HttpResponseStreamOpen`] (streamed, ADR-0128); both key on the
+    /// request's in-flight correlation id. The mid-stream chunk / end mails
+    /// carry a fresh send-correlation and are routed to their own
+    /// `#[handler]`s ([`Self::on_response_chunk`] / [`Self::on_response_stream_end`]),
+    /// keyed by their explicit `stream_id` payload — a second correlation
+    /// regime living beside this one.
     #[fallback]
-    fn on_any(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, env: &Envelope) {
+    fn on_any(state: &mut Self::State, ctx: &mut NativeCtx<'_>, env: &Envelope) {
         let correlation = env.sender.correlation_id;
         let Some(pending) = state.in_flight.get(&correlation).copied() else {
             return;
         };
+        if env.kind == <HttpResponseStreamOpen as Kind>::ID {
+            if let Some(open) = HttpResponseStreamOpen::decode_from_bytes(env.payload.bytes()) {
+                state.open_stream(ctx, correlation, pending.conn_id, &open);
+            } else {
+                state.in_flight.remove(&correlation);
+                state.write_status_response(pending.conn_id, 502, "malformed stream open");
+                state.close_connection(pending.conn_id, "malformed stream open");
+            }
+            return;
+        }
         if env.kind != <HttpServerResponse as Kind>::ID {
             // Unexpected kind with a matching correlation — leave the
             // in-flight entry for the settlement / timeout safety net.
@@ -1086,8 +1514,8 @@ mod unit_tests {
     fn config_layer_defaults_match_the_named_consts() {
         use super::super::{
             DEFAULT_BIND_ADDR, DEFAULT_MAX_CONNECTIONS, DEFAULT_MAX_HEADER_BYTES,
-            DEFAULT_MAX_REQUEST_BYTES, DEFAULT_REQUEST_TIMEOUT_MILLIS, HttpServerConfig,
-            HttpServerConfigLayer,
+            DEFAULT_MAX_REQUEST_BYTES, DEFAULT_REQUEST_TIMEOUT_MILLIS,
+            DEFAULT_RESPONSE_STREAM_WINDOW, HttpServerConfig, HttpServerConfigLayer,
         };
         use confique::Config as _;
         // No `.env()` source: loads the literal defaults only, so this is
@@ -1105,5 +1533,10 @@ mod unit_tests {
         assert_eq!(layer.request_timeout_millis, DEFAULT_REQUEST_TIMEOUT_MILLIS);
         assert_eq!(layer.max_connections, DEFAULT_MAX_CONNECTIONS);
         assert_eq!(layer.max_connections, default.max_connections);
+        assert_eq!(layer.response_stream_window, DEFAULT_RESPONSE_STREAM_WINDOW);
+        assert_eq!(
+            default.response_stream_window,
+            DEFAULT_RESPONSE_STREAM_WINDOW
+        );
     }
 }

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -9,17 +9,26 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use test_handlers::{EchoHttpHandler, FixedBodyHttpHandler, SilentHttpHandler};
+use test_handlers::{
+    EchoHttpHandler, FixedBodyHttpHandler, FloodHttpHandler, STREAM_CHUNK_COUNT, SilentHttpHandler,
+    StreamHttpHandler, stream_chunk_body,
+};
 
 mod test_handlers {
     //! Minimal native handler actors behind the server in the integration
     //! tests: one that replies `200` echoing the request, one that drops
-    //! the request without replying (the `502` safety-net path).
+    //! the request without replying (the `502` safety-net path), and two
+    //! response-streaming handlers (ADR-0128) — a well-behaved one that
+    //! paces chunks against credit, and a flooder that ignores credit.
     use aether_actor::actor;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
 
-    use crate::http::kinds::{HttpHeader, HttpServerRequest, HttpServerResponse};
+    use crate::http::kinds::{
+        HttpHeader, HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen,
+        HttpServerRequest, HttpServerResponse, HttpStreamCredit,
+    };
+    use crate::http::server::HttpServerCapability;
 
     /// Replies `200` and echoes the request's method / path / query /
     /// peer address (as headers) and body (verbatim), so a test can
@@ -141,6 +150,141 @@ mod test_handlers {
             // Intentionally drops the request without replying.
         }
     }
+
+    /// The number of body chunks [`StreamHttpHandler`] emits. Chosen well
+    /// above the test's credit window so the round trip exercises credit
+    /// replenishment across many refills, not just the initial grant.
+    pub const STREAM_CHUNK_COUNT: u32 = 40;
+
+    /// The bytes of chunk `index`: its zero-padded index, so the reassembled
+    /// body is the deterministic concatenation `"000001…039"` a test can
+    /// rebuild and compare against.
+    pub fn stream_chunk_body(index: u32) -> Vec<u8> {
+        format!("{index:03}").into_bytes()
+    }
+
+    /// A well-behaved response-streaming handler (ADR-0128): replies
+    /// `HttpResponseStreamOpen`, then emits [`STREAM_CHUNK_COUNT`] chunks
+    /// paced strictly against the credit it is granted, and terminates with
+    /// `HttpResponseStreamEnd`.
+    pub struct StreamHttpHandler;
+
+    /// Per-stream progress for [`StreamHttpHandler`].
+    pub struct StreamHttpHandlerState {
+        stream_id: u64,
+        next_index: u32,
+        ended: bool,
+    }
+
+    #[actor(singleton)]
+    impl NativeActor for StreamHttpHandler {
+        type State = StreamHttpHandlerState;
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.http.test_stream_handler";
+
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<StreamHttpHandlerState, BootError> {
+            Ok(StreamHttpHandlerState {
+                stream_id: 0,
+                next_index: 0,
+                ended: false,
+            })
+        }
+
+        #[handler]
+        fn on_request(
+            state: &mut Self::State,
+            _ctx: &mut NativeCtx<'_>,
+            _request: HttpServerRequest,
+        ) -> HttpResponseStreamOpen {
+            state.next_index = 0;
+            state.ended = false;
+            HttpResponseStreamOpen {
+                status: 200,
+                headers: vec![HttpHeader {
+                    name: "content-type".to_string(),
+                    value: "text/plain".to_string(),
+                }],
+            }
+        }
+
+        /// Spend the granted credit: send up to `credit.credit` more chunks,
+        /// then terminate once all [`STREAM_CHUNK_COUNT`] have gone out.
+        #[handler]
+        fn on_credit(state: &mut Self::State, ctx: &mut NativeCtx<'_>, credit: HttpStreamCredit) {
+            state.stream_id = credit.stream_id;
+            let mut budget = credit.credit;
+            while budget > 0 && state.next_index < STREAM_CHUNK_COUNT {
+                ctx.actor::<HttpServerCapability>()
+                    .send(&HttpResponseChunk {
+                        stream_id: state.stream_id,
+                        body: stream_chunk_body(state.next_index),
+                    });
+                state.next_index += 1;
+                budget -= 1;
+            }
+            if state.next_index >= STREAM_CHUNK_COUNT && !state.ended {
+                ctx.actor::<HttpServerCapability>()
+                    .send(&HttpResponseStreamEnd {
+                        stream_id: state.stream_id,
+                    });
+                state.ended = true;
+            }
+        }
+    }
+
+    /// The number of chunks [`FloodHttpHandler`] blasts on its first credit,
+    /// far more than any small test window — enough that the cap's credit
+    /// accounting hits zero and the over-window guard tears the stream down.
+    pub const FLOOD_CHUNK_COUNT: u32 = 200;
+
+    /// A misbehaving response-streaming handler (ADR-0128 trust boundary):
+    /// it replies `HttpResponseStreamOpen`, then on its first credit ignores
+    /// the granted amount entirely and floods [`FLOOD_CHUNK_COUNT`] chunks.
+    pub struct FloodHttpHandler;
+
+    /// Guards [`FloodHttpHandler`] against re-flooding on replenishment
+    /// credit (which never arrives once the cap tears the stream down).
+    pub struct FloodHttpHandlerState {
+        flooded: bool,
+    }
+
+    #[actor(singleton)]
+    impl NativeActor for FloodHttpHandler {
+        type State = FloodHttpHandlerState;
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.http.test_flood_handler";
+
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<FloodHttpHandlerState, BootError> {
+            Ok(FloodHttpHandlerState { flooded: false })
+        }
+
+        #[handler]
+        fn on_request(
+            _state: &mut Self::State,
+            _ctx: &mut NativeCtx<'_>,
+            _request: HttpServerRequest,
+        ) -> HttpResponseStreamOpen {
+            HttpResponseStreamOpen {
+                status: 200,
+                headers: Vec::new(),
+            }
+        }
+
+        #[handler]
+        fn on_credit(state: &mut Self::State, ctx: &mut NativeCtx<'_>, credit: HttpStreamCredit) {
+            if state.flooded {
+                return;
+            }
+            state.flooded = true;
+            for _ in 0..FLOOD_CHUNK_COUNT {
+                ctx.actor::<HttpServerCapability>()
+                    .send(&HttpResponseChunk {
+                        stream_id: credit.stream_id,
+                        body: vec![b'x'; 8],
+                    });
+            }
+        }
+    }
 }
 
 fn config_for(handler: &str, max_request_bytes: usize) -> HttpServerConfig {
@@ -151,6 +295,49 @@ fn config_for(handler: &str, max_request_bytes: usize) -> HttpServerConfig {
         request_timeout_millis: 5_000,
         ..HttpServerConfig::default()
     }
+}
+
+/// Server config for the streaming tests (ADR-0128): a small credit window
+/// so a multi-chunk response must replenish credit repeatedly, and a flood
+/// overruns it fast.
+fn stream_config_for(handler: &str, window: u32) -> HttpServerConfig {
+    HttpServerConfig {
+        bind_addr: "127.0.0.1:0".to_string(),
+        handler_mailbox: handler.to_string(),
+        request_timeout_millis: 5_000,
+        response_stream_window: window,
+        ..HttpServerConfig::default()
+    }
+}
+
+/// Index of the first `\r\n` at or after `from`, or `None`.
+fn find_crlf(bytes: &[u8], from: usize) -> Option<usize> {
+    (from..bytes.len().saturating_sub(1)).find(|&i| bytes[i] == b'\r' && bytes[i + 1] == b'\n')
+}
+
+/// Reassemble a chunked transfer-encoding body (everything after the head's
+/// blank line) into its payload, stopping at the zero-length terminator.
+fn dechunk(body: &str) -> String {
+    let bytes = body.as_bytes();
+    let mut pos = 0;
+    let mut out: Vec<u8> = Vec::new();
+    while pos < bytes.len() {
+        let Some(crlf) = find_crlf(bytes, pos) else {
+            break;
+        };
+        let size = usize::from_str_radix(body[pos..crlf].trim(), 16).unwrap_or(0);
+        pos = crlf + 2;
+        if size == 0 {
+            break;
+        }
+        if pos + size > bytes.len() {
+            break;
+        }
+        out.extend_from_slice(&bytes[pos..pos + size]);
+        // Advance past the chunk body and its trailing CRLF.
+        pos += size + 2;
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 fn port_of(chassis: &PassiveChassis<TestChassis>) -> u16 {
@@ -546,4 +733,78 @@ fn over_capacity_connection_is_503() {
     );
 
     drop(held);
+}
+
+/// A streaming handler (ADR-0128) emits its body across more chunks than the
+/// credit window, and the cap streams them as chunked transfer-encoding that
+/// the client reassembles intact — exercising credit replenishment across
+/// many refills, not just the initial grant.
+#[test]
+fn streamed_response_reassembles_across_credit_window() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<StreamHttpHandler>(())
+        .with_actor::<HttpServerCapability>(stream_config_for(
+            <StreamHttpHandler as Addressable>::NAMESPACE,
+            // Window well below the chunk count so credit must replenish.
+            8,
+        ))
+        .build_passive()
+        .expect("caps boot");
+
+    let response = round_trip(
+        port_of(&chassis),
+        b"GET /stream HTTP/1.1\r\nHost: localhost\r\n\r\n",
+    );
+    assert!(response.starts_with("HTTP/1.1 200 OK\r\n"), "{response:?}");
+    assert!(
+        response.contains("Transfer-Encoding: chunked\r\n"),
+        "streamed response is chunked: {response:?}",
+    );
+    assert!(
+        !response.contains("Content-Length:"),
+        "streamed response omits Content-Length: {response:?}",
+    );
+
+    let expected: Vec<u8> = (0..STREAM_CHUNK_COUNT)
+        .flat_map(stream_chunk_body)
+        .collect();
+    assert_eq!(
+        dechunk(body_of(&response)).into_bytes(),
+        expected,
+        "reassembled body matches every emitted chunk in order",
+    );
+}
+
+/// Tripwire: a handler that floods chunks past its granted credit
+/// (ADR-0128 §Consequences trust boundary) is torn down by the cap — the
+/// response head and some chunks arrive, but the stream never reaches its
+/// terminating zero-length chunk, so a misbehaving producer cannot outrun
+/// the window unbounded.
+#[test]
+fn over_window_flood_tears_the_stream_down() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<FloodHttpHandler>(())
+        .with_actor::<HttpServerCapability>(stream_config_for(
+            <FloodHttpHandler as Addressable>::NAMESPACE,
+            // Tiny window so the flood overruns credit within a few chunks.
+            2,
+        ))
+        .build_passive()
+        .expect("caps boot");
+
+    let response = round_trip(
+        port_of(&chassis),
+        b"GET /flood HTTP/1.1\r\nHost: localhost\r\n\r\n",
+    );
+    assert!(response.starts_with("HTTP/1.1 200 OK\r\n"), "{response:?}");
+    assert!(
+        response.contains("Transfer-Encoding: chunked\r\n"),
+        "flood stream head is chunked before teardown: {response:?}",
+    );
+    assert!(
+        !response.contains("0\r\n\r\n"),
+        "flood stream is torn down before the terminator: {response:?}",
+    );
 }

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -27,6 +27,7 @@ use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
+use std::str::from_utf8;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -50,6 +51,49 @@ const HANDLER_NAMESPACE: &str = "web";
 /// The full handler mailbox address the http server cap resolves at
 /// dispatch time (ADR-0108 §3 late binding).
 const HANDLER_MAILBOX: &str = "aether.component/aether.embedded:web";
+
+/// The `StreamingHttpHandler` fixture's `NAMESPACE` const (ADR-0128).
+const STREAM_HANDLER_NAMESPACE: &str = "web_stream";
+
+/// The streaming handler's full lineage mailbox address.
+const STREAM_HANDLER_MAILBOX: &str = "aether.component/aether.embedded:web_stream";
+
+/// The chunk count `StreamingHttpHandler` emits — kept in step with the
+/// fixture's own `STREAM_CHUNK_COUNT`.
+const STREAM_CHUNK_COUNT: u32 = 20;
+
+/// Slice of `response` after the HTTP head's blank line, or empty if absent.
+fn body_after_head(response: &[u8]) -> &[u8] {
+    response
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map_or(&[][..], |i| &response[i + 4..])
+}
+
+/// Reassemble a chunked transfer-encoding body into its payload, stopping at
+/// the zero-length terminating chunk.
+fn dechunk(body: &[u8]) -> Vec<u8> {
+    let mut pos = 0;
+    let mut out = Vec::new();
+    while pos < body.len() {
+        let Some(crlf) =
+            (pos..body.len().saturating_sub(1)).find(|&i| body[i] == b'\r' && body[i + 1] == b'\n')
+        else {
+            break;
+        };
+        let size = from_utf8(&body[pos..crlf])
+            .ok()
+            .and_then(|s| usize::from_str_radix(s.trim(), 16).ok())
+            .unwrap_or(0);
+        pos = crlf + 2;
+        if size == 0 || pos + size > body.len() {
+            break;
+        }
+        out.extend_from_slice(&body[pos..pos + size]);
+        pos += size + 2;
+    }
+    out
+}
 
 /// Write the raw HTTP/1.1 `request` to `port` on loopback, read until
 /// EOF (the cap sends `Connection: close`), and return the raw response
@@ -117,6 +161,7 @@ mod tests {
             max_header_bytes: 8_192,
             request_timeout_millis: 10_000,
             max_connections: 1024,
+            response_stream_window: 16,
         };
 
         let sandbox = init_save_sandbox("http-serving");
@@ -197,6 +242,114 @@ mod tests {
         assert!(
             miss_str.contains("not found"),
             "GET /missing body should contain 'not found', got: {miss_str:?}",
+        );
+    }
+
+    /// Boot a headless chassis with `HttpServerCapability` bound and the
+    /// `StreamingHttpHandler` wasm fixture loaded (ADR-0128). Fire one real
+    /// HTTP/1.1 request over a `TcpStream` and assert the response is a
+    /// `200` chunked stream the client reassembles into every emitted chunk
+    /// in order — the real-wire proof that a wasm handler streams a
+    /// multi-chunk body under the credit protocol.
+    #[test]
+    fn wasm_handler_streams_chunked_response() {
+        let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+        let Some(wasm_path) = locate_component_wasm("aether_test_fixtures_bundle") else {
+            assert!(
+                !strict,
+                "AETHER_REQUIRE_RUNTIME set but http_handler.wasm not pre-built; \
+                 CI's `Pre-build component wasm for scenario tests` step is missing it",
+            );
+            eprintln!(
+                "skipping: http_handler.wasm not built; \
+                 run `cargo build --target wasm32-unknown-unknown \
+                 -p aether-test-fixtures --examples`",
+            );
+            return;
+        };
+        let wasm = fs::read(&wasm_path).expect("read http_handler wasm");
+
+        let server_config = HttpServerConfig {
+            enabled: true,
+            bind_addr: "127.0.0.1:0".to_string(),
+            handler_mailbox: STREAM_HANDLER_MAILBOX.to_string(),
+            max_request_bytes: 65_536,
+            max_header_bytes: 8_192,
+            request_timeout_millis: 10_000,
+            // Window below the chunk count so the round trip must replenish.
+            response_stream_window: 8,
+        };
+
+        let sandbox = init_save_sandbox("http-serving-stream");
+        let env = HeadlessEnv {
+            namespace_roots: test_namespace_roots(sandbox),
+            http: HttpConfig::default(),
+            http_server: Some(server_config),
+            anthropic: AnthropicConfig::default(),
+            gemini: GeminiConfig::default(),
+            contentgen: ContentGenConfig::default(),
+            tick_period: Duration::from_millis(100),
+            rpc_addr: None,
+            workers: None,
+            ring_caps: aether_substrate_bundle::RingCapacities::default(),
+            scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
+            lifecycle_advance_timeout_millis: 1_000,
+            autoload: vec![AutoloadComponent {
+                wasm,
+                config: Vec::new(),
+                name: Some(STREAM_HANDLER_NAMESPACE.to_owned()),
+                export: Some(STREAM_HANDLER_NAMESPACE.to_owned()),
+            }],
+        };
+
+        let built = HeadlessChassis::build(env).expect("build headless chassis with http server");
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if built
+                .resolve_actor::<WasmTrampoline>(STREAM_HANDLER_NAMESPACE)
+                .is_some()
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "streaming trampoline did not register within 30s; \
+                 live trampolines: {:?}",
+                built.resolve_actors::<WasmTrampoline>(),
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+
+        let port = built
+            .handle::<HttpServerHandle>()
+            .expect("HttpServerHandle published by HttpServerCapability")
+            .local_port;
+        assert!(port > 0, "bound to an OS-assigned port");
+
+        let response = round_trip(
+            port,
+            b"GET /stream HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        );
+        let head = String::from_utf8_lossy(&response);
+        assert!(
+            head.starts_with("HTTP/1.1 200 "),
+            "GET /stream should reply 200, got: {head:?}",
+        );
+        assert!(
+            head.contains("Transfer-Encoding: chunked"),
+            "streamed response should be chunked, got: {head:?}",
+        );
+
+        let reassembled = dechunk(body_after_head(&response));
+        let expected: Vec<u8> = (0..STREAM_CHUNK_COUNT)
+            .flat_map(|i| format!("chunk-{i}\n").into_bytes())
+            .collect();
+        assert_eq!(
+            reassembled,
+            expected,
+            "reassembled stream body: {:?}",
+            String::from_utf8_lossy(&reassembled),
         );
     }
 }

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -276,6 +276,7 @@ mod tests {
             max_request_bytes: 65_536,
             max_header_bytes: 8_192,
             request_timeout_millis: 10_000,
+            max_connections: 1024,
             // Window below the chunk count so the round trip must replenish.
             response_stream_window: 8,
         };

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -21,7 +21,11 @@
 #![allow(clippy::needless_pass_by_value, clippy::unused_self)]
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
-use aether_capabilities::http::kinds::{HttpServerRequest, HttpServerResponse};
+use aether_capabilities::http::HttpServerCapability;
+use aether_capabilities::http::kinds::{
+    HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen, HttpServerRequest,
+    HttpServerResponse, HttpStreamCredit,
+};
 
 pub struct HttpHandler;
 
@@ -51,6 +55,91 @@ impl WasmActor for HttpHandler {
             status,
             headers: Vec::new(),
             body: body.to_vec(),
+        }
+    }
+}
+
+/// The number of body chunks [`StreamingHttpHandler`] emits, above a typical
+/// credit window so the e2e round trip exercises credit replenishment.
+const STREAM_CHUNK_COUNT: u32 = 20;
+
+/// Reference response-streaming handler fixture (ADR-0128) for the
+/// `serving-http` streaming e2e test. It replies `HttpResponseStreamOpen`
+/// instead of `HttpServerResponse`, emits `STREAM_CHUNK_COUNT` chunks paced
+/// against the cap's `HttpStreamCredit` grants, and terminates with
+/// `HttpResponseStreamEnd`. Each chunk is `"chunk-{i}\n"`, so the client
+/// reassembles a deterministic body.
+///
+/// Registered at `aether.component/aether.embedded:web_stream` after load.
+pub struct StreamingHttpHandler {
+    /// The stream this handler is feeding, learned from the first credit mail.
+    stream_id: u64,
+    /// Index of the next chunk to emit.
+    next_index: u32,
+    /// Whether the terminator has been sent.
+    ended: bool,
+}
+
+#[actor]
+impl WasmActor for StreamingHttpHandler {
+    const NAMESPACE: &'static str = "web_stream";
+
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(StreamingHttpHandler {
+            stream_id: 0,
+            next_index: 0,
+            ended: false,
+        })
+    }
+
+    /// Open a streamed `200` response. The body arrives later, one chunk per
+    /// unit of credit the cap grants.
+    ///
+    /// # Agent
+    /// Not sent manually — the `aether.http.server` cap dispatches it on
+    /// every inbound request. Route here by pointing
+    /// `HttpServerConfig.handler_mailbox` at
+    /// `"aether.component/aether.embedded:web_stream"`.
+    #[handler]
+    fn on_request(
+        &mut self,
+        _ctx: &mut WasmCtx<'_>,
+        _req: HttpServerRequest,
+    ) -> HttpResponseStreamOpen {
+        self.next_index = 0;
+        self.ended = false;
+        HttpResponseStreamOpen {
+            status: 200,
+            headers: Vec::new(),
+        }
+    }
+
+    /// Spend the granted credit: emit up to `credit.credit` more chunks, then
+    /// terminate once all `STREAM_CHUNK_COUNT` have gone out.
+    ///
+    /// # Agent
+    /// Not sent manually — the cap sends one `HttpStreamCredit` per freed
+    /// window slot; the handler emits at most that many `HttpResponseChunk`s
+    /// in response.
+    #[handler]
+    fn on_credit(&mut self, ctx: &mut WasmCtx<'_>, credit: HttpStreamCredit) {
+        self.stream_id = credit.stream_id;
+        let mut budget = credit.credit;
+        while budget > 0 && self.next_index < STREAM_CHUNK_COUNT {
+            ctx.actor::<HttpServerCapability>()
+                .send(&HttpResponseChunk {
+                    stream_id: self.stream_id,
+                    body: format!("chunk-{}\n", self.next_index).into_bytes(),
+                });
+            self.next_index += 1;
+            budget -= 1;
+        }
+        if self.next_index >= STREAM_CHUNK_COUNT && !self.ended {
+            ctx.actor::<HttpServerCapability>()
+                .send(&HttpResponseStreamEnd {
+                    stream_id: self.stream_id,
+                });
+            self.ended = true;
         }
     }
 }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
@@ -25,7 +25,7 @@ mod stateful_replace;
 mod ui_widget;
 
 pub use cube::Cube;
-pub use http_handler::HttpHandler;
+pub use http_handler::{HttpHandler, StreamingHttpHandler};
 pub use inline_child::{
     InlineDespawnParent, InlineParent, InlineStatefulChild, InlineStatefulParent,
 };
@@ -50,6 +50,7 @@ aether_actor::export!(
     MatSource,
     UiWidget,
     HttpHandler,
+    StreamingHttpHandler,
     SourceObserver,
     MatrixParent,
     MatrixChild,

--- a/docs/adr/0128-http-server-response-streaming.md
+++ b/docs/adr/0128-http-server-response-streaming.md
@@ -1,6 +1,6 @@
 # ADR-0128: HTTP server response streaming with windowed flow control
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-07-03
 
 Extends **ADR-0108** (the `aether.http.server` capability), which parked streaming in its §4 and named a chunk-kind protocol with backpressure as the natural next surface. Builds on the settlement model of **ADR-0080** / **ADR-0106**, the synchronous-inline mail routing of **ADR-0038**, and the off-hot-path staging stance of **ADR-0103**. Reuses the accept → dispatch → reply spine ADR-0108 established.
@@ -30,7 +30,7 @@ New wire kinds in `crates/aether-capabilities/src/http/kinds.rs` (owned by the s
 - `HttpResponseStreamEnd {}` — the handler's terminator. The cap writes the terminating chunk (and any close/keep-alive disposition) and finalizes the stream.
 - `HttpStreamCredit { credit: u32 }` — the flow-control mail the **cap sends to the handler**. It grants the handler permission to send up to `credit` more chunks. This is the backpressure signal the mail layer lacks, modeled one level up as an explicit typed mail between the two endpoints.
 
-Correlation reuses the ADR-0108 in-flight table: the stream is keyed by the original dispatch's correlation id, so every chunk mail and every credit mail rides the same correlation the request opened.
+Correlation reuses the ADR-0108 in-flight table: the stream is keyed by the original dispatch's correlation id. The `HttpResponseStreamOpen` reply rides that correlation directly (the one-shot correlation-echoed reply path), so the open handshake keys on it as written. The chunk / end / credit mails carry the key as an explicit `stream_id: u64` payload field set to that same id, rather than on the transport envelope: a guest reply handle is one-shot (the first reply consumes it), so a handler cannot re-echo the request correlation across many chunks, and each `ctx.send` mints a fresh correlation. Carrying the id in the payload preserves the "keyed by the original dispatch" intent without an SDK or host change — the handler learns its `stream_id` from the first `HttpStreamCredit` and stamps it on every chunk and the terminator, and the cap matches on the field. The two mid-stream inbound kinds (`HttpResponseChunk`, `HttpResponseStreamEnd`) are ordinary `#[handler]` kinds on the cap so a handler addresses them at `HttpServerCapability` type-safely; the open reply stays a fallback interception because a by-value handler cannot read the envelope correlation the open handshake needs.
 
 ### 3. Per-connection writer thread + bounded hand-off — where socket backpressure lives
 

--- a/docs/guide/recipes/serving-http.md
+++ b/docs/guide/recipes/serving-http.md
@@ -128,6 +128,78 @@ ctx.reply(&HttpServerResponse {
 The server sends these after its own `Connection: close` and `Content-Length`
 headers.
 
+## Streaming a response
+
+A handler that serves a large download or a long-lived event stream replies
+`HttpResponseStreamOpen` in place of `HttpServerResponse`, then emits the body
+across many `HttpResponseChunk` mails and terminates with
+`HttpResponseStreamEnd` (ADR-0128). The server renders the response as chunked
+transfer-encoding, so the whole body never resides in memory at once.
+
+The pace is a windowed credit protocol. When the handler opens a stream, the
+server grants it an initial credit window (`AETHER_HTTP_SERVER_RESPONSE_STREAM_WINDOW`,
+default 16) as an `HttpStreamCredit` mail, and replenishes one credit each time
+its per-connection writer thread drains a chunk to the socket. A chunk consumes
+one credit; when credit reaches zero the handler pauses until the next
+`HttpStreamCredit` arrives. So a slow client blocks the writer thread, not the
+scheduler, and the handler cannot outrun the socket:
+
+```rust
+use aether_capabilities::http::HttpServerCapability;
+use aether_capabilities::http::kinds::{
+    HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen, HttpStreamCredit,
+};
+
+pub struct Feed {
+    stream_id: u64,
+    next: u32,
+    done: bool,
+}
+
+#[actor]
+impl WasmActor for Feed {
+    const NAMESPACE: &'static str = "feed";
+
+    fn init<C: Resolver>(_ctx: &mut C) -> Result<Self, ActorInitError> {
+        Ok(Feed { stream_id: 0, next: 0, done: false })
+    }
+
+    // Open the stream. The body arrives later, one chunk per unit of credit.
+    #[handler]
+    fn on_request(&mut self, _ctx: &mut WasmCtx<'_>, _req: HttpServerRequest) -> HttpResponseStreamOpen {
+        self.next = 0;
+        self.done = false;
+        HttpResponseStreamOpen { status: 200, headers: Vec::new() }
+    }
+
+    // Spend the granted credit, then terminate once the body is exhausted.
+    // The handler learns its `stream_id` from the first credit mail.
+    #[handler]
+    fn on_credit(&mut self, ctx: &mut WasmCtx<'_>, credit: HttpStreamCredit) {
+        self.stream_id = credit.stream_id;
+        let mut budget = credit.credit;
+        while budget > 0 && self.next < 100 {
+            ctx.actor::<HttpServerCapability>().send(&HttpResponseChunk {
+                stream_id: self.stream_id,
+                body: format!("line {}\n", self.next).into_bytes(),
+            });
+            self.next += 1;
+            budget -= 1;
+        }
+        if self.next >= 100 && !self.done {
+            ctx.actor::<HttpServerCapability>().send(&HttpResponseStreamEnd {
+                stream_id: self.stream_id,
+            });
+            self.done = true;
+        }
+    }
+}
+```
+
+The buffered `HttpServerResponse` path is unchanged — a handler that replies it
+gets a single `Content-Length`-framed response exactly as before. Streaming is
+purely opt-in per reply.
+
 ## Verify against current code
 
 This recipe names the env keys and kind names live in the source. Before


### PR DESCRIPTION
Closes #2552.

## Summary

Implements windowed-flow-control response streaming for the http server capability (ADR-0128). Four new wire kinds (`HttpResponseStreamOpen`, `HttpStreamCredit`, `HttpResponseChunk`, `HttpResponseStreamEnd`) carry an explicit `stream_id`; a per-connection writer thread fed by a bounded `sync_channel` does credit accounting (writer owns the socket), with stream teardown on `close_connection` / `unwire` and an idle-write deadline via `recv_timeout`. Adds the `response_stream_window` config knob (default 16). ADR-0128 flipped to Accepted.

## Test plan

`cargo nextest run --workspace` = 1745 passed, including `streamed_response_reassembles_across_credit_window`, `over_window_flood_tears_the_stream_down`, and the real-wire e2e `wasm_handler_streams_chunked_response`. Full foreground validation passed (clippy `-D warnings`, strict doc, wasm32 cross-build).

## Generated by

`/implement --sweep` — agent execution of scoped issue #2552.
