### PR TITLE
feat(capabilities): bound concurrent http server connections

### DIFF
--- a/crates/aether-capabilities/src/http/server/config.rs
+++ b/crates/aether-capabilities/src/http/server/config.rs
@@ -3,8 +3,8 @@
 //! `with_actor::<HttpServerCapability>(config)`.
 
 use super::{
-    DEFAULT_BIND_ADDR, DEFAULT_MAX_HEADER_BYTES, DEFAULT_MAX_REQUEST_BYTES,
-    DEFAULT_REQUEST_TIMEOUT_MILLIS,
+    DEFAULT_BIND_ADDR, DEFAULT_MAX_CONNECTIONS, DEFAULT_MAX_HEADER_BYTES,
+    DEFAULT_MAX_REQUEST_BYTES, DEFAULT_REQUEST_TIMEOUT_MILLIS,
 };
 
 /// Init config for [`HttpServerCapability`](super::HttpServerCapability) (ADR-0108).
@@ -14,9 +14,10 @@ use super::{
 /// single component mailbox every request is dispatched to — resolved by
 /// name at dispatch time (late binding), so the handler component can load
 /// or reload independently of the server. `max_request_bytes` caps the
-/// request body, `max_header_bytes` caps the request line + headers, and
+/// request body, `max_header_bytes` caps the request line + headers,
 /// `request_timeout_millis` bounds both the per-read slow-loris timeout and
-/// the handler response deadline.
+/// the handler response deadline, and `max_connections` caps the live
+/// connection table.
 ///
 /// `#[derive(aether_substrate::Config)]` (ADR-0090) emits the env-shaped
 /// `HttpServerConfigLayer`, the clap-shaped `HttpServerOverlay`, and the
@@ -59,6 +60,11 @@ pub struct HttpServerConfig {
     /// handler that doesn't reply in time yields `504`.
     #[cfg_attr(feature = "runtime", config(default = 30_000))]
     pub request_timeout_millis: u64,
+    /// Cap on live connections ([`DEFAULT_MAX_CONNECTIONS`]); once the
+    /// connection table is at capacity a newly-accepted peer is refused
+    /// `503` and closed rather than getting a reader thread.
+    #[cfg_attr(feature = "runtime", config(default = 1024))]
+    pub max_connections: usize,
 }
 
 impl Default for HttpServerConfig {
@@ -70,6 +76,7 @@ impl Default for HttpServerConfig {
             max_request_bytes: DEFAULT_MAX_REQUEST_BYTES,
             max_header_bytes: DEFAULT_MAX_HEADER_BYTES,
             request_timeout_millis: DEFAULT_REQUEST_TIMEOUT_MILLIS,
+            max_connections: DEFAULT_MAX_CONNECTIONS,
         }
     }
 }

--- a/crates/aether-capabilities/src/http/server/mod.rs
+++ b/crates/aether-capabilities/src/http/server/mod.rs
@@ -51,6 +51,11 @@ pub const DEFAULT_MAX_REQUEST_BYTES: usize = 1_048_576;
 pub const DEFAULT_MAX_HEADER_BYTES: usize = 65_536;
 /// Default `request_timeout_millis` (slow-loris read + response deadline): 30 s.
 pub const DEFAULT_REQUEST_TIMEOUT_MILLIS: u64 = 30_000;
+/// Default `max_connections` (live connection-table ceiling): a generous
+/// bound that stops unbounded thread-per-connection resource exhaustion
+/// without tripping legitimate loopback use. Operator-tunable; each unit
+/// costs roughly one reader-thread stack.
+pub const DEFAULT_MAX_CONNECTIONS: usize = 1024;
 
 mod config;
 

--- a/crates/aether-capabilities/src/http/server/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/runtime.rs
@@ -161,6 +161,9 @@ pub struct HttpServerCapabilityState {
     pub handler_mailbox: String,
     pub max_request_bytes: usize,
     pub max_header_bytes: usize,
+    /// Live-connection-table ceiling (ADR-0108 §6); a peer accepted past
+    /// this is refused `503` before a reader thread is spawned.
+    pub max_connections: usize,
     pub request_timeout: Duration,
     pub self_mailbox: MailboxId,
     /// Cached `Arc<Mailer>` so the dispatcher can fire wake mails into
@@ -182,8 +185,25 @@ pub struct HttpServerCapabilityState {
 
 impl HttpServerCapabilityState {
     /// Allocate a fresh `ConnId`, store the connection's write half, and
-    /// spin a reader thread for the read half.
-    pub fn spawn_reader_for_peer(&mut self, stream: TcpStream, peer: SocketAddr) {
+    /// spin a reader thread for the read half. Refuses `503` and closes
+    /// without spawning a reader when the live connection table is
+    /// already at `max_connections` (ADR-0108 §6) — `connections` is the
+    /// single authoritative live-connection count, so no separate
+    /// counter is kept.
+    pub fn spawn_reader_for_peer(&mut self, mut stream: TcpStream, peer: SocketAddr) {
+        if self.connections.len() >= self.max_connections {
+            let bytes = render_status_response(503, "server at connection capacity");
+            let _ = stream.write_all(&bytes).and_then(|()| stream.flush());
+            let _ = stream.shutdown(Shutdown::Both);
+            tracing::warn!(
+                target: "aether_substrate::http_server",
+                %peer,
+                live = self.connections.len(),
+                "http conn refused: at capacity",
+            );
+            return;
+        }
+
         let conn_id = self.next_conn_id;
         self.next_conn_id += 1;
 
@@ -886,6 +906,7 @@ impl NativeActor for HttpServerCapability {
             handler_mailbox: config.handler_mailbox,
             max_request_bytes: config.max_request_bytes,
             max_header_bytes: config.max_header_bytes,
+            max_connections: config.max_connections,
             request_timeout: Duration::from_millis(config.request_timeout_millis),
             self_mailbox: self_id,
             mailer,
@@ -1064,8 +1085,9 @@ mod unit_tests {
     #[test]
     fn config_layer_defaults_match_the_named_consts() {
         use super::super::{
-            DEFAULT_BIND_ADDR, DEFAULT_MAX_HEADER_BYTES, DEFAULT_MAX_REQUEST_BYTES,
-            DEFAULT_REQUEST_TIMEOUT_MILLIS, HttpServerConfig, HttpServerConfigLayer,
+            DEFAULT_BIND_ADDR, DEFAULT_MAX_CONNECTIONS, DEFAULT_MAX_HEADER_BYTES,
+            DEFAULT_MAX_REQUEST_BYTES, DEFAULT_REQUEST_TIMEOUT_MILLIS, HttpServerConfig,
+            HttpServerConfigLayer,
         };
         use confique::Config as _;
         // No `.env()` source: loads the literal defaults only, so this is
@@ -1081,5 +1103,7 @@ mod unit_tests {
         assert_eq!(layer.max_request_bytes, DEFAULT_MAX_REQUEST_BYTES);
         assert_eq!(layer.max_header_bytes, DEFAULT_MAX_HEADER_BYTES);
         assert_eq!(layer.request_timeout_millis, DEFAULT_REQUEST_TIMEOUT_MILLIS);
+        assert_eq!(layer.max_connections, DEFAULT_MAX_CONNECTIONS);
+        assert_eq!(layer.max_connections, default.max_connections);
     }
 }

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -6,6 +6,7 @@ use aether_substrate::testing::{TestChassis, fresh_substrate};
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
 
 use test_handlers::{EchoHttpHandler, FixedBodyHttpHandler, SilentHttpHandler};
@@ -493,4 +494,56 @@ fn head_response_suppresses_body() {
 
     let get_response = round_trip(port, b"GET /x HTTP/1.1\r\nHost: localhost\r\n\r\n");
     assert_eq!(body_of(&get_response), "fixed body");
+}
+
+/// A peer accepted past `max_connections` is refused a canned `503`
+/// and closed before a reader thread is spawned; it never reaches the
+/// handler.
+///
+/// Tripwire: without the capacity guard in `spawn_reader_for_peer`,
+/// this connection is accepted and dispatched (or hangs waiting on
+/// the handler) instead of being refused.
+#[test]
+fn over_capacity_connection_is_503() {
+    let (registry, mailer) = fresh_substrate();
+    let max_connections = 2;
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<EchoHttpHandler>(())
+        .with_actor::<HttpServerCapability>(HttpServerConfig {
+            bind_addr: "127.0.0.1:0".to_string(),
+            handler_mailbox: <EchoHttpHandler as Addressable>::NAMESPACE.to_string(),
+            request_timeout_millis: 5_000,
+            max_connections,
+            ..HttpServerConfig::default()
+        })
+        .build_passive()
+        .expect("caps boot");
+
+    let port = port_of(&chassis);
+
+    // Fill the connection table: each socket sends a partial request
+    // head (no terminating blank line), so its reader thread blocks
+    // waiting for more bytes and its `ConnState` stays resident.
+    let mut held = Vec::new();
+    for _ in 0..max_connections {
+        let mut stream =
+            TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to http server");
+        stream
+            .write_all(b"GET / HTTP/1.1\r\n")
+            .expect("write partial request head");
+        stream.flush().expect("flush partial request head");
+        held.push(stream);
+    }
+
+    // Give the dispatcher a moment to drain the `PeerAccepted` events
+    // into `connections` before the next connect.
+    thread::sleep(Duration::from_millis(200));
+
+    let response = round_trip(port, b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    assert!(
+        response.starts_with("HTTP/1.1 503 "),
+        "expected 503, got: {response:?}",
+    );
+
+    drop(held);
 }

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -116,6 +116,7 @@ mod tests {
             max_request_bytes: 65_536,
             max_header_bytes: 8_192,
             request_timeout_millis: 10_000,
+            max_connections: 1024,
         };
 
         let sandbox = init_save_sandbox("http-serving");


### PR DESCRIPTION
Closes #2548.

## Summary

Bounds concurrent http server connections with a `max_connections` trust cap (default `DEFAULT_MAX_CONNECTIONS`, config-overridable). The `spawn_reader_for_peer` path refuses a connection over the cap with a `503` rather than unbounded acceptance.

## Test plan

`over_capacity_connection_is_503` fills the connection table with partial-request sockets, settles, and asserts the next connect gets a `503`. Full foreground validation passed (nextest workspace 1743, clippy `-D warnings`, strict doc, wasm32 dist).

## Generated by

`/implement --sweep` — agent execution of scoped issue #2548.
