### PR TITLE
feat(capabilities): route registration for the http server

### DIFF
--- a/crates/aether-capabilities/src/component/runtime/mod.rs
+++ b/crates/aether-capabilities/src/component/runtime/mod.rs
@@ -35,8 +35,11 @@ use aether_kinds::{
 // Crate-local wiring the `#[runtime] impl` handler bodies name (sibling caps it
 // mails, the unsubscribe kind, the `Kind` / `MailboxCategory` vocabulary), the
 // state struct, and `forward_to_trampoline` — all used within this module.
+use crate::http::HttpServerCapability;
+use crate::http::kinds::UnregisterRoutesAll;
 use crate::input::{InputCapability, UnsubscribeAll};
 use crate::lifecycle::LifecycleCapability;
+use aether_actor::Addressable;
 use aether_data::{Kind, MailboxCategory};
 use aether_kinds::LifecycleUnsubscribeAll;
 
@@ -165,20 +168,17 @@ impl NativeActor for ComponentHostCapability {
     /// replies `DropResult::Ok` and shuts itself down.
     ///
     /// Before forwarding, purges the dying trampoline's mailbox from
-    /// every fan-out subscriber table so no cap keeps firing at a
+    /// every fan-out / routing table so no cap keeps firing at a
     /// dropped mailbox: `aether.input`'s input-stream tables (via
-    /// [`UnsubscribeAll`]) and `aether.lifecycle`'s per-stage tables
-    /// (via [`LifecycleUnsubscribeAll`]).
+    /// [`UnsubscribeAll`]), `aether.lifecycle`'s per-stage tables
+    /// (via [`LifecycleUnsubscribeAll`]), and `aether.http.server`'s
+    /// route table (via [`UnregisterRoutesAll`], ADR-0130).
     ///
     /// # Agent
     /// `DropComponent { mailbox_id }`. The `mailbox_id` is the
     /// trampoline's id from the `LoadResult.mailbox_id` field.
     #[handler]
-    fn on_drop_component(
-        _state: &mut Self::State,
-        ctx: &mut NativeCtx<'_>,
-        payload: DropComponent,
-    ) {
+    fn on_drop_component(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: DropComponent) {
         // Cap-side cleanup: ask each owning cap to drop the dying
         // trampoline from its fan-out sets. Mail rather than direct
         // mutation post-issue-640 — each cap is the sole owner of its
@@ -190,6 +190,20 @@ impl NativeActor for ComponentHostCapability {
             .send(&LifecycleUnsubscribeAll {
                 mailbox: payload.mailbox_id.0,
             });
+        // The http server registers only when a bind is configured
+        // (ADR-0108), so gate its route purge on the cap being live —
+        // an unguarded typed send would warn-drop on every component
+        // drop in a chassis that serves no HTTP.
+        if state
+            .registry
+            .lookup(<HttpServerCapability as Addressable>::NAMESPACE)
+            .is_some()
+        {
+            ctx.actor::<HttpServerCapability>()
+                .send(&UnregisterRoutesAll {
+                    mailbox: payload.mailbox_id,
+                });
+        }
         forward_to_trampoline(ctx, payload.mailbox_id, DropComponent::ID, &payload);
     }
 

--- a/crates/aether-capabilities/src/http/kinds.rs
+++ b/crates/aether-capabilities/src/http/kinds.rs
@@ -207,6 +207,110 @@ pub struct HttpResponseStreamEnd {
     pub stream_id: u64,
 }
 
+// ADR-0130 route-registration kinds. Mirrors the `aether.input`
+// subscribe family: `_self` variants resolve the registrant from the
+// inbound envelope's host-stamped `Source` (forgery-proof, in-process
+// by construction); the explicit-`mailbox` variants serve external
+// callers and are validated against the registry. A route carries the
+// `KindId` its requests dispatch as — the cap stamps that kind onto
+// the request-shaped payload, so the registered kind's schema must
+// decode `aether.http.server.request`'s byte layout
+// (`aether.http.server.request` itself is the generic choice).
+
+/// `aether.http.server.register_route` — claim a path-prefix route for
+/// `mailbox`. `prefix` is segment-boundary matched (`/api` matches
+/// `/api` and `/api/…`, never `/apiary`; `/` is the catch-all; a
+/// trailing slash is normalized off at registration). `method` filters
+/// the route to one HTTP method; `None` accepts every method. Among
+/// matching routes the longest prefix wins, and a method-specific
+/// route beats a method-agnostic one at equal prefix. A `(prefix,
+/// method)` key already claimed by a *different* mailbox is answered
+/// `Err`; the same mailbox re-claiming its own key is an idempotent
+/// `Ok` (and updates `kind`). Reply: `RegisterRouteResult`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.register_route")]
+pub struct RegisterRoute {
+    pub prefix: String,
+    pub method: Option<HttpMethod>,
+    pub kind: aether_data::KindId,
+    pub mailbox: aether_data::MailboxId,
+}
+
+/// `aether.http.server.register_route_self` — reflexive counterpart of
+/// [`RegisterRoute`]: claim the route for the *sending* actor, with no
+/// explicit `mailbox` field. The cap resolves the registrant from the
+/// inbound envelope's host-stamped `Source` (ADR-0083), so the
+/// registrant cannot be forged and the op is gated to in-process
+/// actors by construction — an external session or another engine gets
+/// an `Err` reply, pushing it onto the named [`RegisterRoute`] form.
+/// This is the common "route to me" case, sent from `wire`. Reply:
+/// `RegisterRouteResult`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.register_route_self")]
+pub struct RegisterRouteSelf {
+    pub prefix: String,
+    pub method: Option<HttpMethod>,
+    pub kind: aether_data::KindId,
+}
+
+/// `aether.http.server.unregister_route` — release the `(prefix,
+/// method)` route held by `mailbox`. Idempotent: releasing a route
+/// that isn't held is still `Ok`. Reply: `RegisterRouteResult`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.unregister_route")]
+pub struct UnregisterRoute {
+    pub prefix: String,
+    pub method: Option<HttpMethod>,
+    pub mailbox: aether_data::MailboxId,
+}
+
+/// `aether.http.server.unregister_route_self` — reflexive counterpart
+/// of [`UnregisterRoute`]: release the *sending* actor's `(prefix,
+/// method)` route, resolved from the host-stamped `Source` like
+/// [`RegisterRouteSelf`]. Idempotent. Reply: `RegisterRouteResult`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.unregister_route_self")]
+pub struct UnregisterRouteSelf {
+    pub prefix: String,
+    pub method: Option<HttpMethod>,
+}
+
+/// Reply to the route registration / unregistration kinds (ADR-0130).
+/// Failure modes: an invalid prefix (must start with `/`), an unknown
+/// or dropped registrant mailbox, a `(prefix, method)` key already
+/// claimed by another mailbox, or a `_self` op from a sender with no
+/// local mailbox.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.register_route_result")]
+pub enum RegisterRouteResult {
+    Ok,
+    Err { error: String },
+}
+
+/// `aether.http.server.unregister_routes_all` — release every route
+/// held by `mailbox`. Issued by `ComponentHostCapability` on
+/// `DropComponent` (alongside its `aether.input.unsubscribe_all` /
+/// `aether.lifecycle.unsubscribe_all` sends) so the route table
+/// doesn't keep dispatching at a dropped trampoline. Idempotent: a
+/// mailbox holding no routes is a no-op. Fire-and-forget; no reply.
+/// Cast-shape (Pod) — one `MailboxId`, fixed size.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.http.server.unregister_routes_all")]
+pub struct UnregisterRoutesAll {
+    pub mailbox: aether_data::MailboxId,
+}
+
 /// `aether.http.server.inbound_ready` — accept / reader sidecar →
 /// `HttpServerCapability` dispatcher wake (ADR-0108, issue 1760).
 /// The HTTP-server analog of `RpcInboundReady`: the sidecar pushes

--- a/crates/aether-capabilities/src/http/server/mod.rs
+++ b/crates/aether-capabilities/src/http/server/mod.rs
@@ -39,8 +39,13 @@
 // `#[actor]` emits the `HandlesKind<K>` markers always-on against the
 // identity, and the `init` / handler bodies name these kinds. The two
 // stream-inbound kinds (ADR-0128) are `#[handler]` kinds so a streaming
-// handler can address them at `HttpServerCapability` type-safely.
+// handler can address them at `HttpServerCapability` type-safely; the
+// route-registration kinds (ADR-0130) are `#[handler]` kinds likewise.
 use crate::http::kinds::{HttpInboundReady, HttpResponseChunk, HttpResponseStreamEnd};
+use crate::http::kinds::{
+    RegisterRoute, RegisterRouteResult, RegisterRouteSelf, UnregisterRoute, UnregisterRouteSelf,
+    UnregisterRoutesAll,
+};
 use aether_kinds::trace::Settled;
 
 // Default bind address. Loopback per ADR-0108 §6 — binding a public

--- a/crates/aether-capabilities/src/http/server/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/runtime.rs
@@ -39,13 +39,15 @@ pub use aether_substrate::actor::native::envelope::Envelope;
 pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
 pub use aether_substrate::chassis::error::BootError;
 pub use aether_substrate::mail::mailer::Mailer;
+pub use aether_substrate::mail::registry::{MailboxEntry, Registry};
 
 // The parent `#[actor] impl` writes the `502` reply path, so it names
 // `HttpServerResponse`; the rest of the kind vocabulary is used only here.
 pub use crate::http::kinds::HttpServerResponse;
 use crate::http::kinds::{
     HttpHeader, HttpMethod, HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen,
-    HttpServerRequest, HttpStreamCredit,
+    HttpServerRequest, HttpStreamCredit, RegisterRoute, RegisterRouteResult, RegisterRouteSelf,
+    UnregisterRoute, UnregisterRouteSelf, UnregisterRoutesAll,
 };
 
 use aether_substrate::Mail;
@@ -172,6 +174,61 @@ pub struct StreamState {
     pending_end: bool,
 }
 
+/// One registered route (ADR-0130): requests whose path matches
+/// `prefix` on a segment boundary (and whose method passes `method`)
+/// dispatch to `mailbox` as kind `kind`. The table keys the route by
+/// the registrant's `MailboxId`, so a route survives
+/// `replace_component` (the id is stable) and dispatch skips name
+/// resolution.
+pub struct Route {
+    pub prefix: String,
+    pub method: Option<HttpMethod>,
+    pub kind: KindId,
+    pub mailbox: MailboxId,
+}
+
+/// Segment-boundary prefix match (ADR-0130): `/api` matches `/api` and
+/// `/api/…`, never `/apiary`; `/` is the catch-all. Prefixes are
+/// normalized at registration ([`normalize_prefix`]), so no trailing
+/// slash reaches this check.
+fn route_matches(prefix: &str, path: &str) -> bool {
+    if prefix == "/" {
+        return true;
+    }
+    path.strip_prefix(prefix)
+        .is_some_and(|rest| rest.is_empty() || rest.starts_with('/'))
+}
+
+/// Validate + normalize a registration prefix: must start with `/`;
+/// trailing slashes are stripped (`/api/` ⇒ `/api`) so the
+/// segment-boundary match has one canonical spelling, with `/` itself
+/// kept as the catch-all.
+fn normalize_prefix(raw: &str) -> Result<String, String> {
+    if !raw.starts_with('/') {
+        return Err(format!("route prefix {raw:?} must start with '/'"));
+    }
+    let trimmed = raw.trim_end_matches('/');
+    Ok(if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        trimmed.to_string()
+    })
+}
+
+/// Registrant-mailbox validation for the explicit-`mailbox`
+/// registration forms — the route twin of `aether.input`'s
+/// `validate_subscriber_mailbox` (that helper lives in the input cap's
+/// private runtime module, so the five-line check is mirrored rather
+/// than imported). The host-stamped `_self` forms skip it: the stamp
+/// already names a live in-process mailbox.
+fn validate_route_mailbox(registry: &Registry, id: MailboxId) -> Result<(), String> {
+    match registry.entry(id) {
+        Some(MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_)) => Ok(()),
+        Some(MailboxEntry::Dropped) => Err(format!("mailbox {id:?} already dropped")),
+        None => Err(format!("unknown mailbox id {id:?}")),
+    }
+}
+
 /// Wake sink shared with the accept + reader sidecar threads: push an
 /// [`InboundEvent`] over the mpsc, then fire an [`HttpInboundReady`]
 /// wake mail at the cap so the dispatcher drains.
@@ -207,6 +264,14 @@ impl WakeSink {
 /// `NativeActor::State` interface without exposing it as crate-public API.
 pub struct HttpServerCapabilityState {
     pub handler_mailbox: String,
+    /// Registered routes (ADR-0130), unordered — [`Self::resolve_route`]
+    /// picks the winner per request by `(prefix length, method
+    /// specificity)`, which is deterministic without a sort: two
+    /// distinct equal-length prefixes cannot both match one path, and
+    /// duplicate `(prefix, method)` keys are rejected at registration.
+    /// Route counts are tens per substrate, so the linear scan is
+    /// dwarfed by the header parse that precedes it (ADR-0130).
+    pub routes: Vec<Route>,
     pub max_request_bytes: usize,
     pub max_header_bytes: usize,
     /// Live-connection-table ceiling (ADR-0108 §6); a peer accepted past
@@ -241,6 +306,78 @@ pub struct HttpServerCapabilityState {
 }
 
 impl HttpServerCapabilityState {
+    /// Claim `(prefix, method)` for `mailbox`, dispatching as `kind`
+    /// (ADR-0130). A key held by a different mailbox is answered
+    /// `Err`; the same mailbox re-claiming its own key is an
+    /// idempotent `Ok` that updates `kind` — so a component
+    /// re-running `wire` after `replace_component` re-registers
+    /// cleanly (its `MailboxId` is stable).
+    pub fn register_route(
+        &mut self,
+        prefix: &str,
+        method: Option<HttpMethod>,
+        kind: KindId,
+        mailbox: MailboxId,
+    ) -> RegisterRouteResult {
+        let prefix = match normalize_prefix(prefix) {
+            Ok(prefix) => prefix,
+            Err(error) => return RegisterRouteResult::Err { error },
+        };
+        if let Some(existing) = self
+            .routes
+            .iter_mut()
+            .find(|r| r.prefix == prefix && r.method == method)
+        {
+            if existing.mailbox == mailbox {
+                existing.kind = kind;
+                return RegisterRouteResult::Ok;
+            }
+            return RegisterRouteResult::Err {
+                error: format!(
+                    "route ({prefix:?}, {method:?}) already claimed by mailbox {:?}",
+                    existing.mailbox,
+                ),
+            };
+        }
+        self.routes.push(Route {
+            prefix,
+            method,
+            kind,
+            mailbox,
+        });
+        RegisterRouteResult::Ok
+    }
+
+    /// Release the `(prefix, method)` route held by `mailbox`.
+    /// Idempotent — releasing a route that isn't held (or is held by
+    /// someone else) is still `Ok`, mirroring the input cap's
+    /// unsubscribe semantics.
+    pub fn unregister_route(
+        &mut self,
+        prefix: &str,
+        method: Option<HttpMethod>,
+        mailbox: MailboxId,
+    ) -> RegisterRouteResult {
+        let prefix = match normalize_prefix(prefix) {
+            Ok(prefix) => prefix,
+            Err(error) => return RegisterRouteResult::Err { error },
+        };
+        self.routes
+            .retain(|r| !(r.prefix == prefix && r.method == method && r.mailbox == mailbox));
+        RegisterRouteResult::Ok
+    }
+
+    /// The longest segment-boundary prefix match among
+    /// method-compatible routes, with a method-specific route beating
+    /// a method-agnostic one at equal prefix (ADR-0130). `None` ⇒ the
+    /// configured `handler_mailbox` fallback.
+    fn resolve_route(&self, path: &str, method: HttpMethod) -> Option<&Route> {
+        self.routes
+            .iter()
+            .filter(|r| r.method.is_none_or(|m| m == method) && route_matches(&r.prefix, path))
+            .max_by_key(|r| (r.prefix.len(), r.method.is_some()))
+    }
+
     /// Allocate a fresh `ConnId`, store the connection's write half, and
     /// spin a reader thread for the read half. Refuses `503` and closes
     /// without spawning a reader when the live connection table is
@@ -358,12 +495,28 @@ impl HttpServerCapabilityState {
             self.close_connection(conn_id, "unsupported method");
             return;
         };
-        // Late-binding handler resolution (ADR-0108 §3): resolve the
-        // configured mailbox by name at dispatch time through the
-        // registry — the sanctioned runtime-name path, which folds a
-        // lineage-rendered name to its id and reports a miss as `None`.
-        // Nothing live under the name → `503`.
-        let Some(handler) = self.mailer.registry().lookup(&self.handler_mailbox) else {
+        // Route resolution (ADR-0130): a registered route names its
+        // handler by stable `MailboxId` and the kind its requests
+        // dispatch as; a dead routed mailbox is answered `503`, the
+        // same surface as an unresolved fallback (falling back instead
+        // would silently reroute a claimed path family). No route ⇒
+        // the ADR-0108 §3 late-binding fallback: resolve the configured
+        // `handler_mailbox` by name at dispatch time through the
+        // registry — the sanctioned runtime-name path — dispatching
+        // the generic request kind. Nothing live either way → `503`.
+        let routed = self
+            .resolve_route(&request.path, method)
+            .map(|route| (route.mailbox, route.kind));
+        let (handler, dispatch_kind) = if let Some((mailbox, kind)) = routed {
+            if validate_route_mailbox(self.mailer.registry(), mailbox).is_err() {
+                self.write_status_response(conn_id, 503, "routed handler gone");
+                self.close_connection(conn_id, "routed mailbox dead");
+                return;
+            }
+            (mailbox, kind)
+        } else if let Some(handler) = self.mailer.registry().lookup(&self.handler_mailbox) {
+            (handler, <HttpServerRequest as Kind>::ID)
+        } else {
             self.write_status_response(conn_id, 503, "no handler registered");
             self.close_connection(conn_id, "handler unresolved");
             return;
@@ -382,7 +535,7 @@ impl HttpServerCapabilityState {
             peer_addr,
         }
         .encode_into_bytes();
-        let mail_id = ctx.send_envelope_as_root(handler, <HttpServerRequest as Kind>::ID, &payload);
+        let mail_id = ctx.send_envelope_as_root(handler, dispatch_kind, &payload);
         // Safety net (ADR-0108 §5): if the chain settles with no
         // response, `on_settled` answers `502`. Best-effort — a chassis
         // without the settlement registry still serves the reply path.
@@ -1256,6 +1409,7 @@ impl NativeActor for HttpServerCapability {
 
         Ok(HttpServerCapabilityState {
             handler_mailbox: config.handler_mailbox,
+            routes: Vec::new(),
             max_request_bytes: config.max_request_bytes,
             max_header_bytes: config.max_header_bytes,
             max_connections: config.max_connections,
@@ -1395,6 +1549,113 @@ impl NativeActor for HttpServerCapability {
         state.end_stream(end.stream_id);
     }
 
+    /// Claim a route for an explicitly named mailbox (ADR-0130).
+    ///
+    /// # Agent
+    /// `RegisterRoute { prefix, method, kind, mailbox }`. The external
+    /// form — an MCP session or test names the handler mailbox
+    /// explicitly; it is validated against the registry. An in-process
+    /// actor registering itself sends `register_route_self` instead.
+    #[handler]
+    fn on_register_route(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        payload: RegisterRoute,
+    ) -> RegisterRouteResult {
+        if let Err(error) = validate_route_mailbox(state.mailer.registry(), payload.mailbox) {
+            return RegisterRouteResult::Err { error };
+        }
+        state.register_route(
+            &payload.prefix,
+            payload.method,
+            payload.kind,
+            payload.mailbox,
+        )
+    }
+
+    /// Claim a route for the *sending* actor (ADR-0130), resolved from
+    /// the inbound envelope's host-stamped `Source` — forgery-proof
+    /// and gated to in-process actors by construction, mirroring
+    /// `aether.input.subscribe_self`.
+    ///
+    /// # Agent
+    /// `RegisterRouteSelf { prefix, method, kind }`, typically sent
+    /// from a component's `wire` hook. An external session or remote
+    /// engine has no local mailbox and gets an `Err` reply — use
+    /// `register_route` with an explicit mailbox instead.
+    #[handler]
+    fn on_register_route_self(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: RegisterRouteSelf,
+    ) -> RegisterRouteResult {
+        match ctx.source_mailbox() {
+            Some(mailbox) => {
+                state.register_route(&payload.prefix, payload.method, payload.kind, mailbox)
+            }
+            None => RegisterRouteResult::Err {
+                error: "aether.http.server.register_route_self requires a local sender; an \
+                        external session or remote engine must use \
+                        aether.http.server.register_route with an explicit mailbox"
+                    .to_string(),
+            },
+        }
+    }
+
+    /// Release an explicitly named mailbox's route (ADR-0130).
+    /// Idempotent.
+    ///
+    /// # Agent
+    /// `UnregisterRoute { prefix, method, mailbox }`.
+    #[handler]
+    fn on_unregister_route(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        payload: UnregisterRoute,
+    ) -> RegisterRouteResult {
+        state.unregister_route(&payload.prefix, payload.method, payload.mailbox)
+    }
+
+    /// Release the *sending* actor's route (ADR-0130), resolved from
+    /// the host-stamped `Source` like `register_route_self`.
+    /// Idempotent.
+    ///
+    /// # Agent
+    /// `UnregisterRouteSelf { prefix, method }`.
+    #[handler]
+    fn on_unregister_route_self(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: UnregisterRouteSelf,
+    ) -> RegisterRouteResult {
+        match ctx.source_mailbox() {
+            Some(mailbox) => state.unregister_route(&payload.prefix, payload.method, mailbox),
+            None => RegisterRouteResult::Err {
+                error: "aether.http.server.unregister_route_self requires a local sender; an \
+                        external session or remote engine must use \
+                        aether.http.server.unregister_route with an explicit mailbox"
+                    .to_string(),
+            },
+        }
+    }
+
+    /// Release every route held by a mailbox (ADR-0130). Issued by
+    /// `ComponentHostCapability` on `DropComponent`, alongside its
+    /// input / lifecycle unsubscribe fan-out, so the route table
+    /// doesn't keep dispatching at a dropped trampoline. Idempotent;
+    /// fire-and-forget.
+    ///
+    /// # Agent
+    /// `UnregisterRoutesAll { mailbox }`.
+    #[handler]
+    fn on_unregister_routes_all(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        payload: UnregisterRoutesAll,
+    ) {
+        state.routes.retain(|r| r.mailbox != payload.mailbox);
+    }
+
     /// Settlement notice. The root corresponds to a dispatched request
     /// we subscribed to; if it settled with no [`HttpServerResponse`]
     /// written, answer `502` (ADR-0108 §5) and clear the entry.
@@ -1467,9 +1728,36 @@ impl NativeActor for HttpServerCapability {
 
 #[cfg(test)]
 mod unit_tests {
-    use super::{http_date, parse_http_method, percent_decode_path, reason_phrase};
+    use super::{
+        http_date, normalize_prefix, parse_http_method, percent_decode_path, reason_phrase,
+        route_matches,
+    };
     use crate::http::kinds::HttpMethod;
     use std::time::{Duration, UNIX_EPOCH};
+
+    /// Segment-boundary semantics (ADR-0130): a prefix matches at `/`
+    /// boundaries only, so `/api` never captures `/apiary`.
+    #[test]
+    fn route_match_is_segment_boundary() {
+        assert!(route_matches("/api", "/api"));
+        assert!(route_matches("/api", "/api/widgets"));
+        assert!(!route_matches("/api", "/apiary"));
+        assert!(!route_matches("/api", "/ap"));
+        assert!(route_matches("/", "/anything"));
+        assert!(route_matches("/", "/"));
+    }
+
+    /// Prefix normalization: leading `/` required, trailing slashes
+    /// stripped to one canonical spelling, `/` kept as the catch-all.
+    #[test]
+    fn prefix_normalization() {
+        assert_eq!(normalize_prefix("/api/"), Ok("/api".to_string()));
+        assert_eq!(normalize_prefix("/api"), Ok("/api".to_string()));
+        assert_eq!(normalize_prefix("/"), Ok("/".to_string()));
+        assert_eq!(normalize_prefix("///"), Ok("/".to_string()));
+        assert!(normalize_prefix("api").is_err());
+        assert!(normalize_prefix("").is_err());
+    }
 
     #[test]
     fn http_date_formats_the_rfc_example() {

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -7,28 +7,215 @@ use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use test_handlers::{
-    EchoHttpHandler, FixedBodyHttpHandler, FloodHttpHandler, STREAM_CHUNK_COUNT, SilentHttpHandler,
-    StreamHttpHandler, stream_chunk_body,
+    ApiRouteHandler, ApiV2Handler, DupFirstHandler, DupSecondHandler, EchoHttpHandler,
+    FixedBodyHttpHandler, FloodHttpHandler, MethodAnyHandler, MethodPostHandler,
+    STREAM_CHUNK_COUNT, SilentHttpHandler, StreamHttpHandler, TmpRouteHandler, stream_chunk_body,
 };
 
 mod test_handlers {
     //! Minimal native handler actors behind the server in the integration
     //! tests: one that replies `200` echoing the request, one that drops
-    //! the request without replying (the `502` safety-net path), and two
+    //! the request without replying (the `502` safety-net path), two
     //! response-streaming handlers (ADR-0128) — a well-behaved one that
-    //! paces chunks against credit, and a flooder that ignores credit.
+    //! paces chunks against credit, and a flooder that ignores credit —
+    //! plus the ADR-0130 routed handlers that claim prefixes from `wire`
+    //! via `register_route_self` — the same registration path a component
+    //! takes — and reply fixed tags so a test can assert which handler a
+    //! request reached.
     use aether_actor::actor;
+    use aether_data::Kind;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
 
     use crate::http::kinds::{
-        HttpHeader, HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen,
-        HttpServerRequest, HttpServerResponse, HttpStreamCredit,
+        HttpHeader, HttpMethod, HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen,
+        HttpServerRequest, HttpServerResponse, HttpStreamCredit, RegisterRouteSelf,
+        UnregisterRouteSelf,
     };
     use crate::http::server::HttpServerCapability;
+
+    /// A minted route kind (ADR-0130): the same shape as
+    /// [`HttpServerRequest`] under a distinct kind name, so the cap's
+    /// route-as-kind dispatch stamps this id and the handler's typed
+    /// `#[handler]` decodes the request-shaped payload as it.
+    #[derive(aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize)]
+    #[kind(name = "aether.http.test.api_route_request")]
+    pub struct ApiRouteRequest {
+        pub method: HttpMethod,
+        pub path: String,
+        pub query: String,
+        pub headers: Vec<HttpHeader>,
+        pub body: Vec<u8>,
+        pub peer_addr: String,
+    }
+
+    /// Claims `/api` from `wire` with the minted [`ApiRouteRequest`]
+    /// kind (registering the same key twice to pin the idempotent
+    /// same-mailbox re-claim), and echoes the decoded path back in the
+    /// body — proving the routed payload decoded as the registered
+    /// kind, not just that dispatch picked the right mailbox.
+    pub struct ApiRouteHandler;
+    pub struct ApiRouteHandlerState;
+
+    #[actor(singleton)]
+    impl NativeActor for ApiRouteHandler {
+        type State = ApiRouteHandlerState;
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.http.test_route_api";
+
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<ApiRouteHandlerState, BootError> {
+            Ok(ApiRouteHandlerState)
+        }
+
+        fn wire(_state: &mut ApiRouteHandlerState, ctx: &mut NativeCtx<'_>) {
+            let claim = RegisterRouteSelf {
+                prefix: "/api".to_string(),
+                method: None,
+                kind: <ApiRouteRequest as Kind>::ID,
+            };
+            ctx.actor::<HttpServerCapability>().send(&claim);
+            // Same mailbox re-claiming its own key: idempotent Ok.
+            ctx.actor::<HttpServerCapability>().send(&claim);
+        }
+
+        #[handler]
+        fn on_request(
+            _state: &mut Self::State,
+            _ctx: &mut NativeCtx<'_>,
+            request: ApiRouteRequest,
+        ) -> HttpServerResponse {
+            HttpServerResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: format!("api:{}", request.path).into_bytes(),
+            }
+        }
+    }
+
+    /// Claims `/tmp` from `wire`; on any request it releases its own
+    /// route via `unregister_route_self` before replying, so the next
+    /// request to `/tmp` falls back to the default handler.
+    pub struct TmpRouteHandler;
+    pub struct TmpRouteHandlerState;
+
+    #[actor(singleton)]
+    impl NativeActor for TmpRouteHandler {
+        type State = TmpRouteHandlerState;
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.http.test_route_tmp";
+
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<TmpRouteHandlerState, BootError> {
+            Ok(TmpRouteHandlerState)
+        }
+
+        fn wire(_state: &mut TmpRouteHandlerState, ctx: &mut NativeCtx<'_>) {
+            ctx.actor::<HttpServerCapability>()
+                .send(&RegisterRouteSelf {
+                    prefix: "/tmp".to_string(),
+                    method: None,
+                    kind: <HttpServerRequest as Kind>::ID,
+                });
+        }
+
+        #[handler]
+        fn on_request(
+            _state: &mut Self::State,
+            ctx: &mut NativeCtx<'_>,
+            _request: HttpServerRequest,
+        ) -> HttpServerResponse {
+            ctx.actor::<HttpServerCapability>()
+                .send(&UnregisterRouteSelf {
+                    prefix: "/tmp".to_string(),
+                    method: None,
+                });
+            HttpServerResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: b"tmp".to_vec(),
+            }
+        }
+    }
+
+    /// A routed handler that claims its prefixes from `wire` with the
+    /// generic request kind and replies `200` with a fixed tag body.
+    macro_rules! routed_handler {
+        ($ty:ident, $state:ident, $namespace:literal, $tag:literal,
+         [$(($method:expr, $prefix:literal)),+ $(,)?]) => {
+            pub struct $ty;
+            pub struct $state;
+
+            #[actor(singleton)]
+            impl NativeActor for $ty {
+                type State = $state;
+                type Config = ();
+                const NAMESPACE: &'static str = $namespace;
+
+                fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<$state, BootError> {
+                    Ok($state)
+                }
+
+                fn wire(_state: &mut $state, ctx: &mut NativeCtx<'_>) {
+                    $(ctx.actor::<HttpServerCapability>().send(&RegisterRouteSelf {
+                        prefix: $prefix.to_string(),
+                        method: $method,
+                        kind: <HttpServerRequest as Kind>::ID,
+                    });)+
+                }
+
+                #[handler]
+                fn on_request(
+                    _state: &mut Self::State,
+                    _ctx: &mut NativeCtx<'_>,
+                    _request: HttpServerRequest,
+                ) -> HttpServerResponse {
+                    HttpServerResponse {
+                        status: 200,
+                        headers: Vec::new(),
+                        body: $tag.to_vec(),
+                    }
+                }
+            }
+        };
+    }
+
+    routed_handler!(
+        ApiV2Handler,
+        ApiV2HandlerState,
+        "aether.http.test_route_api_v2",
+        b"api-v2",
+        [(None, "/api/v2")]
+    );
+    routed_handler!(
+        MethodPostHandler,
+        MethodPostHandlerState,
+        "aether.http.test_route_post_m",
+        b"post-m",
+        [(Some(HttpMethod::Post), "/m")]
+    );
+    routed_handler!(
+        MethodAnyHandler,
+        MethodAnyHandlerState,
+        "aether.http.test_route_any_m",
+        b"any-m",
+        [(None, "/m")]
+    );
+    routed_handler!(
+        DupFirstHandler,
+        DupFirstHandlerState,
+        "aether.http.test_route_dup_first",
+        b"first",
+        [(None, "/dup")]
+    );
+    routed_handler!(
+        DupSecondHandler,
+        DupSecondHandlerState,
+        "aether.http.test_route_dup_second",
+        b"second",
+        [(None, "/dup"), (None, "/second")]
+    );
 
     /// Replies `200` and echoes the request's method / path / query /
     /// peer address (as headers) and body (verbatim), so a test can
@@ -806,5 +993,172 @@ fn over_window_flood_tears_the_stream_down() {
     assert!(
         !response.contains("0\r\n\r\n"),
         "flood stream is torn down before the terminator: {response:?}",
+    );
+}
+
+/// Boot the server (first, so the routed handlers' `wire` registrations
+/// find its mailbox live) with [`FixedBodyHttpHandler`] as the
+/// `handler_mailbox` fallback, then the given routed handlers.
+macro_rules! routed_chassis {
+    ($($handler:ty),+ $(,)?) => {{
+        let (registry, mailer) = fresh_substrate();
+        Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<HttpServerCapability>(config_for(
+                <FixedBodyHttpHandler as Addressable>::NAMESPACE,
+                1024,
+            ))
+            .with_actor::<FixedBodyHttpHandler>(())
+            $(.with_actor::<$handler>(()))+
+            .build_passive()
+            .expect("caps boot")
+    }};
+}
+
+/// Poll `request` until its response body equals `expected` (bounded
+/// deadline, house pattern — see `tcp/tests.rs` / the bundle
+/// `http_serving.rs`). The `wire` route registrations are asynchronous
+/// mail, so a route's *first* positive assertion must poll it live
+/// rather than race the registration; assertions that depend on an
+/// already-proven-live route can then be direct.
+fn poll_body(port: u16, request: &[u8], expected: &str) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let response = round_trip(port, request);
+        if body_of(&response) == expected {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected body {expected:?} within 10s; last response: {response:?}",
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+/// A `wire`-registered route dispatches as the registered kind — the
+/// handler's typed `#[handler]` decodes the request-shaped payload
+/// under the minted kind and echoes the path — and an unrouted path
+/// falls back to the configured `handler_mailbox` (ADR-0130).
+#[test]
+fn routed_prefix_dispatches_as_registered_kind() {
+    let chassis = routed_chassis!(ApiRouteHandler);
+    let port = port_of(&chassis);
+
+    poll_body(
+        port,
+        b"GET /api/widgets HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        "api:/api/widgets",
+    );
+
+    let unrouted = round_trip(port, b"GET /other HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    assert_eq!(
+        body_of(&unrouted),
+        "fixed body",
+        "unrouted path falls back to handler_mailbox",
+    );
+}
+
+/// Longest prefix wins among overlapping routes, matching stops at
+/// segment boundaries (`/apiary` is not under `/api`), and an exact
+/// prefix hit routes (ADR-0130).
+#[test]
+fn longest_prefix_wins_on_segment_boundaries() {
+    let chassis = routed_chassis!(ApiRouteHandler, ApiV2Handler);
+    let port = port_of(&chassis);
+
+    // Prove both routes live before the precedence assertions.
+    poll_body(
+        port,
+        b"GET /api/other HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        "api:/api/other",
+    );
+    poll_body(
+        port,
+        b"GET /api/v2/x HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        "api-v2",
+    );
+
+    let exact = round_trip(port, b"GET /api HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    assert_eq!(body_of(&exact), "api:/api", "exact prefix hit routes");
+
+    let boundary = round_trip(port, b"GET /apiary HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    assert_eq!(
+        body_of(&boundary),
+        "fixed body",
+        "/apiary is not under /api — segment-boundary match",
+    );
+}
+
+/// A method-specific route beats a method-agnostic one at equal
+/// prefix; other methods take the agnostic route (ADR-0130).
+#[test]
+fn method_specific_route_beats_agnostic() {
+    let chassis = routed_chassis!(MethodPostHandler, MethodAnyHandler);
+    let port = port_of(&chassis);
+
+    // Each route's first positive assertion polls it live; together
+    // they then pin the precedence (POST → specific, GET → agnostic).
+    poll_body(
+        port,
+        b"POST /m HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n",
+        "post-m",
+    );
+    poll_body(port, b"GET /m HTTP/1.1\r\nHost: localhost\r\n\r\n", "any-m");
+
+    let specific = round_trip(
+        port,
+        b"POST /m HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n",
+    );
+    assert_eq!(
+        body_of(&specific),
+        "post-m",
+        "POST takes the method-specific route with both routes live",
+    );
+}
+
+/// A `(prefix, method)` key already claimed by another mailbox is
+/// rejected: the first claimant keeps the route, and the rejected
+/// claimant's other registrations are unaffected (ADR-0130). Boot
+/// order makes the winner deterministic — `DupFirstHandler` wires
+/// before `DupSecondHandler`.
+#[test]
+fn conflicting_claim_is_rejected_first_claimant_keeps_route() {
+    let chassis = routed_chassis!(DupFirstHandler, DupSecondHandler);
+    let port = port_of(&chassis);
+
+    // `/second` live proves DupSecondHandler's registrations (sent
+    // after DupFirstHandler's, in boot order) have been processed —
+    // including its rejected `/dup` claim.
+    poll_body(
+        port,
+        b"GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        "second",
+    );
+
+    let dup = round_trip(port, b"GET /dup HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    assert_eq!(body_of(&dup), "first", "first claimant keeps the route");
+}
+
+/// `unregister_route_self` releases the sender's route: the first
+/// request reaches the routed handler (which releases the route while
+/// answering), and a subsequent request falls back. The release is a
+/// separate mail racing the reply, so the fallback is asserted with a
+/// bounded poll rather than a single follow-up request.
+#[test]
+fn self_unregister_releases_route() {
+    let chassis = routed_chassis!(TmpRouteHandler);
+    let port = port_of(&chassis);
+
+    // Poll the route live (a pre-registration request harmlessly falls
+    // back without triggering the handler's release); the first "tmp"
+    // response is also the one that releases the route.
+    poll_body(port, b"GET /tmp HTTP/1.1\r\nHost: localhost\r\n\r\n", "tmp");
+
+    // The release is a separate mail racing the reply, so the fallback
+    // is asserted with the same bounded poll.
+    poll_body(
+        port,
+        b"GET /tmp HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        "fixed body",
     );
 }

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -353,4 +353,151 @@ mod tests {
             String::from_utf8_lossy(&reassembled),
         );
     }
+
+    /// Poll `request` until the response body contains `expected`
+    /// (bounded deadline): route registration, and later the drop's
+    /// route purge, are asynchronous mail the test must not race.
+    fn poll_body_contains(port: u16, request: &[u8], expected: &str) {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            let response = round_trip(port, request);
+            let text = String::from_utf8_lossy(&response);
+            if text
+                .split_once("\r\n\r\n")
+                .is_some_and(|(_, body)| body.contains(expected))
+            {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "expected body containing {expected:?} within 30s; last: {text:?}",
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    /// ADR-0130 drop-purge, end to end over real wasm: a guest claims
+    /// `/routed` via `register_route_self` in `wire`; dropping the
+    /// component (`aether.component.drop` → the component cap's
+    /// `unregister_routes_all` fan-out) purges the route, so the same
+    /// request falls back to the configured `handler_mailbox`. The
+    /// drop is injected through the routed guest itself — the request
+    /// body names the trampoline mailbox id to drop — since the built
+    /// chassis exposes no direct mail surface to the test.
+    #[test]
+    fn dropped_component_routes_are_purged() {
+        const ROUTED_NAMESPACE: &str = "routed_web";
+        let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+        let Some(wasm_path) = locate_component_wasm("aether_test_fixtures_bundle") else {
+            assert!(
+                !strict,
+                "AETHER_REQUIRE_RUNTIME set but http_handler.wasm not pre-built; \
+                 CI's `Pre-build component wasm for scenario tests` step is missing it",
+            );
+            eprintln!(
+                "skipping: http_handler.wasm not built; \
+                 run `cargo build --target wasm32-unknown-unknown \
+                 -p aether-test-fixtures --examples`",
+            );
+            return;
+        };
+        let wasm = fs::read(&wasm_path).expect("read http_handler wasm");
+
+        let server_config = HttpServerConfig {
+            enabled: true,
+            bind_addr: "127.0.0.1:0".to_string(),
+            handler_mailbox: HANDLER_MAILBOX.to_string(),
+            max_request_bytes: 65_536,
+            max_header_bytes: 8_192,
+            request_timeout_millis: 10_000,
+            max_connections: 1024,
+            response_stream_window: 16,
+        };
+
+        let sandbox = init_save_sandbox("http-route-drop");
+        let env = HeadlessEnv {
+            namespace_roots: test_namespace_roots(sandbox),
+            http: HttpConfig::default(),
+            http_server: Some(server_config),
+            anthropic: AnthropicConfig::default(),
+            gemini: GeminiConfig::default(),
+            contentgen: ContentGenConfig::default(),
+            tick_period: Duration::from_millis(100),
+            rpc_addr: None,
+            workers: None,
+            ring_caps: aether_substrate_bundle::RingCapacities::default(),
+            scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
+            lifecycle_advance_timeout_millis: 1_000,
+            autoload: vec![
+                AutoloadComponent {
+                    wasm: wasm.clone(),
+                    config: Vec::new(),
+                    name: Some(HANDLER_NAMESPACE.to_owned()),
+                    export: Some(HANDLER_NAMESPACE.to_owned()),
+                },
+                AutoloadComponent {
+                    wasm,
+                    config: Vec::new(),
+                    name: Some(ROUTED_NAMESPACE.to_owned()),
+                    export: Some(ROUTED_NAMESPACE.to_owned()),
+                },
+            ],
+        };
+
+        let built = HeadlessChassis::build(env).expect("build headless chassis with http server");
+
+        // Wait for both trampolines (fallback + routed guest).
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let routed_mailbox = loop {
+            if let Some(routed) = built.resolve_actor::<WasmTrampoline>(ROUTED_NAMESPACE)
+                && built
+                    .resolve_actor::<WasmTrampoline>(HANDLER_NAMESPACE)
+                    .is_some()
+            {
+                break routed;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "trampolines did not register within 30s; live: {:?}",
+                built.resolve_actors::<WasmTrampoline>(),
+            );
+            thread::sleep(Duration::from_millis(25));
+        };
+
+        let port = built
+            .handle::<HttpServerHandle>()
+            .expect("HttpServerHandle published by HttpServerCapability")
+            .local_port;
+
+        // Route live (registration is async mail — poll, don't race).
+        poll_body_contains(
+            port,
+            b"GET /routed HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            "routed handler",
+        );
+
+        // Drop the routed component through the guest bridge: the body
+        // carries the trampoline mailbox id to drop.
+        let drop_body = routed_mailbox.0.to_string();
+        let drop_request = format!(
+            "POST /routed/drop HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\
+             Content-Length: {}\r\n\r\n{}",
+            drop_body.len(),
+            drop_body,
+        );
+        let drop_response = round_trip(port, drop_request.as_bytes());
+        let drop_str = String::from_utf8_lossy(&drop_response);
+        assert!(
+            drop_str.starts_with("HTTP/1.1 200 ") && drop_str.contains("dropping"),
+            "drop bridge should acknowledge, got: {drop_str:?}",
+        );
+
+        // The purge rides the drop fan-out; once it lands, /routed
+        // falls back to the `web` fixture, which answers 404.
+        poll_body_contains(
+            port,
+            b"GET /routed HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            "not found",
+        );
+    }
 }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -21,11 +21,14 @@
 #![allow(clippy::needless_pass_by_value, clippy::unused_self)]
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::ComponentHostCapability;
 use aether_capabilities::http::HttpServerCapability;
 use aether_capabilities::http::kinds::{
     HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen, HttpServerRequest,
-    HttpServerResponse, HttpStreamCredit,
+    HttpServerResponse, HttpStreamCredit, RegisterRouteSelf,
 };
+use aether_data::{Kind as _, MailboxId};
+use aether_kinds::DropComponent;
 
 pub struct HttpHandler;
 
@@ -140,6 +143,70 @@ impl WasmActor for StreamingHttpHandler {
                     stream_id: self.stream_id,
                 });
             self.ended = true;
+        }
+    }
+}
+
+/// Routed sibling of [`HttpHandler`] for the ADR-0130 drop-purge e2e
+/// test: claims `/routed` from `wire` via `register_route_self` (the
+/// same declaration path a real component takes) and replies a fixed
+/// tag. `GET /routed/drop` doubles as the test's mail bridge into the
+/// chassis — the request body carries a decimal trampoline mailbox id,
+/// and the handler forwards a [`DropComponent`] for it to
+/// `aether.component` (detached: the drop teardown is not part of the
+/// request's causal chain), so the test can drop this component from
+/// outside without a chassis-level mail surface.
+pub struct RoutedHttpHandler;
+
+#[actor]
+impl WasmActor for RoutedHttpHandler {
+    const NAMESPACE: &'static str = "routed_web";
+
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(RoutedHttpHandler)
+    }
+
+    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+        ctx.actor::<HttpServerCapability>()
+            .send(&RegisterRouteSelf {
+                prefix: "/routed".to_string(),
+                method: None,
+                kind: HttpServerRequest::ID,
+            });
+    }
+
+    /// Reply a fixed tag for anything under `/routed`; on
+    /// `/routed/drop` also forward a [`DropComponent`] for the mailbox
+    /// id named in the request body.
+    ///
+    /// # Agent
+    /// Not sent manually — dispatched by `aether.http.server` for the
+    /// `/routed` prefix this actor claims in `wire`.
+    #[handler]
+    fn on_request(&mut self, ctx: &mut WasmCtx<'_>, req: HttpServerRequest) -> HttpServerResponse {
+        if req.path == "/routed/drop" {
+            let target = String::from_utf8_lossy(&req.body).trim().parse::<u64>();
+            let Ok(raw_id) = target else {
+                return HttpServerResponse {
+                    status: 400,
+                    headers: Vec::new(),
+                    body: b"body must be a decimal mailbox id".to_vec(),
+                };
+            };
+            ctx.actor::<ComponentHostCapability>()
+                .send_detached(&DropComponent {
+                    mailbox_id: MailboxId(raw_id),
+                });
+            return HttpServerResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: b"dropping".to_vec(),
+            };
+        }
+        HttpServerResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: b"routed handler".to_vec(),
         }
     }
 }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
@@ -25,7 +25,7 @@ mod stateful_replace;
 mod ui_widget;
 
 pub use cube::Cube;
-pub use http_handler::{HttpHandler, StreamingHttpHandler};
+pub use http_handler::{HttpHandler, RoutedHttpHandler, StreamingHttpHandler};
 pub use inline_child::{
     InlineDespawnParent, InlineParent, InlineStatefulChild, InlineStatefulParent,
 };
@@ -51,6 +51,7 @@ aether_actor::export!(
     UiWidget,
     HttpHandler,
     StreamingHttpHandler,
+    RoutedHttpHandler,
     SourceObserver,
     MatrixParent,
     MatrixChild,

--- a/docs/guide/recipes/serving-http.md
+++ b/docs/guide/recipes/serving-http.md
@@ -100,6 +100,47 @@ the formatted response to the client. The server adds `Connection: close` and
 an appropriate `Content-Length` header; your handler sets the status code,
 optional extra headers, and the body.
 
+## Claiming routes
+
+Several components can each own a path family on the same server (ADR-0130).
+A component claims a prefix from its `wire` hook by mailing
+`aether.http.server.register_route_self` to the server capability; the server
+then dispatches matching requests to that component directly, and everything
+unmatched still goes to the configured `handler_mailbox` default.
+
+```rust
+use aether_capabilities::http::HttpServerCapability;
+use aether_capabilities::http::kinds::{HttpServerRequest, RegisterRouteSelf};
+use aether_data::Kind as _;
+
+fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+    ctx.actor::<HttpServerCapability>().send(&RegisterRouteSelf {
+        prefix: "/api".to_string(),
+        method: None,                        // or Some(HttpMethod::Get)
+        kind: HttpServerRequest::ID,
+    });
+}
+```
+
+Matching is by path segment: `/api` claims `/api` and everything under
+`/api/…`, and leaves `/apiary` alone; `/` claims everything as a catch-all.
+When prefixes overlap, the longest match wins, and a route filtered to one
+method beats a method-agnostic route at the same prefix. A prefix already
+claimed by another component is answered
+`aether.http.server.register_route_result::Err` — first claimant keeps it.
+Routes follow the component: they survive `replace_component` (the mailbox id
+is stable) and are released automatically when the component drops, or
+explicitly via `aether.http.server.unregister_route_self`. External callers
+(an MCP session, a test) use the `register_route` / `unregister_route` forms,
+which name the handler mailbox explicitly.
+
+The `kind` field names the kind the route's requests dispatch as.
+`HttpServerRequest::ID` keeps the generic shape. Registering a route-specific
+kind — a struct with `aether.http.server.request`'s fields under its own
+`#[kind(name = …)]` — routes each prefix to its own `#[handler]`, with its own
+`describe_component` entry and `actor_cost` row; the payload bytes are always
+request-shaped, so the route kind decodes them directly.
+
 ## What happens when the handler doesn't reply
 
 If the handler receives the request but returns without calling `ctx.reply`, the


### PR DESCRIPTION
Closes #2549.

## Summary

Implements ADR-0130: HTTP routing as a mail-driven registration protocol on the `aether.http.server` mailbox. A component claims a path prefix from its `wire` hook (`register_route_self`, resolved from the host-stamped envelope sender like `aether.input.subscribe_self`; an explicit-`mailbox` `register_route` form serves external callers), and the server dispatches matching requests to it directly. Matching is segment-boundary longest-prefix (`/api` matches `/api` and `/api/...`, never `/apiary`; `/` is the catch-all) with an optional method filter — a method-specific route beats a method-agnostic one at equal prefix. A duplicate `(prefix, method)` claim from a different mailbox is answered `Err`; the same mailbox re-claiming its own key is an idempotent `Ok`.

A route names the `KindId` its requests dispatch as: the cap stamps the registered kind onto the request-shaped payload at the existing envelope-level send, so each route can land in its own typed `#[handler]` with its own `describe_component` entry and `actor_cost` row. The table keys routes by registrant `MailboxId` (survives `replace_component`; dispatch skips name resolution); a dead routed mailbox answers `503`, the same surface as an unresolved fallback. The component cap's `on_drop_component` fan-out gains `unregister_routes_all` (guarded on the http server being booted) so a dropped component's routes are purged. Unrouted requests fall back to `handler_mailbox` — an empty table is byte-for-byte today's behavior.

## Test plan

- Unit: segment-boundary matching + prefix normalization tripwires (`runtime.rs::unit_tests`).
- Capabilities loopback round-trips (`http/server/tests.rs`): routed dispatch decoding as a minted registered kind, fallback for unrouted paths, longest-prefix + segment-boundary precedence, method-specific-beats-agnostic, cross-mailbox conflict rejection with the first claimant retained, `unregister_route_self` release. Route registrations are async mail, so every route's first positive assertion uses the house bounded-poll pattern rather than racing the registration.
- Bundle e2e (`http_serving.rs::dropped_component_routes_are_purged`): a real wasm guest claims `/routed` in `wire`, serves it, and after `aether.component.drop` the same request falls back — covering the drop fan-out purge end to end.
- `cargo nextest run --workspace` green via `scripts/preflight.sh`.

## Generated by

`/implement` — agent execution of [scoped issue #2549](https://github.com/iamacoffeepot/aether/issues/2549).
