### PR TITLE
feat(capabilities): websocket upgrade for the http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "aether-data",
  "aether-kinds",
  "aether-substrate",
+ "base64",
  "bytemuck",
  "clap",
  "confique",

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -42,6 +42,7 @@ default = ["runtime"]
 # macro arm references. Always on for chassis.
 runtime = [
     "dep:aether-substrate",
+    "dep:base64",
     "dep:clap",
     "dep:confique",
     "dep:dirs",
@@ -116,6 +117,11 @@ serde = { workspace = true, default-features = false, features = ["derive", "all
 # Native-only: gated behind the `runtime` feature so wasm builds
 # don't drag in wasmtime / cpal / wgpu transitively.
 aether-substrate = { path = "../aether-substrate", optional = true }
+# ADR-0129: the `Sec-WebSocket-Accept` handshake key is base64(SHA-1(key +
+# GUID)). SHA-1 is hand-rolled in `http/server/runtime.rs` (one fixed hash
+# does not earn a `sha1` crate); base64 is already a workspace dependency, so
+# the cap inherits it — runtime-gated, the websocket handshake is native-only.
+base64 = { workspace = true, optional = true }
 bytemuck = { workspace = true, features = ["derive"] }
 # ADR-0090 unit g (iamacoffeepot/aether#1264): the `Config` derive
 # emits per-cap `*Overlay` structs (`#[derive(clap::Args)]`) next to

--- a/crates/aether-capabilities/src/http/kinds.rs
+++ b/crates/aether-capabilities/src/http/kinds.rs
@@ -282,6 +282,66 @@ pub struct HttpRequestCredit {
     pub credit: u32,
 }
 
+// ADR-0129 HTTP server websocket upgrade. Three kinds, reusing `HttpHeader`
+// and ADR-0128's `HttpStreamCredit`. An inbound request carrying `Upgrade:
+// websocket` dispatches to the handler as an ordinary `HttpServerRequest`; the
+// handler replies `WebSocketAccept` to accept (the websocket analog of
+// `HttpResponseStreamOpen`) or an ordinary `HttpServerResponse` to decline. On
+// accept the connection carries `WebSocketMessage`s both directions — cap →
+// handler on inbound (a fresh causal root per message), handler → cap on
+// outbound (framed under the ADR-0128 credit window). `WebSocketClose` is the
+// close handshake, both directions. Ping / pong are cap-owned and never
+// surface as kinds.
+
+/// `aether.http.server.websocket.accept` — the handler's opt-in reply to an
+/// upgrade request (ADR-0129), the websocket analog of
+/// [`HttpResponseStreamOpen`]. Declares an optional negotiated `subprotocol`
+/// (echoed as `Sec-WebSocket-Protocol`) and any extra `101` response
+/// `headers`; the cap supplies `Upgrade` / `Connection` /
+/// `Sec-WebSocket-Accept` itself. Replied like [`HttpServerResponse`]
+/// (correlation-echoed), so the cap keys the accept on the request's in-flight
+/// correlation id.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.websocket.accept")]
+pub struct WebSocketAccept {
+    pub subprotocol: Option<String>,
+    pub headers: Vec<HttpHeader>,
+}
+
+/// `aether.http.server.websocket.message` — one complete, de-fragmented
+/// application message, both directions (ADR-0129). Cap → handler on inbound
+/// (dispatched as a fresh causal root that settles as the handler finishes
+/// it); handler → cap on outbound (serialized to an RFC 6455 frame and framed
+/// to the peer under the ADR-0128 credit window). `binary` selects the RFC
+/// 6455 opcode (`true` = binary `0x2`, `false` = text `0x1`); `data` is the
+/// reassembled payload, raw bytes so binary messages round-trip without loss.
+///
+/// An outbound `WebSocketMessage` carries no connection id: it rides the
+/// inbound message's causal chain (the handler sends it while handling an
+/// inbound message, inheriting that message's root), and the cap routes it to
+/// the originating connection by that root — so a handler answers the socket a
+/// message arrived on without naming it.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.websocket.message")]
+pub struct WebSocketMessage {
+    pub binary: bool,
+    pub data: Vec<u8>,
+}
+
+/// `aether.http.server.websocket.close` — the close handshake, both directions
+/// (ADR-0129). Handler → cap initiates a close; cap → handler reports a
+/// peer-initiated close. The cap writes / echoes the RFC 6455 close frame and
+/// tears the connection down. `code` is the RFC 6455 close status code (`1000`
+/// = normal); `reason` is the optional UTF-8 reason phrase. Like an outbound
+/// [`WebSocketMessage`], a handler-initiated close rides the inbound chain and
+/// is routed to the connection by its root.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.http.server.websocket.close")]
+pub struct WebSocketClose {
+    pub code: u16,
+    pub reason: String,
+}
+
 // ADR-0130 route-registration kinds. Mirrors the `aether.input`
 // subscribe family: `_self` variants resolve the registrant from the
 // inbound envelope's host-stamped `Source` (forgery-proof, in-process

--- a/crates/aether-capabilities/src/http/server/config.rs
+++ b/crates/aether-capabilities/src/http/server/config.rs
@@ -5,7 +5,7 @@
 use super::{
     DEFAULT_BIND_ADDR, DEFAULT_KEEP_ALIVE_TIMEOUT_MILLIS, DEFAULT_MAX_CONNECTIONS,
     DEFAULT_MAX_HEADER_BYTES, DEFAULT_MAX_REQUEST_BYTES, DEFAULT_REQUEST_STREAM_WINDOW,
-    DEFAULT_REQUEST_TIMEOUT_MILLIS, DEFAULT_RESPONSE_STREAM_WINDOW,
+    DEFAULT_REQUEST_TIMEOUT_MILLIS, DEFAULT_RESPONSE_STREAM_WINDOW, DEFAULT_WS_IDLE_TIMEOUT_MILLIS,
 };
 
 /// Init config for [`HttpServerCapability`](super::HttpServerCapability) (ADR-0108).
@@ -94,6 +94,14 @@ pub struct HttpServerConfig {
     /// [`HttpRequestCredit`]: crate::http::kinds::HttpRequestCredit
     #[cfg_attr(feature = "runtime", config(default = 16))]
     pub request_stream_window: u32,
+    /// Websocket idle timeout in milliseconds ([`DEFAULT_WS_IDLE_TIMEOUT_MILLIS`],
+    /// ADR-0129): the read deadline between frames on an upgraded websocket
+    /// connection. Distinct from `request_timeout_millis` (the slow-loris
+    /// in-flight read deadline) and much longer — an idle websocket between
+    /// messages is normal, so it is bounded by a generous keepalive window, on
+    /// expiry the idle socket is torn down rather than pinning a reader thread.
+    #[cfg_attr(feature = "runtime", config(default = 300_000))]
+    pub websocket_idle_timeout_millis: u64,
 }
 
 impl Default for HttpServerConfig {
@@ -109,6 +117,7 @@ impl Default for HttpServerConfig {
             max_connections: DEFAULT_MAX_CONNECTIONS,
             response_stream_window: DEFAULT_RESPONSE_STREAM_WINDOW,
             request_stream_window: DEFAULT_REQUEST_STREAM_WINDOW,
+            websocket_idle_timeout_millis: DEFAULT_WS_IDLE_TIMEOUT_MILLIS,
         }
     }
 }

--- a/crates/aether-capabilities/src/http/server/mod.rs
+++ b/crates/aether-capabilities/src/http/server/mod.rs
@@ -44,7 +44,8 @@
 // type-safely; the route-registration kinds (ADR-0130) are `#[handler]` kinds
 // likewise.
 use crate::http::kinds::{
-    HttpInboundReady, HttpRequestCredit, HttpResponseChunk, HttpResponseStreamEnd,
+    HttpInboundReady, HttpRequestCredit, HttpResponseChunk, HttpResponseStreamEnd, WebSocketClose,
+    WebSocketMessage,
 };
 use crate::http::kinds::{
     RegisterRoute, RegisterRouteResult, RegisterRouteSelf, UnregisterRoute, UnregisterRouteSelf,
@@ -84,6 +85,13 @@ pub const DEFAULT_RESPONSE_STREAM_WINDOW: u32 = 16;
 /// [`HttpRequestChunk`]: crate::http::kinds::HttpRequestChunk
 /// [`HttpRequestCredit`]: crate::http::kinds::HttpRequestCredit
 pub const DEFAULT_REQUEST_STREAM_WINDOW: u32 = 16;
+/// Default `websocket_idle_timeout_millis` (ADR-0129): the read deadline on an
+/// upgraded websocket connection between frames, 5 minutes. Distinct from
+/// `request_timeout_millis` (the slow-loris in-flight read deadline) and much
+/// longer — an idle websocket sitting between messages is normal, not a
+/// slow-loris attack, so it is bounded by a generous keepalive window rather
+/// than the request deadline.
+pub const DEFAULT_WS_IDLE_TIMEOUT_MILLIS: u64 = 300_000;
 
 mod config;
 

--- a/crates/aether-capabilities/src/http/server/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/runtime.rs
@@ -48,11 +48,15 @@ use crate::http::kinds::{
     HttpHeader, HttpMethod, HttpRequestChunk, HttpRequestCredit, HttpRequestStreamEnd,
     HttpRequestStreamOpen, HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen,
     HttpServerRequest, HttpStreamCredit, RegisterRoute, RegisterRouteResult, RegisterRouteSelf,
-    UnregisterRoute, UnregisterRouteSelf, UnregisterRoutesAll,
+    UnregisterRoute, UnregisterRouteSelf, UnregisterRoutesAll, WebSocketAccept, WebSocketClose,
+    WebSocketMessage,
 };
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 
 use aether_substrate::Mail;
 use std::io::{self, Read, Write};
+use std::mem;
 use std::str::from_utf8;
 use std::thread::JoinHandle;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -115,6 +119,12 @@ pub enum ReaderControl {
     /// Keep-alive resume: the response was written; read the next request on
     /// the same socket.
     Resume,
+    /// Websocket upgrade accepted (ADR-0129): the `101` was written and the
+    /// connection is now in websocket mode. The parked reader leaves the
+    /// HTTP request lifecycle and enters the RFC 6455 frame loop, reading
+    /// under the websocket idle deadline (not `request_timeout`), carrying
+    /// forward any bytes it over-read past the handshake head.
+    Upgrade,
 }
 
 /// One parsed inbound HTTP/1.1 request the reader hands to the
@@ -185,6 +195,27 @@ pub enum InboundEvent {
     /// socket error occurred — so the dispatcher tears the stream +
     /// connection down (ADR-0128).
     StreamFinished { stream_id: u64 },
+    /// A websocket reader reassembled one complete application message
+    /// (ADR-0129); the dispatcher delivers it to the handler as a
+    /// [`WebSocketMessage`] on its own fresh causal root.
+    WebSocketMessage {
+        conn_id: ConnId,
+        binary: bool,
+        data: Vec<u8>,
+    },
+    /// A websocket reader received a ping frame (ADR-0129); the dispatcher
+    /// answers it with a pong on the writer thread, transparently — the ping
+    /// never reaches the handler. Carries the ping payload the pong echoes.
+    WebSocketPing { conn_id: ConnId, payload: Vec<u8> },
+    /// A websocket reader received a peer close frame, or hit a protocol error
+    /// / oversize frame / idle timeout on the upgraded socket (ADR-0129). The
+    /// dispatcher reports a [`WebSocketClose`] to the handler, echoes the close
+    /// frame on the writer, and tears the connection down.
+    WebSocketClose {
+        conn_id: ConnId,
+        code: u16,
+        reason: String,
+    },
 }
 
 /// One frame handed to a per-connection response-stream writer thread over
@@ -193,6 +224,19 @@ pub enum InboundEvent {
 enum WriterMsg {
     Chunk(Vec<u8>),
     End,
+    /// A pre-serialized websocket data frame (ADR-0129), written verbatim.
+    /// Consumes one credit like [`Self::Chunk`]: on write the writer posts
+    /// [`InboundEvent::StreamSlotFreed`] so the cap replenishes the handler's
+    /// outbound send window.
+    WsData(Vec<u8>),
+    /// A pre-serialized websocket control frame (ADR-0129) — a cap-owned pong,
+    /// written verbatim. Uncredited (control frames are not paced by the
+    /// handler's window), so no slot-freed event follows.
+    WsControl(Vec<u8>),
+    /// A pre-serialized websocket close frame (ADR-0129). Written verbatim,
+    /// then the writer posts [`InboundEvent::StreamFinished`] and exits — the
+    /// close handshake's final write, after which the connection tears down.
+    WsClose(Vec<u8>),
 }
 
 /// Per-connection state owned by the cap dispatcher. The reader sidecar
@@ -220,6 +264,27 @@ pub struct ConnState {
     pub active_stream: Option<u64>,
     /// Reader thread handle. Joined in `unwire`, detached on close.
     pub reader_thread: Option<JoinHandle<()>>,
+    /// The connection's `Sec-WebSocket-Key`, stashed by the dispatcher when it
+    /// validates an inbound RFC 6455 upgrade handshake (ADR-0129) and consumed
+    /// when the handler accepts (to compute `Sec-WebSocket-Accept`). `None` on
+    /// a non-upgrade connection; cleared once consumed.
+    pub ws_pending_key: Option<String>,
+    /// Per-connection websocket state once upgraded (ADR-0129). `None` until
+    /// the handler replies `WebSocketAccept` and the cap flips the connection
+    /// into websocket mode.
+    pub websocket: Option<WsConn>,
+}
+
+/// Per-connection websocket state (ADR-0129), set on accept. Outbound frames
+/// ride the ADR-0128 writer thread through the [`StreamState`] keyed by
+/// `stream_id` in [`HttpServerCapabilityState::streams`]; `handler` is the
+/// mailbox each inbound message is dispatched to.
+pub struct WsConn {
+    /// The handler mailbox resolved at handshake — inbound messages dispatch
+    /// here, and outbound credit grants address it.
+    pub handler: MailboxId,
+    /// The `stream_id` of this connection's outbound writer [`StreamState`].
+    pub stream_id: u64,
 }
 
 /// Bookkeeping for one in-flight request. Looked up by the dispatch's
@@ -236,6 +301,10 @@ pub struct PendingRequest {
     /// `Connection: keep-alive` and resumes the reader) rather than
     /// closing it. Set from the [`ParsedRequest`] at dispatch.
     pub keep_alive: bool,
+    /// The handler this request dispatched to. Carried so a `WebSocketAccept`
+    /// reply (ADR-0129) resolves the same handler for the upgraded
+    /// connection's inbound dispatch + credit grants without re-resolving.
+    pub handler: MailboxId,
 }
 
 /// Per-connection response-stream state (ADR-0128), keyed in
@@ -247,6 +316,11 @@ pub struct StreamState {
     /// The connection this stream writes to. Teardown paths locate a stream
     /// by connection through this field.
     conn_id: ConnId,
+    /// The handler mailbox this stream's credit grants address. For a response
+    /// stream (ADR-0128) it is the late-bound `handler_mailbox`; for a
+    /// websocket (ADR-0129) it is the handler resolved at handshake. Stored so
+    /// credit replenishment addresses the right actor without a re-lookup.
+    handler: MailboxId,
     /// Bounded hand-off to the writer thread. `try_send` never blocks the
     /// dispatcher: the credit accounting keeps the invariant
     /// `credit_outstanding + queued <= window`, so a slot is always free when
@@ -436,6 +510,16 @@ pub struct HttpServerCapabilityState {
     /// stream ids (those reuse the request's dispatch correlation), so the two
     /// tables never collide.
     pub next_stream_id: u64,
+    /// Read deadline between frames on an upgraded websocket connection
+    /// (ADR-0129), from `websocket_idle_timeout_millis` — longer than
+    /// `request_timeout`, since an idle websocket is normal.
+    pub ws_idle_timeout: Duration,
+    /// Routing index for outbound websocket frames (ADR-0129). Each inbound
+    /// `WebSocketMessage` dispatches on its own fresh root; the handler answers
+    /// on that same causal chain, so this maps an in-flight inbound message's
+    /// root `correlation_id` to its connection. Cleared when the chain settles
+    /// (`on_settled`) or the connection closes.
+    pub ws_message_conn: HashMap<u64, ConnId>,
 }
 
 impl HttpServerCapabilityState {
@@ -575,6 +659,8 @@ impl HttpServerCapabilityState {
             request_timeout: self.request_timeout,
             idle_timeout: self.keep_alive_timeout,
             max_header_bytes: self.max_header_bytes,
+            ws_idle_timeout: self.ws_idle_timeout,
+            ws_max_message_bytes: self.max_request_bytes,
         };
 
         // Per-connection transport reader below the mail layer — carries
@@ -614,6 +700,8 @@ impl HttpServerCapabilityState {
                 control_tx,
                 active_stream: None,
                 reader_thread: Some(thread),
+                ws_pending_key: None,
+                websocket: None,
             },
         );
         tracing::debug!(
@@ -696,6 +784,7 @@ impl HttpServerCapabilityState {
                 conn_id,
                 method,
                 keep_alive,
+                handler,
             },
         );
     }
@@ -741,6 +830,27 @@ impl HttpServerCapabilityState {
             self.close_connection(conn_id, "handler unresolved");
             return;
         };
+        // ADR-0129: a websocket upgrade handshake. The cap validates the
+        // protocol layer (`426`/`400`, cap-owned) before dispatch; on a valid
+        // handshake it stashes the `Sec-WebSocket-Key` and dispatches the
+        // request as an ordinary buffered `HttpServerRequest` the handler
+        // answers with `WebSocketAccept` (accept) or `HttpServerResponse`
+        // (decline). An upgrade request carries no body, so it always buffers.
+        if header_has_token(&head.headers, "upgrade", "websocket") {
+            match validate_ws_handshake(&head.headers) {
+                Ok(key) => {
+                    if let Some(conn) = self.connections.get_mut(&conn_id) {
+                        conn.ws_pending_key = Some(key);
+                    }
+                    self.signal_reader(conn_id, ReaderControl::Buffered);
+                }
+                Err((status, message)) => {
+                    self.write_status_response(conn_id, status, message);
+                    self.close_connection(conn_id, "invalid websocket handshake");
+                }
+            }
+            return;
+        }
         let streaming = self
             .mailer
             .capability_registry()
@@ -863,6 +973,7 @@ impl HttpServerCapabilityState {
                 conn_id,
                 method: stream.method,
                 keep_alive: stream.keep_alive,
+                handler: stream.handler,
             },
         );
     }
@@ -968,6 +1079,10 @@ impl HttpServerCapabilityState {
         // write to a dead socket.
         self.in_flight
             .retain(|_, pending| pending.conn_id != conn_id);
+        // Drop websocket outbound-routing entries for this connection (ADR-0129)
+        // so a late handler reply on a settled chain doesn't route to a dead
+        // socket.
+        self.ws_message_conn.retain(|_, mapped| *mapped != conn_id);
         tracing::debug!(
             target: "aether_substrate::http_server",
             conn = conn_id,
@@ -990,8 +1105,16 @@ impl HttpServerCapabilityState {
         open: &HttpResponseStreamOpen,
     ) {
         // The stream chain settles here; the request is no longer in-flight
-        // (ADR-0128 §4), so `on_settled` won't `502` it.
+        // (ADR-0128 §4), so `on_settled` won't `502` it. Resolve the handler
+        // once here (it just replied, so it is live) and store it on the
+        // stream for credit grants; a missing handler leaves the sentinel and
+        // credit sends drop harmlessly, the pre-store no-op behavior.
         self.in_flight.remove(&stream_id);
+        let handler = self
+            .mailer
+            .registry()
+            .lookup(&self.handler_mailbox)
+            .unwrap_or(MailboxId(0));
         let head = render_stream_head(open);
         self.write_raw_to(conn_id, &head);
 
@@ -1048,6 +1171,7 @@ impl HttpServerCapabilityState {
             stream_id,
             StreamState {
                 conn_id,
+                handler,
                 tx,
                 writer_thread: Some(writer_thread),
                 credit_outstanding: window,
@@ -1151,11 +1275,13 @@ impl HttpServerCapabilityState {
         }
     }
 
-    /// Resolve the handler mailbox and send it a credit grant on `stream_id`.
-    /// A fresh causal root per grant keeps credit mails settling per-chunk,
-    /// never holding one chain open across the stream (ADR-0128 §4).
+    /// Send the stream's handler a credit grant on `stream_id`. A fresh causal
+    /// root per grant keeps credit mails settling per-chunk, never holding one
+    /// chain open across the stream (ADR-0128 §4). The handler is the one
+    /// resolved and stored at stream open (a response stream's late-bound
+    /// `handler_mailbox`, or a websocket's handshake handler, ADR-0129).
     fn send_stream_credit(&self, ctx: &mut NativeCtx<'_>, stream_id: u64, credit: u32) {
-        let Some(handler) = self.mailer.registry().lookup(&self.handler_mailbox) else {
+        let Some(handler) = self.streams.get(&stream_id).map(|stream| stream.handler) else {
             return;
         };
         let payload = HttpStreamCredit { stream_id, credit }.encode_into_bytes();
@@ -1169,6 +1295,261 @@ impl HttpServerCapabilityState {
     fn teardown_stream(&mut self, stream_id: u64) {
         if let Some(mut stream) = self.streams.remove(&stream_id) {
             drop(stream.writer_thread.take());
+        }
+    }
+
+    /// Accept a websocket upgrade (ADR-0129 §1): the handler replied
+    /// `WebSocketAccept` to a stashed-key upgrade request. Compute
+    /// `Sec-WebSocket-Accept`, write the `101 Switching Protocols` head
+    /// (inline, strictly before the writer thread starts, so the two never
+    /// interleave on the shared fd), spawn the ADR-0128 writer thread for
+    /// outbound frames, grant the handler its initial outbound credit window,
+    /// and flip the reader into the RFC 6455 frame loop. `correlation` is the
+    /// handshake request's in-flight key.
+    fn accept_websocket(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        correlation: u64,
+        conn_id: ConnId,
+        handler: MailboxId,
+        accept: &WebSocketAccept,
+    ) {
+        self.in_flight.remove(&correlation);
+        let Some(key) = self
+            .connections
+            .get_mut(&conn_id)
+            .and_then(|conn| conn.ws_pending_key.take())
+        else {
+            // A `WebSocketAccept` with no stashed key — the handler replied it
+            // to a non-upgrade request. Cap-level error, close the connection.
+            self.write_status_response(conn_id, 500, "websocket accept without upgrade");
+            self.close_connection(conn_id, "websocket accept without upgrade");
+            return;
+        };
+        let head = render_ws_accept(&key, accept);
+        self.write_raw_to(conn_id, &head);
+
+        let Some(conn) = self.connections.get(&conn_id) else {
+            return;
+        };
+        let write_half = match conn.write_half.try_clone() {
+            Ok(half) => half,
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::http_server",
+                    conn = conn_id,
+                    error = %e,
+                    "http websocket: writer clone failed; closing",
+                );
+                self.close_connection(conn_id, "websocket writer clone failed");
+                return;
+            }
+        };
+
+        let stream_id = self.next_stream_id;
+        self.next_stream_id += 1;
+        let window = self.response_stream_window.max(1);
+        let (tx, rx) = mpsc::sync_channel::<WriterMsg>(window as usize);
+        let sink = WakeSink {
+            inbound_tx: self.inbound_tx.clone(),
+            mailer: Arc::clone(&self.mailer),
+            self_id: self.self_mailbox,
+            wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
+        };
+        // The writer's idle deadline is the websocket idle timeout: an upgraded
+        // socket with nothing to write for minutes is normal, unlike a stalled
+        // response stream.
+        let idle_deadline = self.ws_idle_timeout;
+
+        #[allow(clippy::disallowed_methods)]
+        let writer_thread = match thread::Builder::new()
+            .name(format!("aether-http-writer-{conn_id}"))
+            .spawn(move || {
+                run_writer_loop(write_half, stream_id, &rx, &sink, idle_deadline);
+            }) {
+            Ok(thread) => thread,
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::http_server",
+                    conn = conn_id,
+                    error = %e,
+                    "http websocket: writer thread spawn failed; closing",
+                );
+                self.close_connection(conn_id, "websocket writer spawn failed");
+                return;
+            }
+        };
+
+        self.streams.insert(
+            stream_id,
+            StreamState {
+                conn_id,
+                handler,
+                tx,
+                writer_thread: Some(writer_thread),
+                credit_outstanding: window,
+                pending_end: false,
+            },
+        );
+        if let Some(conn) = self.connections.get_mut(&conn_id) {
+            conn.websocket = Some(WsConn { handler, stream_id });
+        }
+        // Grant the initial outbound window; the handler learns its `stream_id`
+        // from this first credit mail (ADR-0128 / ADR-0129 §3).
+        self.send_stream_credit(ctx, stream_id, window);
+        // Flip the parked reader into the frame loop.
+        self.signal_reader(conn_id, ReaderControl::Upgrade);
+        tracing::debug!(
+            target: "aether_substrate::http_server",
+            conn = conn_id,
+            stream = stream_id,
+            window,
+            "http websocket upgraded",
+        );
+    }
+
+    /// Deliver one reassembled inbound websocket message to the handler
+    /// (ADR-0129 §4) as a `WebSocketMessage` on its own fresh causal root, and
+    /// record the root → connection routing so the handler's answer (an
+    /// outbound `WebSocketMessage` / `WebSocketClose` inheriting the chain)
+    /// routes back to this socket. Subscribes to settlement so the routing
+    /// entry is reclaimed when the message's chain drains.
+    fn dispatch_ws_message(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        conn_id: ConnId,
+        binary: bool,
+        data: Vec<u8>,
+    ) {
+        let Some(handler) = self
+            .connections
+            .get(&conn_id)
+            .and_then(|conn| conn.websocket.as_ref())
+            .map(|ws| ws.handler)
+        else {
+            return;
+        };
+        let payload = WebSocketMessage { binary, data }.encode_into_bytes();
+        let mail_id = ctx.send_envelope_as_root(handler, <WebSocketMessage as Kind>::ID, &payload);
+        self.ws_message_conn.insert(mail_id.correlation_id, conn_id);
+        if let Some(registry) = self.mailer.settlement_registry() {
+            registry.subscribe_settlement_mail(
+                mail_id,
+                self.self_mailbox,
+                <Settled as Kind>::ID,
+                Arc::clone(&self.mailer),
+            );
+        }
+    }
+
+    /// Report a peer-initiated websocket close to the handler (ADR-0129 §5) as
+    /// a `WebSocketClose` on its own fresh root — the inbound-close analog of
+    /// [`Self::dispatch_ws_message`], so the handler observes the disconnect.
+    fn report_ws_close(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        conn_id: ConnId,
+        code: u16,
+        reason: &str,
+    ) {
+        let Some(handler) = self
+            .connections
+            .get(&conn_id)
+            .and_then(|conn| conn.websocket.as_ref())
+            .map(|ws| ws.handler)
+        else {
+            return;
+        };
+        let payload = WebSocketClose {
+            code,
+            reason: reason.to_string(),
+        }
+        .encode_into_bytes();
+        let _ = ctx.send_envelope_as_root(handler, <WebSocketClose as Kind>::ID, &payload);
+    }
+
+    /// Frame an outbound application message and hand it to the connection's
+    /// writer thread (ADR-0129 §3). Mirrors [`Self::push_chunk`]: a message
+    /// arriving with zero outstanding credit is an over-window flood and tears
+    /// the connection down; otherwise it spends one credit and queues the
+    /// serialized frame.
+    fn send_ws_message(&mut self, conn_id: ConnId, binary: bool, data: &[u8]) {
+        let Some(stream_id) = self
+            .connections
+            .get(&conn_id)
+            .and_then(|conn| conn.websocket.as_ref())
+            .map(|ws| ws.stream_id)
+        else {
+            return;
+        };
+        let opcode = if binary { OPCODE_BINARY } else { OPCODE_TEXT };
+        let frame = serialize_ws_frame(opcode, data, None);
+        let Some(has_credit) = self
+            .streams
+            .get(&stream_id)
+            .map(|stream| stream.credit_outstanding > 0)
+        else {
+            return;
+        };
+        if !has_credit {
+            self.teardown_stream(stream_id);
+            self.close_connection(conn_id, "websocket send credit exceeded");
+            return;
+        }
+        let send_result = {
+            let stream = self
+                .streams
+                .get_mut(&stream_id)
+                .expect("stream present under the same borrow");
+            stream.credit_outstanding -= 1;
+            stream.tx.try_send(WriterMsg::WsData(frame))
+        };
+        if send_result.is_err() {
+            self.teardown_stream(stream_id);
+            self.close_connection(conn_id, "websocket writer unavailable");
+        }
+    }
+
+    /// Queue a cap-owned pong answering an inbound ping (ADR-0129 §5) on the
+    /// connection's writer thread. Uncredited and best-effort — a full writer
+    /// channel drops the pong rather than blocking or tearing down.
+    fn send_ws_pong(&mut self, conn_id: ConnId, payload: &[u8]) {
+        let Some(stream_id) = self
+            .connections
+            .get(&conn_id)
+            .and_then(|conn| conn.websocket.as_ref())
+            .map(|ws| ws.stream_id)
+        else {
+            return;
+        };
+        let frame = serialize_ws_frame(OPCODE_PONG, payload, None);
+        if let Some(stream) = self.streams.get(&stream_id) {
+            let _ = stream.tx.try_send(WriterMsg::WsControl(frame));
+        }
+    }
+
+    /// Initiate / complete a websocket close (ADR-0129 §5): queue a close frame
+    /// on the writer as its final write (the writer posts `StreamFinished`,
+    /// which tears the connection down). Serves both a handler-initiated close
+    /// and the echo of a peer close frame.
+    fn send_ws_close(&mut self, conn_id: ConnId, code: u16, reason: &str) {
+        let Some(stream_id) = self
+            .connections
+            .get(&conn_id)
+            .and_then(|conn| conn.websocket.as_ref())
+            .map(|ws| ws.stream_id)
+        else {
+            return;
+        };
+        let frame = serialize_ws_close_frame(code, reason);
+        if let Some(stream) = self.streams.get(&stream_id) {
+            if stream.tx.try_send(WriterMsg::WsClose(frame)).is_err() {
+                // Writer gone — tear down directly.
+                self.teardown_stream(stream_id);
+                self.close_connection(conn_id, "websocket close write failed");
+            }
+        } else {
+            self.close_connection(conn_id, "websocket already closed");
         }
     }
 }
@@ -1357,6 +1738,13 @@ struct ReaderTuning {
     request_timeout: Duration,
     idle_timeout: Duration,
     max_header_bytes: usize,
+    /// Read deadline between frames once the connection upgrades to a websocket
+    /// (ADR-0129). The frame loop reads under this rather than `request_timeout`.
+    ws_idle_timeout: Duration,
+    /// Cap on a single reassembled websocket message (ADR-0129), reusing the
+    /// request-body cap — an inbound message past this is a protocol error the
+    /// reader answers with a close rather than buffering unboundedly.
+    ws_max_message_bytes: usize,
 }
 
 /// Whether the `Connection` header names `token` (case-insensitive), across
@@ -1372,6 +1760,49 @@ fn connection_has_token(headers: &[HttpHeader], token: &str) -> bool {
                 .split(',')
                 .any(|value| value.trim().eq_ignore_ascii_case(token))
         })
+}
+
+/// First value of the header named `name` (case-insensitive), or `None` if the
+/// request carries no such header. Trimmed of surrounding whitespace.
+fn first_header_value<'a>(headers: &'a [HttpHeader], name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|header| header.name.eq_ignore_ascii_case(name))
+        .map(|header| header.value.trim())
+}
+
+/// Whether the header named `name` lists `token` (case-insensitive), across
+/// comma-separated values and repeated header lines — the general form of
+/// [`connection_has_token`], used for `Upgrade: websocket`.
+fn header_has_token(headers: &[HttpHeader], name: &str, token: &str) -> bool {
+    headers
+        .iter()
+        .filter(|header| header.name.eq_ignore_ascii_case(name))
+        .any(|header| {
+            header
+                .value
+                .split(',')
+                .any(|value| value.trim().eq_ignore_ascii_case(token))
+        })
+}
+
+/// Validate an RFC 6455 upgrade handshake's protocol layer (ADR-0129 §1),
+/// cap-owned before any dispatch. The caller has already seen `Upgrade:
+/// websocket`; this checks `Connection: Upgrade`, `Sec-WebSocket-Version: 13`,
+/// and a non-empty `Sec-WebSocket-Key`, returning the key on success or the
+/// canned status the cap answers (`426` for a wrong version, `400` for a
+/// malformed handshake) on failure.
+fn validate_ws_handshake(headers: &[HttpHeader]) -> Result<String, (u16, &'static str)> {
+    if !connection_has_token(headers, "upgrade") {
+        return Err((400, "websocket upgrade requires Connection: Upgrade"));
+    }
+    if first_header_value(headers, "sec-websocket-version") != Some("13") {
+        return Err((426, "unsupported websocket version"));
+    }
+    match first_header_value(headers, "sec-websocket-key") {
+        Some(key) if !key.is_empty() => Ok(key.to_string()),
+        _ => Err((400, "missing sec-websocket-key")),
+    }
 }
 
 /// Whether a request wants its connection kept alive after the response.
@@ -1421,6 +1852,7 @@ fn run_reader_loop(
         request_timeout,
         idle_timeout,
         max_header_bytes,
+        ..
     } = tuning;
     let mut stream = read_half;
     let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
@@ -1606,9 +2038,11 @@ fn run_reader_loop(
                     StreamOutcome::Closed => return,
                 }
             }
-            // The dispatcher never sends a bare credit / resume as the first
-            // control after a head — treat it as a torn-down connection.
-            ReaderControl::Credit { .. } | ReaderControl::Resume => return,
+            // The dispatcher never sends a bare credit / resume / upgrade as
+            // the first control after a head (an upgrade rides the Buffered
+            // dispatch, then arrives at the response wait) — treat it as a
+            // torn-down connection.
+            ReaderControl::Credit { .. } | ReaderControl::Resume | ReaderControl::Upgrade => return,
         };
 
         // Phase 3: response deadline. Wait for the dispatcher's resume signal
@@ -1618,6 +2052,13 @@ fn run_reader_loop(
         match control_rx.recv_timeout(request_timeout) {
             Ok(ReaderControl::Resume) => {
                 buf = next_buf;
+            }
+            Ok(ReaderControl::Upgrade) => {
+                // ADR-0129: the handshake was accepted (`101` written) — leave
+                // the HTTP request lifecycle for the RFC 6455 frame loop,
+                // carrying any bytes over-read past the handshake head.
+                run_ws_reader_loop(&mut stream, conn_id, shutdown, sink, next_buf, tuning);
+                return;
             }
             Ok(_) => return,
             Err(mpsc::RecvTimeoutError::Timeout) => {
@@ -1842,9 +2283,9 @@ impl BodyStreamer<'_> {
                 Ok(ReaderControl::Credit { credit } | ReaderControl::Stream { credit }) => {
                     self.credit = self.credit.saturating_add(credit);
                 }
-                // A bare buffered / resume mid-stream, or the control channel
-                // dropped, means a torn-down connection — stop.
-                Ok(ReaderControl::Buffered | ReaderControl::Resume)
+                // A bare buffered / resume / upgrade mid-stream, or the control
+                // channel dropped, means a torn-down connection — stop.
+                Ok(ReaderControl::Buffered | ReaderControl::Resume | ReaderControl::Upgrade)
                 | Err(mpsc::RecvTimeoutError::Disconnected) => return Err(()),
                 Err(mpsc::RecvTimeoutError::Timeout) => {
                     self.post_closed("stream credit timeout");
@@ -2070,6 +2511,32 @@ fn run_writer_loop(
                 sink.post(InboundEvent::StreamFinished { stream_id });
                 return;
             }
+            Ok(WriterMsg::WsData(frame)) => {
+                // A pre-serialized websocket data frame (ADR-0129): write it
+                // verbatim, then free a credit slot like a response chunk.
+                if write_all_flush(&mut write_half, &frame).is_err() {
+                    sink.post(InboundEvent::StreamFinished { stream_id });
+                    return;
+                }
+                if !sink.post(InboundEvent::StreamSlotFreed { stream_id }) {
+                    return;
+                }
+            }
+            Ok(WriterMsg::WsControl(frame)) => {
+                // A cap-owned pong (ADR-0129 §5): verbatim, uncredited — no
+                // slot-freed event, so it never inflates the handler's window.
+                if write_all_flush(&mut write_half, &frame).is_err() {
+                    sink.post(InboundEvent::StreamFinished { stream_id });
+                    return;
+                }
+            }
+            Ok(WriterMsg::WsClose(frame)) => {
+                // The close handshake's final write (ADR-0129 §5): verbatim,
+                // then finish so the dispatcher tears the connection down.
+                let _ = write_all_flush(&mut write_half, &frame);
+                sink.post(InboundEvent::StreamFinished { stream_id });
+                return;
+            }
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 // Idle-write deadline (ADR-0128 §4): the handler stalled.
                 sink.post(InboundEvent::StreamFinished { stream_id });
@@ -2104,6 +2571,494 @@ fn write_terminator(write_half: &mut TcpStream) -> io::Result<()> {
     write_half.flush()
 }
 
+/// Write `bytes` verbatim and flush — a pre-serialized websocket frame
+/// (ADR-0129), with no chunked-transfer framing layered on.
+fn write_all_flush(write_half: &mut TcpStream, bytes: &[u8]) -> io::Result<()> {
+    write_half.write_all(bytes)?;
+    write_half.flush()
+}
+
+// ADR-0129 websocket support: the RFC 6455 handshake accept-key (hand-rolled
+// SHA-1 + base64), the frame codec (parse / serialize / masking / continuation
+// reassembly), the `101` render, and the reader-thread frame loop. All under
+// `feature = "runtime"` with the rest of this module — the wasm-safe `kinds.rs`
+// half is untouched.
+
+/// RFC 6455 §1.3 handshake GUID, concatenated with the client
+/// `Sec-WebSocket-Key` before the SHA-1 that forms `Sec-WebSocket-Accept`.
+const WS_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+/// RFC 6455 opcodes the cap emits / matches.
+const OPCODE_CONTINUATION: u8 = 0x0;
+const OPCODE_TEXT: u8 = 0x1;
+const OPCODE_BINARY: u8 = 0x2;
+const OPCODE_CLOSE: u8 = 0x8;
+const OPCODE_PING: u8 = 0x9;
+const OPCODE_PONG: u8 = 0xA;
+
+/// Compute `Sec-WebSocket-Accept` (RFC 6455 §4.2.2): base64(SHA-1(key + GUID)).
+fn sec_websocket_accept(key: &str) -> String {
+    let mut input = key.as_bytes().to_vec();
+    input.extend_from_slice(WS_GUID.as_bytes());
+    BASE64_STANDARD.encode(sha1(&input))
+}
+
+/// Hand-rolled SHA-1 (RFC 3174) over `data`, returning the 20-byte digest. Not
+/// a general crypto primitive — a fixed, short, non-secret hash for the RFC
+/// 6455 handshake (ADR-0129 §6), pinned by the RFC's own worked vector rather
+/// than earning a `sha1` crate. SHA-1 is broken for collision resistance; the
+/// handshake does not rely on that property (it echoes a nonce), so this use is
+/// correct.
+// SHA-1's working variables are single letters by the RFC 3174 spec
+// (a/b/c/d/e/f/h/w/k); renaming them would obscure the transcription.
+#[allow(clippy::many_single_char_names)]
+fn sha1(data: &[u8]) -> [u8; 20] {
+    let mut h: [u32; 5] = [
+        0x6745_2301,
+        0xEFCD_AB89,
+        0x98BA_DCFE,
+        0x1032_5476,
+        0xC3D2_E1F0,
+    ];
+    let bit_len = (data.len() as u64).wrapping_mul(8);
+    // Pad: append 0x80, zero-fill to 56 mod 64, then the 64-bit big-endian
+    // message length in bits.
+    let mut msg = data.to_vec();
+    msg.push(0x80);
+    while msg.len() % 64 != 56 {
+        msg.push(0);
+    }
+    msg.extend_from_slice(&bit_len.to_be_bytes());
+
+    let mut w = [0u32; 80];
+    for block in msg.chunks_exact(64) {
+        for (i, word) in w.iter_mut().take(16).enumerate() {
+            let j = i * 4;
+            *word = u32::from_be_bytes([block[j], block[j + 1], block[j + 2], block[j + 3]]);
+        }
+        for i in 16..80 {
+            w[i] = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);
+        }
+        let [mut a, mut b, mut c, mut d, mut e] = h;
+        for (i, &word) in w.iter().enumerate() {
+            let (f, k) = match i {
+                0..=19 => ((b & c) | ((!b) & d), 0x5A82_7999),
+                20..=39 => (b ^ c ^ d, 0x6ED9_EBA1),
+                40..=59 => ((b & c) | (b & d) | (c & d), 0x8F1B_BCDC),
+                _ => (b ^ c ^ d, 0xCA62_C1D6),
+            };
+            let tmp = a
+                .rotate_left(5)
+                .wrapping_add(f)
+                .wrapping_add(e)
+                .wrapping_add(k)
+                .wrapping_add(word);
+            e = d;
+            d = c;
+            c = b.rotate_left(30);
+            b = a;
+            a = tmp;
+        }
+        h[0] = h[0].wrapping_add(a);
+        h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c);
+        h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e);
+    }
+
+    let mut out = [0u8; 20];
+    for (i, word) in h.iter().enumerate() {
+        out[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    out
+}
+
+/// Serialize one RFC 6455 frame with FIN set: `opcode`, `payload`, optionally
+/// masked with `mask`. A server→client frame is unmasked (`mask = None`, ADR-0129
+/// §3); the masked path exists for the codec's own round-trip tests.
+fn serialize_ws_frame(opcode: u8, payload: &[u8], mask: Option<[u8; 4]>) -> Vec<u8> {
+    let mut out = Vec::with_capacity(payload.len() + 14);
+    out.push(0x80 | (opcode & 0x0F));
+    let masked_bit: u8 = if mask.is_some() { 0x80 } else { 0x00 };
+    let len = payload.len();
+    if len < 126 {
+        out.push(masked_bit | u8::try_from(len).unwrap_or(0));
+    } else if let Ok(short) = u16::try_from(len) {
+        out.push(masked_bit | 0x7E);
+        out.extend_from_slice(&short.to_be_bytes());
+    } else {
+        out.push(masked_bit | 0x7F);
+        out.extend_from_slice(&(len as u64).to_be_bytes());
+    }
+    match mask {
+        Some(key) => {
+            out.extend_from_slice(&key);
+            for (i, byte) in payload.iter().enumerate() {
+                out.push(byte ^ key[i % 4]);
+            }
+        }
+        None => out.extend_from_slice(payload),
+    }
+    out
+}
+
+/// Serialize an RFC 6455 close frame (opcode `0x8`): a 2-byte big-endian status
+/// code followed by the UTF-8 reason, unmasked.
+fn serialize_ws_close_frame(code: u16, reason: &str) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(2 + reason.len());
+    payload.extend_from_slice(&code.to_be_bytes());
+    payload.extend_from_slice(reason.as_bytes());
+    serialize_ws_frame(OPCODE_CLOSE, &payload, None)
+}
+
+/// One parsed RFC 6455 frame — header decoded, payload unmasked.
+struct WsFrame {
+    fin: bool,
+    opcode: u8,
+    payload: Vec<u8>,
+}
+
+/// Outcome of [`parse_ws_frame`].
+enum WsFrameParse {
+    Complete {
+        frame: WsFrame,
+        consumed: usize,
+    },
+    NeedMore,
+    /// A protocol violation (an unmasked client frame, a reserved bit set, or a
+    /// length past the cap). Carries the RFC 6455 close code + reason the cap
+    /// answers before tearing down — untrusted input never panics (ADR-0129).
+    Error {
+        code: u16,
+        reason: &'static str,
+    },
+}
+
+/// Parse one frame from the front of `buf`. A client→server frame MUST be
+/// masked (RFC 6455 §5.1); `max_payload` bounds one frame's payload so an
+/// oversize length is a protocol error, not an allocation.
+fn parse_ws_frame(buf: &[u8], max_payload: usize) -> WsFrameParse {
+    if buf.len() < 2 {
+        return WsFrameParse::NeedMore;
+    }
+    let b0 = buf[0];
+    let b1 = buf[1];
+    if b0 & 0x70 != 0 {
+        return WsFrameParse::Error {
+            code: 1002,
+            reason: "reserved bits set",
+        };
+    }
+    let fin = b0 & 0x80 != 0;
+    let opcode = b0 & 0x0F;
+    if b1 & 0x80 == 0 {
+        return WsFrameParse::Error {
+            code: 1002,
+            reason: "client frame not masked",
+        };
+    }
+    let len7 = usize::from(b1 & 0x7F);
+    let mut cursor = 2;
+    let payload_len = match len7 {
+        126 => {
+            if buf.len() < cursor + 2 {
+                return WsFrameParse::NeedMore;
+            }
+            let n = usize::from(u16::from_be_bytes([buf[cursor], buf[cursor + 1]]));
+            cursor += 2;
+            n
+        }
+        127 => {
+            if buf.len() < cursor + 8 {
+                return WsFrameParse::NeedMore;
+            }
+            let mut arr = [0u8; 8];
+            arr.copy_from_slice(&buf[cursor..cursor + 8]);
+            cursor += 8;
+            match usize::try_from(u64::from_be_bytes(arr)) {
+                Ok(n) => n,
+                Err(_) => {
+                    return WsFrameParse::Error {
+                        code: 1009,
+                        reason: "frame too large",
+                    };
+                }
+            }
+        }
+        n => n,
+    };
+    if payload_len > max_payload {
+        return WsFrameParse::Error {
+            code: 1009,
+            reason: "frame too large",
+        };
+    }
+    if buf.len() < cursor + 4 + payload_len {
+        return WsFrameParse::NeedMore;
+    }
+    let mask = [
+        buf[cursor],
+        buf[cursor + 1],
+        buf[cursor + 2],
+        buf[cursor + 3],
+    ];
+    cursor += 4;
+    let mut payload = Vec::with_capacity(payload_len);
+    for (i, &byte) in buf[cursor..cursor + payload_len].iter().enumerate() {
+        payload.push(byte ^ mask[i % 4]);
+    }
+    cursor += payload_len;
+    WsFrameParse::Complete {
+        frame: WsFrame {
+            fin,
+            opcode,
+            payload,
+        },
+        consumed: cursor,
+    }
+}
+
+/// Decode a close frame payload: an optional 2-byte big-endian status code
+/// followed by a UTF-8 reason. An absent code is reported as `1005` (RFC 6455
+/// "no status received").
+fn parse_ws_close_payload(payload: &[u8]) -> (u16, String) {
+    if payload.len() < 2 {
+        return (1005, String::new());
+    }
+    let code = u16::from_be_bytes([payload[0], payload[1]]);
+    (code, String::from_utf8_lossy(&payload[2..]).into_owned())
+}
+
+/// Render the RFC 6455 `101 Switching Protocols` handshake response (ADR-0129
+/// §1): the mandated `Upgrade` / `Connection` / `Sec-WebSocket-Accept`, the
+/// handler's optional negotiated subprotocol, and any extra handler headers
+/// (the three cap-owned handshake headers are stripped so a handler cannot
+/// double them).
+fn render_ws_accept(key: &str, accept: &WebSocketAccept) -> Vec<u8> {
+    use std::fmt::Write as _;
+    let mut head = String::from("HTTP/1.1 101 Switching Protocols\r\n");
+    head.push_str("Upgrade: websocket\r\n");
+    head.push_str("Connection: Upgrade\r\n");
+    let _ = write!(
+        head,
+        "Sec-WebSocket-Accept: {}\r\n",
+        sec_websocket_accept(key)
+    );
+    if let Some(protocol) = &accept.subprotocol {
+        let _ = write!(head, "Sec-WebSocket-Protocol: {protocol}\r\n");
+    }
+    for header in &accept.headers {
+        if header.name.eq_ignore_ascii_case("upgrade")
+            || header.name.eq_ignore_ascii_case("connection")
+            || header.name.eq_ignore_ascii_case("sec-websocket-accept")
+        {
+            continue;
+        }
+        let _ = write!(head, "{}: {}\r\n", header.name, header.value);
+    }
+    head.push_str("\r\n");
+    head.into_bytes()
+}
+
+/// Whether the reader's frame loop keeps running or stops (peer close /
+/// protocol error / receiver gone).
+enum WsLoop {
+    Continue,
+    Stop,
+}
+
+/// Act on one parsed inbound frame (ADR-0129 §4/§5), driving continuation
+/// reassembly and control-frame handling. Application messages / pings / peer
+/// closes post an [`InboundEvent`]; the cap (dispatcher + writer thread) does
+/// all the writing — the reader only reads and reports.
+#[allow(clippy::too_many_arguments)]
+fn handle_ws_frame(
+    frame: WsFrame,
+    conn_id: ConnId,
+    sink: &WakeSink,
+    msg: &mut Vec<u8>,
+    msg_binary: &mut bool,
+    fragmenting: &mut bool,
+    max_message_bytes: usize,
+) -> WsLoop {
+    let protocol_close = |code: u16, reason: &str| {
+        sink.post(InboundEvent::WebSocketClose {
+            conn_id,
+            code,
+            reason: reason.to_string(),
+        });
+        WsLoop::Stop
+    };
+    match frame.opcode {
+        OPCODE_PING => {
+            if !frame.fin {
+                return protocol_close(1002, "fragmented control frame");
+            }
+            if sink.post(InboundEvent::WebSocketPing {
+                conn_id,
+                payload: frame.payload,
+            }) {
+                WsLoop::Continue
+            } else {
+                WsLoop::Stop
+            }
+        }
+        // A pong (peer keepalive answer) is transparent — nothing to do.
+        OPCODE_PONG => WsLoop::Continue,
+        OPCODE_CLOSE => {
+            let (code, reason) = parse_ws_close_payload(&frame.payload);
+            sink.post(InboundEvent::WebSocketClose {
+                conn_id,
+                code,
+                reason,
+            });
+            WsLoop::Stop
+        }
+        OPCODE_TEXT | OPCODE_BINARY => {
+            if *fragmenting {
+                return protocol_close(1002, "interleaved data frame");
+            }
+            let binary = frame.opcode == OPCODE_BINARY;
+            if frame.fin {
+                if sink.post(InboundEvent::WebSocketMessage {
+                    conn_id,
+                    binary,
+                    data: frame.payload,
+                }) {
+                    WsLoop::Continue
+                } else {
+                    WsLoop::Stop
+                }
+            } else {
+                *msg = frame.payload;
+                *msg_binary = binary;
+                *fragmenting = true;
+                WsLoop::Continue
+            }
+        }
+        OPCODE_CONTINUATION => {
+            if !*fragmenting {
+                return protocol_close(1002, "unexpected continuation frame");
+            }
+            if msg.len() + frame.payload.len() > max_message_bytes {
+                return protocol_close(1009, "message too large");
+            }
+            msg.extend_from_slice(&frame.payload);
+            if frame.fin {
+                *fragmenting = false;
+                let data = mem::take(msg);
+                if sink.post(InboundEvent::WebSocketMessage {
+                    conn_id,
+                    binary: *msg_binary,
+                    data,
+                }) {
+                    WsLoop::Continue
+                } else {
+                    WsLoop::Stop
+                }
+            } else {
+                WsLoop::Continue
+            }
+        }
+        _ => protocol_close(1002, "unknown opcode"),
+    }
+}
+
+/// The websocket frame loop (ADR-0129 §4): once upgraded, the reader reads RFC
+/// 6455 frames under the idle deadline, reassembles continuation frames into
+/// complete messages, and posts each application message / ping / peer close as
+/// an [`InboundEvent`]. It writes nothing — every outbound byte (pong, close
+/// echo, and the handler's messages) goes through the single writer thread, so
+/// no two writers race on the shared fd. `leftover` carries any bytes over-read
+/// past the handshake head. Exits on peer close / protocol error / EOF / idle
+/// timeout, posting a [`InboundEvent::WebSocketClose`] so the dispatcher tears
+/// the connection down.
+fn run_ws_reader_loop(
+    stream: &mut TcpStream,
+    conn_id: ConnId,
+    shutdown: &AtomicBool,
+    sink: &WakeSink,
+    leftover: Vec<u8>,
+    tuning: ReaderTuning,
+) {
+    let ReaderTuning {
+        ws_idle_timeout,
+        ws_max_message_bytes,
+        ..
+    } = tuning;
+    // An idle websocket is normal — read under the (longer) idle deadline.
+    let _ = stream.set_read_timeout(Some(ws_idle_timeout));
+    let mut buf = leftover;
+    let mut msg: Vec<u8> = Vec::new();
+    let mut msg_binary = false;
+    let mut fragmenting = false;
+    let mut chunk = [0u8; 8 * 1024];
+
+    loop {
+        // Drain every whole frame the buffer already holds before reading more.
+        loop {
+            if shutdown.load(Ordering::Acquire) {
+                return;
+            }
+            match parse_ws_frame(&buf, ws_max_message_bytes) {
+                WsFrameParse::Complete { frame, consumed } => {
+                    buf.drain(..consumed);
+                    if matches!(
+                        handle_ws_frame(
+                            frame,
+                            conn_id,
+                            sink,
+                            &mut msg,
+                            &mut msg_binary,
+                            &mut fragmenting,
+                            ws_max_message_bytes,
+                        ),
+                        WsLoop::Stop
+                    ) {
+                        return;
+                    }
+                }
+                WsFrameParse::NeedMore => break,
+                WsFrameParse::Error { code, reason } => {
+                    sink.post(InboundEvent::WebSocketClose {
+                        conn_id,
+                        code,
+                        reason: reason.to_string(),
+                    });
+                    return;
+                }
+            }
+        }
+        match read_more(stream, &mut chunk) {
+            ReadStep::Filled(n) => buf.extend_from_slice(&chunk[..n]),
+            ReadStep::Eof => {
+                sink.post(InboundEvent::WebSocketClose {
+                    conn_id,
+                    code: 1006,
+                    reason: "peer disconnected".to_string(),
+                });
+                return;
+            }
+            ReadStep::Timeout => {
+                sink.post(InboundEvent::WebSocketClose {
+                    conn_id,
+                    code: 1001,
+                    reason: "idle timeout".to_string(),
+                });
+                return;
+            }
+            ReadStep::Error(reason) => {
+                sink.post(InboundEvent::WebSocketClose {
+                    conn_id,
+                    code: 1006,
+                    reason,
+                });
+                return;
+            }
+        }
+    }
+}
+
 /// Map a raw HTTP method token to the typed [`HttpMethod`]; `None` for a
 /// non-enumerated verb (answered `501` before any dispatch).
 fn parse_http_method(method: &str) -> Option<HttpMethod> {
@@ -2130,6 +3085,7 @@ fn reason_phrase(status: u16) -> &'static str {
         411 => "Length Required",
         413 => "Payload Too Large",
         414 => "URI Too Long",
+        426 => "Upgrade Required",
         431 => "Request Header Fields Too Large",
         500 => "Internal Server Error",
         501 => "Not Implemented",
@@ -2273,6 +3229,8 @@ impl NativeActor for HttpServerCapability {
             request_stream_window: config.request_stream_window,
             request_streams: HashMap::new(),
             next_stream_id: 0,
+            ws_idle_timeout: Duration::from_millis(config.websocket_idle_timeout_millis),
+            ws_message_conn: HashMap::new(),
         })
     }
 
@@ -2367,6 +3325,27 @@ impl NativeActor for HttpServerCapability {
                 }
                 InboundEvent::StreamFinished { stream_id } => {
                     state.finish_stream(stream_id);
+                }
+                InboundEvent::WebSocketMessage {
+                    conn_id,
+                    binary,
+                    data,
+                } => {
+                    state.dispatch_ws_message(ctx, conn_id, binary, data);
+                }
+                InboundEvent::WebSocketPing { conn_id, payload } => {
+                    state.send_ws_pong(conn_id, &payload);
+                }
+                InboundEvent::WebSocketClose {
+                    conn_id,
+                    code,
+                    reason,
+                } => {
+                    // Report the close to the handler on its own root, echo the
+                    // close frame on the writer (its final write finishes the
+                    // stream, tearing the connection down, ADR-0129 §5).
+                    state.report_ws_close(ctx, conn_id, code, &reason);
+                    state.send_ws_close(conn_id, code, &reason);
                 }
             }
         }
@@ -2541,6 +3520,11 @@ impl NativeActor for HttpServerCapability {
     #[handler]
     fn on_settled(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: Settled) {
         let correlation = mail.root.correlation_id;
+        // An inbound websocket message's chain settled (ADR-0129): reclaim its
+        // outbound-routing entry. Not an `in_flight` request, so no `502`.
+        if state.ws_message_conn.remove(&correlation).is_some() {
+            return;
+        }
         let Some(pending) = state.in_flight.remove(&correlation) else {
             // Already answered (the reply landed first) or never ours.
             return;
@@ -2567,12 +3551,63 @@ impl NativeActor for HttpServerCapability {
     /// `#[handler]`s ([`Self::on_response_chunk`] / [`Self::on_response_stream_end`]),
     /// keyed by their explicit `stream_id` payload — a second correlation
     /// regime living beside this one.
+    /// An outbound websocket message from the handler (ADR-0129 §3). Routed by
+    /// the causal chain, not the payload: the handler answers an inbound
+    /// message on its chain (a wasm `ctx.send` inherits the inbound `root`), so
+    /// `in_flight_root` names the originating connection through
+    /// `ws_message_conn` — the fresh-root-per-message model gives the routing
+    /// key without a connection id on the wire.
+    ///
+    /// # Agent
+    /// Not user-callable — an upgraded connection's handler sends this to
+    /// answer the peer; the cap frames it and drains it under the credit
+    /// window.
+    #[handler]
+    fn on_websocket_message(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        msg: WebSocketMessage,
+    ) {
+        let root = ctx.in_flight_root().correlation_id;
+        if let Some(&conn_id) = state.ws_message_conn.get(&root) {
+            state.send_ws_message(conn_id, msg.binary, &msg.data);
+        }
+    }
+
+    /// A handler-initiated websocket close (ADR-0129 §5). Routed by the causal
+    /// chain like [`Self::on_websocket_message`]: the cap writes the close
+    /// frame on the connection's writer and tears it down.
+    ///
+    /// # Agent
+    /// Not user-callable — an upgraded connection's handler sends this to close
+    /// the socket.
+    #[handler]
+    fn on_websocket_close(state: &mut Self::State, ctx: &mut NativeCtx<'_>, close: WebSocketClose) {
+        let root = ctx.in_flight_root().correlation_id;
+        if let Some(&conn_id) = state.ws_message_conn.get(&root) {
+            state.send_ws_close(conn_id, close.code, &close.reason);
+        }
+    }
+
     #[fallback]
     fn on_any(state: &mut Self::State, ctx: &mut NativeCtx<'_>, env: &Envelope) {
         let correlation = env.sender.correlation_id;
         let Some(pending) = state.in_flight.get(&correlation).copied() else {
             return;
         };
+        // ADR-0129: the handler accepted the upgrade. `WebSocketAccept` is a
+        // one-shot reply (correlation-echoed) keyed on the handshake request's
+        // in-flight correlation, like `HttpResponseStreamOpen`.
+        if env.kind == <WebSocketAccept as Kind>::ID {
+            if let Some(accept) = WebSocketAccept::decode_from_bytes(env.payload.bytes()) {
+                state.accept_websocket(ctx, correlation, pending.conn_id, pending.handler, &accept);
+            } else {
+                state.in_flight.remove(&correlation);
+                state.write_status_response(pending.conn_id, 502, "malformed websocket accept");
+                state.close_connection(pending.conn_id, "malformed websocket accept");
+            }
+            return;
+        }
         if env.kind == <HttpResponseStreamOpen as Kind>::ID {
             if let Some(open) = HttpResponseStreamOpen::decode_from_bytes(env.payload.bytes()) {
                 state.open_stream(ctx, correlation, pending.conn_id, &open);
@@ -2614,8 +3649,9 @@ impl NativeActor for HttpServerCapability {
 #[cfg(test)]
 mod unit_tests {
     use super::{
-        http_date, normalize_prefix, parse_http_method, percent_decode_path, reason_phrase,
-        request_keeps_alive, route_matches,
+        OPCODE_BINARY, OPCODE_CONTINUATION, OPCODE_TEXT, WsFrameParse, http_date, normalize_prefix,
+        parse_http_method, parse_ws_frame, percent_decode_path, reason_phrase, request_keeps_alive,
+        route_matches, sec_websocket_accept, serialize_ws_frame, sha1, validate_ws_handshake,
     };
     use crate::http::kinds::{HttpHeader, HttpMethod};
     use std::time::{Duration, UNIX_EPOCH};
@@ -2713,12 +3749,187 @@ mod unit_tests {
     }
 
     #[test]
+    fn sha1_matches_the_rfc_3174_vector() {
+        // Tripwire: RFC 3174 §7.3 worked example sha1("abc"). A computed digest
+        // that drifts if the block schedule / padding / round logic breaks.
+        use std::fmt::Write as _;
+        let digest = sha1(b"abc");
+        let hex = digest.iter().fold(String::new(), |mut acc, byte| {
+            let _ = write!(acc, "{byte:02x}");
+            acc
+        });
+        assert_eq!(hex, "a9993e364706816aba3e25717850c26c9cd0d89d");
+    }
+
+    #[test]
+    fn sec_websocket_accept_matches_the_rfc_6455_vector() {
+        // Tripwire: RFC 6455 §1.3 worked handshake vector — base64(SHA-1(key +
+        // GUID)). A computed value pinning the SHA-1, the GUID, and the base64
+        // together; it drifts if any of the three is wrong (the GUID's last
+        // byte especially).
+        assert_eq!(
+            sec_websocket_accept("dGhlIHNhbXBsZSBub25jZQ=="),
+            "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+        );
+    }
+
+    #[test]
+    fn ws_frame_serialize_matches_rfc_6455_examples() {
+        // Tripwire: RFC 6455 §5.7 byte-layout examples — computed frame bytes.
+        // #1 single unmasked text "Hello".
+        assert_eq!(
+            serialize_ws_frame(OPCODE_TEXT, b"Hello", None),
+            vec![0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f]
+        );
+        // #2 single masked text "Hello" (mask 0x37fa213d).
+        assert_eq!(
+            serialize_ws_frame(OPCODE_TEXT, b"Hello", Some([0x37, 0xfa, 0x21, 0x3d])),
+            vec![
+                0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58
+            ]
+        );
+        // #4 256-byte binary: the 16-bit extended-length header.
+        let big = serialize_ws_frame(OPCODE_BINARY, &[0u8; 256], None);
+        assert_eq!(&big[..4], &[0x82, 0x7e, 0x01, 0x00]);
+        // #5 65536-byte binary: the 64-bit extended-length header.
+        let huge = serialize_ws_frame(OPCODE_BINARY, &vec![0u8; 65_536], None);
+        assert_eq!(
+            &huge[..10],
+            &[0x82, 0x7f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00]
+        );
+    }
+
+    #[test]
+    fn ws_frame_parse_unmasks_the_rfc_6455_masked_example() {
+        // Tripwire: parse RFC 6455 §5.7 #2 (masked "Hello") back to its
+        // payload — the mask XOR and header decode as a round-trip of the
+        // serialize tripwire above.
+        let bytes = [
+            0x81u8, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58,
+        ];
+        match parse_ws_frame(&bytes, 1024) {
+            WsFrameParse::Complete { frame, consumed } => {
+                assert!(frame.fin);
+                assert_eq!(frame.opcode, OPCODE_TEXT);
+                assert_eq!(frame.payload, b"Hello");
+                assert_eq!(consumed, bytes.len());
+            }
+            _ => panic!("expected a complete frame"),
+        }
+    }
+
+    #[test]
+    fn ws_frame_parse_rejects_an_unmasked_client_frame() {
+        // A client→server frame MUST be masked (RFC 6455 §5.1); an unmasked one
+        // is a `1002` protocol error, never a panic on untrusted input.
+        let bytes = [0x81u8, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f];
+        assert!(matches!(
+            parse_ws_frame(&bytes, 1024),
+            WsFrameParse::Error { code: 1002, .. }
+        ));
+    }
+
+    #[test]
+    fn ws_frame_parse_needs_more_on_a_partial_frame() {
+        // A header that announces more payload than is buffered yields NeedMore,
+        // not a panic or a wrong-length read.
+        let bytes = [0x81u8, 0x85, 0x37, 0xfa, 0x21]; // header cut mid-mask-key
+        assert!(matches!(
+            parse_ws_frame(&bytes, 1024),
+            WsFrameParse::NeedMore
+        ));
+    }
+
+    #[test]
+    fn ws_continuation_frames_decode_as_a_fragmented_message() {
+        // Tripwire: a fragmented text message "Hel" + "lo" as masked frames —
+        // the first non-final (FIN clear, opcode text), the second final (FIN
+        // set, opcode continuation). Field-by-field decode of masking + the FIN
+        // bit + the continuation opcode; concatenating the payloads yields the
+        // original message (the reassembly the frame loop performs).
+        let mask = [0x01u8, 0x02, 0x03, 0x04];
+        let mut first = serialize_ws_frame(OPCODE_TEXT, b"Hel", Some(mask));
+        first[0] &= 0x7f; // clear FIN — a non-final fragment
+        let second = serialize_ws_frame(OPCODE_CONTINUATION, b"lo", Some(mask));
+
+        let WsFrameParse::Complete { frame: f1, .. } = parse_ws_frame(&first, 1024) else {
+            panic!("first fragment must parse");
+        };
+        assert!(!f1.fin);
+        assert_eq!(f1.opcode, OPCODE_TEXT);
+        assert_eq!(f1.payload, b"Hel");
+
+        let WsFrameParse::Complete { frame: f2, .. } = parse_ws_frame(&second, 1024) else {
+            panic!("continuation fragment must parse");
+        };
+        assert!(f2.fin);
+        assert_eq!(f2.opcode, OPCODE_CONTINUATION);
+        assert_eq!(f2.payload, b"lo");
+
+        let mut message = f1.payload;
+        message.extend_from_slice(&f2.payload);
+        assert_eq!(message, b"Hello");
+    }
+
+    #[test]
+    fn ws_handshake_validation_enforces_version_and_key() {
+        let base = |extra: &[(&str, &str)]| -> Vec<HttpHeader> {
+            let mut headers = vec![HttpHeader {
+                name: "Connection".to_string(),
+                value: "Upgrade".to_string(),
+            }];
+            for (name, value) in extra {
+                headers.push(HttpHeader {
+                    name: (*name).to_string(),
+                    value: (*value).to_string(),
+                });
+            }
+            headers
+        };
+        // Valid: version 13 + a key echoes the key back.
+        assert_eq!(
+            validate_ws_handshake(&base(&[
+                ("Sec-WebSocket-Version", "13"),
+                ("Sec-WebSocket-Key", "abc"),
+            ])),
+            Ok("abc".to_string())
+        );
+        // Wrong version → 426.
+        assert!(matches!(
+            validate_ws_handshake(&base(&[
+                ("Sec-WebSocket-Version", "8"),
+                ("Sec-WebSocket-Key", "abc"),
+            ])),
+            Err((426, _))
+        ));
+        // Missing key → 400.
+        assert!(matches!(
+            validate_ws_handshake(&base(&[("Sec-WebSocket-Version", "13")])),
+            Err((400, _))
+        ));
+        // Missing Connection: Upgrade → 400.
+        assert!(matches!(
+            validate_ws_handshake(&[
+                HttpHeader {
+                    name: "Sec-WebSocket-Version".to_string(),
+                    value: "13".to_string(),
+                },
+                HttpHeader {
+                    name: "Sec-WebSocket-Key".to_string(),
+                    value: "abc".to_string(),
+                },
+            ]),
+            Err((400, _))
+        ));
+    }
+
+    #[test]
     fn config_layer_defaults_match_the_named_consts() {
         use super::super::{
             DEFAULT_BIND_ADDR, DEFAULT_KEEP_ALIVE_TIMEOUT_MILLIS, DEFAULT_MAX_CONNECTIONS,
             DEFAULT_MAX_HEADER_BYTES, DEFAULT_MAX_REQUEST_BYTES, DEFAULT_REQUEST_STREAM_WINDOW,
-            DEFAULT_REQUEST_TIMEOUT_MILLIS, DEFAULT_RESPONSE_STREAM_WINDOW, HttpServerConfig,
-            HttpServerConfigLayer,
+            DEFAULT_REQUEST_TIMEOUT_MILLIS, DEFAULT_RESPONSE_STREAM_WINDOW,
+            DEFAULT_WS_IDLE_TIMEOUT_MILLIS, HttpServerConfig, HttpServerConfigLayer,
         };
         use confique::Config as _;
         // No `.env()` source: loads the literal defaults only, so this is
@@ -2751,5 +3962,13 @@ mod unit_tests {
         );
         assert_eq!(layer.request_stream_window, DEFAULT_REQUEST_STREAM_WINDOW);
         assert_eq!(default.request_stream_window, DEFAULT_REQUEST_STREAM_WINDOW);
+        assert_eq!(
+            layer.websocket_idle_timeout_millis,
+            DEFAULT_WS_IDLE_TIMEOUT_MILLIS
+        );
+        assert_eq!(
+            default.websocket_idle_timeout_millis,
+            DEFAULT_WS_IDLE_TIMEOUT_MILLIS
+        );
     }
 }

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -62,6 +62,19 @@ const STREAM_HANDLER_MAILBOX: &str = "aether.component/aether.embedded:web_strea
 /// fixture's own `STREAM_CHUNK_COUNT`.
 const STREAM_CHUNK_COUNT: u32 = 20;
 
+/// The `WebSocketHandler` fixture's `NAMESPACE` const (ADR-0129).
+const WS_HANDLER_NAMESPACE: &str = "web_socket";
+
+/// The websocket handler's full lineage mailbox address.
+const WS_HANDLER_MAILBOX: &str = "aether.component/aether.embedded:web_socket";
+
+/// RFC 6455 §1.3 worked-vector handshake key, and the `Sec-WebSocket-Accept`
+/// the server must echo for it (base64(SHA-1(key + GUID))). Using the fixed
+/// vector keeps the crypto out of the test — the cap's own tripwire pins the
+/// computation.
+const WS_TEST_KEY: &str = "dGhlIHNhbXBsZSBub25jZQ==";
+const WS_TEST_ACCEPT: &str = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+
 /// Slice of `response` after the HTTP head's blank line, or empty if absent.
 fn body_after_head(response: &[u8]) -> &[u8] {
     response
@@ -125,6 +138,86 @@ fn round_trip(port: u16, request: &[u8]) -> Vec<u8> {
     response
 }
 
+/// RFC 6455 opcodes the websocket e2e client uses.
+const WS_OPCODE_TEXT: u8 = 0x1;
+const WS_OPCODE_CONTINUATION: u8 = 0x0;
+const WS_OPCODE_CLOSE: u8 = 0x8;
+
+/// Serialize a masked client→server frame (RFC 6455 §5.1 requires client
+/// frames be masked). `fin` marks the final fragment.
+fn ws_client_frame(opcode: u8, payload: &[u8], fin: bool) -> Vec<u8> {
+    let mask = [0x12u8, 0x34, 0x56, 0x78];
+    let mut out = Vec::with_capacity(payload.len() + 6);
+    let fin_bit = if fin { 0x80 } else { 0x00 };
+    out.push(fin_bit | opcode);
+    let len = payload.len();
+    if len < 126 {
+        out.push(0x80 | u8::try_from(len).unwrap_or(0));
+    } else if let Ok(short) = u16::try_from(len) {
+        out.push(0x80 | 0x7E);
+        out.extend_from_slice(&short.to_be_bytes());
+    } else {
+        out.push(0x80 | 0x7F);
+        out.extend_from_slice(&(len as u64).to_be_bytes());
+    }
+    out.extend_from_slice(&mask);
+    for (i, byte) in payload.iter().enumerate() {
+        out.push(byte ^ mask[i % 4]);
+    }
+    out
+}
+
+/// Read exactly `n` bytes off the socket (the e2e client controls the timing,
+/// so a short read means a bug, not partial data).
+fn read_exact_n(stream: &mut TcpStream, n: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; n];
+    stream.read_exact(&mut buf).expect("read exact frame bytes");
+    buf
+}
+
+/// Read one server→client frame (unmasked, RFC 6455 §5.1) and return its
+/// opcode + payload.
+fn read_server_frame(stream: &mut TcpStream) -> (u8, Vec<u8>) {
+    let header = read_exact_n(stream, 2);
+    let opcode = header[0] & 0x0F;
+    assert_eq!(
+        header[1] & 0x80,
+        0,
+        "a server→client frame must be unmasked"
+    );
+    let len = match header[1] & 0x7F {
+        126 => {
+            let ext = read_exact_n(stream, 2);
+            usize::from(u16::from_be_bytes([ext[0], ext[1]]))
+        }
+        127 => {
+            let ext = read_exact_n(stream, 8);
+            let mut arr = [0u8; 8];
+            arr.copy_from_slice(&ext);
+            usize::try_from(u64::from_be_bytes(arr)).unwrap_or(0)
+        }
+        n => usize::from(n),
+    };
+    let payload = read_exact_n(stream, len);
+    (opcode, payload)
+}
+
+/// Read the HTTP response head (through the blank line) one byte at a time, so
+/// the read stops exactly at the head boundary and does not consume any
+/// following websocket frame bytes.
+fn read_http_head(stream: &mut TcpStream) -> String {
+    let mut head = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        stream.read_exact(&mut byte).expect("read head byte");
+        head.push(byte[0]);
+        if head.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    String::from_utf8_lossy(&head).into_owned()
+}
+
 mod tests {
     use super::*;
 
@@ -164,6 +257,7 @@ mod tests {
             max_connections: 1024,
             response_stream_window: 16,
             request_stream_window: 16,
+            websocket_idle_timeout_millis: 300_000,
         };
 
         let sandbox = init_save_sandbox("http-serving");
@@ -283,6 +377,7 @@ mod tests {
             // Window below the chunk count so the round trip must replenish.
             response_stream_window: 8,
             request_stream_window: 16,
+            websocket_idle_timeout_millis: 300_000,
         };
 
         let sandbox = init_save_sandbox("http-serving-stream");
@@ -358,6 +453,158 @@ mod tests {
         );
     }
 
+    /// Boot a headless chassis with `HttpServerCapability` bound and the
+    /// `WebSocketHandler` wasm fixture loaded (ADR-0129). Over a real
+    /// `TcpStream`: perform the RFC 6455 upgrade handshake, exchange a message
+    /// each direction (a single frame, then a fragmented message to exercise
+    /// continuation reassembly), and close cleanly — the end-to-end proof that
+    /// a wasm handler serves a live bidirectional websocket.
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn wasm_handler_serves_a_websocket_round_trip() {
+        let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+        let Some(wasm_path) = locate_component_wasm("aether_test_fixtures_bundle") else {
+            assert!(
+                !strict,
+                "AETHER_REQUIRE_RUNTIME set but http_handler.wasm not pre-built; \
+                 CI's `Pre-build component wasm for scenario tests` step is missing it",
+            );
+            eprintln!(
+                "skipping: http_handler.wasm not built; \
+                 run `cargo build --target wasm32-unknown-unknown \
+                 -p aether-test-fixtures --examples`",
+            );
+            return;
+        };
+        let wasm = fs::read(&wasm_path).expect("read http_handler wasm");
+
+        let server_config = HttpServerConfig {
+            enabled: true,
+            bind_addr: "127.0.0.1:0".to_string(),
+            handler_mailbox: WS_HANDLER_MAILBOX.to_string(),
+            max_request_bytes: 65_536,
+            max_header_bytes: 8_192,
+            request_timeout_millis: 10_000,
+            keep_alive_timeout_millis: 5_000,
+            max_connections: 1024,
+            response_stream_window: 8,
+            request_stream_window: 16,
+            websocket_idle_timeout_millis: 10_000,
+        };
+
+        let sandbox = init_save_sandbox("http-serving-websocket");
+        let env = HeadlessEnv {
+            namespace_roots: test_namespace_roots(sandbox),
+            http: HttpConfig::default(),
+            http_server: Some(server_config),
+            anthropic: AnthropicConfig::default(),
+            gemini: GeminiConfig::default(),
+            contentgen: ContentGenConfig::default(),
+            tick_period: Duration::from_millis(100),
+            rpc_addr: None,
+            workers: None,
+            ring_caps: aether_substrate_bundle::RingCapacities::default(),
+            scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
+            lifecycle_advance_timeout_millis: 1_000,
+            autoload: vec![AutoloadComponent {
+                wasm,
+                config: Vec::new(),
+                name: Some(WS_HANDLER_NAMESPACE.to_owned()),
+                export: Some(WS_HANDLER_NAMESPACE.to_owned()),
+            }],
+        };
+
+        let built = HeadlessChassis::build(env).expect("build headless chassis with http server");
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if built
+                .resolve_actor::<WasmTrampoline>(WS_HANDLER_NAMESPACE)
+                .is_some()
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "websocket trampoline did not register within 30s; \
+                 live trampolines: {:?}",
+                built.resolve_actors::<WasmTrampoline>(),
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+
+        let port = built
+            .handle::<HttpServerHandle>()
+            .expect("HttpServerHandle published by HttpServerCapability")
+            .local_port;
+        assert!(port > 0, "bound to an OS-assigned port");
+
+        let mut stream =
+            TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to http server");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .expect("set_read_timeout");
+
+        // Handshake.
+        let handshake = format!(
+            "GET /ws HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\n\
+             Connection: Upgrade\r\nSec-WebSocket-Version: 13\r\n\
+             Sec-WebSocket-Key: {WS_TEST_KEY}\r\n\r\n"
+        );
+        stream
+            .write_all(handshake.as_bytes())
+            .expect("write handshake");
+        stream.flush().expect("flush handshake");
+
+        let head = read_http_head(&mut stream);
+        assert!(
+            head.starts_with("HTTP/1.1 101 "),
+            "upgrade should reply 101, got: {head:?}",
+        );
+        assert!(
+            head.contains(&format!("Sec-WebSocket-Accept: {WS_TEST_ACCEPT}")),
+            "101 should echo the computed accept key, got: {head:?}",
+        );
+
+        // A single-frame message echoes back verbatim.
+        stream
+            .write_all(&ws_client_frame(WS_OPCODE_TEXT, b"hello websocket", true))
+            .expect("write text frame");
+        stream.flush().expect("flush text frame");
+        let (opcode, payload) = read_server_frame(&mut stream);
+        assert_eq!(opcode, WS_OPCODE_TEXT, "echo should be a text frame");
+        assert_eq!(
+            payload, b"hello websocket",
+            "echo should match what was sent"
+        );
+
+        // A fragmented message (two frames) reassembles into one echoed message
+        // — the cap reassembles inbound continuation frames before dispatch.
+        stream
+            .write_all(&ws_client_frame(WS_OPCODE_TEXT, b"frag-", false))
+            .expect("write fragment 1");
+        stream
+            .write_all(&ws_client_frame(WS_OPCODE_CONTINUATION, b"ment", true))
+            .expect("write fragment 2");
+        stream.flush().expect("flush fragments");
+        let (opcode, payload) = read_server_frame(&mut stream);
+        assert_eq!(opcode, WS_OPCODE_TEXT, "reassembled echo is a text frame");
+        assert_eq!(
+            payload, b"frag-ment",
+            "the cap should reassemble the fragmented message before dispatch",
+        );
+
+        // Clean close: send a close frame, read the cap's echoed close.
+        let mut close_payload = Vec::new();
+        close_payload.extend_from_slice(&1000u16.to_be_bytes());
+        stream
+            .write_all(&ws_client_frame(WS_OPCODE_CLOSE, &close_payload, true))
+            .expect("write close frame");
+        stream.flush().expect("flush close frame");
+        let (opcode, _payload) = read_server_frame(&mut stream);
+        assert_eq!(opcode, WS_OPCODE_CLOSE, "the cap should echo a close frame");
+    }
+
     /// Poll `request` until the response body contains `expected`
     /// (bounded deadline): route registration, and later the drop's
     /// route purge, are asynchronous mail the test must not race.
@@ -419,6 +666,7 @@ mod tests {
             max_connections: 1024,
             response_stream_window: 16,
             request_stream_window: 16,
+            websocket_idle_timeout_millis: 300_000,
         };
 
         let sandbox = init_save_sandbox("http-route-drop");

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -25,7 +25,8 @@ use aether_capabilities::ComponentHostCapability;
 use aether_capabilities::http::HttpServerCapability;
 use aether_capabilities::http::kinds::{
     HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen, HttpServerRequest,
-    HttpServerResponse, HttpStreamCredit, RegisterRouteSelf,
+    HttpServerResponse, HttpStreamCredit, RegisterRouteSelf, WebSocketAccept, WebSocketClose,
+    WebSocketMessage,
 };
 use aether_data::{Kind as _, MailboxId};
 use aether_kinds::DropComponent;
@@ -145,6 +146,69 @@ impl WasmActor for StreamingHttpHandler {
             self.ended = true;
         }
     }
+}
+
+/// Reference websocket handler fixture (ADR-0129) for the `serving-http`
+/// websocket e2e test. On an upgrade request it opts in with `WebSocketAccept`
+/// (any inbound request is treated as an upgrade — the cap only dispatches here
+/// after it has validated the RFC 6455 handshake); thereafter it echoes each
+/// inbound `WebSocketMessage` straight back, preserving the text/binary flag,
+/// so the client reads back exactly what it sent. The echo is sent on the
+/// inbound message's causal chain (a plain `.send`), so the cap routes it to
+/// the originating socket (ADR-0129 §3).
+///
+/// Registered at `aether.component/aether.embedded:web_socket` after load.
+pub struct WebSocketHandler;
+
+#[actor]
+impl WasmActor for WebSocketHandler {
+    const NAMESPACE: &'static str = "web_socket";
+
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(WebSocketHandler)
+    }
+
+    /// Accept every upgrade the cap routes here (the cap has already validated
+    /// the handshake). A real handler would apply auth / path policy first.
+    ///
+    /// # Agent
+    /// Not sent manually — the `aether.http.server` cap dispatches an
+    /// `HttpServerRequest` for a websocket upgrade; replying `WebSocketAccept`
+    /// completes the handshake, `HttpServerResponse` declines it.
+    #[handler]
+    fn on_request(&mut self, _ctx: &mut WasmCtx<'_>, _req: HttpServerRequest) -> WebSocketAccept {
+        WebSocketAccept {
+            subprotocol: None,
+            headers: Vec::new(),
+        }
+    }
+
+    /// Echo one inbound message back to the peer on the same causal chain.
+    ///
+    /// # Agent
+    /// Not sent manually — the cap dispatches one per complete inbound
+    /// websocket message on the upgraded connection.
+    #[handler]
+    fn on_message(&mut self, ctx: &mut WasmCtx<'_>, msg: WebSocketMessage) {
+        ctx.actor::<HttpServerCapability>().send(&msg);
+    }
+
+    /// The cap's outbound send window (ADR-0128 / ADR-0129 §3). The echo never
+    /// outruns the window, so this handler tracks no credit — it accepts the
+    /// grant to keep the log quiet.
+    ///
+    /// # Agent
+    /// Not sent manually — the cap grants credit as writer slots free.
+    #[handler]
+    fn on_credit(&mut self, _ctx: &mut WasmCtx<'_>, _credit: HttpStreamCredit) {}
+
+    /// A peer-initiated close (ADR-0129 §5). Nothing to do — the cap has
+    /// already echoed the close frame and is tearing the connection down.
+    ///
+    /// # Agent
+    /// Not sent manually — the cap reports a peer close here.
+    #[handler]
+    fn on_close(&mut self, _ctx: &mut WasmCtx<'_>, _close: WebSocketClose) {}
 }
 
 /// Routed sibling of [`HttpHandler`] for the ADR-0130 drop-purge e2e

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
@@ -25,7 +25,7 @@ mod stateful_replace;
 mod ui_widget;
 
 pub use cube::Cube;
-pub use http_handler::{HttpHandler, RoutedHttpHandler, StreamingHttpHandler};
+pub use http_handler::{HttpHandler, RoutedHttpHandler, StreamingHttpHandler, WebSocketHandler};
 pub use inline_child::{
     InlineDespawnParent, InlineParent, InlineStatefulChild, InlineStatefulParent,
 };
@@ -52,6 +52,7 @@ aether_actor::export!(
     HttpHandler,
     StreamingHttpHandler,
     RoutedHttpHandler,
+    WebSocketHandler,
     SourceObserver,
     MatrixParent,
     MatrixChild,


### PR DESCRIPTION
Closes #2553.

## Summary

Adds websocket `Upgrade` support to `aether.http.server` (ADR-0129). The handler decides, the cap owns the protocol: an inbound request carrying `Upgrade: websocket` dispatches as an ordinary `HttpServerRequest`; the handler replies `HttpServerResponse` to decline or a new `WebSocketAccept` to accept. On accept the cap computes `Sec-WebSocket-Accept` (base64(SHA-1(key + RFC 6455 GUID))), writes `101 Switching Protocols`, and flips the connection into websocket mode. The cap validates the protocol layer (missing key / version ≠ 13 → `426`/`400` before dispatch); the handler owns policy.

Once upgraded: the reader enters an RFC 6455 frame loop (read, unmask, reassemble continuation frames), posting each complete application message as a fresh-root dispatch; outbound reuses the ADR-0128 writer thread + `HttpStreamCredit` credit protocol. Ping/pong are cap-owned and transparent; close is a handshake. Three wire kinds (`WebSocketAccept`, `WebSocketMessage`, `WebSocketClose`), hand-rolled SHA-1 + RFC 6455 frame codec (no `sha1`/`tungstenite` deps; `base64` reused from the workspace).

## ⚠️ Reviewer decision — outbound is reply-driven only (no unsolicited server-push)

`WebSocketMessage { binary, data }` (pinned by ADR-0129) carries **no connection id**, so the cap cannot address a specific connection out of band. Outbound is routed by mapping the **inbound message's causal-chain root** to a `ConnId` (`ws_message_conn: HashMap<root_correlation, ConnId>`, populated at inbound dispatch, reclaimed on settlement) — verified sound because a wasm `ctx.send` inherits the inbound root (`component.rs:456`). Consequence: a handler can **reply** to a client message, but **cannot push to a client unsolicited** (e.g. timer- or peer-driven telemetry) — there is no inbound chain to route on, and no wire field to name the connection.

This satisfies issue #2553's literal done-bar (a message each way, verified e2e) but is narrower than ADR-0129's stated bidirectional / live-dashboard / telemetry intent. Closing the gap means adding a connection/session id to `WebSocketMessage`/`WebSocketClose` (mirroring #2554's `stream_id`) — an additive wire change that amends the already-merged ADR-0129, so it is out of this issue's scope. **Recommend: land this as reply-driven v1 and take connection-addressed server-push as a focused follow-up (ADR-0129 amendment).**

## Reviewer notes — adaptations against the moved base (built on landed #2546 + #2552 + #2554)

- **Reader lifecycle:** added a `ReaderControl::Upgrade` variant; upgrade detection/validation lives in `decide_request_head` (#2554's head-round-trip point), which stashes the `Sec-WebSocket-Key` and signals `Buffered` so the upgrade dispatches as an ordinary buffered request. On the response-wait the reader hands off to `run_ws_reader_loop`, carrying over-read bytes and re-timing reads to the ws idle deadline.
- **Outbound writer reuse (#2552):** `WriterMsg::{WsData, WsControl, WsClose}` write pre-serialized frames verbatim; `WsData` frees a credit slot, `WsControl` (pong) is uncredited, `WsClose` posts teardown. The single writer thread owns every post-upgrade write (the `101` is written inline before the writer spawns), so no fd interleave. `StreamState` gained a `handler: MailboxId` resolved once at open.
- **GUID typo in ADR-0129 §Context:** the ADR prose writes the RFC 6455 GUID as `…C5AB0DC85B49`; the correct value (pinned by the RFC §1.3 accept-key tripwire) is `…C5AB0DC85B11`. The code uses the correct GUID; the ADR prose needs a one-line fix (not touched here — flag for a follow-up).

## Test plan

- Real-wire e2e (`wasm_handler_serves_a_websocket_round_trip`, ~1.7s) in `crates/aether-substrate-bundle/tests/http_serving.rs` (HeadlessChassis + real `TcpStream` + a real wasm `WebSocketHandler` echo actor added to `aether-test-fixtures-bundle`): handshake with the RFC accept-key echo, a single-frame message echoed, a fragmented (2-frame) message reassembled + echoed, a clean close.
- Tripwire units: RFC 6455 §1.3 accept vector, RFC 3174 SHA-1 vector, RFC 6455 §5.7 frame byte-layout examples (serialize/parse/masking/length-forms/fragmentation).
- Config: `websocket_idle_timeout_millis` + `DEFAULT_WS_IDLE_TIMEOUT_MILLIS` asserted by the extended `config_layer_defaults_match_the_named_consts`.
- Full workspace validation green: `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (1787 passed / 8 skipped), strict `cargo doc --workspace --no-deps`, wasm32 component cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #2553](https://github.com/iamacoffeepot/aether/issues/2553).
