### PR TITLE
fix(capabilities): route websocket messages by explicit stream id

### DIFF
--- a/crates/aether-capabilities/src/http/kinds.rs
+++ b/crates/aether-capabilities/src/http/kinds.rs
@@ -282,16 +282,21 @@ pub struct HttpRequestCredit {
     pub credit: u32,
 }
 
-// ADR-0129 HTTP server websocket upgrade. Three kinds, reusing `HttpHeader`
-// and ADR-0128's `HttpStreamCredit`. An inbound request carrying `Upgrade:
-// websocket` dispatches to the handler as an ordinary `HttpServerRequest`; the
-// handler replies `WebSocketAccept` to accept (the websocket analog of
-// `HttpResponseStreamOpen`) or an ordinary `HttpServerResponse` to decline. On
-// accept the connection carries `WebSocketMessage`s both directions — cap →
-// handler on inbound (a fresh causal root per message), handler → cap on
-// outbound (framed under the ADR-0128 credit window). `WebSocketClose` is the
-// close handshake, both directions. Ping / pong are cap-owned and never
-// surface as kinds.
+// ADR-0129 HTTP server websocket upgrade, amended by ADR-0132. Three kinds,
+// reusing `HttpHeader` and ADR-0128's `HttpStreamCredit`. An inbound request
+// carrying `Upgrade: websocket` dispatches to the handler as an ordinary
+// `HttpServerRequest`; the handler replies `WebSocketAccept` to accept (the
+// websocket analog of `HttpResponseStreamOpen`) or an ordinary
+// `HttpServerResponse` to decline. On accept the connection carries
+// `WebSocketMessage`s both directions — cap → handler on inbound (a fresh
+// causal root per message), handler → cap on outbound (framed under the
+// ADR-0128 credit window). `WebSocketClose` is the close handshake, both
+// directions. Every data-phase kind carries the connection's `stream_id`
+// (ADR-0132): the cap mints it at accept, the handler learns it from the
+// initial `HttpStreamCredit` grant, and outbound mail names its target
+// connection with it — routing that holds from any causal chain, so a
+// handler can push unprompted. Ping / pong are cap-owned and never surface
+// as kinds.
 
 /// `aether.http.server.websocket.accept` — the handler's opt-in reply to an
 /// upgrade request (ADR-0129), the websocket analog of
@@ -309,35 +314,41 @@ pub struct WebSocketAccept {
 }
 
 /// `aether.http.server.websocket.message` — one complete, de-fragmented
-/// application message, both directions (ADR-0129). Cap → handler on inbound
-/// (dispatched as a fresh causal root that settles as the handler finishes
-/// it); handler → cap on outbound (serialized to an RFC 6455 frame and framed
-/// to the peer under the ADR-0128 credit window). `binary` selects the RFC
-/// 6455 opcode (`true` = binary `0x2`, `false` = text `0x1`); `data` is the
-/// reassembled payload, raw bytes so binary messages round-trip without loss.
+/// application message, both directions (ADR-0129 / ADR-0132). Cap → handler
+/// on inbound (dispatched as a fresh causal root that settles as the handler
+/// finishes it); handler → cap on outbound (serialized to an RFC 6455 frame
+/// and framed to the peer under the ADR-0128 credit window). `binary` selects
+/// the RFC 6455 opcode (`true` = binary `0x2`, `false` = text `0x1`); `data`
+/// is the reassembled payload, raw bytes so binary messages round-trip
+/// without loss.
 ///
-/// An outbound `WebSocketMessage` carries no connection id: it rides the
-/// inbound message's causal chain (the handler sends it while handling an
-/// inbound message, inheriting that message's root), and the cap routes it to
-/// the originating connection by that root — so a handler answers the socket a
-/// message arrived on without naming it.
+/// `stream_id` names the connection (ADR-0132). Inbound, the cap stamps the
+/// upgraded connection's stream id — the same id the handler's
+/// [`HttpStreamCredit`] grants carry — so a handler serving several sockets
+/// tells their messages apart. Outbound, the handler addresses the target
+/// connection with it and the cap resolves the socket through its stream
+/// table, exactly as it routes an [`HttpResponseChunk`]; the send routes
+/// identically from any causal chain, so a handler can push with no inbound
+/// message in flight. An unknown or torn-down `stream_id` drops the message.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.http.server.websocket.message")]
 pub struct WebSocketMessage {
+    pub stream_id: u64,
     pub binary: bool,
     pub data: Vec<u8>,
 }
 
 /// `aether.http.server.websocket.close` — the close handshake, both directions
-/// (ADR-0129). Handler → cap initiates a close; cap → handler reports a
-/// peer-initiated close. The cap writes / echoes the RFC 6455 close frame and
-/// tears the connection down. `code` is the RFC 6455 close status code (`1000`
-/// = normal); `reason` is the optional UTF-8 reason phrase. Like an outbound
-/// [`WebSocketMessage`], a handler-initiated close rides the inbound chain and
-/// is routed to the connection by its root.
+/// (ADR-0129 / ADR-0132). Handler → cap initiates a close; cap → handler
+/// reports a peer-initiated close. The cap writes / echoes the RFC 6455 close
+/// frame and tears the connection down. `code` is the RFC 6455 close status
+/// code (`1000` = normal); `reason` is the optional UTF-8 reason phrase.
+/// `stream_id` names the connection like [`WebSocketMessage`]'s (ADR-0132),
+/// both directions.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.http.server.websocket.close")]
 pub struct WebSocketClose {
+    pub stream_id: u64,
     pub code: u16,
     pub reason: String,
 }

--- a/crates/aether-capabilities/src/http/server/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/runtime.rs
@@ -514,12 +514,6 @@ pub struct HttpServerCapabilityState {
     /// (ADR-0129), from `websocket_idle_timeout_millis` — longer than
     /// `request_timeout`, since an idle websocket is normal.
     pub ws_idle_timeout: Duration,
-    /// Routing index for outbound websocket frames (ADR-0129). Each inbound
-    /// `WebSocketMessage` dispatches on its own fresh root; the handler answers
-    /// on that same causal chain, so this maps an in-flight inbound message's
-    /// root `correlation_id` to its connection. Cleared when the chain settles
-    /// (`on_settled`) or the connection closes.
-    pub ws_message_conn: HashMap<u64, ConnId>,
 }
 
 impl HttpServerCapabilityState {
@@ -1079,10 +1073,6 @@ impl HttpServerCapabilityState {
         // write to a dead socket.
         self.in_flight
             .retain(|_, pending| pending.conn_id != conn_id);
-        // Drop websocket outbound-routing entries for this connection (ADR-0129)
-        // so a late handler reply on a settled chain doesn't route to a dead
-        // socket.
-        self.ws_message_conn.retain(|_, mapped| *mapped != conn_id);
         tracing::debug!(
             target: "aether_substrate::http_server",
             conn = conn_id,
@@ -1409,11 +1399,10 @@ impl HttpServerCapabilityState {
     }
 
     /// Deliver one reassembled inbound websocket message to the handler
-    /// (ADR-0129 §4) as a `WebSocketMessage` on its own fresh causal root, and
-    /// record the root → connection routing so the handler's answer (an
-    /// outbound `WebSocketMessage` / `WebSocketClose` inheriting the chain)
-    /// routes back to this socket. Subscribes to settlement so the routing
-    /// entry is reclaimed when the message's chain drains.
+    /// (ADR-0129 §4) as a `WebSocketMessage` on its own fresh causal root,
+    /// stamped with the connection's `stream_id` (ADR-0132) so the handler
+    /// knows which socket it arrived on and can answer — or push later — by
+    /// naming that id.
     fn dispatch_ws_message(
         &mut self,
         ctx: &mut NativeCtx<'_>,
@@ -1421,25 +1410,21 @@ impl HttpServerCapabilityState {
         binary: bool,
         data: Vec<u8>,
     ) {
-        let Some(handler) = self
+        let Some((handler, stream_id)) = self
             .connections
             .get(&conn_id)
             .and_then(|conn| conn.websocket.as_ref())
-            .map(|ws| ws.handler)
+            .map(|ws| (ws.handler, ws.stream_id))
         else {
             return;
         };
-        let payload = WebSocketMessage { binary, data }.encode_into_bytes();
-        let mail_id = ctx.send_envelope_as_root(handler, <WebSocketMessage as Kind>::ID, &payload);
-        self.ws_message_conn.insert(mail_id.correlation_id, conn_id);
-        if let Some(registry) = self.mailer.settlement_registry() {
-            registry.subscribe_settlement_mail(
-                mail_id,
-                self.self_mailbox,
-                <Settled as Kind>::ID,
-                Arc::clone(&self.mailer),
-            );
+        let payload = WebSocketMessage {
+            stream_id,
+            binary,
+            data,
         }
+        .encode_into_bytes();
+        let _ = ctx.send_envelope_as_root(handler, <WebSocketMessage as Kind>::ID, &payload);
     }
 
     /// Report a peer-initiated websocket close to the handler (ADR-0129 §5) as
@@ -1452,15 +1437,16 @@ impl HttpServerCapabilityState {
         code: u16,
         reason: &str,
     ) {
-        let Some(handler) = self
+        let Some((handler, stream_id)) = self
             .connections
             .get(&conn_id)
             .and_then(|conn| conn.websocket.as_ref())
-            .map(|ws| ws.handler)
+            .map(|ws| (ws.handler, ws.stream_id))
         else {
             return;
         };
         let payload = WebSocketClose {
+            stream_id,
             code,
             reason: reason.to_string(),
         }
@@ -3230,7 +3216,6 @@ impl NativeActor for HttpServerCapability {
             request_streams: HashMap::new(),
             next_stream_id: 0,
             ws_idle_timeout: Duration::from_millis(config.websocket_idle_timeout_millis),
-            ws_message_conn: HashMap::new(),
         })
     }
 
@@ -3520,17 +3505,64 @@ impl NativeActor for HttpServerCapability {
     #[handler]
     fn on_settled(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: Settled) {
         let correlation = mail.root.correlation_id;
-        // An inbound websocket message's chain settled (ADR-0129): reclaim its
-        // outbound-routing entry. Not an `in_flight` request, so no `502`.
-        if state.ws_message_conn.remove(&correlation).is_some() {
-            return;
-        }
         let Some(pending) = state.in_flight.remove(&correlation) else {
             // Already answered (the reply landed first) or never ours.
             return;
         };
         state.write_status_response(pending.conn_id, 502, "no response from handler");
         state.close_connection(pending.conn_id, "settled without response");
+    }
+
+    /// An outbound websocket message from the handler (ADR-0129 §3), routed by
+    /// the payload's `stream_id` through the stream table like
+    /// [`Self::on_response_chunk`] (ADR-0132) — so the send routes identically
+    /// from any causal chain, and a handler can push with no inbound message
+    /// in flight. An unknown or torn-down stream drops the message.
+    ///
+    /// # Agent
+    /// Not user-callable — an upgraded connection's handler sends this to
+    /// speak to the peer; the cap frames it and drains it under the credit
+    /// window.
+    #[handler]
+    fn on_websocket_message(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        msg: WebSocketMessage,
+    ) {
+        if let Some(conn_id) = state.streams.get(&msg.stream_id).map(|s| s.conn_id) {
+            state.send_ws_message(conn_id, msg.binary, &msg.data);
+        } else {
+            tracing::debug!(
+                target: "aether_substrate::http_server",
+                stream = msg.stream_id,
+                "outbound websocket message for unknown stream dropped",
+            );
+        }
+    }
+
+    /// A handler-initiated websocket close (ADR-0129 §5), routed by the
+    /// payload's `stream_id` like [`Self::on_websocket_message`] (ADR-0132):
+    /// the cap writes the close frame on the connection's writer and tears it
+    /// down. An unknown or torn-down stream drops the close.
+    ///
+    /// # Agent
+    /// Not user-callable — an upgraded connection's handler sends this to close
+    /// the socket.
+    #[handler]
+    fn on_websocket_close(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        close: WebSocketClose,
+    ) {
+        if let Some(conn_id) = state.streams.get(&close.stream_id).map(|s| s.conn_id) {
+            state.send_ws_close(conn_id, close.code, &close.reason);
+        } else {
+            tracing::debug!(
+                target: "aether_substrate::http_server",
+                stream = close.stream_id,
+                "outbound websocket close for unknown stream dropped",
+            );
+        }
     }
 
     /// Reply interception. Any mail addressed at this cap that isn't one
@@ -3548,47 +3580,9 @@ impl NativeActor for HttpServerCapability {
     /// [`HttpResponseStreamOpen`] (streamed, ADR-0128); both key on the
     /// request's in-flight correlation id. The mid-stream chunk / end mails
     /// carry a fresh send-correlation and are routed to their own
-    /// `#[handler]`s ([`Self::on_response_chunk`] / [`Self::on_response_stream_end`]),
-    /// keyed by their explicit `stream_id` payload — a second correlation
-    /// regime living beside this one.
-    /// An outbound websocket message from the handler (ADR-0129 §3). Routed by
-    /// the causal chain, not the payload: the handler answers an inbound
-    /// message on its chain (a wasm `ctx.send` inherits the inbound `root`), so
-    /// `in_flight_root` names the originating connection through
-    /// `ws_message_conn` — the fresh-root-per-message model gives the routing
-    /// key without a connection id on the wire.
-    ///
-    /// # Agent
-    /// Not user-callable — an upgraded connection's handler sends this to
-    /// answer the peer; the cap frames it and drains it under the credit
-    /// window.
-    #[handler]
-    fn on_websocket_message(
-        state: &mut Self::State,
-        ctx: &mut NativeCtx<'_>,
-        msg: WebSocketMessage,
-    ) {
-        let root = ctx.in_flight_root().correlation_id;
-        if let Some(&conn_id) = state.ws_message_conn.get(&root) {
-            state.send_ws_message(conn_id, msg.binary, &msg.data);
-        }
-    }
-
-    /// A handler-initiated websocket close (ADR-0129 §5). Routed by the causal
-    /// chain like [`Self::on_websocket_message`]: the cap writes the close
-    /// frame on the connection's writer and tears it down.
-    ///
-    /// # Agent
-    /// Not user-callable — an upgraded connection's handler sends this to close
-    /// the socket.
-    #[handler]
-    fn on_websocket_close(state: &mut Self::State, ctx: &mut NativeCtx<'_>, close: WebSocketClose) {
-        let root = ctx.in_flight_root().correlation_id;
-        if let Some(&conn_id) = state.ws_message_conn.get(&root) {
-            state.send_ws_close(conn_id, close.code, &close.reason);
-        }
-    }
-
+    /// `#[handler]`s ([`Self::on_response_chunk`] / [`Self::on_response_stream_end`]
+    /// / [`Self::on_websocket_message`]), keyed by their explicit `stream_id`
+    /// payload — a second correlation regime living beside this one.
     #[fallback]
     fn on_any(state: &mut Self::State, ctx: &mut NativeCtx<'_>, env: &Envelope) {
         let correlation = env.sender.correlation_id;

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -454,11 +454,15 @@ mod tests {
     }
 
     /// Boot a headless chassis with `HttpServerCapability` bound and the
-    /// `WebSocketHandler` wasm fixture loaded (ADR-0129). Over a real
-    /// `TcpStream`: perform the RFC 6455 upgrade handshake, exchange a message
-    /// each direction (a single frame, then a fragmented message to exercise
-    /// continuation reassembly), and close cleanly — the end-to-end proof that
-    /// a wasm handler serves a live bidirectional websocket.
+    /// `WebSocketHandler` wasm fixture loaded (ADR-0129 / ADR-0132). Over a
+    /// real `TcpStream`: perform the RFC 6455 upgrade handshake, read the
+    /// fixture's unsolicited greeting (stream-id-addressed push with no
+    /// inbound message in flight — the ADR-0132 case chain-root routing could
+    /// not serve), exchange a message each direction (a single frame, then a
+    /// fragmented message to exercise continuation reassembly), prove an
+    /// unknown-stream send is dropped without teardown, and close cleanly —
+    /// the end-to-end proof that a wasm handler serves a live bidirectional
+    /// websocket.
     #[test]
     #[allow(clippy::too_many_lines)]
     fn wasm_handler_serves_a_websocket_round_trip() {
@@ -566,6 +570,16 @@ mod tests {
             "101 should echo the computed accept key, got: {head:?}",
         );
 
+        // The fixture pushes an unsolicited greeting on its first credit
+        // grant (ADR-0132) — read it before sending anything: outbound
+        // routing holds with no inbound websocket message in flight.
+        let (opcode, payload) = read_server_frame(&mut stream);
+        assert_eq!(opcode, WS_OPCODE_TEXT, "greeting should be a text frame");
+        assert_eq!(
+            payload, b"server greeting",
+            "the fixture's unsolicited push should arrive before any client frame",
+        );
+
         // A single-frame message echoes back verbatim.
         stream
             .write_all(&ws_client_frame(WS_OPCODE_TEXT, b"hello websocket", true))
@@ -592,6 +606,27 @@ mod tests {
         assert_eq!(
             payload, b"frag-ment",
             "the cap should reassemble the fragmented message before dispatch",
+        );
+
+        // An outbound send naming an unknown stream id is dropped without
+        // tearing the connection down (ADR-0132): the fixture echoes
+        // `misroute` to a deliberately wrong stream id, so the next frame the
+        // client reads must be the echo of the following message — server
+        // writes are ordered, so reading the second echo first proves the
+        // misrouted frame never reached the socket, and reading it at all
+        // proves the connection survived the drop.
+        stream
+            .write_all(&ws_client_frame(WS_OPCODE_TEXT, b"misroute", true))
+            .expect("write misroute frame");
+        stream
+            .write_all(&ws_client_frame(WS_OPCODE_TEXT, b"after misroute", true))
+            .expect("write post-misroute frame");
+        stream.flush().expect("flush misroute frames");
+        let (opcode, payload) = read_server_frame(&mut stream);
+        assert_eq!(opcode, WS_OPCODE_TEXT, "post-misroute echo is a text frame");
+        assert_eq!(
+            payload, b"after misroute",
+            "the misrouted echo must be dropped and the connection must survive",
         );
 
         // Clean close: send a close frame, read the cap's echoed close.

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -148,24 +148,30 @@ impl WasmActor for StreamingHttpHandler {
     }
 }
 
-/// Reference websocket handler fixture (ADR-0129) for the `serving-http`
-/// websocket e2e test. On an upgrade request it opts in with `WebSocketAccept`
-/// (any inbound request is treated as an upgrade — the cap only dispatches here
-/// after it has validated the RFC 6455 handshake); thereafter it echoes each
-/// inbound `WebSocketMessage` straight back, preserving the text/binary flag,
-/// so the client reads back exactly what it sent. The echo is sent on the
-/// inbound message's causal chain (a plain `.send`), so the cap routes it to
-/// the originating socket (ADR-0129 §3).
+/// Reference websocket handler fixture (ADR-0129 / ADR-0132) for the
+/// `serving-http` websocket e2e test. On an upgrade request it opts in with
+/// `WebSocketAccept` (any inbound request is treated as an upgrade — the cap
+/// only dispatches here after it has validated the RFC 6455 handshake). On the
+/// first `HttpStreamCredit` grant — before any peer traffic — it pushes an
+/// unsolicited text greeting to the granted `stream_id`, exercising the
+/// ADR-0132 push path from a chain with no inbound websocket message.
+/// Thereafter it echoes each inbound `WebSocketMessage` straight back
+/// (preserving `stream_id` and the text/binary flag), except the text message
+/// `misroute`, which it echoes to a deliberately wrong `stream_id` so the e2e
+/// can assert the cap drops an unknown-stream send without tearing the
+/// connection down.
 ///
 /// Registered at `aether.component/aether.embedded:web_socket` after load.
-pub struct WebSocketHandler;
+pub struct WebSocketHandler {
+    greeted: bool,
+}
 
 #[actor]
 impl WasmActor for WebSocketHandler {
     const NAMESPACE: &'static str = "web_socket";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
-        Ok(WebSocketHandler)
+        Ok(WebSocketHandler { greeted: false })
     }
 
     /// Accept every upgrade the cap routes here (the cap has already validated
@@ -183,24 +189,46 @@ impl WasmActor for WebSocketHandler {
         }
     }
 
-    /// Echo one inbound message back to the peer on the same causal chain.
+    /// Echo one inbound message back to the peer by its `stream_id`
+    /// (ADR-0132). The `misroute` text message instead echoes to a wrong
+    /// stream id, which the cap must drop without touching the connection.
     ///
     /// # Agent
     /// Not sent manually — the cap dispatches one per complete inbound
     /// websocket message on the upgraded connection.
     #[handler]
     fn on_message(&mut self, ctx: &mut WasmCtx<'_>, msg: WebSocketMessage) {
+        if !msg.binary && msg.data == b"misroute" {
+            ctx.actor::<HttpServerCapability>().send(&WebSocketMessage {
+                stream_id: msg.stream_id.wrapping_add(1000),
+                binary: msg.binary,
+                data: msg.data,
+            });
+            return;
+        }
         ctx.actor::<HttpServerCapability>().send(&msg);
     }
 
-    /// The cap's outbound send window (ADR-0128 / ADR-0129 §3). The echo never
-    /// outruns the window, so this handler tracks no credit — it accepts the
-    /// grant to keep the log quiet.
+    /// The cap's outbound send window (ADR-0128 / ADR-0129 §3). The first
+    /// grant is the accept-time window (ADR-0132): it names this connection's
+    /// `stream_id`, so push the unsolicited greeting here — no inbound
+    /// websocket message exists yet, proving outbound routing holds off the
+    /// inbound chain. Beyond that the echo never outruns the window, so no
+    /// credit is tracked.
     ///
     /// # Agent
     /// Not sent manually — the cap grants credit as writer slots free.
     #[handler]
-    fn on_credit(&mut self, _ctx: &mut WasmCtx<'_>, _credit: HttpStreamCredit) {}
+    fn on_credit(&mut self, ctx: &mut WasmCtx<'_>, credit: HttpStreamCredit) {
+        if !self.greeted {
+            self.greeted = true;
+            ctx.actor::<HttpServerCapability>().send(&WebSocketMessage {
+                stream_id: credit.stream_id,
+                binary: false,
+                data: b"server greeting".to_vec(),
+            });
+        }
+    }
 
     /// A peer-initiated close (ADR-0129 §5). Nothing to do — the cap has
     /// already echoed the close frame and is tearing the connection down.

--- a/docs/adr/0129-http-server-websocket-upgrade.md
+++ b/docs/adr/0129-http-server-websocket-upgrade.md
@@ -1,6 +1,7 @@
 # ADR-0129: HTTP server websocket upgrade
 
 - **Status:** Proposed
+- **Amended by:** ADR-0132 — the data-phase kinds (`WebSocketMessage`, `WebSocketClose`) carry an explicit `stream_id` and outbound mail routes by it; the causal-chain-root routing this ADR describes for outbound messages is superseded.
 - **Date:** 2026-07-03
 
 Extends **ADR-0108** (the `aether.http.server` capability) and **ADR-0128** (response streaming with windowed flow control). ADR-0128 named websocket upgrade as a distinct later increment on its protocol foundation: "adds the `Upgrade` handshake and a bidirectional framed message protocol on the upgraded socket. It composes with the writer thread and credit mechanism but is a distinct surface." This ADR is that increment. Builds on the settlement model of **ADR-0080** / **ADR-0106** and the synchronous-inline mail routing of **ADR-0038**.
@@ -35,7 +36,7 @@ Policy lives in the handler; the fixed RFC handshake (key echo, `101` framing) l
 New wire kinds in `crates/aether-capabilities/src/http/kinds.rs` (owned by the server capability per ADR-0121), reusing `HttpHeader`:
 
 - `WebSocketAccept { subprotocol: Option<String>, headers: Vec<HttpHeader> }` — the handler's opt-in reply to an upgrade request (the websocket analog of ADR-0128's `HttpResponseStreamOpen`). Declares an optional negotiated subprotocol and any extra `101` headers; the cap supplies `Upgrade` / `Connection` / `Sec-WebSocket-Accept` itself.
-- `WebSocketMessage { binary: bool, data: Vec<u8> }` — one complete, de-fragmented application message, **both directions**. Cap → handler on inbound (dispatched as a fresh root, §4); handler → cap on outbound (framed to the peer under credit, §3). `binary` selects the RFC 6455 opcode (`0x2` binary / `0x1` text); `data` is the reassembled payload.
+- `WebSocketMessage { stream_id: u64, binary: bool, data: Vec<u8> }` — one complete, de-fragmented application message, **both directions**. Cap → handler on inbound (dispatched as a fresh root, §4); handler → cap on outbound (framed to the peer under credit, §3). `stream_id` names the connection and outbound mail routes by it (ADR-0132; `WebSocketClose` carries it identically); `binary` selects the RFC 6455 opcode (`0x2` binary / `0x1` text); `data` is the reassembled payload.
 - `WebSocketClose { code: u16, reason: String }` — the close handshake, **both directions**. Handler → cap initiates a close; cap → handler reports a peer-initiated close. The cap writes/echoes the RFC 6455 close frame and tears the connection down.
 
 Outbound backpressure reuses ADR-0128's `HttpStreamCredit { credit: u32 }` unchanged: outbound `WebSocketMessage`s ride the same per-connection writer-thread bounded channel, and the cap replenishes the handler's send window as writer slots free. Control frames (ping / pong) are **not** surfaced as kinds — the cap owns them (§5).


### PR DESCRIPTION
Closes #2575.

## Summary

The websocket data phase routed a handler's outbound `WebSocketMessage` / `WebSocketClose` by the inbound message's causal-chain root, through a per-message `ws_message_conn` table reclaimed on settlement. That made server push impossible (a send from a `Tick` or any non-inbound chain was silently dropped), left inbound messages without connection identity, foreclosed external callers, and paid a settlement subscription per message to garbage-collect routing state.

Per ADR-0132 (PR #2576, amending ADR-0129): both kinds now carry the connection's `stream_id` both directions — the id the cap already mints at accept and already hands the handler in the initial `HttpStreamCredit` grant. The cap stamps it on inbound dispatch and routes outbound mail through the `streams` table exactly as `on_response_chunk` routes ADR-0128 body chunks; an unknown or torn-down stream drops the mail (debug-logged) without touching the connection. The chain-root machinery — the `ws_message_conn` table, its per-message settlement subscription, the `Settled` reclaim branch, and the teardown sweep — is deleted. The accept/decline handshake is unchanged (one-shot correlation-echoed reply).

The `WebSocketHandler` fixture now pushes an unsolicited text greeting on its first credit grant (before any peer traffic — the case chain-root routing could not serve) and echoes by `stream_id`, with a `misroute` trigger that sends to a wrong stream id so the drop posture is observable over the wire.

One placement deviation from the issue plan: the unknown-stream drop assertion lives in the `http_serving` e2e rather than `src/http/server/tests.rs` — the plan's cited `tests.rs` match set turned out empty (no websocket fixtures exist there), and the e2e already owns the only RFC 6455 client.

## Test plan

- `wasm_handler_serves_a_websocket_round_trip` (extended): after the 101, the client reads the fixture's unsolicited greeting before sending any frame — proving stream-id routing holds with no inbound message in flight; then the existing single-frame echo and fragmentation-reassembly assertions; then the misroute pair — `misroute` (echoed by the fixture to a wrong stream id, dropped by the cap) followed by a normal message whose echo arriving next proves, via server write ordering, that the misrouted frame never reached the socket and the connection survived; then the clean close handshake.
- Full `http_serving` suite (4 tests) and the `aether-capabilities` suite (211 lib tests) pass; wasm32 fixture cross-build clean.

## Generated by

`/implement` — agent execution of [scoped issue #2575](https://github.com/iamacoffeepot/aether/issues/2575).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
