### PR TITLE
feat(capabilities): typed route authoring surface for the http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ name = "aether-capabilities"
 version = "0.3.0-alpha"
 dependencies = [
  "aether-actor",
+ "aether-capabilities-derive",
  "aether-codec",
  "aether-data",
  "aether-kinds",
@@ -92,6 +93,15 @@ dependencies = [
  "uuid",
  "wasmtime",
  "wgpu",
+]
+
+[[package]]
+name = "aether-capabilities-derive"
+version = "0.3.0-alpha"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/aether-math",
     "crates/aether-actor",
     "crates/aether-actor-derive",
+    "crates/aether-capabilities-derive",
     "crates/aether-data-derive",
     "crates/aether-derive",
     "crates/aether-mesh",

--- a/crates/aether-capabilities-derive/Cargo.toml
+++ b/crates/aether-capabilities-derive/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "aether-capabilities-derive"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# ADR-0131: the `#[http::router]` / `#[http::route]` proc macros for the
+# typed route-authoring surface over the `aether.http.server` cap. A leaf
+# below `aether-capabilities`, which depends on it unconditionally and
+# re-exports both macros through its wasm-safe `http` module. Proc-macro
+# crates are host-compiled, so the wasm-header-only build of the parent is
+# unaffected by the dep. The runtime types the macros compile down to
+# (`FromRequest`, `Ctx`, `Route`, `HttpServerRequest`, `RegisterRouteSelf`)
+# live in `aether-capabilities`; this crate only emits paths at them.
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full"] }
+
+[lints]
+workspace = true

--- a/crates/aether-capabilities-derive/src/lib.rs
+++ b/crates/aether-capabilities-derive/src/lib.rs
@@ -1,0 +1,642 @@
+//! Proc macros for the typed route-authoring surface over the
+//! `aether.http.server` capability (ADR-0131). Two attribute macros,
+//! re-exported through `aether_capabilities::http` so consumers write
+//! `#[http::router]` / `#[http::route]` next to the `http::FromRequest`
+//! / `http::Ctx` runtime types the parent crate owns.
+//!
+//! `#[http::router]` sits on an actor's `impl` block, *above* `#[actor]`
+//! (or `#[runtime]`). Attribute macros expand outer-first, so `router`
+//! runs first: it consumes the `#[http::route(<Method|any>, "<prefix>")]`
+//! attributes on methods, mints a hidden request-shaped route kind per
+//! route, rewrites each routed method into a `#[handler]` glue method
+//! driven by `FromRequest` extraction, injects the `RegisterRouteSelf`
+//! registration into `wire`, and hands `#[actor]` an ordinary impl block.
+//!
+//! The macros only emit token paths at the runtime vocabulary
+//! (`::aether_capabilities::http::…`, `::aether_data::…`, `::serde::…`);
+//! they name none of those types directly, so this crate depends on
+//! nothing but `syn` / `quote` / `proc-macro2`.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote, quote_spanned};
+use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned;
+use syn::{
+    Attribute, Expr, ExprLit, FnArg, GenericArgument, Ident, ImplItem, ImplItemFn, ItemImpl, Lit,
+    LitStr, Pat, PatType, PathArguments, ReturnType, Type, TypePath, parse_macro_input,
+    parse_quote,
+};
+
+/// `#[http::route(<Method|any>, "<prefix>")]` — a marker attribute
+/// consumed by `#[http::router]` on the enclosing impl. Reaching this
+/// expansion means the impl is missing `#[http::router]`; the emitted
+/// `compile_error!` says so. Under correct usage `router` strips the
+/// attribute before the compiler resolves it, so this body never runs.
+#[proc_macro_attribute]
+pub fn route(_args: TokenStream, item: TokenStream) -> TokenStream {
+    let item = TokenStream2::from(item);
+    quote_spanned! { item.span() =>
+        ::core::compile_error!(
+            "#[http::route] requires #[http::router] on the enclosing impl block (written above #[actor])"
+        );
+        #item
+    }
+    .into()
+}
+
+/// `#[http::router]` — the impl-block attribute that expands the typed
+/// route-authoring surface (ADR-0131). Written above `#[actor]`.
+#[proc_macro_attribute]
+pub fn router(_args: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as ItemImpl);
+    match expand_router(item) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.into_compile_error().into(),
+    }
+}
+
+/// Parsed `#[http::route(Get, "/api/users")]` arguments: an HTTP-method
+/// identifier (or the bare `any`) and a path-prefix string literal.
+struct RouteArgs {
+    method: Ident,
+    prefix: LitStr,
+}
+
+impl Parse for RouteArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let method: Ident = input.parse()?;
+        let _comma: syn::Token![,] = input.parse()?;
+        let prefix: LitStr = input.parse()?;
+        Ok(Self { method, prefix })
+    }
+}
+
+/// Everything the emitter needs about one routed method, gathered as
+/// `#[http::router]` walks the impl block.
+struct Routed {
+    /// The retained user method's name (also the glue's call target).
+    fn_name: Ident,
+    /// `Some(HttpMethod::…)` / `None` token for the method filter.
+    method_expr: TokenStream2,
+    /// The route's path prefix.
+    prefix: LitStr,
+    /// Minted route-kind struct identifier (a sibling item).
+    kind_struct: Ident,
+    /// Minted route-kind wire name (`"{NAMESPACE}.route.{fn_name}"`).
+    kind_name: LitStr,
+    /// The method's first parameter (receiver or `state: &mut Self::State`),
+    /// copied verbatim onto the glue handler.
+    first_arg: FnArg,
+    /// How the glue calls back into the retained method.
+    call_style: CallStyle,
+    /// The transport ctx type `C` from `http::Ctx<'_, C>`.
+    ctx_c: Type,
+    /// The `(ident, type)` of each `FromRequest` extractor parameter.
+    extractors: Vec<(Ident, Type)>,
+    /// `#[doc]` attributes carried onto the glue handler for
+    /// `describe_component` prose.
+    docs: Vec<Attribute>,
+}
+
+/// How a glue handler dispatches back into the retained user method:
+/// a `self`-receiver method call, or an associated call threading a
+/// fresh split-cap state binding of the carried state type. (The glue
+/// mints its own state binding rather than reusing the user's — which
+/// is typically `_state` — so it never *uses* an underscore binding.)
+enum CallStyle {
+    SelfReceiver,
+    State(Box<Type>),
+}
+
+fn expand_router(mut item: ItemImpl) -> syn::Result<TokenStream2> {
+    if !item.generics.params.is_empty() {
+        return Err(syn::Error::new(
+            item.generics.span(),
+            "#[http::router] does not support generic impl blocks",
+        ));
+    }
+
+    let namespace = read_namespace(&item)?;
+    let self_ident = self_type_ident(&item.self_ty)?;
+
+    // Collect routed methods, stripping the `#[http::route]` marker so
+    // each survives as a plain helper `#[actor]` re-emits verbatim.
+    let mut routed = Vec::new();
+    for impl_item in &mut item.items {
+        let ImplItem::Fn(method) = impl_item else {
+            continue;
+        };
+        if let Some(desc) = take_routed(method, &namespace, &self_ident)? {
+            routed.push(desc);
+        }
+    }
+
+    if routed.is_empty() {
+        return Err(syn::Error::new(
+            item.span(),
+            "#[http::router] found no #[http::route(...)] methods on the impl block",
+        ));
+    }
+
+    let minted = routed.iter().map(emit_minted_kind).collect::<Vec<_>>();
+    let glue = routed.iter().map(emit_glue_handler).collect::<Vec<_>>();
+    for handler in glue {
+        item.items.push(parse_quote!(#handler));
+    }
+
+    inject_registration(&mut item, &routed)?;
+
+    Ok(quote! {
+        #(#minted)*
+        #item
+    })
+}
+
+/// Read the required `const NAMESPACE: &'static str = "…"` literal.
+fn read_namespace(item: &ItemImpl) -> syn::Result<LitStr> {
+    for impl_item in &item.items {
+        let ImplItem::Const(konst) = impl_item else {
+            continue;
+        };
+        if konst.ident != "NAMESPACE" {
+            continue;
+        }
+        // A `macro_rules` `:literal` metavariable reaches a proc macro
+        // wrapped in an invisible `Expr::Group`; peel it before matching.
+        let Expr::Lit(ExprLit {
+            lit: Lit::Str(value),
+            ..
+        }) = peel_group(&konst.expr)
+        else {
+            return Err(syn::Error::new(
+                konst.expr.span(),
+                "#[http::router] needs `const NAMESPACE` to be a string literal",
+            ));
+        };
+        return Ok(value.clone());
+    }
+    Err(syn::Error::new(
+        item.span(),
+        "#[http::router] requires `const NAMESPACE: &'static str = \"…\"` on the impl block",
+    ))
+}
+
+/// The last path segment of the impl's self type, used to name the
+/// minted sibling structs uniquely per actor.
+fn self_type_ident(ty: &Type) -> syn::Result<Ident> {
+    let Type::Path(TypePath { path, .. }) = ty else {
+        return Err(syn::Error::new(
+            ty.span(),
+            "#[http::router] expects a named self type (e.g. `impl WasmActor for MyActor`)",
+        ));
+    };
+    path.segments
+        .last()
+        .map(|seg| seg.ident.clone())
+        .ok_or_else(|| syn::Error::new(ty.span(), "#[http::router] could not name the self type"))
+}
+
+/// If `method` carries `#[http::route(...)]`, strip it and build the
+/// routed-method descriptor; otherwise return `None`.
+fn take_routed(
+    method: &mut ImplItemFn,
+    namespace: &LitStr,
+    self_ident: &Ident,
+) -> syn::Result<Option<Routed>> {
+    let route_positions: Vec<usize> = method
+        .attrs
+        .iter()
+        .enumerate()
+        .filter(|(_, attr)| attr_is_route(attr))
+        .map(|(index, _)| index)
+        .collect();
+    let Some(&index) = route_positions.first() else {
+        return Ok(None);
+    };
+    if route_positions.len() > 1 {
+        return Err(syn::Error::new(
+            method.attrs[route_positions[1]].span(),
+            "a routed method takes exactly one #[http::route(...)] attribute",
+        ));
+    }
+
+    let route_attr = method.attrs.remove(index);
+    let args: RouteArgs = route_attr.parse_args()?;
+    let method_expr = method_filter_token(&args.method)?;
+
+    let fn_name = method.sig.ident.clone();
+    let kind_struct = format_ident!("{}Route{}", self_ident, to_camel(&fn_name.to_string()));
+    let kind_name = LitStr::new(
+        &format!("{}.route.{fn_name}", namespace.value()),
+        fn_name.span(),
+    );
+
+    let (first_arg, call_style) = parse_receiver(method)?;
+    let ctx_c = parse_ctx_type(method)?;
+    let extractors = parse_extractors(method)?;
+    ensure_response_return(&method.sig.output)?;
+
+    let docs = method
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("doc"))
+        .cloned()
+        .collect();
+
+    Ok(Some(Routed {
+        fn_name,
+        method_expr,
+        prefix: args.prefix,
+        kind_struct,
+        kind_name,
+        first_arg,
+        call_style,
+        ctx_c,
+        extractors,
+        docs,
+    }))
+}
+
+/// True for `#[http::route]` / `#[route]` (matched on the last path
+/// segment, so it works through any import style).
+fn attr_is_route(attr: &Attribute) -> bool {
+    attr.path()
+        .segments
+        .last()
+        .is_some_and(|seg| seg.ident == "route")
+}
+
+/// Map a `#[http::route]` method identifier to its
+/// `Option<HttpMethod>` filter token: `any` → `None`, a variant name →
+/// `Some(HttpMethod::Variant)`.
+fn method_filter_token(method: &Ident) -> syn::Result<TokenStream2> {
+    if method == "any" {
+        return Ok(quote! { ::core::option::Option::None });
+    }
+    let known = ["Get", "Post", "Put", "Delete", "Patch", "Head", "Options"];
+    if known.iter().any(|name| method == name) {
+        return Ok(quote! {
+            ::core::option::Option::Some(::aether_capabilities::http::kinds::HttpMethod::#method)
+        });
+    }
+    Err(syn::Error::new(
+        method.span(),
+        "#[http::route] method must be one of Get/Post/Put/Delete/Patch/Head/Options or `any`",
+    ))
+}
+
+/// Read the method's first parameter — a `self` receiver (self-hosted
+/// actor) or `state: &mut Self::State` (split native cap) — and derive
+/// the glue's call style.
+fn parse_receiver(method: &ImplItemFn) -> syn::Result<(FnArg, CallStyle)> {
+    let first = method.sig.inputs.first().ok_or_else(|| {
+        syn::Error::new(
+            method.sig.span(),
+            "a routed method needs a `self` receiver or a `state: &mut Self::State` parameter",
+        )
+    })?;
+    match first {
+        FnArg::Receiver(_) => Ok((first.clone(), CallStyle::SelfReceiver)),
+        FnArg::Typed(PatType { pat, ty, .. }) => {
+            if !matches!(pat.as_ref(), Pat::Ident(_)) {
+                return Err(syn::Error::new(
+                    pat.span(),
+                    "the state parameter of a routed method must be a plain identifier",
+                ));
+            }
+            Ok((first.clone(), CallStyle::State(Box::new((**ty).clone()))))
+        }
+    }
+}
+
+/// Extract the transport ctx type `C` from the method's second
+/// parameter, which must be `http::Ctx<'_, C>`.
+fn parse_ctx_type(method: &ImplItemFn) -> syn::Result<Type> {
+    let ctx_arg = method.sig.inputs.iter().nth(1).ok_or_else(|| {
+        syn::Error::new(
+            method.sig.span(),
+            "a routed method's second parameter must be `ctx: http::Ctx<'_, C>`",
+        )
+    })?;
+    let FnArg::Typed(PatType { ty, .. }) = ctx_arg else {
+        return Err(syn::Error::new(
+            ctx_arg.span(),
+            "a routed method's second parameter must be `ctx: http::Ctx<'_, C>`",
+        ));
+    };
+    let Type::Path(TypePath { path, .. }) = ty.as_ref() else {
+        return Err(syn::Error::new(
+            ty.span(),
+            "a routed method's ctx parameter must be `http::Ctx<'_, C>`",
+        ));
+    };
+    let seg = path.segments.last().ok_or_else(|| {
+        syn::Error::new(
+            ty.span(),
+            "a routed method's ctx parameter must be `http::Ctx<'_, C>`",
+        )
+    })?;
+    if seg.ident != "Ctx" {
+        return Err(syn::Error::new(
+            ty.span(),
+            "a routed method's ctx parameter must be `http::Ctx<'_, C>`",
+        ));
+    }
+    let PathArguments::AngleBracketed(args) = &seg.arguments else {
+        return Err(syn::Error::new(
+            ty.span(),
+            "http::Ctx needs a transport ctx type argument: `http::Ctx<'_, C>`",
+        ));
+    };
+    args.args
+        .iter()
+        .rev()
+        .find_map(|arg| match arg {
+            GenericArgument::Type(ty) => Some(ty.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            syn::Error::new(
+                ty.span(),
+                "http::Ctx needs a transport ctx type argument: `http::Ctx<'_, C>`",
+            )
+        })
+}
+
+/// Collect the `(ident, type)` of every extractor parameter (those
+/// after the receiver and ctx). Each must be a plainly-named parameter.
+fn parse_extractors(method: &ImplItemFn) -> syn::Result<Vec<(Ident, Type)>> {
+    let mut extractors = Vec::new();
+    for arg in method.sig.inputs.iter().skip(2) {
+        let FnArg::Typed(PatType { pat, ty, .. }) = arg else {
+            return Err(syn::Error::new(
+                arg.span(),
+                "a routed method cannot take a second `self` receiver",
+            ));
+        };
+        let Pat::Ident(ident) = pat.as_ref() else {
+            return Err(syn::Error::new(
+                pat.span(),
+                "an extractor parameter must be a plain identifier (`name: Extractor`)",
+            ));
+        };
+        extractors.push((ident.ident.clone(), ty.as_ref().clone()));
+    }
+    Ok(extractors)
+}
+
+/// Require the routed method to return `HttpServerResponse` — the v1
+/// buffered-reply contract. Streaming routes keep the raw `#[handler]`
+/// surface, so a non-`HttpServerResponse` return is an error here.
+fn ensure_response_return(output: &ReturnType) -> syn::Result<()> {
+    let ReturnType::Type(_, ty) = output else {
+        return Err(syn::Error::new(
+            output.span(),
+            "a routed method must return HttpServerResponse",
+        ));
+    };
+    let Type::Path(TypePath { path, .. }) = ty.as_ref() else {
+        return Err(syn::Error::new(
+            ty.span(),
+            "a routed method must return HttpServerResponse",
+        ));
+    };
+    let is_response = path
+        .segments
+        .last()
+        .is_some_and(|seg| seg.ident == "HttpServerResponse");
+    if is_response {
+        Ok(())
+    } else {
+        Err(syn::Error::new(
+            ty.span(),
+            "a routed method must return HttpServerResponse (a streaming route keeps the raw #[handler] surface)",
+        ))
+    }
+}
+
+/// The `#[doc(hidden)]` single-field wrapper kind for one route. Its
+/// wire encoding is field-concatenation, so it decodes an
+/// `HttpServerRequest` payload byte-for-byte however that type grows
+/// (ADR-0131) — while the ordinary derives keep ID derivation, the
+/// `aether.kinds` link-sections, and the descriptor inventory.
+fn emit_minted_kind(routed: &Routed) -> TokenStream2 {
+    let Routed {
+        kind_struct,
+        kind_name,
+        ..
+    } = routed;
+    quote! {
+        #[doc(hidden)]
+        #[derive(
+            ::aether_data::Kind,
+            ::aether_data::Schema,
+            ::serde::Serialize,
+            ::serde::Deserialize,
+        )]
+        #[kind(name = #kind_name)]
+        pub struct #kind_struct {
+            pub request: ::aether_capabilities::http::kinds::HttpServerRequest,
+        }
+    }
+}
+
+/// The `#[handler]` glue for one route: decode the minted kind, run the
+/// extractors in declaration order (first `Err` becomes the reply),
+/// build `http::Ctx`, and call the retained user method.
+fn emit_glue_handler(routed: &Routed) -> TokenStream2 {
+    let Routed {
+        fn_name,
+        method_expr,
+        prefix,
+        kind_struct,
+        first_arg,
+        call_style,
+        ctx_c,
+        extractors,
+        docs,
+        ..
+    } = routed;
+
+    let glue_name = format_ident!("__aether_route_{}", fn_name);
+    let ext_idents = extractors
+        .iter()
+        .map(|(ident, _)| ident)
+        .collect::<Vec<_>>();
+    let ext_types = extractors.iter().map(|(_, ty)| ty);
+
+    // The glue mints its own `__aether_state` binding for the split-cap
+    // call rather than reusing the user's first parameter (typically
+    // `_state`), so it never uses an underscore-prefixed binding.
+    let (glue_first, call) = match call_style {
+        CallStyle::SelfReceiver => (
+            quote! { #first_arg },
+            quote! { self.#fn_name(__aether_http_ctx #(, #ext_idents)*) },
+        ),
+        CallStyle::State(state_ty) => (
+            quote! { __aether_state: #state_ty },
+            quote! { Self::#fn_name(__aether_state, __aether_http_ctx #(, #ext_idents)*) },
+        ),
+    };
+
+    quote! {
+        #(#docs)*
+        #[handler]
+        fn #glue_name(
+            #glue_first,
+            __aether_ctx: &mut #ctx_c,
+            __aether_mail: #kind_struct,
+        ) -> ::aether_capabilities::http::kinds::HttpServerResponse {
+            let __aether_request = __aether_mail.request;
+            #(
+                let #ext_idents = match <#ext_types as ::aether_capabilities::http::FromRequest>::from_request(
+                    &__aether_request,
+                ) {
+                    ::core::result::Result::Ok(__aether_value) => __aether_value,
+                    ::core::result::Result::Err(__aether_response) => return __aether_response,
+                };
+            )*
+            let __aether_http_ctx = ::aether_capabilities::http::Ctx::new(
+                __aether_ctx,
+                __aether_request,
+                ::aether_capabilities::http::Route {
+                    prefix: #prefix,
+                    method: #method_expr,
+                },
+            );
+            #call
+        }
+    }
+}
+
+/// Build the `RegisterRouteSelf` send for one route, addressed with the
+/// given `wire` ctx binding.
+fn registration_send(routed: &Routed, ctx: &Ident) -> TokenStream2 {
+    let Routed {
+        method_expr,
+        prefix,
+        kind_struct,
+        ..
+    } = routed;
+    quote! {
+        #ctx.actor::<::aether_capabilities::http::HttpServerCapability>()
+            .send(&::aether_capabilities::http::kinds::RegisterRouteSelf {
+                prefix: #prefix.to_string(),
+                method: #method_expr,
+                kind: <#kind_struct as ::aether_data::Kind>::ID,
+            });
+    }
+}
+
+/// Inject the per-route `RegisterRouteSelf` registrations into `wire` —
+/// appended to an author-written `wire` body, or synthesized as a new
+/// `wire` when the impl has none. Receiver and ctx shapes are copied
+/// from the routed methods, so one rewrite serves both transports.
+fn inject_registration(item: &mut ItemImpl, routed: &[Routed]) -> syn::Result<()> {
+    let existing = item.items.iter_mut().find_map(|impl_item| match impl_item {
+        ImplItem::Fn(method) if method.sig.ident == "wire" => Some(method),
+        _ => None,
+    });
+
+    if let Some(wire) = existing {
+        let ctx = wire_ctx_ident(wire)?;
+        for route in routed {
+            let send = registration_send(route, &ctx);
+            wire.block.stmts.push(parse_quote!(#send));
+        }
+        return Ok(());
+    }
+
+    // Synthesize a fresh `wire`, copying the receiver + ctx shape from
+    // the first routed method (all routes on one impl share a transport).
+    let template = &routed[0];
+    let first_arg = &template.first_arg;
+    let ctx_c = &template.ctx_c;
+    let ctx = format_ident!("__aether_ctx");
+    let sends = routed
+        .iter()
+        .map(|route| registration_send(route, &ctx))
+        .collect::<Vec<_>>();
+    let wire: ImplItemFn = parse_quote! {
+        fn wire(#first_arg, #ctx: &mut #ctx_c) {
+            #(#sends)*
+        }
+    };
+    item.items.push(ImplItem::Fn(wire));
+    Ok(())
+}
+
+/// The ctx-parameter identifier of an author-written `wire`, so
+/// appended registration sends address the same binding.
+fn wire_ctx_ident(wire: &ImplItemFn) -> syn::Result<Ident> {
+    let ctx_arg = wire.sig.inputs.iter().nth(1).ok_or_else(|| {
+        syn::Error::new(
+            wire.sig.span(),
+            "`wire` must take a ctx parameter (`fn wire(&mut self, ctx: &mut …)`)",
+        )
+    })?;
+    let FnArg::Typed(PatType { pat, .. }) = ctx_arg else {
+        return Err(syn::Error::new(
+            ctx_arg.span(),
+            "`wire`'s ctx parameter must be a plainly-named `&mut` ctx",
+        ));
+    };
+    let Pat::Ident(ident) = pat.as_ref() else {
+        return Err(syn::Error::new(
+            pat.span(),
+            "name `wire`'s ctx parameter so route registration can address it",
+        ));
+    };
+    Ok(ident.ident.clone())
+}
+
+/// Peel invisible `Expr::Group` wrappers a `macro_rules` `:literal` /
+/// `:expr` metavariable carries when it reaches a proc macro.
+fn peel_group(expr: &Expr) -> &Expr {
+    let mut current = expr;
+    while let Expr::Group(group) = current {
+        current = &group.expr;
+    }
+    current
+}
+
+/// Convert a `snake_case` identifier to `CamelCase` for minting a
+/// struct name (`on_users` → `OnUsers`).
+fn to_camel(snake: &str) -> String {
+    let mut camel = String::with_capacity(snake.len());
+    let mut upper_next = true;
+    for ch in snake.chars() {
+        if ch == '_' {
+            upper_next = true;
+        } else if upper_next {
+            camel.extend(ch.to_uppercase());
+            upper_next = false;
+        } else {
+            camel.push(ch);
+        }
+    }
+    camel
+}
+
+// The proc-macro logic here (kind minting, extraction ordering, wire
+// synthesis) is exercised end-to-end through the http server's native
+// route fixtures and the `RoutedHttpHandler` wasm fixture — a routed
+// dispatch decoding a request under the minted kind, an extractor
+// failure early-returning its 400, and registration reaching the cap
+// over the wire — rather than by unit tests over token output here,
+// which would only restate the `quote!` blocks.
+#[cfg(test)]
+mod tests {
+    use super::to_camel;
+
+    // Tripwire: minted struct names are built from this snake→camel
+    // fold; a regression that mangled multi-segment names would collide
+    // sibling kinds silently.
+    #[test]
+    fn camel_folds_snake_segments() {
+        assert_eq!(to_camel("on_users"), "OnUsers");
+        assert_eq!(to_camel("list"), "List");
+        assert_eq!(to_camel("get_api_v2"), "GetApiV2");
+    }
+}

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -108,6 +108,10 @@ ui-runtime = ["ui", "runtime", "render", "text"]
 aether-actor = { path = "../aether-actor" }
 aether-codec = { path = "../aether-codec" }
 aether-data = { path = "../aether-data" }
+# ADR-0131: the `#[http::router]` / `#[http::route]` proc macros, re-exported
+# through the wasm-safe `http` module. Proc-macro crates are host-compiled, so
+# an unconditional dep leaves the wasm-header-only build unaffected.
+aether-capabilities-derive = { path = "../aether-capabilities-derive" }
 aether-kinds = { path = "../aether-kinds" }
 # `alloc` rides along for the `rpc::wire` + `trace_walk` modules (folded
 # in per ADR-0124), whose owned-`String`/`Vec` wire types need serde's

--- a/crates/aether-capabilities/src/http/mod.rs
+++ b/crates/aether-capabilities/src/http/mod.rs
@@ -9,8 +9,17 @@
 pub mod client;
 pub mod kinds;
 pub mod server;
+pub mod typed;
 
 pub use kinds::*;
+
+// ADR-0131 typed route-authoring surface. The `#[router]` / `#[route]`
+// proc macros (host-compiled, so wasm-safe) re-exported from the
+// cap-owned derive crate, alongside the runtime types they compile down
+// to — consumers write `#[http::router]` / `#[http::route]` next to
+// `http::FromRequest` / `http::Ctx` / `http::Route`.
+pub use aether_capabilities_derive::{route, router};
+pub use typed::{Ctx, FromRequest, Route};
 
 // Egress client surface (`client.rs`). `HttpConfig` is the always-on
 // domain struct; the `Config`-derive `HttpConfigLayer` / `HttpOverlay`

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -11,9 +11,9 @@ use std::time::{Duration, Instant};
 
 use test_handlers::{
     ApiRouteHandler, ApiV2Handler, DupFirstHandler, DupSecondHandler, EchoHttpHandler,
-    FixedBodyHttpHandler, FloodHttpHandler, MethodAnyHandler, MethodPostHandler,
-    STREAM_CHUNK_COUNT, SilentHttpHandler, StreamHttpHandler, StreamingUploadHandler,
-    TmpRouteHandler, stream_chunk_body,
+    ExtractRouteHandler, FixedBodyHttpHandler, FloodHttpHandler, MethodAnyHandler,
+    MethodPostHandler, STREAM_CHUNK_COUNT, SilentHttpHandler, StreamHttpHandler,
+    StreamingUploadHandler, TmpRouteHandler, WiredRouteHandler, stream_chunk_body,
 };
 
 mod test_handlers {
@@ -22,46 +22,37 @@ mod test_handlers {
     //! the request without replying (the `502` safety-net path), two
     //! response-streaming handlers (ADR-0128) — a well-behaved one that
     //! paces chunks against credit, and a flooder that ignores credit —
-    //! plus the ADR-0130 routed handlers that claim prefixes from `wire`
-    //! via `register_route_self` — the same registration path a component
-    //! takes — and reply fixed tags so a test can assert which handler a
-    //! request reached.
+    //! plus the routed handlers. Most route handlers author their routes
+    //! through the typed `#[http::router]` / `#[http::route]` surface
+    //! (ADR-0131) — the macro mints each route's kind and injects its
+    //! `register_route_self` registration — so the tests exercise what a
+    //! component author writes. The conflict-`Err` and idempotent
+    //! double-claim handlers stay on the raw registration surface, so a
+    //! macro regression cannot mask a registration-semantics one.
     use aether_actor::actor;
     use aether_data::Kind;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
 
+    use crate::http;
     use crate::http::kinds::{
-        HttpHeader, HttpMethod, HttpRequestChunk, HttpRequestCredit, HttpRequestStreamEnd,
+        HttpHeader, HttpRequestChunk, HttpRequestCredit, HttpRequestStreamEnd,
         HttpRequestStreamOpen, HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen,
         HttpServerRequest, HttpServerResponse, HttpStreamCredit, RegisterRouteSelf,
         UnregisterRouteSelf,
     };
     use crate::http::server::HttpServerCapability;
 
-    /// A minted route kind (ADR-0130): the same shape as
-    /// [`HttpServerRequest`] under a distinct kind name, so the cap's
-    /// route-as-kind dispatch stamps this id and the handler's typed
-    /// `#[handler]` decodes the request-shaped payload as it.
-    #[derive(aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize)]
-    #[kind(name = "aether.http.test.api_route_request")]
-    pub struct ApiRouteRequest {
-        pub method: HttpMethod,
-        pub path: String,
-        pub query: String,
-        pub headers: Vec<HttpHeader>,
-        pub body: Vec<u8>,
-        pub peer_addr: String,
-    }
-
-    /// Claims `/api` from `wire` with the minted [`ApiRouteRequest`]
-    /// kind (registering the same key twice to pin the idempotent
-    /// same-mailbox re-claim), and echoes the decoded path back in the
-    /// body — proving the routed payload decoded as the registered
-    /// kind, not just that dispatch picked the right mailbox.
+    /// Claims `/api` through the typed authoring surface (`#[http::router]`
+    /// / `#[http::route]`, ADR-0131): the macro mints the route's
+    /// request-shaped kind, injects its `wire` registration, and decodes
+    /// the dispatched payload under the minted kind. The handler echoes
+    /// the decoded path, proving the payload round-tripped as the minted
+    /// kind (not merely that dispatch picked the right mailbox).
     pub struct ApiRouteHandler;
     pub struct ApiRouteHandlerState;
 
+    #[http::router]
     #[actor(singleton)]
     impl NativeActor for ApiRouteHandler {
         type State = ApiRouteHandlerState;
@@ -72,37 +63,87 @@ mod test_handlers {
             Ok(ApiRouteHandlerState)
         }
 
-        fn wire(_state: &mut ApiRouteHandlerState, ctx: &mut NativeCtx<'_>) {
-            let claim = RegisterRouteSelf {
-                prefix: "/api".to_string(),
-                method: None,
-                kind: <ApiRouteRequest as Kind>::ID,
-            };
-            ctx.actor::<HttpServerCapability>().send(&claim);
-            // Same mailbox re-claiming its own key: idempotent Ok.
-            ctx.actor::<HttpServerCapability>().send(&claim);
-        }
-
-        #[handler]
-        fn on_request(
-            _state: &mut Self::State,
-            _ctx: &mut NativeCtx<'_>,
-            request: ApiRouteRequest,
+        /// Echo the decoded request path back under `/api`.
+        #[http::route(any, "/api")]
+        fn on_api(
+            _state: &mut ApiRouteHandlerState,
+            ctx: http::Ctx<'_, NativeCtx<'_>>,
         ) -> HttpServerResponse {
             HttpServerResponse {
                 status: 200,
                 headers: Vec::new(),
-                body: format!("api:{}", request.path).into_bytes(),
+                body: format!("api:{}", ctx.request().path).into_bytes(),
             }
         }
     }
 
-    /// Claims `/tmp` from `wire`; on any request it releases its own
-    /// route via `unregister_route_self` before replying, so the next
-    /// request to `/tmp` falls back to the default handler.
+    /// A required-`name`-query extractor: parses `?name=…` off the
+    /// request, or returns the `400` the routed glue replies with in
+    /// place of dispatching the handler (ADR-0131's typed boundary).
+    pub struct QueryName(pub String);
+
+    impl http::FromRequest for QueryName {
+        fn from_request(request: &HttpServerRequest) -> Result<Self, HttpServerResponse> {
+            for pair in request.query.split('&') {
+                if let Some(value) = pair.strip_prefix("name=") {
+                    return Ok(Self(value.to_string()));
+                }
+            }
+            Err(HttpServerResponse {
+                status: 400,
+                headers: Vec::new(),
+                body: b"missing name query parameter".to_vec(),
+            })
+        }
+    }
+
+    /// Claims `/extract` and threads a real [`QueryName`] extractor into
+    /// the routed method, so a request under the prefix either dispatches
+    /// with the extracted value (echoed at `200`) or short-circuits to
+    /// the extractor's `400` before the handler runs.
+    pub struct ExtractRouteHandler;
+    pub struct ExtractRouteHandlerState;
+
+    #[http::router]
+    #[actor(singleton)]
+    impl NativeActor for ExtractRouteHandler {
+        type State = ExtractRouteHandlerState;
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.http.test_route_extract";
+
+        fn init(
+            (): (),
+            _ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<ExtractRouteHandlerState, BootError> {
+            Ok(ExtractRouteHandlerState)
+        }
+
+        /// Echo the extracted `name` query value; the glue never reaches
+        /// here when the extractor returns its `400`.
+        #[http::route(any, "/extract")]
+        fn on_extract(
+            _state: &mut ExtractRouteHandlerState,
+            _ctx: http::Ctx<'_, NativeCtx<'_>>,
+            name: QueryName,
+        ) -> HttpServerResponse {
+            HttpServerResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: format!("hello:{}", name.0).into_bytes(),
+            }
+        }
+    }
+
+    /// Claims `/tmp` through the macro surface; on any request the routed
+    /// method releases its own route via the raw `unregister_route_self`
+    /// (a protocol op the typed surface leaves to the body), so the next
+    /// request to `/tmp` falls back to the default handler. `ctx` derefs
+    /// to `NativeCtx`, so the raw send reads exactly as an ordinary
+    /// handler's.
     pub struct TmpRouteHandler;
     pub struct TmpRouteHandlerState;
 
+    #[http::router]
     #[actor(singleton)]
     impl NativeActor for TmpRouteHandler {
         type State = TmpRouteHandlerState;
@@ -113,20 +154,11 @@ mod test_handlers {
             Ok(TmpRouteHandlerState)
         }
 
-        fn wire(_state: &mut TmpRouteHandlerState, ctx: &mut NativeCtx<'_>) {
-            ctx.actor::<HttpServerCapability>()
-                .send(&RegisterRouteSelf {
-                    prefix: "/tmp".to_string(),
-                    method: None,
-                    kind: <HttpServerRequest as Kind>::ID,
-                });
-        }
-
-        #[handler]
-        fn on_request(
-            _state: &mut Self::State,
-            ctx: &mut NativeCtx<'_>,
-            _request: HttpServerRequest,
+        /// Release `/tmp`, then reply the `tmp` tag.
+        #[http::route(any, "/tmp")]
+        fn on_tmp(
+            _state: &mut TmpRouteHandlerState,
+            ctx: http::Ctx<'_, NativeCtx<'_>>,
         ) -> HttpServerResponse {
             ctx.actor::<HttpServerCapability>()
                 .send(&UnregisterRouteSelf {
@@ -141,9 +173,130 @@ mod test_handlers {
         }
     }
 
-    /// A routed handler that claims its prefixes from `wire` with the
-    /// generic request kind and replies `200` with a fixed tag body.
+    /// A macro route alongside a hand-written `wire`: the macro appends
+    /// its `/wired` registration to the author's `wire` (which
+    /// independently claims `/wired-extra` on the raw surface for a
+    /// generic-kind `#[handler]`), so both routes dispatch and the
+    /// hand-written registration survives the append.
+    pub struct WiredRouteHandler;
+    pub struct WiredRouteHandlerState;
+
+    #[http::router]
+    #[actor(singleton)]
+    impl NativeActor for WiredRouteHandler {
+        type State = WiredRouteHandlerState;
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.http.test_route_wired";
+
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<WiredRouteHandlerState, BootError> {
+            Ok(WiredRouteHandlerState)
+        }
+
+        fn wire(_state: &mut WiredRouteHandlerState, ctx: &mut NativeCtx<'_>) {
+            ctx.actor::<HttpServerCapability>()
+                .send(&RegisterRouteSelf {
+                    prefix: "/wired-extra".to_string(),
+                    method: None,
+                    kind: <HttpServerRequest as Kind>::ID,
+                });
+        }
+
+        /// Generic-kind dispatch for the hand-registered `/wired-extra`.
+        #[handler]
+        fn on_extra(
+            _state: &mut Self::State,
+            _ctx: &mut NativeCtx<'_>,
+            _request: HttpServerRequest,
+        ) -> HttpServerResponse {
+            HttpServerResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: b"wired-raw".to_vec(),
+            }
+        }
+
+        /// The macro route whose registration is appended to `wire`.
+        #[http::route(any, "/wired")]
+        fn on_wired(
+            _state: &mut WiredRouteHandlerState,
+            _ctx: http::Ctx<'_, NativeCtx<'_>>,
+        ) -> HttpServerResponse {
+            HttpServerResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: b"wired-macro".to_vec(),
+            }
+        }
+    }
+
+    /// A macro-authored routed handler that claims its prefixes through
+    /// `#[http::route]` and replies `200` with a fixed tag body. Drives
+    /// the longest-prefix and method-filter precedence tests through the
+    /// typed authoring surface (the macro emits the registration).
     macro_rules! routed_handler {
+        ($ty:ident, $state:ident, $namespace:literal, $tag:literal,
+         $method:ident, $prefix:literal) => {
+            pub struct $ty;
+            pub struct $state;
+
+            #[http::router]
+            #[actor(singleton)]
+            impl NativeActor for $ty {
+                type State = $state;
+                type Config = ();
+                const NAMESPACE: &'static str = $namespace;
+
+                fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<$state, BootError> {
+                    Ok($state)
+                }
+
+                #[http::route($method, $prefix)]
+                fn on_route(
+                    _state: &mut $state,
+                    _ctx: http::Ctx<'_, NativeCtx<'_>>,
+                ) -> HttpServerResponse {
+                    HttpServerResponse {
+                        status: 200,
+                        headers: Vec::new(),
+                        body: $tag.to_vec(),
+                    }
+                }
+            }
+        };
+    }
+
+    routed_handler!(
+        ApiV2Handler,
+        ApiV2HandlerState,
+        "aether.http.test_route_api_v2",
+        b"api-v2",
+        any,
+        "/api/v2"
+    );
+    routed_handler!(
+        MethodPostHandler,
+        MethodPostHandlerState,
+        "aether.http.test_route_post_m",
+        b"post-m",
+        Post,
+        "/m"
+    );
+    routed_handler!(
+        MethodAnyHandler,
+        MethodAnyHandlerState,
+        "aether.http.test_route_any_m",
+        b"any-m",
+        any,
+        "/m"
+    );
+
+    /// A raw-surface routed handler that hand-writes its `wire`
+    /// registration with the generic request kind and replies `200` with
+    /// a fixed tag body. The conflict-`Err` and idempotent double-claim
+    /// tests key on the protocol directly, so they stay on this raw
+    /// surface rather than the macro's — a macro regression cannot then
+    /// mask a registration-semantics regression.
+    macro_rules! raw_routed_handler {
         ($ty:ident, $state:ident, $namespace:literal, $tag:literal,
          [$(($method:expr, $prefix:literal)),+ $(,)?]) => {
             pub struct $ty;
@@ -183,35 +336,17 @@ mod test_handlers {
         };
     }
 
-    routed_handler!(
-        ApiV2Handler,
-        ApiV2HandlerState,
-        "aether.http.test_route_api_v2",
-        b"api-v2",
-        [(None, "/api/v2")]
-    );
-    routed_handler!(
-        MethodPostHandler,
-        MethodPostHandlerState,
-        "aether.http.test_route_post_m",
-        b"post-m",
-        [(Some(HttpMethod::Post), "/m")]
-    );
-    routed_handler!(
-        MethodAnyHandler,
-        MethodAnyHandlerState,
-        "aether.http.test_route_any_m",
-        b"any-m",
-        [(None, "/m")]
-    );
-    routed_handler!(
+    // The first claimant sends its `/dup` claim twice, pinning the
+    // idempotent same-mailbox re-claim (both `Ok`) alongside the
+    // cross-mailbox conflict the second claimant loses.
+    raw_routed_handler!(
         DupFirstHandler,
         DupFirstHandlerState,
         "aether.http.test_route_dup_first",
         b"first",
-        [(None, "/dup")]
+        [(None, "/dup"), (None, "/dup")]
     );
-    routed_handler!(
+    raw_routed_handler!(
         DupSecondHandler,
         DupSecondHandlerState,
         "aether.http.test_route_dup_second",
@@ -1282,6 +1417,36 @@ fn routed_prefix_dispatches_as_registered_kind() {
     );
 }
 
+/// A macro-authored route with a real `FromRequest` extractor dispatches
+/// the routed method with the extracted value on success, and — when the
+/// extractor returns `Err` — replies that response without ever calling
+/// the handler (ADR-0131's typed `400` boundary), both over the wire.
+#[test]
+fn routed_extractor_success_and_failure() {
+    let chassis = routed_chassis!(ExtractRouteHandler);
+    let port = port_of(&chassis);
+
+    // Success: the extracted `name` reaches the handler and is echoed.
+    poll_body(
+        port,
+        b"GET /extract?name=ada HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        "hello:ada",
+    );
+
+    // Failure: with the route proven live, a request missing `name`
+    // short-circuits to the extractor's 400 response body.
+    let missing = round_trip(port, b"GET /extract HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    assert!(
+        missing.starts_with("HTTP/1.1 400 "),
+        "extractor Err becomes the reply status: {missing:?}",
+    );
+    assert_eq!(
+        body_of(&missing),
+        "missing name query parameter",
+        "extractor Err body is replied verbatim",
+    );
+}
+
 /// Longest prefix wins among overlapping routes, matching stops at
 /// segment boundaries (`/apiary` is not under `/api`), and an exact
 /// prefix hit routes (ADR-0130).
@@ -1361,6 +1526,29 @@ fn conflicting_claim_is_rejected_first_claimant_keeps_route() {
 
     let dup = round_trip(port, b"GET /dup HTTP/1.1\r\nHost: localhost\r\n\r\n");
     assert_eq!(body_of(&dup), "first", "first claimant keeps the route");
+}
+
+/// A macro route composes with a hand-written `wire`: the macro appends
+/// its `/wired` registration to the author's `wire` without displacing
+/// the raw `/wired-extra` claim already there, so both dispatch (ADR-0131
+/// append path).
+#[test]
+fn hand_written_wire_and_macro_route_compose() {
+    let chassis = routed_chassis!(WiredRouteHandler);
+    let port = port_of(&chassis);
+
+    // The macro-appended registration reaches the cap.
+    poll_body(
+        port,
+        b"GET /wired HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        "wired-macro",
+    );
+    // The author's own `wire` registration survived the append.
+    poll_body(
+        port,
+        b"GET /wired-extra HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        "wired-raw",
+    );
 }
 
 /// `unregister_route_self` releases the sender's route: the first

--- a/crates/aether-capabilities/src/http/typed.rs
+++ b/crates/aether-capabilities/src/http/typed.rs
@@ -1,0 +1,109 @@
+//! The typed route-authoring runtime surface (ADR-0131): the trait and
+//! ctx types the `#[http::router]` / `#[http::route]` macros compile
+//! down to. Always-on and wasm-safe — it names only `HttpServerRequest`
+//! / `HttpServerResponse` / `HttpMethod` from `kinds.rs` and the core
+//! `Deref` machinery, so a `default-features = false` guest that authors
+//! routes gets it without the native runtime.
+//!
+//! ADR-0130 forecloses cap-side field extraction: the wire payload for a
+//! routed kind is always request-shaped, so parsing a request into
+//! domain values is guest-side, ordinary type-checked Rust. [`FromRequest`]
+//! is that parse; its `Err` is the response the glue replies with,
+//! typically a `400`.
+
+use core::ops::{Deref, DerefMut};
+
+use super::kinds::{HttpMethod, HttpServerRequest, HttpServerResponse};
+
+/// Parse a value out of an inbound [`HttpServerRequest`]. The `Ok` value
+/// is threaded to a routed method as a parameter; the `Err` is the
+/// [`HttpServerResponse`] the generated glue replies with instead of
+/// calling the handler — the boundary where a malformed request becomes
+/// a `400` rather than an ad-hoc parse failure inside the handler.
+///
+/// Implement it for the domain types a route wants to receive
+/// (`Json<T>`, a path capture, a validated query struct). The blanket
+/// impl for [`HttpServerRequest`] itself hands a handler the raw request
+/// as a parameter.
+pub trait FromRequest: Sized {
+    /// Parse `self` from `request`, or return the response to send in
+    /// place of dispatching the handler.
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`HttpServerResponse`] (typically a `400`) to reply
+    /// with when the request cannot be parsed into this type.
+    fn from_request(request: &HttpServerRequest) -> Result<Self, HttpServerResponse>;
+}
+
+/// Identity extractor: a routed method that wants the whole request as a
+/// parameter takes an `HttpServerRequest`, cloned from the dispatched
+/// payload.
+impl FromRequest for HttpServerRequest {
+    fn from_request(request: &HttpServerRequest) -> Result<Self, HttpServerResponse> {
+        Ok(request.clone())
+    }
+}
+
+/// The route a glue handler serves — compile-time constants the
+/// `#[http::route]` macro stamps in, surfaced through [`Ctx::route`].
+/// `prefix` is the claimed path prefix; `method` is the method filter
+/// (`None` for a method-agnostic route).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Route {
+    /// The path prefix this route claimed.
+    pub prefix: &'static str,
+    /// The HTTP method filter, or `None` for a method-agnostic route.
+    pub method: Option<HttpMethod>,
+}
+
+/// The routing ctx handed to a routed method: the transport ctx (`C` —
+/// `WasmCtx` or `NativeCtx`) plus the original request and the matched
+/// route. Derefs to `C`, so a routed method sends mail and reaches
+/// capabilities exactly as an ordinary handler does; [`Ctx::request`]
+/// and [`Ctx::route`] are both total because a routed payload is always
+/// request-shaped (ADR-0130) and the route is known statically per glue
+/// handler.
+pub struct Ctx<'a, C> {
+    transport: &'a mut C,
+    request: HttpServerRequest,
+    route: Route,
+}
+
+impl<'a, C> Ctx<'a, C> {
+    /// Wrap a transport ctx with the dispatched request and matched
+    /// route. Called by the `#[http::route]` glue, not by hand.
+    pub fn new(transport: &'a mut C, request: HttpServerRequest, route: Route) -> Self {
+        Self {
+            transport,
+            request,
+            route,
+        }
+    }
+
+    /// The original inbound request this route dispatched.
+    #[must_use]
+    pub fn request(&self) -> &HttpServerRequest {
+        &self.request
+    }
+
+    /// The route that selected this handler.
+    #[must_use]
+    pub fn route(&self) -> Route {
+        self.route
+    }
+}
+
+impl<C> Deref for Ctx<'_, C> {
+    type Target = C;
+
+    fn deref(&self) -> &C {
+        self.transport
+    }
+}
+
+impl<C> DerefMut for Ctx<'_, C> {
+    fn deref_mut(&mut self) -> &mut C {
+        self.transport
+    }
+}

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -25,6 +25,12 @@
 //! [`NativeActor`]: aether_substrate::actor::native::NativeActor
 //! [`Addressable`]: aether_actor::Addressable
 
+// ADR-0131: self-alias so the `#[http::router]` macro's emitted
+// `::aether_capabilities::…` paths resolve inside this crate's own
+// route fixtures (the pattern `aether-actor` / `aether-substrate`
+// already use for their derive-emitted paths).
+extern crate self as aether_capabilities;
+
 // `aether.anthropic` content-gen cap (ADR-0050, issue 1014). Native-
 // only — embeds the native-only contentgen dispatch helper and makes
 // blocking ureq / subprocess calls.

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -22,13 +22,13 @@
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::ComponentHostCapability;
+use aether_capabilities::http;
 use aether_capabilities::http::HttpServerCapability;
 use aether_capabilities::http::kinds::{
     HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen, HttpServerRequest,
-    HttpServerResponse, HttpStreamCredit, RegisterRouteSelf, WebSocketAccept, WebSocketClose,
-    WebSocketMessage,
+    HttpServerResponse, HttpStreamCredit, WebSocketAccept, WebSocketClose, WebSocketMessage,
 };
-use aether_data::{Kind as _, MailboxId};
+use aether_data::MailboxId;
 use aether_kinds::DropComponent;
 
 pub struct HttpHandler;
@@ -240,16 +240,19 @@ impl WasmActor for WebSocketHandler {
 }
 
 /// Routed sibling of [`HttpHandler`] for the ADR-0130 drop-purge e2e
-/// test: claims `/routed` from `wire` via `register_route_self` (the
-/// same declaration path a real component takes) and replies a fixed
-/// tag. `GET /routed/drop` doubles as the test's mail bridge into the
-/// chassis — the request body carries a decimal trampoline mailbox id,
-/// and the handler forwards a [`DropComponent`] for it to
-/// `aether.component` (detached: the drop teardown is not part of the
-/// request's causal chain), so the test can drop this component from
-/// outside without a chassis-level mail surface.
+/// test, authored through the typed route surface (`#[http::router]` /
+/// `#[http::route]`, ADR-0131): the macro mints the route's kind and
+/// injects the `register_route_self` registration, so this fixture is
+/// the wasm32 + `Lifecycle<S>` universality proof for the macro layer.
+/// It replies a fixed tag for `/routed`. `GET /routed/drop` doubles as
+/// the test's mail bridge into the chassis — the request body carries a
+/// decimal trampoline mailbox id, and the handler forwards a
+/// [`DropComponent`] for it to `aether.component` (detached: the drop
+/// teardown is not part of the request's causal chain), so the test can
+/// drop this component from outside without a chassis-level mail surface.
 pub struct RoutedHttpHandler;
 
+#[http::router]
 #[actor]
 impl WasmActor for RoutedHttpHandler {
     const NAMESPACE: &'static str = "routed_web";
@@ -258,24 +261,23 @@ impl WasmActor for RoutedHttpHandler {
         Ok(RoutedHttpHandler)
     }
 
-    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
-        ctx.actor::<HttpServerCapability>()
-            .send(&RegisterRouteSelf {
-                prefix: "/routed".to_string(),
-                method: None,
-                kind: HttpServerRequest::ID,
-            });
-    }
-
     /// Reply a fixed tag for anything under `/routed`; on
     /// `/routed/drop` also forward a [`DropComponent`] for the mailbox
-    /// id named in the request body.
+    /// id named in the request body. The request arrives via the
+    /// identity [`HttpServerRequest`] extractor; `ctx` derefs to
+    /// `WasmCtx`, so the detached `DropComponent` send reads exactly as
+    /// an ordinary handler's.
     ///
     /// # Agent
     /// Not sent manually — dispatched by `aether.http.server` for the
-    /// `/routed` prefix this actor claims in `wire`.
-    #[handler]
-    fn on_request(&mut self, ctx: &mut WasmCtx<'_>, req: HttpServerRequest) -> HttpServerResponse {
+    /// `/routed` prefix this actor claims (the `#[http::route]` macro
+    /// injects the registration into `wire`).
+    #[http::route(any, "/routed")]
+    fn on_routed(
+        &mut self,
+        ctx: http::Ctx<'_, WasmCtx<'_>>,
+        req: HttpServerRequest,
+    ) -> HttpServerResponse {
         if req.path == "/routed/drop" {
             let target = String::from_utf8_lossy(&req.body).trim().parse::<u64>();
             let Ok(raw_id) = target else {

--- a/docs/adr/0131-typed-route-authoring-surface-for-the-http-server.md
+++ b/docs/adr/0131-typed-route-authoring-surface-for-the-http-server.md
@@ -1,6 +1,6 @@
 # ADR-0131: Typed Route Authoring Surface for the HTTP Server
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-07-03
 
 Realizes the guest-side typed-routing layer **ADR-0130** decided and scoped as its follow-on arc. Builds on **ADR-0033** / **ADR-0123** (the `#[actor]` dispatch macro and its impl-hosted / struct-hosted forms), **ADR-0121** (capabilities own their kinds), and the shared `Lifecycle<S>` hook of iamacoffeepot/aether#2048.

--- a/docs/guide/recipes/serving-http.md
+++ b/docs/guide/recipes/serving-http.md
@@ -145,6 +145,81 @@ kind — a struct with `aether.http.server.request`'s fields under its own
 `describe_component` entry and `actor_cost` row; the payload bytes are always
 request-shaped, so the route kind decodes them directly.
 
+## Typed route authoring
+
+The typed surface writes that whole registration for you (ADR-0131). Put
+`#[http::router]` on the actor's impl block, above `#[actor]`, and
+`#[http::route(<Method|any>, "<prefix>")]` on a method; the macros mint the
+route's request-shaped kind, inject the `register_route_self` send into `wire`,
+and turn the method into the route's `#[handler]`. A routed method takes an
+`http::Ctx<'_, C>` — the transport ctx (`WasmCtx` here) plus the request and
+matched route, dereffing to the ctx so mail sends read as usual — and returns
+`HttpServerResponse`:
+
+```rust
+use aether_capabilities::http;
+use aether_capabilities::http::kinds::{HttpServerRequest, HttpServerResponse};
+
+#[http::router]
+#[actor]
+impl WasmActor for ApiHandler {
+    const NAMESPACE: &'static str = "api";
+
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(ApiHandler)
+    }
+
+    #[http::route(Get, "/api/users")]
+    fn list_users(&mut self, ctx: http::Ctx<'_, WasmCtx<'_>>) -> HttpServerResponse {
+        HttpServerResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: format!("path: {}", ctx.request().path).into_bytes(),
+        }
+    }
+}
+```
+
+To parse a request into domain values, add parameters that implement
+`http::FromRequest`. Each runs in declaration order before the method body; the
+first one that returns `Err` becomes the reply — the boundary where a malformed
+request turns into a `400` instead of ad-hoc parsing inside the handler:
+
+```rust
+struct UserId(u64);
+
+impl http::FromRequest for UserId {
+    fn from_request(request: &HttpServerRequest) -> Result<Self, HttpServerResponse> {
+        request
+            .path
+            .rsplit('/')
+            .next()
+            .and_then(|seg| seg.parse().ok())
+            .map(UserId)
+            .ok_or(HttpServerResponse {
+                status: 400,
+                headers: Vec::new(),
+                body: b"expected a numeric user id".to_vec(),
+            })
+    }
+}
+
+#[http::route(Get, "/api/users")]
+fn get_user(&mut self, _ctx: http::Ctx<'_, WasmCtx<'_>>, id: UserId) -> HttpServerResponse {
+    // `id` is already parsed; a bad id never reaches here.
+    HttpServerResponse { status: 200, headers: Vec::new(), body: format!("user {}", id.0).into_bytes() }
+}
+```
+
+An `HttpServerRequest` parameter hands the method the whole request (the
+identity extractor). The same surface serves native actors — a routed method on
+an `impl NativeActor` takes `http::Ctx<'_, NativeCtx<'_>>` with a
+`state: &mut YourState` first parameter, and the macros write the native `wire`.
+
+Drop to the raw `register_route_self` surface above for a streaming route
+(`HttpResponseStreamOpen`) — the typed surface returns `HttpServerResponse`, so
+a streamed response keeps its own hand-written `#[handler]`.
+
 ## What happens when the handler doesn't reply
 
 If the handler receives the request but returns without calling `ctx.reply`, the
@@ -249,5 +324,6 @@ purely opt-in per reply.
 
 This recipe names the env keys and kind names live in the source. Before
 following it, confirm `AETHER_HTTP_SERVER_ENABLED`, `HttpServerRequest`,
-`HttpServerResponse`, and `HttpServerConfig` still exist where named — grep the
-crates, and if a name has drifted, fix the recipe as part of your work.
+`HttpServerResponse`, `HttpServerConfig`, and the `http::{router, route,
+FromRequest, Ctx}` authoring surface still exist where named — grep the crates,
+and if a name has drifted, fix the recipe as part of your work.


### PR DESCRIPTION
Closes #2568.

## Summary

Realizes ADR-0131, the typed route-authoring surface over the `aether.http.server` route-registration protocol (ADR-0130). A routed handler is now authored declaratively instead of by hand-minting a kind, hand-writing the `wire` registration, and hand-parsing the request:

- **`aether-capabilities-derive`** (new proc-macro crate, a leaf below `aether-capabilities`) hosts `#[http::router]` / `#[http::route]`, re-exported through the wasm-safe `http` module. `#[http::router]` sits above `#[actor]` (outer-first expansion): per route it mints a `#[doc(hidden)]` single-field `{ request: HttpServerRequest }` wrapper kind (layout agreement with the request is structural, so it decodes byte-for-byte however `HttpServerRequest` grows), rewrites the method into `#[handler]` glue that runs each `FromRequest` extractor in order (first `Err` becomes the reply, typically a 400), and injects the `register_route_self` send into `wire` — appended to a hand-written `wire` or synthesized when there is none.
- **`http::FromRequest` / `http::Ctx<'_, C>` / `http::Route`** — the runtime types the macros compile down to. `Ctx` derefs to the transport ctx (`WasmCtx` / `NativeCtx`), so a routed method sends mail as an ordinary handler does; `request()` / `route()` are total.
- Universal over both transports: the rewrite copies the receiver and ctx shapes from the routed method, so one macro serves `impl WasmActor` and split `impl NativeActor` alike.

The http server's native route fixtures and the `RoutedHttpHandler` wasm fixture are rewritten against the macro surface, so the tests exercise what a consumer author writes. The conflict-`Err` and idempotent double-claim fixtures stay on the raw registration surface, so a macro regression cannot mask a registration-semantics one. `docs/guide/recipes/serving-http.md` gains the typed-authoring recipe.

## Test plan

- `aether-capabilities` route tests (native, in-process): routed dispatch decodes the payload under the minted kind and echoes it; a real `FromRequest` extractor threads its value on success and short-circuits to its 400 over the wire on failure; longest-prefix, method-precedence, self-unregister, conflict-`Err`, and idempotent double-claim all pass; a hand-written `wire` composes with a macro route (the append path).
- `aether-test-fixtures-bundle` cross-builds for `wasm32-unknown-unknown` (the macro layer compiles on the wasm transport), and the `dropped_component_routes_are_purged` e2e drives the macro-authored `/routed` route through the full drop-purge over real wasm.
- Derive-crate unit tripwire on the snake→camel minted-name fold.

## Generated by

`/implement` — agent execution of [scoped issue #2568](https://github.com/iamacoffeepot/aether/issues/2568).
