### PR TITLE
fix(capabilities): streamed http responses ignore keep-alive and close the connection

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/render.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/render.rs
@@ -68,7 +68,10 @@ pub fn render_status_response(status: u16, message: &str) -> Vec<u8> {
 /// Render the response head for a streamed response (ADR-0128): the status
 /// line, the handler's headers (cap-owned ones stripped), `Transfer-Encoding:
 /// chunked` in place of `Content-Length`, and `Date` / `Connection`.
-pub fn render_stream_head(open: &HttpResponseStreamOpen) -> Vec<u8> {
+/// `keep_alive` renders `Connection: keep-alive` (the connection is held for
+/// the next request once the stream ends) vs `Connection: close`, exactly
+/// like [`render_handler_response`]'s buffered decision.
+pub fn render_stream_head(open: &HttpResponseStreamOpen, keep_alive: bool) -> Vec<u8> {
     use std::fmt::Write as _;
     let mut head = format!(
         "HTTP/1.1 {} {}\r\n",
@@ -83,7 +86,11 @@ pub fn render_stream_head(open: &HttpResponseStreamOpen) -> Vec<u8> {
     }
     head.push_str("Transfer-Encoding: chunked\r\n");
     let _ = write!(head, "Date: {}\r\n", http_date(SystemTime::now()));
-    head.push_str("Connection: close\r\n\r\n");
+    if keep_alive {
+        head.push_str("Connection: keep-alive\r\n\r\n");
+    } else {
+        head.push_str("Connection: close\r\n\r\n");
+    }
     head.into_bytes()
 }
 

--- a/crates/aether-capabilities/src/http/server/runtime/streaming.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/streaming.rs
@@ -135,13 +135,16 @@ impl HttpServerCapabilityState {
         // once here (it just replied, so it is live) and store it on the
         // stream for credit grants; a missing handler leaves the sentinel and
         // credit sends drop harmlessly, the pre-store no-op behavior.
-        self.in_flight.remove(&stream_id);
+        let keep_alive = self
+            .in_flight
+            .remove(&stream_id)
+            .is_some_and(|pending| pending.keep_alive);
         let handler = self
             .mailer
             .registry()
             .lookup(&self.handler_mailbox)
             .unwrap_or(MailboxId(0));
-        let head = render_stream_head(open);
+        let head = render_stream_head(open, keep_alive);
         self.write_raw_to(conn_id, &head);
 
         let Some(conn) = self.connections.get(&conn_id) else {
@@ -202,6 +205,7 @@ impl HttpServerCapabilityState {
                 writer_thread: Some(writer_thread),
                 credit_outstanding: window,
                 pending_end: false,
+                keep_alive,
             },
         );
         // Grant the initial credit window — the handler learns its
@@ -280,14 +284,26 @@ impl HttpServerCapabilityState {
         self.try_flush_end(stream_id);
     }
 
-    /// A writer thread finished (ADR-0128) — tear the stream down and close
-    /// its connection.
+    /// A writer thread finished (ADR-0128) — tear the stream down, then
+    /// either resume the connection for the next request (keep-alive,
+    /// mirroring the buffered path's decision) or close it. A keep-alive
+    /// stream that outran the reader's response deadline finds the reader
+    /// already gone; `resume_connection`'s send fails and it falls back to
+    /// `close_connection` on that same path.
     pub fn finish_stream(&mut self, stream_id: u64) {
-        let Some(conn_id) = self.streams.get(&stream_id).map(|stream| stream.conn_id) else {
+        let Some((conn_id, keep_alive)) = self
+            .streams
+            .get(&stream_id)
+            .map(|stream| (stream.conn_id, stream.keep_alive))
+        else {
             return;
         };
         self.teardown_stream(stream_id);
-        self.close_connection(conn_id, "stream finished");
+        if keep_alive {
+            self.resume_connection(conn_id);
+        } else {
+            self.close_connection(conn_id, "stream finished");
+        }
     }
 
     /// Try to hand a deferred terminator to the writer; on success clear the

--- a/crates/aether-capabilities/src/http/server/runtime/types.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/types.rs
@@ -281,6 +281,12 @@ pub struct StreamState {
     /// fit the bounded channel yet (chunks still queued). Flushed as slots
     /// free so the terminating chunk always follows the body in order.
     pub pending_end: bool,
+    /// Whether the connection is kept alive once this stream finishes
+    /// (renders `Connection: keep-alive` in the stream head and resumes the
+    /// reader at [`HttpServerCapabilityState::finish_stream`]) rather than
+    /// closing it. Set from the promoted request's [`PendingRequest`] at
+    /// stream open, mirroring `PendingRequest::keep_alive`.
+    pub keep_alive: bool,
 }
 
 /// Per-connection *inbound* request-stream state (ADR-0128), keyed in

--- a/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
@@ -1,7 +1,8 @@
 use super::{
-    OPCODE_BINARY, OPCODE_CONTINUATION, OPCODE_TEXT, WsFrameParse, http_date, normalize_prefix,
-    parse_http_method, parse_ws_frame, percent_decode_path, reason_phrase, request_keeps_alive,
-    route_matches, sec_websocket_accept, serialize_ws_frame, sha1, validate_ws_handshake,
+    HttpResponseStreamOpen, OPCODE_BINARY, OPCODE_CONTINUATION, OPCODE_TEXT, WsFrameParse,
+    http_date, normalize_prefix, parse_http_method, parse_ws_frame, percent_decode_path,
+    reason_phrase, render_stream_head, request_keeps_alive, route_matches, sec_websocket_accept,
+    serialize_ws_frame, sha1, validate_ws_handshake,
 };
 use crate::http::kinds::{HttpHeader, HttpMethod};
 use std::time::{Duration, UNIX_EPOCH};
@@ -73,6 +74,24 @@ fn known_methods_map_unknown_is_none() {
     assert_eq!(parse_http_method("OPTIONS"), Some(HttpMethod::Options));
     assert_eq!(parse_http_method("FROB"), None);
     assert_eq!(parse_http_method("get"), None);
+}
+
+/// Tripwire: `render_stream_head`'s `Connection` disposition is branch logic
+/// over its `keep_alive` argument, not a hardcoded `close` — pins the ADR-0128
+/// keep-alive-after-stream fix (issue #2582) at the unit level.
+#[test]
+fn render_stream_head_honors_keep_alive() {
+    let open = HttpResponseStreamOpen {
+        status: 200,
+        headers: vec![],
+    };
+    let keep_alive_head = String::from_utf8(render_stream_head(&open, true)).expect("head is utf8");
+    assert!(keep_alive_head.contains("Connection: keep-alive\r\n"));
+    assert!(!keep_alive_head.contains("Connection: close"));
+
+    let close_head = String::from_utf8(render_stream_head(&open, false)).expect("head is utf8");
+    assert!(close_head.contains("Connection: close\r\n"));
+    assert!(!close_head.contains("Connection: keep-alive"));
 }
 
 #[test]

--- a/crates/aether-capabilities/src/http/server/runtime/websocket.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/websocket.rs
@@ -577,6 +577,11 @@ impl HttpServerCapabilityState {
                 writer_thread: Some(writer_thread),
                 credit_outstanding: window,
                 pending_end: false,
+                // A websocket's `StreamFinished` (the close handshake's final
+                // write, a protocol error, or an idle timeout) always tears
+                // the connection down — there is no keep-alive resume once a
+                // connection has upgraded.
+                keep_alive: false,
             },
         );
         if let Some(conn) = self.connections.get_mut(&conn_id) {

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -1631,6 +1631,44 @@ fn content_length_of(head: &[u8]) -> usize {
     0
 }
 
+/// Read exactly one *chunked* transfer-encoding HTTP/1.1 response off
+/// `stream` (a streamed response, ADR-0128) — the head up to its blank line,
+/// then the chunked body up to and including its terminating zero-length
+/// chunk (`0\r\n\r\n`) — leaving any bytes read past it (a pipelined next
+/// response) in `carry` for the following call. The chunked mirror of
+/// [`read_one_response`], which only handles the buffered `Content-Length`
+/// case.
+fn read_one_chunked_response(stream: &mut TcpStream, carry: &mut Vec<u8>) -> String {
+    let mut chunk = [0u8; 4096];
+    let head_end = loop {
+        if let Some(pos) = carry.windows(4).position(|window| window == b"\r\n\r\n") {
+            break pos + 4;
+        }
+        let n = stream.read(&mut chunk).expect("read response head");
+        assert!(
+            n > 0,
+            "eof before response head; buffered: {:?}",
+            String::from_utf8_lossy(carry),
+        );
+        carry.extend_from_slice(&chunk[..n]);
+    };
+    let terminator = b"0\r\n\r\n";
+    let body_end = loop {
+        if let Some(pos) = carry[head_end..]
+            .windows(terminator.len())
+            .position(|window| window == terminator)
+        {
+            break head_end + pos + terminator.len();
+        }
+        let n = stream.read(&mut chunk).expect("read chunked response body");
+        assert!(n > 0, "eof mid chunked response body");
+        carry.extend_from_slice(&chunk[..n]);
+    };
+    let response = String::from_utf8_lossy(&carry[..body_end]).into_owned();
+    carry.drain(..body_end);
+    response
+}
+
 /// Assert that the next read on `stream` observes the server's close (EOF).
 /// The stream's read timeout bounds this so a server that failed to close
 /// surfaces as a timeout rather than a hang.
@@ -1715,6 +1753,109 @@ fn keep_alive_serves_sequential_requests_on_one_socket() {
     assert!(
         third.contains("Connection: close\r\n"),
         "third response closes: {third:?}",
+    );
+    assert_closed(&mut stream);
+}
+
+/// Tripwire (issue #2582): a streamed (chunked) response to a keep-alive
+/// request renders `Connection: keep-alive` and the socket is reused for a
+/// second request — the streamed mirror of
+/// [`keep_alive_serves_sequential_requests_on_one_socket`]. Before the fix,
+/// `render_stream_head` hardcoded `Connection: close` and `finish_stream`
+/// unconditionally closed the connection, so this second read would hang /
+/// fail against the pre-fix behavior.
+#[test]
+fn keep_alive_reuses_socket_after_streamed_response() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<StreamHttpHandler>(())
+        .with_actor::<HttpServerCapability>(stream_config_for(
+            <StreamHttpHandler as Addressable>::NAMESPACE,
+            8,
+        ))
+        .build_passive()
+        .expect("caps boot");
+    let port = port_of(&chassis);
+
+    let mut stream =
+        TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to http server");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set_read_timeout");
+    let mut carry: Vec<u8> = Vec::new();
+
+    let expected: Vec<u8> = (0..STREAM_CHUNK_COUNT)
+        .flat_map(stream_chunk_body)
+        .collect();
+
+    // First streamed request, HTTP/1.1 default (no `Connection: close`).
+    stream
+        .write_all(b"GET /stream HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .expect("write first request");
+    stream.flush().expect("flush");
+    let first = read_one_chunked_response(&mut stream, &mut carry);
+    assert!(first.starts_with("HTTP/1.1 200 OK\r\n"), "{first:?}");
+    assert!(
+        first.contains("Connection: keep-alive\r\n"),
+        "streamed response keeps alive: {first:?}",
+    );
+    assert_eq!(
+        dechunk(body_of(&first)).into_bytes(),
+        expected,
+        "first stream reassembles in order",
+    );
+
+    // The reuse invariant: a second request on the same socket after the
+    // stream ended gets served rather than the socket being closed.
+    stream
+        .write_all(b"GET /stream HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .expect("write second request");
+    stream.flush().expect("flush");
+    let second = read_one_chunked_response(&mut stream, &mut carry);
+    assert!(second.starts_with("HTTP/1.1 200 OK\r\n"), "{second:?}");
+    assert!(
+        second.contains("Connection: keep-alive\r\n"),
+        "second streamed response keeps alive too: {second:?}",
+    );
+    assert_eq!(
+        dechunk(body_of(&second)).into_bytes(),
+        expected,
+        "second stream reassembles in order",
+    );
+}
+
+/// Pins the negative alongside the reuse tripwire above: a streamed request
+/// carrying `Connection: close` still tears the socket down once the stream
+/// ends, exactly like the buffered path.
+#[test]
+fn streamed_response_honors_explicit_connection_close() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<StreamHttpHandler>(())
+        .with_actor::<HttpServerCapability>(stream_config_for(
+            <StreamHttpHandler as Addressable>::NAMESPACE,
+            8,
+        ))
+        .build_passive()
+        .expect("caps boot");
+    let port = port_of(&chassis);
+
+    let mut stream =
+        TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to http server");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set_read_timeout");
+    let mut carry: Vec<u8> = Vec::new();
+
+    stream
+        .write_all(b"GET /stream HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .expect("write request");
+    stream.flush().expect("flush");
+    let response = read_one_chunked_response(&mut stream, &mut carry);
+    assert!(response.starts_with("HTTP/1.1 200 OK\r\n"), "{response:?}");
+    assert!(
+        response.contains("Connection: close\r\n"),
+        "streamed response honors explicit close: {response:?}",
     );
     assert_closed(&mut stream);
 }


### PR DESCRIPTION
Closes #2582.

## Summary

A streamed (chunked) HTTP server response always sent `Connection: close` and tore the socket down at `HttpResponseStreamEnd`, ignoring the request's computed keep-alive — so a keep-alive client could not reuse the connection after a stream, even though the buffered path honored it. Chunked transfer-encoding's zero-length terminating chunk self-delimits the body, so reuse after a stream is protocol-legal (ADR-0128).

Threads the request's `keep_alive` bit (previously discarded when the stream opened) through the streaming path, mirroring the buffered path's decision: `render_stream_head` renders `Connection: keep-alive` vs `close`; `StreamState` carries the bit; `finish_stream` branches `resume_connection` vs `close_connection`. A websocket close always tears down (`keep_alive: false`).

## Test plan

`render_stream_head` unit tripwire on the `Connection:` header; two real-socket tests in `http/server/tests.rs` — `keep_alive_reuses_socket_after_streamed_response` (reuse) and `streamed_response_honors_explicit_connection_close` (close still closes). Full `cargo nextest run --workspace` green (1793 passed), clippy + rustdoc clean.

## Generated by

`/implement` — agent execution of scoped issue #2582.
