### PR TITLE
fix(capabilities): native build of a marker-only component crate fails inside aether-capabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,26 @@ jobs:
             -D rustdoc::private_intra_doc_links
         run: cargo doc --workspace --no-deps
 
+  # Marker-only host build (iamacoffeepot/aether#2583). The transport-only
+  # tier — `aether-capabilities` with `default-features = false`, so the
+  # `runtime` feature is off — must compile on the host triple, the config a
+  # component author's reflexive `cargo build` hits against a marker-only
+  # consumer. The other jobs never exercise it: clippy / docs / test build
+  # `--workspace`, where resolver-3 feature unification turns `runtime` back on
+  # for the crate (ADR-0122 §33), and the wasm cross-build elides the native
+  # half. So this guard is an isolated `-p` build — never `--workspace`, which
+  # would mask the failure vacuously.
+  marker-build:
+    name: Marker-only host build
+    needs: changes
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.attested != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build -p aether-capabilities --no-default-features
+
   # Workspace-wide tests run on linux only. Non-chassis crates
   # (aether-kinds, aether-data, aether-actor, aether-actor-derive,
   # demo components) are pure Rust with no per-OS behavior — a matrix
@@ -342,7 +362,7 @@ jobs:
   ci-pass:
     name: CI pass
     if: always()
-    needs: [ changes, fmt, hook-tests, clippy, docs, test, desktop, qodana ]
+    needs: [ changes, fmt, hook-tests, clippy, docs, marker-build, test, desktop, qodana ]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
@@ -352,6 +372,7 @@ jobs:
           echo "hook-tests: ${{ needs.hook-tests.result }}"
           echo "clippy:  ${{ needs.clippy.result }}"
           echo "docs:    ${{ needs.docs.result }}"
+          echo "marker-build: ${{ needs.marker-build.result }}"
           echo "test:    ${{ needs.test.result }}"
           echo "desktop: ${{ needs.desktop.result }}"
           echo "qodana:  ${{ needs.qodana.result }}"
@@ -361,6 +382,7 @@ jobs:
           [[ "${{ needs.hook-tests.result }}" == "success" ]] || fail=1
           [[ "${{ needs.clippy.result }}"  == "success" || "${{ needs.clippy.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.docs.result }}"    == "success" || "${{ needs.docs.result }}" == "skipped" ]] || fail=1
+          [[ "${{ needs.marker-build.result }}" == "success" || "${{ needs.marker-build.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.test.result }}"    == "success" || "${{ needs.test.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.desktop.result }}" == "success" || "${{ needs.desktop.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.qodana.result }}"  == "success" || "${{ needs.qodana.result }}" == "skipped" ]] || fail=1

--- a/crates/aether-capabilities/src/component/mod.rs
+++ b/crates/aether-capabilities/src/component/mod.rs
@@ -51,7 +51,7 @@
 #![allow(clippy::needless_pass_by_value)]
 
 mod route;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub use route::ComponentHostNativeExt;
 pub use route::{ComponentHostWasmExt, resolve_embedded};
 

--- a/crates/aether-capabilities/src/component/route.rs
+++ b/crates/aether-capabilities/src/component/route.rs
@@ -2,7 +2,7 @@
 //! the "routing" seam of the `aether.component` capability.
 
 use aether_actor::{Addressable, WasmActorMailbox};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 use aether_substrate::actor::native::NativeActorMailbox;
 
 use super::ComponentHostCapability;
@@ -48,7 +48,7 @@ impl ComponentHostWasmExt for WasmActorMailbox<'_, ComponentHostCapability> {
 /// returned handle inherits the parent mailbox's `'a` binding ref so
 /// `.send::<K>(&mail)` dispatches through the same `NativeBinding`
 /// without re-threading the ctx.
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub trait ComponentHostNativeExt {
     /// Resolve a typed peer-component mailbox for the loaded component
     /// named `name`. The full mailbox address is
@@ -56,7 +56,7 @@ pub trait ComponentHostNativeExt {
     fn loaded<R: Addressable>(&self, name: &str) -> NativeActorMailbox<'_, R>;
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 impl ComponentHostNativeExt for NativeActorMailbox<'_, ComponentHostCapability> {
     fn loaded<R: Addressable>(&self, name: &str) -> NativeActorMailbox<'_, R> {
         self.resolve_peer_scoped::<R>(WasmTrampoline::NAMESPACE, name)

--- a/crates/aether-capabilities/src/engine/mod.rs
+++ b/crates/aether-capabilities/src/engine/mod.rs
@@ -19,5 +19,5 @@ pub use proxy::EngineProxy;
 #[cfg(not(target_family = "wasm"))]
 pub use proxy::EngineProxyConfig;
 pub use server::EngineServer;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub use server::{EngineConfig, EngineConfigLayer, EngineOverlay};

--- a/crates/aether-capabilities/src/engine/proxy/mod.rs
+++ b/crates/aether-capabilities/src/engine/proxy/mod.rs
@@ -57,24 +57,30 @@ use crate::rpc::RpcInboundReady;
 // alongside the runtime half.
 #[cfg(not(target_family = "wasm"))]
 mod config;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 mod connect;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 mod heartbeat;
 #[cfg(test)]
 mod sinks;
 
 // `EngineProxyConfig` / `HeartbeatParams` carry only wasm-safe types,
 // but the proxy that consumes them is native-only, so the re-export is
-// gated like `TcpListenerConfig`.
+// gated like `TcpListenerConfig`. `EngineProxyConfig` rides `not(wasm)`
+// because it re-exports on up to the crate root for chassis builders;
+// `HeartbeatParams` has no consumer outside the `runtime` half (the
+// `connect` / `heartbeat` modules and `server::runtime`), so it rides the
+// `runtime` gate to stay off a marker-only host build.
 #[cfg(not(target_family = "wasm"))]
-pub use config::{EngineProxyConfig, HeartbeatParams};
+pub use config::EngineProxyConfig;
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
+pub use config::HeartbeatParams;
 
 // The engines cap (`aether.engine`) classifies a failed `spawn_child`
 // with this to decide whether to re-fork on a fresh port (a stolen-port
 // child-exited death) or report a dead spawn. Native-only — it names
 // `SpawnError` / `BootError`.
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub use connect::is_reforkable_spawn_failure;
 
 /// `aether.engine.proxy:<id>` cap **identity** (ADR-0122 identity/runtime

--- a/crates/aether-capabilities/src/engine/server/mod.rs
+++ b/crates/aether-capabilities/src/engine/server/mod.rs
@@ -46,6 +46,19 @@ use aether_kinds::{
     ListComponentBinaries, ListEngineBinaries, ListEngines, ResolveComponent, SpawnEngine,
     TerminateEngine, UploadBinary, UploadComponent,
 };
+// The per-handler reply kinds the `#[actor]`-emitted native markers name.
+// Those markers ride `not(wasm)`, so they exist on every host build — `runtime`
+// on or off — but a marker-only host build (`--no-default-features`) has no
+// `use runtime::*` to bring the reply kinds into scope. This fills exactly that
+// gap: it imports them only when the runtime glob is absent (`not(runtime)`),
+// so the two paths are complementary rather than overlapping. A `runtime` host
+// build still reaches these kinds through `use runtime::*`.
+#[cfg(all(not(target_family = "wasm"), not(feature = "runtime")))]
+use aether_kinds::{
+    ListComponentBinariesResult, ListEngineBinariesResult, ListEnginesResult,
+    ResolveComponentResult, SpawnEngineResult, TerminateEngineResult, UploadBinaryResult,
+    UploadComponentResult,
+};
 #[cfg(test)]
 use std::sync::{Arc, Mutex};
 
@@ -56,11 +69,11 @@ use std::sync::{Arc, Mutex};
 // spawn-dir resolution). All three are native-only — the cap forks
 // processes and owns sockets — so they elide on wasm alongside the
 // runtime half.
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 mod artifacts;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 mod config;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 mod fleet;
 
 // `EngineConfig` (+ its derive-emitted `EngineOverlay`) ride through
@@ -68,7 +81,7 @@ mod fleet;
 // `HubCli`, resolves argv-then-env, and passes the config to
 // `with_actor::<EngineServer>(cfg)` (ADR-0090). Native-only re-export —
 // the engines cap is native-only, so the config has no wasm consumer.
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub use config::{EngineConfig, EngineConfigLayer, EngineOverlay};
 
 /// `aether.engine` engines-cap **identity** (ADR-0122 identity/runtime

--- a/crates/aether-capabilities/src/fs/mod.rs
+++ b/crates/aether-capabilities/src/fs/mod.rs
@@ -38,7 +38,7 @@ pub use registry::{AdapterRegistry, build_registry};
 // for X {}` markers always-on against the identity, outside the
 // `feature = "runtime"` gate, so they reference these kinds from here.
 use aether_actor::WasmActorMailbox;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 use aether_substrate::actor::native::NativeActorMailbox;
 
 /// Sender-side facade for actors addressed via
@@ -135,7 +135,7 @@ impl FsMailboxExt for WasmActorMailbox<'_, FsCapability> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 impl FsMailboxExt for NativeActorMailbox<'_, FsCapability> {
     fn read(&self, namespace: &str, path: &str) {
         self.send(&Read {

--- a/crates/aether-capabilities/src/http/client/mod.rs
+++ b/crates/aether-capabilities/src/http/client/mod.rs
@@ -27,7 +27,7 @@ pub use config::{HttpConfigLayer, HttpOverlay};
 // reference `Fetch` from here. `HttpMethod` is named by `HttpMailboxExt`.
 use crate::http::kinds::{Fetch, HttpMethod};
 use aether_actor::WasmActorMailbox;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 use aether_substrate::actor::native::NativeActorMailbox;
 
 // The wire reply kind. Named by the always-on (non-wasm) handler-inventory
@@ -105,7 +105,7 @@ impl HttpMailboxExt for WasmActorMailbox<'_, HttpCapability> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 impl HttpMailboxExt for NativeActorMailbox<'_, HttpCapability> {
     //noinspection DuplicatedCode
     fn get(&self, url: &str) {

--- a/crates/aether-capabilities/src/input/mod.rs
+++ b/crates/aether-capabilities/src/input/mod.rs
@@ -38,7 +38,7 @@ pub use config::InputConfig;
 
 use aether_actor::WasmActorMailbox;
 use aether_data::{Kind, MailboxId};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 use aether_substrate::actor::native::NativeActorMailbox;
 
 use aether_actor::actor;
@@ -176,7 +176,7 @@ impl InputMailboxExt for WasmActorMailbox<'_, InputCapability> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 impl InputMailboxExt for NativeActorMailbox<'_, InputCapability> {
     fn subscribe<K: Kind>(&self) {
         self.send(&SubscribeInputSelf { kind: K::ID });

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -34,7 +34,7 @@ extern crate self as aether_capabilities;
 // `aether.anthropic` content-gen cap (ADR-0050, issue 1014). Native-
 // only — embeds the native-only contentgen dispatch helper and makes
 // blocking ureq / subprocess calls.
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub mod anthropic;
 #[cfg(feature = "audio")]
 pub mod audio;
@@ -43,14 +43,14 @@ pub mod component;
 // dispatch helper, staging, and adapter traits all lean on the
 // substrate runtime (`Mailer`, `LocalFileAdapter`), so the module
 // elides cleanly on the wasm-component build.
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub mod shared;
 
 pub mod engine;
 pub mod fs;
 // `aether.gemini` content-gen cap (ADR-0050, issue 1015). Native-only
 // for the same reason as `anthropic`.
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub mod gemini;
 // The two HTTP capabilities, co-located under one submodule (ADR-0121):
 // the `aether.http` egress client and the `aether.http.server` inbound
@@ -91,14 +91,14 @@ pub use audio::AudioCapability;
 pub use audio::AudioConfig;
 // ADR-0050 `aether.anthropic` cap (issue 1014). `AnthropicConfig` is
 // part of the same native-only module.
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub use anthropic::{AnthropicCapability, AnthropicConfig};
 pub use component::{ComponentHostCapability, resolve_embedded};
 // ADR-0050 §2 shared content-gen infrastructure. Native-only — the two
 // provider caps (issue 1014 / 1015) embed these.
 #[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub use shared::contentgen::ContentGenConfigLayer;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub use shared::contentgen::{
     AnthropicAdapter, ContentGenConfig, GeminiAdapter, StubAnthropicAdapter, StubGeminiAdapter,
     TaskQueue,
@@ -115,7 +115,7 @@ pub use engine::EngineProxy;
 #[cfg(not(target_family = "wasm"))]
 pub use engine::EngineProxyConfig;
 pub use engine::EngineServer;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub use engine::{EngineConfig, EngineConfigLayer, EngineOverlay};
 pub use http::{HttpCapability, HttpConfig};
 // ADR-0108 `aether.http.server` cap (issue 1760). `HttpServerConfig` is the
@@ -141,7 +141,7 @@ pub use lifecycle::{LifecycleCapability, LifecycleMailboxExt};
 
 pub use fs::FsCapability;
 // ADR-0050 `aether.gemini` cap (issue 1015).
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub use gemini::{GeminiCapability, GeminiConfig};
 #[cfg(feature = "render")]
 pub use render::HeadlessRenderCapability;

--- a/crates/aether-capabilities/src/lifecycle/subscribers.rs
+++ b/crates/aether-capabilities/src/lifecycle/subscribers.rs
@@ -12,15 +12,15 @@ use aether_kinds::{
 
 use super::LifecycleCapability;
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 use aether_actor::ReplyMode;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 use aether_data::KindId;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 use aether_substrate::actor::native::{NativeActorMailbox, NativeCtx};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 use aether_substrate::mail::MailboxId as SubstrateMailboxId;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Sender-side facade for callers addressing [`LifecycleCapability`]
@@ -96,7 +96,7 @@ impl LifecycleMailboxExt for WasmActorMailbox<'_, LifecycleCapability> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 impl LifecycleMailboxExt for NativeActorMailbox<'_, LifecycleCapability> {
     fn subscribe<K: Kind>(&self) {
         self.send(&LifecycleSubscribeSelf { stage: K::ID.0 });
@@ -124,7 +124,7 @@ impl LifecycleMailboxExt for NativeActorMailbox<'_, LifecycleCapability> {
 /// state's), not a compile-site `K`; the path preserves the inbound
 /// `(parent, root)` lineage so settlement counts each child against
 /// the root (ADR-0080 §6).
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub fn broadcast_to_subscribers<M: ReplyMode>(
     ctx: &mut NativeCtx<'_, M>,
     subscribers: &BTreeMap<KindId, BTreeSet<MailboxId>>,

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -47,7 +47,7 @@ mod session;
 
 pub use kinds::*;
 pub use listener::TcpListenerActor;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub use route::TcpNativeExt;
 pub use route::TcpWasmExt;
 pub use session::TcpSessionActor;

--- a/crates/aether-capabilities/src/tcp/route.rs
+++ b/crates/aether-capabilities/src/tcp/route.rs
@@ -3,7 +3,7 @@
 
 use aether_actor::{Addressable, WasmActorMailbox};
 use aether_data::{ActorId, Tag, fold_lineage, with_tag};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 use aether_substrate::actor::native::NativeActorMailbox;
 
 use super::{
@@ -180,7 +180,7 @@ impl TcpWasmExt for WasmActorMailbox<'_, TcpCapability> {
 /// FFI, and a single trait can't carry both signatures. The precedent
 /// is [`crate::component::ComponentHostWasmExt`] /
 /// [`crate::component::ComponentHostNativeExt`] (issue 654).
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 pub trait TcpNativeExt {
     /// Mail `aether.tcp.bind_listener { addr, name }` to the cap.
     fn bind_listener(&self, addr: &str, name: Option<&str>);
@@ -217,7 +217,7 @@ pub trait TcpNativeExt {
     ) -> NativeActorMailbox<'_, R>;
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "runtime"))]
 impl TcpNativeExt for NativeActorMailbox<'_, TcpCapability> {
     //noinspection DuplicatedCode
     fn bind_listener(&self, addr: &str, name: Option<&str>) {

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -12,7 +12,7 @@
 # there surfaces as a red canary.
 
 # Ordered canonical step names.
-CANONICAL_STEPS="fmt clippy doc dist test qodana"
+CANONICAL_STEPS="fmt clippy doc dist marker test qodana"
 
 # The identifying command for a step. The producer runs exactly this, adding
 # per-run wrappers (RUSTDOCFLAGS for doc, AETHER_REQUIRE_RUNTIME for test,
@@ -25,6 +25,13 @@ canonical_cmd() {
         clippy) echo "cargo clippy --workspace --all-targets -- -D warnings" ;;
         doc)    echo "cargo doc --workspace --no-deps" ;;
         dist)   echo "cargo xtask dist --no-bins" ;;
+        # Marker-only host build (iamacoffeepot/aether#2583): the transport-only
+        # tier (`aether-capabilities` with `default-features = false`, so the
+        # `runtime` feature is off) must compile on the host triple. Isolated
+        # `-p` on purpose — a `--workspace` build's resolver-3 feature
+        # unification turns `runtime` back on for the crate and masks the
+        # failure (ADR-0122 §33), so this guard must never fold into one.
+        marker) echo "cargo build -p aether-capabilities --no-default-features" ;;
         test)   echo "cargo nextest run --workspace --all-features --profile ci" ;;
         qodana) echo "qodana scan" ;;
         *)      return 1 ;;

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -168,6 +168,16 @@ read -ra dist_cmd <<< "$(canonical_cmd dist)"
 run_step "$(canonical_cmd dist) (component wasm cross-build)" \
     "${dist_cmd[@]}"
 
+# Marker-only host build (iamacoffeepot/aether#2583). Reproduces a component
+# author's reflexive `cargo build` against a `default-features = false`
+# consumer of `aether-capabilities`: an isolated `-p` build with `runtime` off
+# on the host triple. It must stay a standalone `-p` invocation — folding it
+# into the `--workspace` clippy/test builds would let resolver-3 feature
+# unification turn `runtime` back on and mask the failure (ADR-0122 §33).
+read -ra marker_cmd <<< "$(canonical_cmd marker)"
+run_step "$(canonical_cmd marker) (marker-only host build)" \
+    "${marker_cmd[@]}"
+
 # Slowest Rust step. The whole suite runs at full parallelism — the
 # `aether-substrate-bundle` integration tests that fork real substrates carry
 # a generous per-test slow-timeout in `.config/nextest.toml`, so concurrent


### PR DESCRIPTION
Closes #2583.

## Summary

A host-target `cargo build` of a `default-features = false` (marker-only) consumer of `aether-capabilities` failed with ~70 errors *inside* the crate: hand-written `#[cfg(not(target_family = "wasm"))]` gates guarded code naming the now-runtime-only deps (`ureq`, `serde_json`, `aether_substrate`, `tracing`, …), so a native marker-only build compiled those modules without linking their deps.

Completes ADR-0122 §28 — flips every hand-written `not(wasm)` gate guarding runtime-dep code to `all(not(target_family = "wasm"), feature = "runtime")`, driving the oracle `cargo build -p aether-capabilities --no-default-features` from 69 errors to clean. Touches 13 source files across 8 module areas (`lib.rs`, `engine/*`, `component/*`, `fs`, `http/client`, `input`, `lifecycle/subscribers`, `tcp/*`). Two judgment calls preserved public wasm-safe API (`EngineProxyConfig` stays `not(wasm)`; only runtime-only `HeartbeatParams` moved to the runtime gate) and filled a marker-only reply-kind import gap with a complementary `all(not(wasm), not(feature = "runtime"))` gate.

## Test plan

Adds the isolated marker-only host build (`cargo build -p aether-capabilities --no-default-features` — never `--workspace`, whose feature unification masks the bug) as a canonical check (`scripts/checks.sh`), a preflight step, and a gated CI job wired into `ci-pass`. Full `cargo nextest run --workspace` green (1790/1790); default + wasm32 + marker-only builds green; clippy + rustdoc + component wasm cross-build clean.

## Generated by

`/implement` — agent execution of scoped issue #2583.
