### PR TITLE
feat(capabilities): reply-based stream handle for the http server data phase

### DIFF
--- a/crates/aether-actor/src/model/ctx/mail_sender.rs
+++ b/crates/aether-actor/src/model/ctx/mail_sender.rs
@@ -19,7 +19,7 @@
 //! sends uses the trait's [`MailSender::send`] / [`MailSender::send_many`]
 //! / [`MailSender::send_to_named`] methods.
 
-use aether_data::Kind;
+use aether_data::{Kind, MailboxId};
 
 use crate::model::{HandlesKind, Singleton};
 
@@ -101,4 +101,28 @@ pub trait MailSender {
     fn send_detached_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
         self.send_to_named::<K>(name, payload);
     }
+
+    /// By-id counterpart to [`Self::send_detached`]: fire-and-forget send
+    /// of `payload` to the mailbox `id`, minting a fresh causal root
+    /// rather than inheriting the caller's in-flight chain (ADR-0080 §7).
+    ///
+    /// This fills the last cell of the send grid — typed / by-name / by-id
+    /// crossed with inherit / detached. [`Self::send`] and
+    /// [`Self::send_detached`] are the typed pair; [`Self::send_to_named`]
+    /// / [`Self::send_detached_to_named`] the by-name pair; the
+    /// inherit-by-id send is each ctx's inherent `send_to`, and this is its
+    /// detached partner. Its motivating consumer is a stored stream handle
+    /// that answers whoever dispatched to a handler (ADR-0133): the
+    /// counterparty address is captured at runtime, so a typed `R` can't
+    /// name it and a fresh root is wanted per send.
+    ///
+    /// **Fire-and-forget only.** Same contract as [`Self::send_detached`]:
+    /// the send mints no parent linkage, so any reply the recipient issues
+    /// inherits the *recipient's* tree rather than the sender's. Reply-
+    /// correlated requests do not use it.
+    ///
+    /// Required rather than defaulted: there is no by-id inherit method on
+    /// this trait to delegate to (the inherit-by-id send is the per-ctx
+    /// inherent `send_to`), so each concrete ctx supplies its own body.
+    fn send_detached_to<K: Kind>(&mut self, id: MailboxId, payload: &K);
 }

--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -708,6 +708,14 @@ impl<M: ReplyMode> MailSender for WasmCtx<'_, M> {
             self.mailbox,
         );
     }
+
+    //noinspection DuplicatedCode
+    // By-id detached send: the inherent `send_to` with `ChainMode::Detached`.
+    fn send_detached_to<K: Kind>(&mut self, id: MailboxId, payload: &K) {
+        let bytes = payload.encode_into_bytes();
+        self.inline
+            .route_or_enqueue(id.0, K::ID.0, &bytes, 1, ChainMode::Detached, self.mailbox);
+    }
 }
 
 // ADR-0112: the reply surface is per-mode. `Manual` carries it (a
@@ -927,6 +935,13 @@ impl MailSender for WasmDropCtx<'_> {
             true,
             self.mailbox,
         );
+    }
+
+    //noinspection DuplicatedCode
+    // By-id detached send — the by-name body with the caller's id.
+    fn send_detached_to<K: Kind>(&mut self, id: MailboxId, payload: &K) {
+        let bytes = payload.encode_into_bytes();
+        mail::send_mail(id.0, K::ID.0, &bytes, 1, true, self.mailbox);
     }
 }
 

--- a/crates/aether-capabilities/src/http/mod.rs
+++ b/crates/aether-capabilities/src/http/mod.rs
@@ -9,6 +9,7 @@
 pub mod client;
 pub mod kinds;
 pub mod server;
+pub mod stream;
 pub mod typed;
 
 pub use kinds::*;
@@ -20,6 +21,11 @@ pub use kinds::*;
 // `http::FromRequest` / `http::Ctx` / `http::Route`.
 pub use aether_capabilities_derive::{route, router};
 pub use typed::{Ctx, FromRequest, Route};
+
+// ADR-0133 reply-based data-phase stream handles. Wasm-safe like `typed`,
+// so a `default-features = false` guest that streams gets them without the
+// native runtime.
+pub use stream::{RequestStream, ResponseStream, WebSocketStream};
 
 // Egress client surface (`client.rs`). `HttpConfig` is the always-on
 // domain struct; the `Config`-derive `HttpConfigLayer` / `HttpOverlay`

--- a/crates/aether-capabilities/src/http/stream.rs
+++ b/crates/aether-capabilities/src/http/stream.rs
@@ -248,7 +248,7 @@ mod tests {
         }
     }
 
-    const CAP: MailboxId = MailboxId(0xC0FFEE);
+    const CAP: MailboxId = MailboxId(0x00C0_FFEE);
 
     /// The one send this handler recorded, decoded to `K`. Panics if it did
     /// not send exactly once, to the wrong recipient, or the wrong kind.

--- a/crates/aether-capabilities/src/http/stream.rs
+++ b/crates/aether-capabilities/src/http/stream.rs
@@ -1,0 +1,372 @@
+//! Durable stream handles for the HTTP server data phase (ADR-0133).
+//!
+//! The handshake legs of a streamed or websocket response are `ctx.reply`s
+//! that route to whoever dispatched the request. These handles extend the
+//! same invariant to the data phase: a handler answers the counterparty
+//! that dispatched to it — the real [`HttpServerCapability`], a test mock,
+//! or a middleware forwarding in front of the cap — never a compile-time
+//! singleton.
+//!
+//! A handle is plain data: the `counterparty` [`MailboxId`] captured from
+//! the dispatch that opened the stream, plus the `stream_id` naming the
+//! connection. It is constructed once (from the first credit grant, or the
+//! request-stream open), stored on the handler, and used from later
+//! handlers to emit the stream. Every send is a detached chain root at the
+//! stored counterparty ([`MailSender::send_detached_to`]): the data-phase
+//! mails are per-message causal chains (ADR-0128 / ADR-0132), so a chunk
+//! is attributed to its own root rather than to whatever handler happened
+//! to emit it, and a handler can push unprompted from any chain.
+//!
+//! Wasm-safe like [`super::typed`]: it names only `kinds.rs` payloads and
+//! the `aether-actor` model traits, so a `default-features = false` guest
+//! gets it without the native runtime.
+//!
+//! [`HttpServerCapability`]: super::HttpServerCapability
+//! [`MailboxId`]: aether_data::MailboxId
+
+use aether_actor::{MailSender, OutboundReply};
+use aether_data::MailboxId;
+
+use super::kinds::{
+    HttpRequestCredit, HttpRequestStreamOpen, HttpResponseChunk, HttpResponseStreamEnd,
+    HttpStreamCredit, WebSocketClose, WebSocketMessage,
+};
+
+/// A streamed response a handler is feeding (ADR-0128 / ADR-0133): the
+/// counterparty that opened the stream plus the `stream_id` naming it.
+/// Constructed from the first [`HttpStreamCredit`] grant, then used from
+/// the credit handler to emit body chunks and the terminator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResponseStream {
+    /// The mailbox that dispatched the opening credit — the cap, a mock, or
+    /// a middleware. Every send on this handle targets it.
+    pub counterparty: MailboxId,
+    /// The stream id the cap assigned this response (ADR-0128), stamped on
+    /// every chunk and the terminator.
+    pub stream_id: u64,
+}
+
+impl ResponseStream {
+    /// Capture the handle from the first [`HttpStreamCredit`] the cap
+    /// dispatched. `None` when the dispatch has no component source
+    /// (broadcast / session / substrate-origin mail cannot open a stream) —
+    /// so a handler stores an `Option<ResponseStream>` and sends only once
+    /// the first grant has armed it.
+    #[must_use]
+    pub fn from_credit(ctx: &impl OutboundReply, credit: &HttpStreamCredit) -> Option<Self> {
+        Some(Self {
+            counterparty: ctx.source_mailbox()?,
+            stream_id: credit.stream_id,
+        })
+    }
+
+    /// Emit one body chunk on this stream (ADR-0128 [`HttpResponseChunk`]),
+    /// a detached root at the stored counterparty.
+    pub fn chunk(&self, ctx: &mut impl MailSender, body: Vec<u8>) {
+        ctx.send_detached_to(
+            self.counterparty,
+            &HttpResponseChunk {
+                stream_id: self.stream_id,
+                body,
+            },
+        );
+    }
+
+    /// Terminate this stream (ADR-0128 [`HttpResponseStreamEnd`]). The cap
+    /// writes the terminating zero-length chunk and closes the connection.
+    pub fn end(&self, ctx: &mut impl MailSender) {
+        ctx.send_detached_to(
+            self.counterparty,
+            &HttpResponseStreamEnd {
+                stream_id: self.stream_id,
+            },
+        );
+    }
+}
+
+/// A streamed request a handler is draining (ADR-0128 / ADR-0133): the
+/// counterparty that opened the stream plus its `stream_id`. Constructed
+/// from the [`HttpRequestStreamOpen`] the cap dispatches when a streamed
+/// upload begins, then used to grant read credit back as chunks drain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequestStream {
+    /// The mailbox that opened the request stream — every credit grant on
+    /// this handle targets it.
+    pub counterparty: MailboxId,
+    /// The stream id the cap assigned this upload (ADR-0128), stamped on
+    /// every credit grant.
+    pub stream_id: u64,
+}
+
+impl RequestStream {
+    /// Capture the handle from the [`HttpRequestStreamOpen`] that begins a
+    /// streamed upload. `None` when the dispatch has no component source
+    /// (the same guard as [`ResponseStream::from_credit`]).
+    #[must_use]
+    pub fn from_open(ctx: &impl OutboundReply, open: &HttpRequestStreamOpen) -> Option<Self> {
+        Some(Self {
+            counterparty: ctx.source_mailbox()?,
+            stream_id: open.stream_id,
+        })
+    }
+
+    /// Grant the cap credit to deliver up to `credit` more inbound chunks
+    /// (ADR-0128 [`HttpRequestCredit`]), a detached root at the stored
+    /// counterparty.
+    pub fn credit(&self, ctx: &mut impl MailSender, credit: u32) {
+        ctx.send_detached_to(
+            self.counterparty,
+            &HttpRequestCredit {
+                stream_id: self.stream_id,
+                credit,
+            },
+        );
+    }
+}
+
+/// An upgraded websocket connection (ADR-0129 / ADR-0132 / ADR-0133): the
+/// counterparty that owns the socket plus its `stream_id`. Constructed
+/// from the first [`HttpStreamCredit`] grant (the accept-time window), then
+/// used to push messages and initiate a close from any chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WebSocketStream {
+    /// The mailbox that owns the upgraded connection — every outbound
+    /// message and close on this handle targets it.
+    pub counterparty: MailboxId,
+    /// The connection's stream id (ADR-0132), stamped on every outbound
+    /// message and close.
+    pub stream_id: u64,
+}
+
+impl WebSocketStream {
+    /// Capture the handle from the first [`HttpStreamCredit`] grant, which
+    /// the cap sends at accept time before any peer traffic (ADR-0132).
+    /// `None` when the dispatch has no component source.
+    #[must_use]
+    pub fn from_credit(ctx: &impl OutboundReply, credit: &HttpStreamCredit) -> Option<Self> {
+        Some(Self {
+            counterparty: ctx.source_mailbox()?,
+            stream_id: credit.stream_id,
+        })
+    }
+
+    /// Push one application message to the peer (ADR-0132
+    /// [`WebSocketMessage`]), a detached root at the stored counterparty.
+    /// `binary` selects the RFC 6455 opcode.
+    pub fn message(&self, ctx: &mut impl MailSender, binary: bool, data: Vec<u8>) {
+        ctx.send_detached_to(
+            self.counterparty,
+            &WebSocketMessage {
+                stream_id: self.stream_id,
+                binary,
+                data,
+            },
+        );
+    }
+
+    /// Initiate the close handshake (ADR-0129 [`WebSocketClose`]). `code` is
+    /// the RFC 6455 close status; `reason` the optional UTF-8 phrase.
+    pub fn close(&self, ctx: &mut impl MailSender, code: u16, reason: String) {
+        ctx.send_detached_to(
+            self.counterparty,
+            &WebSocketClose {
+                stream_id: self.stream_id,
+                code,
+                reason,
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aether_actor::{HandlesKind, Singleton};
+    use aether_data::{Kind, KindId};
+
+    use super::super::kinds::HttpMethod;
+    use super::*;
+
+    /// A `MailSender` + `OutboundReply` that records every
+    /// `send_detached_to` and reports a configurable inbound source, so the
+    /// handle constructors and send methods are exercisable with no
+    /// transport. Only `send_detached_to` and `source_mailbox` carry a real
+    /// body — the handles use nothing else, so the rest assert their own
+    /// disuse.
+    #[derive(Default)]
+    struct RecordingCtx {
+        source: Option<MailboxId>,
+        sent: Vec<(MailboxId, KindId, Vec<u8>)>,
+    }
+
+    impl MailSender for RecordingCtx {
+        fn send<R, K>(&mut self, _payload: &K)
+        where
+            R: Singleton + HandlesKind<K>,
+            K: Kind,
+        {
+            unreachable!("stream handles send only via send_detached_to")
+        }
+
+        fn send_many<R, K>(&mut self, _payloads: &[K])
+        where
+            R: Singleton + HandlesKind<K>,
+            K: Kind + bytemuck::NoUninit,
+        {
+            unreachable!("stream handles send only via send_detached_to")
+        }
+
+        fn send_to_named<K: Kind>(&mut self, _name: &str, _payload: &K) {
+            unreachable!("stream handles send only via send_detached_to")
+        }
+
+        fn prev_correlation(&self) -> u64 {
+            0
+        }
+
+        fn send_detached_to<K: Kind>(&mut self, id: MailboxId, payload: &K) {
+            self.sent.push((id, K::ID, payload.encode_into_bytes()));
+        }
+    }
+
+    impl OutboundReply for RecordingCtx {
+        type ReplyHandle = ();
+
+        fn reply_target(&self) -> Option<()> {
+            None
+        }
+
+        fn source_mailbox(&self) -> Option<MailboxId> {
+            self.source
+        }
+
+        fn reply<K: Kind>(&mut self, _payload: &K) {
+            unreachable!("stream handles never reply")
+        }
+
+        fn reply_to<K: Kind>(&mut self, _sender: (), _payload: &K) {
+            unreachable!("stream handles never reply")
+        }
+    }
+
+    const CAP: MailboxId = MailboxId(0xC0FFEE);
+
+    /// The one send this handler recorded, decoded to `K`. Panics if it did
+    /// not send exactly once, to the wrong recipient, or the wrong kind.
+    fn only_send<K: Kind>(ctx: &RecordingCtx, recipient: MailboxId) -> K {
+        assert_eq!(ctx.sent.len(), 1, "exactly one send");
+        let (id, kind, bytes) = &ctx.sent[0];
+        assert_eq!(*id, recipient, "recipient is the stored counterparty");
+        assert_eq!(*kind, K::ID, "kind matches the send method");
+        K::decode_from_bytes(bytes).expect("payload decodes back to its kind")
+    }
+
+    #[test]
+    fn response_stream_captures_counterparty_and_stream_id() {
+        let ctx = RecordingCtx {
+            source: Some(CAP),
+            ..RecordingCtx::default()
+        };
+        let handle = ResponseStream::from_credit(
+            &ctx,
+            &HttpStreamCredit {
+                stream_id: 42,
+                credit: 8,
+            },
+        )
+        .expect("a component-source credit opens the stream");
+        assert_eq!(handle.counterparty, CAP);
+        assert_eq!(handle.stream_id, 42);
+    }
+
+    #[test]
+    fn from_credit_refuses_a_sourceless_dispatch() {
+        let ctx = RecordingCtx::default();
+        assert!(
+            ResponseStream::from_credit(
+                &ctx,
+                &HttpStreamCredit {
+                    stream_id: 1,
+                    credit: 1
+                }
+            )
+            .is_none(),
+            "no component source → no handle"
+        );
+        assert!(
+            WebSocketStream::from_credit(
+                &ctx,
+                &HttpStreamCredit {
+                    stream_id: 1,
+                    credit: 1
+                }
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn response_stream_chunk_and_end_target_the_counterparty() {
+        let handle = ResponseStream {
+            counterparty: CAP,
+            stream_id: 7,
+        };
+
+        let mut ctx = RecordingCtx::default();
+        handle.chunk(&mut ctx, b"body-piece".to_vec());
+        let chunk: HttpResponseChunk = only_send(&ctx, CAP);
+        assert_eq!(chunk.stream_id, 7);
+        assert_eq!(chunk.body, b"body-piece");
+
+        let mut ctx = RecordingCtx::default();
+        handle.end(&mut ctx);
+        let end: HttpResponseStreamEnd = only_send(&ctx, CAP);
+        assert_eq!(end.stream_id, 7);
+    }
+
+    #[test]
+    fn request_stream_credit_targets_the_counterparty() {
+        let ctx = RecordingCtx {
+            source: Some(CAP),
+            ..RecordingCtx::default()
+        };
+        let handle = RequestStream::from_open(
+            &ctx,
+            &HttpRequestStreamOpen {
+                stream_id: 9,
+                method: HttpMethod::Post,
+                path: "/upload".to_string(),
+                query: String::new(),
+                headers: Vec::new(),
+            },
+        )
+        .expect("a component-source open arms the request stream");
+
+        let mut ctx = RecordingCtx::default();
+        handle.credit(&mut ctx, 4);
+        let credit: HttpRequestCredit = only_send(&ctx, CAP);
+        assert_eq!(credit.stream_id, 9);
+        assert_eq!(credit.credit, 4);
+    }
+
+    #[test]
+    fn websocket_message_and_close_target_the_counterparty() {
+        let handle = WebSocketStream {
+            counterparty: CAP,
+            stream_id: 3,
+        };
+
+        let mut ctx = RecordingCtx::default();
+        handle.message(&mut ctx, true, b"\x00\x01".to_vec());
+        let msg: WebSocketMessage = only_send(&ctx, CAP);
+        assert_eq!(msg.stream_id, 3);
+        assert!(msg.binary);
+        assert_eq!(msg.data, b"\x00\x01");
+
+        let mut ctx = RecordingCtx::default();
+        handle.close(&mut ctx, 1000, "bye".to_string());
+        let close: WebSocketClose = only_send(&ctx, CAP);
+        assert_eq!(close.stream_id, 3);
+        assert_eq!(close.code, 1000);
+        assert_eq!(close.reason, "bye");
+    }
+}

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -1124,6 +1124,15 @@ impl<M: ReplyMode> MailSender for NativeCtx<'_, M> {
             None,
         );
     }
+
+    //noinspection DuplicatedCode
+    // By-id detached send — the by-name body with the caller's id, `None` /
+    // `None` lineage minting a fresh root (ADR-0080 §7).
+    fn send_detached_to<K: Kind>(&mut self, id: MailboxId, payload: &K) {
+        let bytes = payload.encode_into_bytes();
+        self.binding
+            .push_envelope_buffered(id.0, K::ID.0, &bytes, 1, None, None);
+    }
 }
 
 // ADR-0112: the reply surface is per-mode. `Manual` carries it (a

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -42,7 +42,7 @@ use std::thread::{self, JoinHandle};
 
 use aether_actor::{Addressable, HandlesKind};
 use aether_actor::{MailSender, Singleton};
-use aether_data::{Kind, MailId, mailbox_id_from_name};
+use aether_data::{Kind, MailId, MailboxId, mailbox_id_from_name};
 
 use super::binding::NativeBinding;
 use crate::runtime::trace::SettlementHold;
@@ -179,6 +179,15 @@ impl<A: Addressable> MailSender for InheritCtx<A> {
     fn prev_correlation(&self) -> u64 {
         self.binding.prev_correlation()
     }
+
+    //noinspection DuplicatedCode
+    // By-id detached send: `None` / `None` lineage mints a fresh root
+    // rather than inheriting this ctx's captured chain (ADR-0080 §7).
+    fn send_detached_to<K: Kind>(&mut self, id: MailboxId, payload: &K) {
+        let bytes = payload.encode_into_bytes();
+        self.binding
+            .send_mail_with_lineage(id.0, K::ID.0, &bytes, 1, None, None);
+    }
 }
 
 /// ADR-0080 §12 spawn-context with no in-flight inheritance. Each
@@ -259,6 +268,15 @@ impl<A: Addressable> MailSender for RootCtx<A> {
 
     fn prev_correlation(&self) -> u64 {
         self.binding.prev_correlation()
+    }
+
+    //noinspection DuplicatedCode
+    // By-id detached send. A root ctx already mints a fresh chain per send,
+    // so this matches its other sends' `None` / `None` lineage.
+    fn send_detached_to<K: Kind>(&mut self, id: MailboxId, payload: &K) {
+        let bytes = payload.encode_into_bytes();
+        self.binding
+            .send_mail_with_lineage(id.0, K::ID.0, &bytes, 1, None, None);
     }
 }
 

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -20,14 +20,14 @@
 // ignores `self` is correct but triggers `unused_self`.
 #![allow(clippy::needless_pass_by_value, clippy::unused_self)]
 
-use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, Manual, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::ComponentHostCapability;
 use aether_capabilities::http;
-use aether_capabilities::http::HttpServerCapability;
 use aether_capabilities::http::kinds::{
-    HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen, HttpServerRequest,
-    HttpServerResponse, HttpStreamCredit, WebSocketAccept, WebSocketClose, WebSocketMessage,
+    HttpResponseStreamOpen, HttpServerRequest, HttpServerResponse, HttpStreamCredit, WebSocketAccept,
+    WebSocketClose, WebSocketMessage,
 };
+use aether_capabilities::http::{ResponseStream, WebSocketStream};
 use aether_data::MailboxId;
 use aether_kinds::DropComponent;
 
@@ -76,8 +76,10 @@ const STREAM_CHUNK_COUNT: u32 = 20;
 ///
 /// Registered at `aether.component/aether.embedded:web_stream` after load.
 pub struct StreamingHttpHandler {
-    /// The stream this handler is feeding, learned from the first credit mail.
-    stream_id: u64,
+    /// The stream this handler is feeding (ADR-0133), captured from the
+    /// first credit mail — the counterparty that dispatched it plus the
+    /// stream id. `None` until that first grant arms it.
+    stream: Option<ResponseStream>,
     /// Index of the next chunk to emit.
     next_index: u32,
     /// Whether the terminator has been sent.
@@ -90,7 +92,7 @@ impl WasmActor for StreamingHttpHandler {
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(StreamingHttpHandler {
-            stream_id: 0,
+            stream: None,
             next_index: 0,
             ended: false,
         })
@@ -125,24 +127,26 @@ impl WasmActor for StreamingHttpHandler {
     /// Not sent manually — the cap sends one `HttpStreamCredit` per freed
     /// window slot; the handler emits at most that many `HttpResponseChunk`s
     /// in response.
-    #[handler]
-    fn on_credit(&mut self, ctx: &mut WasmCtx<'_>, credit: HttpStreamCredit) {
-        self.stream_id = credit.stream_id;
+    #[handler::manual]
+    fn on_credit(&mut self, ctx: &mut WasmCtx<'_, Manual>, credit: HttpStreamCredit) {
+        // ADR-0133: capture the stream handle from the first credit grant —
+        // the counterparty that dispatched it, so chunks flow back to
+        // whoever paced the stream rather than a hard-coded cap singleton.
+        let stream = match self.stream {
+            Some(stream) => stream,
+            None => match ResponseStream::from_credit(ctx, &credit) {
+                Some(stream) => *self.stream.insert(stream),
+                None => return,
+            },
+        };
         let mut budget = credit.credit;
         while budget > 0 && self.next_index < STREAM_CHUNK_COUNT {
-            ctx.actor::<HttpServerCapability>()
-                .send(&HttpResponseChunk {
-                    stream_id: self.stream_id,
-                    body: format!("chunk-{}\n", self.next_index).into_bytes(),
-                });
+            stream.chunk(ctx, format!("chunk-{}\n", self.next_index).into_bytes());
             self.next_index += 1;
             budget -= 1;
         }
         if self.next_index >= STREAM_CHUNK_COUNT && !self.ended {
-            ctx.actor::<HttpServerCapability>()
-                .send(&HttpResponseStreamEnd {
-                    stream_id: self.stream_id,
-                });
+            stream.end(ctx);
             self.ended = true;
         }
     }
@@ -163,6 +167,9 @@ impl WasmActor for StreamingHttpHandler {
 ///
 /// Registered at `aether.component/aether.embedded:web_socket` after load.
 pub struct WebSocketHandler {
+    /// The upgraded connection (ADR-0133), captured from the first credit
+    /// grant. `None` until that accept-time grant arms it.
+    stream: Option<WebSocketStream>,
     greeted: bool,
 }
 
@@ -171,7 +178,10 @@ impl WasmActor for WebSocketHandler {
     const NAMESPACE: &'static str = "web_socket";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
-        Ok(WebSocketHandler { greeted: false })
+        Ok(WebSocketHandler {
+            stream: None,
+            greeted: false,
+        })
     }
 
     /// Accept every upgrade the cap routes here (the cap has already validated
@@ -198,15 +208,23 @@ impl WasmActor for WebSocketHandler {
     /// websocket message on the upgraded connection.
     #[handler]
     fn on_message(&mut self, ctx: &mut WasmCtx<'_>, msg: WebSocketMessage) {
+        // The connection handle was captured on the accept-time credit
+        // grant (ADR-0132/ADR-0133), which always precedes peer traffic.
+        let Some(stream) = self.stream else {
+            return;
+        };
         if !msg.binary && msg.data == b"misroute" {
-            ctx.actor::<HttpServerCapability>().send(&WebSocketMessage {
+            // Echo to a deliberately wrong stream id on the same
+            // counterparty — the cap must drop an unknown-stream send
+            // without tearing the connection down.
+            let misrouted = WebSocketStream {
+                counterparty: stream.counterparty,
                 stream_id: msg.stream_id.wrapping_add(1000),
-                binary: msg.binary,
-                data: msg.data,
-            });
+            };
+            misrouted.message(ctx, msg.binary, msg.data);
             return;
         }
-        ctx.actor::<HttpServerCapability>().send(&msg);
+        stream.message(ctx, msg.binary, msg.data);
     }
 
     /// The cap's outbound send window (ADR-0128 / ADR-0129 §3). The first
@@ -218,15 +236,20 @@ impl WasmActor for WebSocketHandler {
     ///
     /// # Agent
     /// Not sent manually — the cap grants credit as writer slots free.
-    #[handler]
-    fn on_credit(&mut self, ctx: &mut WasmCtx<'_>, credit: HttpStreamCredit) {
+    #[handler::manual]
+    fn on_credit(&mut self, ctx: &mut WasmCtx<'_, Manual>, credit: HttpStreamCredit) {
+        // ADR-0133: capture the connection handle from the accept-time
+        // credit grant — its counterparty is whoever owns the socket.
+        let stream = match self.stream {
+            Some(stream) => stream,
+            None => match WebSocketStream::from_credit(ctx, &credit) {
+                Some(stream) => *self.stream.insert(stream),
+                None => return,
+            },
+        };
         if !self.greeted {
             self.greeted = true;
-            ctx.actor::<HttpServerCapability>().send(&WebSocketMessage {
-                stream_id: credit.stream_id,
-                binary: false,
-                data: b"server greeting".to_vec(),
-            });
+            stream.message(ctx, false, b"server greeting".to_vec());
         }
     }
 

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -24,8 +24,8 @@ use aether_actor::{ActorInitError, Manual, WasmActor, WasmCtx, WasmInitCtx, acto
 use aether_capabilities::ComponentHostCapability;
 use aether_capabilities::http;
 use aether_capabilities::http::kinds::{
-    HttpResponseStreamOpen, HttpServerRequest, HttpServerResponse, HttpStreamCredit, WebSocketAccept,
-    WebSocketClose, WebSocketMessage,
+    HttpResponseStreamOpen, HttpServerRequest, HttpServerResponse, HttpStreamCredit,
+    WebSocketAccept, WebSocketClose, WebSocketMessage,
 };
 use aether_capabilities::http::{ResponseStream, WebSocketStream};
 use aether_data::MailboxId;

--- a/docs/guide/recipes/serving-http.md
+++ b/docs/guide/recipes/serving-http.md
@@ -289,18 +289,28 @@ default 16) as an `HttpStreamCredit` mail, and replenishes one credit each time
 its per-connection writer thread drains a chunk to the socket. A chunk consumes
 one credit; when credit reaches zero the handler pauses until the next
 `HttpStreamCredit` arrives. So a slow client blocks the writer thread, not the
-scheduler, and the handler cannot outrun the socket:
+scheduler, and the handler cannot outrun the socket.
+
+The data phase answers whoever dispatched to the handler — the same invariant the
+`HttpResponseStreamOpen` reply already honours (ADR-0133). The handler captures a
+`ResponseStream` handle from its first credit mail — the counterparty that paced
+the stream, plus the `stream_id` — and emits every chunk through it. The stream
+flows back to that counterparty, so a test mock or a middleware forwarding in
+front of the server receives it exactly as the real server does. Each send is a
+detached chain root, so a chunk settles on its own causal chain instead of the
+credit grant that triggered it. Reading the dispatch's sender needs the `Manual`
+ctx, so the credit handler is `#[handler::manual]`:
 
 ```rust
-use aether_actor::WasmInitCtx;
-use aether_capabilities::http::HttpServerCapability;
+use aether_actor::{Manual, WasmCtx, WasmInitCtx};
+use aether_capabilities::http::ResponseStream;
 use aether_capabilities::http::kinds::{
-    HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen, HttpServerRequest,
-    HttpStreamCredit,
+    HttpResponseStreamOpen, HttpServerRequest, HttpStreamCredit,
 };
 
 pub struct Feed {
-    stream_id: u64,
+    // The stream this handler is feeding, captured from the first credit mail.
+    stream: Option<ResponseStream>,
     next: u32,
     done: bool,
 }
@@ -310,7 +320,7 @@ impl WasmActor for Feed {
     const NAMESPACE: &'static str = "feed";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
-        Ok(Feed { stream_id: 0, next: 0, done: false })
+        Ok(Feed { stream: None, next: 0, done: false })
     }
 
     // Open the stream. The body arrives later, one chunk per unit of credit.
@@ -322,23 +332,25 @@ impl WasmActor for Feed {
     }
 
     // Spend the granted credit, then terminate once the body is exhausted.
-    // The handler learns its `stream_id` from the first credit mail.
-    #[handler]
-    fn on_credit(&mut self, ctx: &mut WasmCtx<'_>, credit: HttpStreamCredit) {
-        self.stream_id = credit.stream_id;
+    // The first credit mail arms the stream handle — its counterparty is
+    // whoever paced the stream, and every chunk flows back through it.
+    #[handler::manual]
+    fn on_credit(&mut self, ctx: &mut WasmCtx<'_, Manual>, credit: HttpStreamCredit) {
+        let stream = match self.stream {
+            Some(stream) => stream,
+            None => match ResponseStream::from_credit(ctx, &credit) {
+                Some(stream) => *self.stream.insert(stream),
+                None => return,
+            },
+        };
         let mut budget = credit.credit;
         while budget > 0 && self.next < 100 {
-            ctx.actor::<HttpServerCapability>().send(&HttpResponseChunk {
-                stream_id: self.stream_id,
-                body: format!("line {}\n", self.next).into_bytes(),
-            });
+            stream.chunk(ctx, format!("line {}\n", self.next).into_bytes());
             self.next += 1;
             budget -= 1;
         }
         if self.next >= 100 && !self.done {
-            ctx.actor::<HttpServerCapability>().send(&HttpResponseStreamEnd {
-                stream_id: self.stream_id,
-            });
+            stream.end(ctx);
             self.done = true;
         }
     }
@@ -384,6 +396,7 @@ reply shapes; return from a bare `#[handler]` otherwise.
 
 This recipe names the env keys and kind names live in the source. Before
 following it, confirm `AETHER_HTTP_SERVER_ENABLED`, `HttpServerRequest`,
-`HttpServerResponse`, `HttpServerConfig`, and the `http::{router, route,
-FromRequest, Ctx}` authoring surface still exist where named — grep the crates,
-and if a name has drifted, fix the recipe as part of your work.
+`HttpServerResponse`, `HttpServerConfig`, the `http::{router, route,
+FromRequest, Ctx}` authoring surface, and `http::ResponseStream` still exist
+where named — grep the crates, and if a name has drifted, fix the recipe as part
+of your work.


### PR DESCRIPTION
Closes #2594.

## Summary

A streaming or websocket handler could only answer the real `HttpServerCapability`: every data-phase message it emitted (`HttpResponseChunk`, `HttpResponseStreamEnd`, `HttpRequestCredit`, outbound `WebSocketMessage` / `WebSocketClose`) was addressed by compile-time singleton resolution, so a mock never received the stream and a middleware in front of the cap was bypassed by the response path. The handshake legs are already `ctx.reply`s that route to whoever dispatched — the data phase was the inconsistency.

This makes the data phase honour the same invariant. A handler emits its stream through a durable handle that captures the counterparty from the opening dispatch's sender (`ctx.source_mailbox()`) plus the `stream_id`, and each send is a detached chain root at that stored address:

- **`MailSender::send_detached_to`** — the by-id detached send, filling the last cell of the send grid (typed / by-name / by-id × inherit / detached). Bodies on every ctx impl (`WasmCtx`, `WasmDropCtx`, `NativeCtx`, `InheritCtx`, `RootCtx`).
- **`aether_capabilities::http::stream`** — wasm-safe like `typed`, with three plain-data handles (`ResponseStream`, `RequestStream`, `WebSocketStream`; public `{ counterparty, stream_id }`). Constructors capture the source from the first credit / request-stream open and refuse a sourceless dispatch; send methods emit each leg via `send_detached_to`.
- **Fixtures** move onto the handles; the credit handlers that read the source become `#[handler::manual]`.
- **Recipe** rewritten off the singleton send, stating the counterparty invariant.

The cap side is untouched — its data-phase handlers are already keyed by payload `stream_id` and sender-agnostic. No wire-format or schema change. Amends ADR-0128/0129/0132 via ADR-0133 (#2595, merged).

## Test plan

- New in-module unit tests over a recording `MailSender` + `OutboundReply` fake: each handle captures the counterparty / refuses a sourceless dispatch, and each send targets the stored counterparty with the right kind and `stream_id`.
- The existing `http_serving` e2e (streaming reassembly, websocket greeting / echo / misroute-drop over real sockets, driving the migrated wasm fixtures) passes unchanged — the proof the cap receives handle-addressed data-phase mail.

## Generated by

`/implement` — agent execution of [scoped issue #2594](https://github.com/iamacoffeepot/aether/issues/2594).
