### PR TITLE
chore(substrate): unify chain-mode vocabulary on 'detached'

### DIFF
--- a/crates/aether-capabilities/src/component/runtime/mod.rs
+++ b/crates/aether-capabilities/src/component/runtime/mod.rs
@@ -88,7 +88,7 @@ pub struct ComponentHostCapabilityState {
 ///
 /// The forward threads the child mail under the cap's current in-flight root
 /// and bumps that root's `in_flight` count before the calling handler returns
-/// (`send_envelope_traced_with_reply_to`), so the originating call stays open
+/// (`send_envelope_tracked_with_reply_to`), so the originating call stays open
 /// across the boundary: the trampoline's deferred `ctx.reply` streams back
 /// under a still-open root and settlement fires `ReplyEnd` only after it. A
 /// bare enqueue would let the cap handler's return settle the call before the
@@ -107,7 +107,7 @@ fn forward_to_trampoline<P>(
     P: Kind,
 {
     let bytes = payload.encode_into_bytes();
-    let _ = ctx.send_envelope_traced_with_reply_to(recipient, kind, &bytes, ctx.reply_target());
+    let _ = ctx.send_envelope_tracked_with_reply_to(recipient, kind, &bytes, ctx.reply_target());
 }
 
 #[runtime]

--- a/crates/aether-capabilities/src/engine/proxy/runtime.rs
+++ b/crates/aether-capabilities/src/engine/proxy/runtime.rs
@@ -122,7 +122,7 @@ impl EngineProxyState {
         let alive = EngineAlive {
             engine_id: self.engine_id.0.to_string(),
         };
-        let _ = ctx.send_envelope_as_root(
+        let _ = ctx.send_envelope_detached(
             engine_cap_mailbox(),
             <EngineAlive as Kind>::ID,
             &alive.encode_into_bytes(),
@@ -142,7 +142,7 @@ impl EngineProxyState {
             engine_id: self.engine_id.0.to_string(),
             reason,
         };
-        let _ = ctx.send_envelope_as_root(
+        let _ = ctx.send_envelope_detached(
             engine_cap_mailbox(),
             <EngineDied as Kind>::ID,
             &died.encode_into_bytes(),

--- a/crates/aether-capabilities/src/engine/server/runtime.rs
+++ b/crates/aether-capabilities/src/engine/server/runtime.rs
@@ -495,7 +495,7 @@ impl NativeActor for EngineServer {
         // reply, and the table entry is already gone, so the
         // returned MailId has nothing to subscribe against.
         let payload = mail.encode_into_bytes();
-        let _ = ctx.send_envelope_traced(proxy_mailbox, <TerminateEngine as Kind>::ID, &payload);
+        let _ = ctx.send_envelope_tracked(proxy_mailbox, <TerminateEngine as Kind>::ID, &payload);
         TerminateEngineResult::Ok
     }
 

--- a/crates/aether-capabilities/src/http/server/mod.rs
+++ b/crates/aether-capabilities/src/http/server/mod.rs
@@ -12,7 +12,7 @@
 //! On a parsed request the cap dispatches an
 //! [`HttpServerRequest`](crate::http::kinds::HttpServerRequest) to the configured
 //! handler mailbox as a fresh causal chain via
-//! `NativeCtx::send_envelope_as_root` (the wake mail is causally unrelated
+//! `NativeCtx::send_envelope_detached` (the wake mail is causally unrelated
 //! to the inbound request), records the open response socket in an
 //! in-flight table keyed by the dispatch's correlation id, and subscribes
 //! to settlement of the dispatched root. The handler replies

--- a/crates/aether-capabilities/src/http/server/runtime/state.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/state.rs
@@ -320,7 +320,7 @@ impl HttpServerCapabilityState {
             peer_addr,
         }
         .encode_into_bytes();
-        let mail_id = ctx.send_envelope_as_root(handler, dispatch_kind, &payload);
+        let mail_id = ctx.send_envelope_detached(handler, dispatch_kind, &payload);
         // Safety net (ADR-0108 §5): if the chain settles with no
         // response, `on_settled` answers `502`. Best-effort — a chassis
         // without the settlement registry still serves the reply path.

--- a/crates/aether-capabilities/src/http/server/runtime/streaming.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/streaming.rs
@@ -40,7 +40,7 @@ impl HttpServerCapabilityState {
             headers: head.headers,
         }
         .encode_into_bytes();
-        let _ = ctx.send_envelope_as_root(handler, <HttpRequestStreamOpen as Kind>::ID, &payload);
+        let _ = ctx.send_envelope_detached(handler, <HttpRequestStreamOpen as Kind>::ID, &payload);
         self.signal_reader(conn_id, ReaderControl::Stream { credit: window });
         tracing::debug!(
             target: "aether_substrate::http_server",
@@ -67,7 +67,7 @@ impl HttpServerCapabilityState {
             return;
         };
         let payload = HttpRequestChunk { stream_id, body }.encode_into_bytes();
-        let _ = ctx.send_envelope_as_root(handler, <HttpRequestChunk as Kind>::ID, &payload);
+        let _ = ctx.send_envelope_detached(handler, <HttpRequestChunk as Kind>::ID, &payload);
     }
 
     /// Finish an inbound request stream (ADR-0128): send the handler an
@@ -88,8 +88,11 @@ impl HttpServerCapabilityState {
             return;
         };
         let payload = HttpRequestStreamEnd { stream_id }.encode_into_bytes();
-        let mail_id =
-            ctx.send_envelope_as_root(stream.handler, <HttpRequestStreamEnd as Kind>::ID, &payload);
+        let mail_id = ctx.send_envelope_detached(
+            stream.handler,
+            <HttpRequestStreamEnd as Kind>::ID,
+            &payload,
+        );
         if let Some(registry) = self.mailer.settlement_registry() {
             registry.subscribe_settlement_mail(
                 mail_id,
@@ -327,7 +330,7 @@ impl HttpServerCapabilityState {
             return;
         };
         let payload = HttpStreamCredit { stream_id, credit }.encode_into_bytes();
-        let _ = ctx.send_envelope_as_root(handler, <HttpStreamCredit as Kind>::ID, &payload);
+        let _ = ctx.send_envelope_detached(handler, <HttpStreamCredit as Kind>::ID, &payload);
     }
 
     /// Remove a stream and detach its writer thread without joining inline —

--- a/crates/aether-capabilities/src/http/server/runtime/types.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/types.rs
@@ -233,7 +233,7 @@ pub struct WsConn {
 /// Bookkeeping for one in-flight request. Looked up by the dispatch's
 /// auto-minted `correlation_id` (== the dispatched envelope's
 /// `MailId.correlation_id`, which is also the root id since the cap
-/// always dispatches via `send_envelope_as_root`).
+/// always dispatches via `send_envelope_detached`).
 #[derive(Copy, Clone)]
 pub struct PendingRequest {
     pub conn_id: ConnId,

--- a/crates/aether-capabilities/src/http/server/runtime/websocket.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/websocket.rs
@@ -627,7 +627,7 @@ impl HttpServerCapabilityState {
             data,
         }
         .encode_into_bytes();
-        let _ = ctx.send_envelope_as_root(handler, <WebSocketMessage as Kind>::ID, &payload);
+        let _ = ctx.send_envelope_detached(handler, <WebSocketMessage as Kind>::ID, &payload);
     }
 
     /// Report a peer-initiated websocket close to the handler (ADR-0129 §5) as
@@ -654,7 +654,7 @@ impl HttpServerCapabilityState {
             reason: reason.to_string(),
         }
         .encode_into_bytes();
-        let _ = ctx.send_envelope_as_root(handler, <WebSocketClose as Kind>::ID, &payload);
+        let _ = ctx.send_envelope_detached(handler, <WebSocketClose as Kind>::ID, &payload);
     }
 
     /// Frame an outbound application message and hand it to the connection's

--- a/crates/aether-capabilities/src/lifecycle/subscribers.rs
+++ b/crates/aether-capabilities/src/lifecycle/subscribers.rs
@@ -119,7 +119,7 @@ impl LifecycleMailboxExt for NativeActorMailbox<'_, LifecycleCapability> {
 }
 
 /// Push the current stage's empty signal to each subscriber as an
-/// untyped envelope. Uses the runtime-id `send_envelope_traced` path
+/// untyped envelope. Uses the runtime-id `send_envelope_tracked` path
 /// because the broadcast kind is chosen at runtime (the current
 /// state's), not a compile-site `K`; the path preserves the inbound
 /// `(parent, root)` lineage so settlement counts each child against
@@ -134,6 +134,6 @@ pub fn broadcast_to_subscribers<M: ReplyMode>(
         return;
     };
     for mailbox in set {
-        let _ = ctx.send_envelope_traced(SubstrateMailboxId(mailbox.0), stage, &[]);
+        let _ = ctx.send_envelope_tracked(SubstrateMailboxId(mailbox.0), stage, &[]);
     }
 }

--- a/crates/aether-capabilities/src/render/runtime/mod.rs
+++ b/crates/aether-capabilities/src/render/runtime/mod.rs
@@ -284,7 +284,7 @@ impl NativeActor for RenderCapability {
         };
 
         // iamacoffeepot/aether#860: dispatch each pre-mail as a
-        // fresh chassis-rooted chain via `send_envelope_as_root`
+        // fresh chassis-rooted chain via `send_envelope_detached`
         // and subscribe to its settlement, so the driver can wait
         // for the full causal chain (component handler → emitted
         // DrawTriangle → render cap accumulator) to land before
@@ -304,7 +304,7 @@ impl NativeActor for RenderCapability {
         let settlement_registry = state.mailer.settlement_registry().cloned();
         let mut pre_settlements = Vec::with_capacity(pre.len());
         for envelope in pre {
-            let mail_id = ctx.send_envelope_as_root(
+            let mail_id = ctx.send_envelope_detached(
                 envelope.recipient,
                 envelope.kind,
                 envelope.payload.bytes(),

--- a/crates/aether-capabilities/src/rpc/server/mod.rs
+++ b/crates/aether-capabilities/src/rpc/server/mod.rs
@@ -8,7 +8,7 @@
 //! cap's dispatcher to drain.
 //!
 //! On `Call`, the cap dispatches the wire-borne envelope via
-//! `NativeCtx::send_envelope_as_root` (fresh causal chain — the wake
+//! `NativeCtx::send_envelope_detached` (fresh causal chain — the wake
 //! mail is causally unrelated to the wire-borne Call) and subscribes
 //! to settlement of the resulting root via
 //! `SettlementRegistry::subscribe_settlement_mail`. Any reply mail

--- a/crates/aether-capabilities/src/rpc/server/runtime.rs
+++ b/crates/aether-capabilities/src/rpc/server/runtime.rs
@@ -71,7 +71,7 @@ pub struct RpcServerHandle {
 /// wire). Looked up by the dispatch's auto-minted
 /// `correlation_id` (== `MailId.correlation_id` of the dispatched
 /// envelope, which is also the root id since we always dispatch
-/// as chassis-root via `send_envelope_as_root`). Fields are
+/// as chassis-root via `send_envelope_detached`). Fields are
 /// `pub` so the parent's `on_settled` / `on_any` handlers can
 /// read them after `remove` / `get`.
 #[derive(Copy, Clone)]
@@ -287,7 +287,7 @@ impl RpcServerState {
             // sibling type to resolve through.
             #[allow(clippy::disallowed_methods)]
             let engine_cap = mailbox_id_from_name(<EngineServer as Addressable>::NAMESPACE);
-            let mail_id = ctx.send_envelope_as_root(
+            let mail_id = ctx.send_envelope_detached(
                 engine_cap,
                 <RouteEnvelope as Kind>::ID,
                 &route.encode_into_bytes(),
@@ -304,7 +304,7 @@ impl RpcServerState {
         let recipient = envelope.to.mailbox;
         let kind = envelope.kind;
         let payload = envelope.payload;
-        let mail_id: MailId = ctx.send_envelope_as_root(recipient, kind, &payload);
+        let mail_id: MailId = ctx.send_envelope_detached(recipient, kind, &payload);
 
         let Some(wire_cid) = cid else {
             // Fire-and-forget at the wire layer. No bookkeeping.

--- a/crates/aether-capabilities/src/rpc/server/tests.rs
+++ b/crates/aether-capabilities/src/rpc/server/tests.rs
@@ -380,7 +380,7 @@ fn call_deferred_echo_settles_after_reply() {
 /// failure shape: each child is itself a deferred-reply path
 /// (spawn → loopback → re-reply), routed through the trace cap rather
 /// than directly. Pre-fix the trace cap dispatched each child via
-/// `ctx.send_envelope_traced` which stamps `reply_to` at the
+/// `ctx.send_envelope_tracked` which stamps `reply_to` at the
 /// dispatcher's own mailbox (the `push_envelope_buffered` default);
 /// child deferred replies landed at the trace cap, which has no
 /// handler for the reply kind and no `#[fallback]`, so they were

--- a/crates/aether-capabilities/src/trace/runtime.rs
+++ b/crates/aether-capabilities/src/trace/runtime.rs
@@ -100,7 +100,7 @@ impl NativeActor for TraceDispatchCapability {
             }
         };
         for mail in resolved {
-            let _ = ctx.send_envelope_traced_with_reply_to(
+            let _ = ctx.send_envelope_tracked_with_reply_to(
                 mail.recipient,
                 mail.kind,
                 mail.payload.bytes(),
@@ -162,7 +162,7 @@ mod tests {
     /// Issue 749: `on_dispatch_traced` resolves each envelope's
     /// name addressing through the registry (matching
     /// `CaptureFrame`'s bundle pattern), dispatches each via
-    /// `send_envelope_traced` so children inherit the chain, and
+    /// `send_envelope_tracked` so children inherit the chain, and
     /// replies synchronously with `DispatchTracedAck::Ok { root }`
     /// carrying the inbound mail id.
     #[test]

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -1975,7 +1975,7 @@ mod tests {
         let armed_reply_id = MailId::new(cap_mailbox, 1 << 63);
         let settle_rx = settlement.subscribe_settlement(root);
         let sender = Source::with_correlation(SourceAddr::Component(reply_mailbox), 7);
-        mailer.send_reply_with_lineage(
+        mailer.send_reply(
             sender,
             &LifecycleAdvanceComplete {
                 completed: 1,
@@ -2004,7 +2004,7 @@ mod tests {
         // all proves the guard was disarmed.
         let armed_reply_id_2 = MailId::new(cap_mailbox, (1 << 63) + 1);
         let sender_2 = Source::with_correlation(SourceAddr::Component(reply_mailbox), 8);
-        mailer.send_reply_with_lineage(
+        mailer.send_reply(
             sender_2,
             &LifecycleAdvanceComplete {
                 completed: 2,

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -210,7 +210,7 @@ impl Dispatch<Self> for Relay {
         // stamps its own `t_sent`, so later children in a fan-out reveal
         // any per-child enqueue skew.
         for &down in state.downstreams.iter() {
-            let _ = ctx.send_envelope_traced(down, Ping::ID, payload);
+            let _ = ctx.send_envelope_tracked(down, Ping::ID, payload);
             state.sent += 1;
         }
         Some(())
@@ -301,7 +301,7 @@ impl Dispatch<Self> for TickSource {
         for _ in 0..state.burst {
             let bytes = Ping { seq: state.seq }.encode_into_bytes();
             state.seq = state.seq.wrapping_add(1);
-            let _ = ctx.send_envelope_traced(state.entry, Ping::ID, &bytes);
+            let _ = ctx.send_envelope_tracked(state.entry, Ping::ID, &bytes);
             state.sent += 1;
         }
         Some(())

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -1538,7 +1538,7 @@ mod tests {
         // (goes through the lifecycle cap's on_subscribe handler), then
         // advance one tick. The advance issues a `LifecycleAdvance` whose
         // chain root the lifecycle cap threads through
-        // `broadcast_to_subscribers` (`send_envelope_traced`) to every
+        // `broadcast_to_subscribers` (`send_envelope_tracked`) to every
         // stage subscriber (issue 723 lineage, ADR-0082 §6). Sequencing
         // both through `execute` settles the subscribe before the tick
         // fires.

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -87,7 +87,7 @@ impl Dispatch<Self> for RingRelay {
         let ping = Ping::decode_from_bytes(payload)?;
         if ping.seq > 0 {
             let bytes = Ping { seq: ping.seq - 1 }.encode_into_bytes();
-            let _ = ctx.send_envelope_traced(state.next, Ping::ID, &bytes);
+            let _ = ctx.send_envelope_tracked(state.next, Ping::ID, &bytes);
         }
         Some(())
     }

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -461,7 +461,7 @@ impl NativeBinding {
     /// Reply path for native actors (ADR-0080 §5 / #1695). Mints the
     /// reply's lineage `MailId` from this actor's disjoint
     /// `reply_lineage` allocator and routes through
-    /// [`Mailer::send_reply_with_lineage`], so the reply joins the
+    /// [`Mailer::send_reply`], so the reply joins the
     /// caller's causal chain: it inherits the handler's `root` and
     /// `parent`, and its `Sent` is recorded against that root (keeping
     /// the §6 hold contract exact — a synchronous reply's `Sent`
@@ -487,7 +487,7 @@ impl NativeBinding {
         let correlation = self.reply_lineage.mint();
         let reply_id = MailId::new(self.self_mailbox, correlation);
         self.mailer
-            .send_reply_with_lineage(sender, payload, reply_id, root, parent);
+            .send_reply(sender, payload, reply_id, root, parent);
     }
 }
 

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -827,7 +827,12 @@ impl<M: ReplyMode> NativeCtx<'_, M> {
     /// `send` / `send_many` on `NativeActorMailbox` cover the
     /// fire-and-forget case.
     #[must_use]
-    pub fn send_envelope_traced(&self, recipient: MailboxId, kind: KindId, bytes: &[u8]) -> MailId {
+    pub fn send_envelope_tracked(
+        &self,
+        recipient: MailboxId,
+        kind: KindId,
+        bytes: &[u8],
+    ) -> MailId {
         self.binding.push_envelope_buffered(
             recipient.0,
             kind.0,
@@ -838,7 +843,7 @@ impl<M: ReplyMode> NativeCtx<'_, M> {
         )
     }
 
-    /// Re-dispatch variant of [`Self::send_envelope_traced`] that pins the
+    /// Re-dispatch variant of [`Self::send_envelope_tracked`] that pins the
     /// child mail's `reply_to` to the supplied [`Source`] instead of
     /// stamping the default `(Component(self_mailbox), auto_correlation)`.
     /// The minted [`MailId`] and the chain's `in_flight` accounting are
@@ -856,11 +861,11 @@ impl<M: ReplyMode> NativeCtx<'_, M> {
     ///
     /// Pass `ctx.reply_target()` as `reply_to` to forward to whoever
     /// invoked this cap. Single-Call paths (the RPC server's
-    /// `send_envelope_as_root` dispatching directly at the receiver)
+    /// `send_envelope_detached` dispatching directly at the receiver)
     /// never reach this method — the default `reply_to` lands at the
     /// dispatcher which is also the call-correlation owner.
     #[must_use]
-    pub fn send_envelope_traced_with_reply_to(
+    pub fn send_envelope_tracked_with_reply_to(
         &self,
         recipient: MailboxId,
         kind: KindId,
@@ -878,7 +883,7 @@ impl<M: ReplyMode> NativeCtx<'_, M> {
         )
     }
 
-    /// Like [`Self::send_envelope_traced`] but always starts a fresh
+    /// Like [`Self::send_envelope_tracked`] but always starts a fresh
     /// causal chain — ignores the ctx's in-flight lineage and passes
     /// `parent_mail = None, inherited_root = None` to the dispatch
     /// path. The returned [`MailId`] is the root of the new chain, so
@@ -896,7 +901,7 @@ impl<M: ReplyMode> NativeCtx<'_, M> {
     /// (descendants don't settle individually; only the chain root
     /// does).
     #[must_use]
-    pub fn send_envelope_as_root(
+    pub fn send_envelope_detached(
         &self,
         recipient: MailboxId,
         kind: KindId,

--- a/crates/aether-substrate/src/chassis/inbox.rs
+++ b/crates/aether-substrate/src/chassis/inbox.rs
@@ -28,7 +28,7 @@
 //! ADR-0080 §6 requires a reply's `Sent` to be recorded before the
 //! inbound's `Finished`, so a consume-time discharge would close the
 //! caller's chain before the reply joins it. [`InboundMail::reply`]
-//! routes through [`Mailer::send_reply_with_lineage`] with the inbound's
+//! routes through [`Mailer::send_reply`] with the inbound's
 //! chain and a drain-owned reply-id counter, so a claimed-mailbox
 //! consumer never reaches the bare, lineage-less `send_reply`.
 
@@ -319,7 +319,7 @@ impl InboundMail {
     /// (ADR-0080 §5/§6). Mints the reply id from the drain-owned
     /// reply-id counter in the disjoint reply-lineage space (`1 << 63`
     /// base) and stamps the inbound's `root` / parent, routing through
-    /// [`Mailer::send_reply_with_lineage`]. Returns whether the reply
+    /// [`Mailer::send_reply`]. Returns whether the reply
     /// was routed (`false` for a `SourceAddr::None` sender — nobody
     /// asked for a reply). The reply's `Sent` is recorded here, before
     /// this guard's `Drop` records the inbound's `Finished`, so the §6
@@ -334,13 +334,8 @@ impl InboundMail {
         } else {
             Some(self.env.mail_id)
         };
-        self.mailer.send_reply_with_lineage(
-            self.env.sender,
-            result,
-            reply_id,
-            self.env.root,
-            parent,
-        )
+        self.mailer
+            .send_reply(self.env.sender, result, reply_id, self.env.root, parent)
     }
 }
 

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -371,7 +371,7 @@ impl Mailer {
     ///
     /// A reply that should join the caller's ADR-0080 causal chain goes
     /// through the lineage-carrying path instead:
-    /// [`Self::send_reply_with_lineage`] (the
+    /// [`Self::send_reply`] (the
     /// `NativeBinding::send_reply_for_handler` form),
     /// [`InboundMail::reply`](crate::chassis::inbox::InboundMail::reply)
     /// (the claimed-inbox drain guard), or the typed `ctx.reply()` on a
@@ -379,7 +379,7 @@ impl Mailer {
     /// unchained form silently detaches it from the caller's settlement
     /// window — the bug class #1701 fixed for handler replies.
     ///
-    /// Equivalent to [`Self::send_reply_with_lineage`] with a `NONE`
+    /// Equivalent to [`Self::send_reply`] with a `NONE`
     /// triple — the bare-vs-lineage split mirrors
     /// [`NativeBinding::send_mail`](crate::actor::native::NativeBinding)'s
     /// `send_mail` / `send_mail_with_lineage` pair.
@@ -387,7 +387,7 @@ impl Mailer {
     where
         K: Kind,
     {
-        self.send_reply_with_lineage(
+        self.send_reply(
             sender,
             result,
             aether_data::MailId::NONE,
@@ -420,7 +420,7 @@ impl Mailer {
     /// `reply_id` skips the hook and stamps the `NONE` triple,
     /// reproducing the pre-lineage reply shape for callers without a
     /// handler chain (the bare [`Self::send_reply_unchained`]).
-    pub fn send_reply_with_lineage<K>(
+    pub fn send_reply<K>(
         &self,
         sender: Source,
         result: &K,
@@ -1106,7 +1106,7 @@ mod tests {
     }
 
     /// #1695 / ADR-0080 §5/§6: a `Component`-addressed reply routed
-    /// through `send_reply_with_lineage` carries the caller's `root` +
+    /// through `send_reply` carries the caller's `root` +
     /// `parent` and a real (non-`NONE`) `mail_id`, and records the
     /// reply's `Sent` against the caller root so the chain stays open
     /// until the reply's `Finished` (the conformance fix — replies were
@@ -1114,7 +1114,7 @@ mod tests {
     /// (standing in for the recipient dispatcher) balances that `Sent`
     /// exactly, reclaiming the root cell.
     #[test]
-    fn send_reply_with_lineage_stamps_caller_chain() {
+    fn send_reply_stamps_caller_chain() {
         use aether_data::MailId;
 
         // Capture the delivered reply's lineage triple off the
@@ -1146,7 +1146,7 @@ mod tests {
         let counter = mailer.trace_handle().settlement_counter();
         assert_eq!(counter.live_roots(), 0, "no live root before the reply");
 
-        let sent = mailer.send_reply_with_lineage(
+        let sent = mailer.send_reply(
             Source::with_correlation(SourceAddr::Component(sink_id), 7),
             &CastReply {
                 code: 1,
@@ -1172,7 +1172,7 @@ mod tests {
         assert_eq!(
             counter.live_roots(),
             1,
-            "send_reply_with_lineage records the reply's Sent on the caller root"
+            "send_reply records the reply's Sent on the caller root"
         );
 
         // The recipient's dispatcher would record the matching `Finished`;

--- a/crates/aether-substrate/src/mail/mod.rs
+++ b/crates/aether-substrate/src/mail/mod.rs
@@ -130,7 +130,7 @@ impl Mail {
 
     /// ADR-0080 §1 / §5: stamp the producer-minted lineage triple
     /// (`mail_id`, `root`, `parent_mail`) onto this mail. Producer
-    /// paths (`NativeBinding::send_mail`, `Mailer::send_reply_with_lineage`,
+    /// paths (`NativeBinding::send_mail`, `Mailer::send_reply`,
     /// chassis-root push sites) call this immediately after minting — a
     /// reply joins the caller's chain by inheriting its `root` / `parent`
     /// (#1695). Mail with no lineage stamped retains `MailId::NONE`


### PR DESCRIPTION
Closes #2593.

## Summary

The mail layer spent multiple synonyms on three chain-mode concepts. This unifies the vocabulary so the default (traced, with lineage) is the unmarked name and only deviations carry a suffix, mirroring how the unmarked `send` is the inherit default:

- `send_envelope_as_root` → `send_envelope_detached` (conforms to the typed `send_detached` / `send_detached_to`)
- `send_envelope_traced` → `send_envelope_tracked`, and its sibling `send_envelope_traced_with_reply_to` → `send_envelope_tracked_with_reply_to` (conforms to the typed `send_tracked`)
- `send_reply_with_lineage` → `send_reply` (`send_reply_unchained` stays as the marked no-lineage deviation)

`send_mail_with_lineage` / `push_envelope_buffered` are deliberately left alone (low-level primitives, not default-marking synonyms). `OutboundReply::send_reply` is a distinct type's method — no collision. Mechanical rename, no behavior change; spans aether-substrate, aether-capabilities, aether-substrate-bundle as one atomic PR (splitting mid-rename breaks compilation).

## Test plan

No new tests — a rename-refactor is proven by the workspace continuing to build and pass. Every call site was enumerated by `git grep` before and after (0 old names remaining); `cargo clippy --workspace --all-targets -- -D warnings` and `cargo nextest run --workspace` (1799 passed, 0 failed) are the proof the rename landed in lockstep across all three crates.

## Generated by

`/implement` — agent execution of [scoped issue #2593](https://github.com/iamacoffeepot/aether/issues/2593).
