### PR TITLE
refactor(test-fixtures): standardize fixture actor namespaces on a dotted test. prefix

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -532,7 +532,7 @@ impl TestBench {
     /// substrate-default cap (currently 100). The framework dispatch loop
     /// answers [`LogTail`] for every native actor and wasm trampoline, so
     /// `mailbox_name` is any live mailbox path (e.g.
-    /// `"aether.component/aether.embedded:test_fixture_probe"`).
+    /// `"aether.component/aether.embedded:test.probe"`).
     ///
     /// # Panics
     /// Panics on a decode failure — implies a kind shape mismatch,

--- a/crates/aether-substrate-bundle/tests/dispatch_decode_failure.rs
+++ b/crates/aether-substrate-bundle/tests/dispatch_decode_failure.rs
@@ -8,7 +8,7 @@
 //! fallback / unknown-kind path) and hanging a request-shaped caller to its
 //! settlement timeout with no diagnostic.
 //!
-//! Drives the strict `Probe` fixture (namespace `test_fixture_probe`, no
+//! Drives the strict `Probe` fixture (namespace `test.probe`, no
 //! `#[fallback]`, an `on_set_render(SetRender)` handler) directly through the pub
 //! `Component::instantiate` / `deliver` API: deliver a `Mail` carrying
 //! `SetRender::ID` (a `#[repr(C)]` 4-byte cast-shape kind) with a 2-byte payload,

--- a/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
@@ -25,7 +25,7 @@ mod tests {
 
     /// The probe fixture's declared `Addressable::NAMESPACE` (distinct from the
     /// `probe` wasm stem).
-    const PROBE_NAMESPACE: &str = "test_fixture_probe";
+    const PROBE_NAMESPACE: &str = "test.probe";
 
     /// The probe's registered ADR-0099 lineage address.
     fn probe_lineage_addr() -> String {

--- a/crates/aether-substrate-bundle/tests/fleetbench_describe.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_describe.rs
@@ -54,7 +54,7 @@ mod tests {
             }
         };
 
-        // The probe entry actor (`test_fixture_probe`) typed-handles Tick,
+        // The probe entry actor (`test.probe`) typed-handles Tick,
         // Key, and SetRender. Asserting two substrate kinds round-trip proves
         // the wire carried the full retained handler set, not an empty stub.
         let handler_ids: Vec<_> = capabilities.handlers.iter().map(|h| h.id).collect();

--- a/crates/aether-substrate-bundle/tests/fleetbench_load.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_load.rs
@@ -17,7 +17,7 @@ mod tests {
     /// `/`-rendered lineage
     /// `aether.component/aether.embedded:<NAMESPACE>` (ADR-0099
     /// §3/§4). The probe example's `Addressable::NAMESPACE` is
-    /// `test_fixture_probe` — distinct from the wasm stem (`probe`),
+    /// `test.probe` — distinct from the wasm stem (`probe`),
     /// so this also pins that the registered name comes from the
     /// component's declared namespace, not the file name. Also
     /// asserts the recorded `CallRecord` trace captured the load
@@ -31,10 +31,7 @@ mod tests {
         let engine = bench.spawn_headless();
         let addr = bench.load(engine, "aether_test_fixtures_bundle");
 
-        let expected = format!(
-            "aether.component/{}:test_fixture_probe",
-            WasmTrampoline::NAMESPACE,
-        );
+        let expected = format!("aether.component/{}:test.probe", WasmTrampoline::NAMESPACE);
         assert_eq!(
             addr, expected,
             "LoadResult.name should be the ADR-0099 lineage address",

--- a/crates/aether-substrate-bundle/tests/fleetbench_mail.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_mail.rs
@@ -47,7 +47,7 @@ mod tests {
             engine,
             "aether_test_fixtures_bundle",
             &config,
-            "test_fixtures_probe_with_config",
+            "test.probe_with_config",
         );
 
         let replies = bench.send(engine, &addr, &ConfigQuery);

--- a/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
@@ -52,10 +52,7 @@ mod tests {
             "probe should not declare a CameraCreate handler: {:?}",
             loaded.capabilities.handlers,
         );
-        let expected = format!(
-            "aether.component/{}:test_fixture_probe",
-            WasmTrampoline::NAMESPACE,
-        );
+        let expected = format!("aether.component/{}:test.probe", WasmTrampoline::NAMESPACE);
         assert_eq!(
             loaded.addr, expected,
             "probe should load at its ADR-0099 lineage address",
@@ -96,7 +93,7 @@ mod tests {
     /// ADR-0096 wire regression for `ReplaceComponent.export`: load
     /// the `multi_actor` module's **entry** actor (`RootManager`, a
     /// strict receiver — no `#[fallback]`), then replace it with the
-    /// non-entry export `ui.panel` (`Panel`, which carries a
+    /// non-entry export `test.ui.panel` (`Panel`, which carries a
     /// `#[fallback]`) at the same trampoline `mailbox_id`. The
     /// post-replace capabilities must be `Panel`'s — `fallback`
     /// flips from `None` to `Some` — proving the new `export` field
@@ -114,9 +111,9 @@ mod tests {
         let engine = bench.spawn_headless();
 
         // Load the `RootManager` actor (a strict receiver) from the
-        // bundle by its `ui.root` export. It is a non-entry actor in the
+        // bundle by its `test.ui.root` export. It is a non-entry actor in the
         // bundle (the entry is `Probe`), so it is selected explicitly.
-        let loaded = bench.load_full_export(engine, "aether_test_fixtures_bundle", "ui.root");
+        let loaded = bench.load_full_export(engine, "aether_test_fixtures_bundle", "test.ui.root");
 
         // Pre-replace: the entry is a strict receiver — it declares a
         // Ping handler and no fallback.
@@ -135,13 +132,13 @@ mod tests {
             loaded.capabilities.fallback,
         );
 
-        // Replace into the non-entry export `ui.panel`, at the same
+        // Replace into the non-entry export `test.ui.panel`, at the same
         // mailbox id, carrying the export over the wire.
         let caps = bench.replace_export(
             engine,
             loaded.mailbox_id,
             "aether_test_fixtures_bundle",
-            "ui.panel",
+            "test.ui.panel",
         );
 
         // Post-replace: Panel's capability group is active — still a

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -45,28 +45,28 @@ use aether_substrate_bundle::test_bench::test_helpers::{
 
 /// The `http_handler` fixture's `NAMESPACE` const — the subname under
 /// which `WasmTrampoline` registers it, and the last segment of its
-/// full lineage address (`aether.component/aether.embedded:web`).
-const HANDLER_NAMESPACE: &str = "web";
+/// full lineage address (`aether.component/aether.embedded:test.web`).
+const HANDLER_NAMESPACE: &str = "test.web";
 
 /// The full handler mailbox address the http server cap resolves at
 /// dispatch time (ADR-0108 §3 late binding).
-const HANDLER_MAILBOX: &str = "aether.component/aether.embedded:web";
+const HANDLER_MAILBOX: &str = "aether.component/aether.embedded:test.web";
 
 /// The `StreamingHttpHandler` fixture's `NAMESPACE` const (ADR-0128).
-const STREAM_HANDLER_NAMESPACE: &str = "web_stream";
+const STREAM_HANDLER_NAMESPACE: &str = "test.web_stream";
 
 /// The streaming handler's full lineage mailbox address.
-const STREAM_HANDLER_MAILBOX: &str = "aether.component/aether.embedded:web_stream";
+const STREAM_HANDLER_MAILBOX: &str = "aether.component/aether.embedded:test.web_stream";
 
 /// The chunk count `StreamingHttpHandler` emits — kept in step with the
 /// fixture's own `STREAM_CHUNK_COUNT`.
 const STREAM_CHUNK_COUNT: u32 = 20;
 
 /// The `WebSocketHandler` fixture's `NAMESPACE` const (ADR-0129).
-const WS_HANDLER_NAMESPACE: &str = "web_socket";
+const WS_HANDLER_NAMESPACE: &str = "test.web_socket";
 
 /// The websocket handler's full lineage mailbox address.
-const WS_HANDLER_MAILBOX: &str = "aether.component/aether.embedded:web_socket";
+const WS_HANDLER_MAILBOX: &str = "aether.component/aether.embedded:test.web_socket";
 
 /// RFC 6455 §1.3 worked-vector handshake key, and the `Sec-WebSocket-Accept`
 /// the server must echo for it (base64(SHA-1(key + GUID))). Using the fixed
@@ -673,7 +673,7 @@ mod tests {
     #[test]
     #[allow(clippy::too_many_lines)]
     fn dropped_component_routes_are_purged() {
-        const ROUTED_NAMESPACE: &str = "routed_web";
+        const ROUTED_NAMESPACE: &str = "test.routed_web";
         let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
         let Some(wasm_path) = locate_component_wasm("aether_test_fixtures_bundle") else {
             assert!(

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -150,10 +150,10 @@ fn load_cube(bench: &mut TestBench, wasm_path: &Path) {
                 "aether.component",
                 &LoadComponent {
                     wasm,
-                    name: Some("cube".to_owned()),
+                    name: Some("test.cube".to_owned()),
                     config: Vec::new(),
                     // `Cube` is a non-entry actor in the bundle.
-                    export: Some("cube".to_owned()),
+                    export: Some("test.cube".to_owned()),
                 },
             ),
         )])
@@ -225,7 +225,7 @@ fn input_subscription_yields_one_tick_observed_per_advance() {
 /// instantiating its entry export — the first type in the `export!`
 /// list, `Probe` — via the boxed `ErasedWasmActor` path. Omitting `name`
 /// exercises the `aether.namespace` section, which carries the entry
-/// type's `NAMESPACE` (`test_fixture_probe`), and the `LoadResult`
+/// type's `NAMESPACE` (`test.probe`), and the `LoadResult`
 /// capabilities come from the entry type's `aether.kinds.inputs`
 /// manifest. Proves init-through-the-box and the multi-actor section
 /// emission end-to-end; selecting a non-entry export is the follow-on.
@@ -260,9 +260,9 @@ fn multi_actor_module_loads_entry_export() {
             name, capabilities, ..
         } => {
             assert!(
-                name.ends_with(":test_fixture_probe"),
+                name.ends_with(":test.probe"),
                 "entry export should resolve to the first type's NAMESPACE \
-                 (test_fixture_probe); got {name}",
+                 (test.probe); got {name}",
             );
             assert!(
                 !capabilities.handlers.is_empty(),
@@ -273,11 +273,11 @@ fn multi_actor_module_loads_entry_export() {
     }
 }
 
-/// ADR-0096: passing `export: "ui.panel"` instantiates the non-entry
+/// ADR-0096: passing `export: "test.ui.panel"` instantiates the non-entry
 /// type from the same multi-actor module. The host resolves the
 /// selector to the actor-type tag, `init_typed_p32` constructs `Panel`
 /// (not the entry `RootManager`), the trampoline name defaults to the
-/// selected type's namespace (`:ui.panel`), and the `LoadResult`
+/// selected type's namespace (`:test.ui.panel`), and the `LoadResult`
 /// capabilities come from `Panel`'s `aether.kinds.inputs` group — which
 /// carries a `#[fallback]` the entry type lacks, so the reply proves
 /// the right group was selected.
@@ -298,7 +298,7 @@ fn multi_actor_module_loads_selected_export() {
                     // No name: defaults to the selected export's namespace.
                     name: None,
                     config: Vec::new(),
-                    export: Some("ui.panel".to_owned()),
+                    export: Some("test.ui.panel".to_owned()),
                 },
             ),
         )])
@@ -311,8 +311,8 @@ fn multi_actor_module_loads_selected_export() {
             name, capabilities, ..
         } => {
             assert!(
-                name.ends_with(":ui.panel"),
-                "selected export should resolve to Panel's NAMESPACE (ui.panel); got {name}",
+                name.ends_with(":test.ui.panel"),
+                "selected export should resolve to Panel's NAMESPACE (test.ui.panel); got {name}",
             );
             assert!(
                 capabilities.fallback.is_some(),
@@ -389,9 +389,9 @@ fn multi_actor_sibling_spawn() {
                     wasm,
                     name: None,
                     // `RootManager` is a non-entry actor in the bundle; select
-                    // it by its `ui.root` export.
+                    // it by its `test.ui.root` export.
                     config: Vec::new(),
-                    export: Some("ui.root".to_owned()),
+                    export: Some("test.ui.root".to_owned()),
                 },
             ),
         )])
@@ -404,8 +404,8 @@ fn multi_actor_sibling_spawn() {
         LoadResult::Err { error } => panic!("multi-actor load failed: {error}"),
     };
     assert!(
-        root_name.ends_with(":ui.root"),
-        "selected export should resolve to ui.root; got {root_name}",
+        root_name.ends_with(":test.ui.root"),
+        "selected export should resolve to test.ui.root; got {root_name}",
     );
 
     // ADR-0099 §3/§4: a spawned sibling nests under its spawner, so the
@@ -463,7 +463,7 @@ fn multi_actor_sibling_spawn_twice_in_one_receive() {
                     wasm,
                     name: None,
                     config: Vec::new(),
-                    export: Some("ui.root".to_owned()),
+                    export: Some("test.ui.root".to_owned()),
                 },
             ),
         )])
@@ -1284,7 +1284,7 @@ fn replace_preserves_multi_actor_state_via_dehydrate_rehydrate() {
                     wasm,
                     name: Some(FIXTURE_NAME.to_owned()),
                     config: Vec::new(),
-                    export: Some("stateful.counter".to_owned()),
+                    export: Some("test.stateful.counter".to_owned()),
                 },
             ),
         )])
@@ -2653,7 +2653,7 @@ fn childless_component_hot_reloads_unchanged() {
                     name: Some(FIXTURE_NAME.to_owned()),
                     config: Vec::new(),
                     // `Counter` is a non-entry actor in the bundle.
-                    export: Some("stateful.counter".to_owned()),
+                    export: Some("test.stateful.counter".to_owned()),
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/typed_config.rs
+++ b/crates/aether-substrate-bundle/tests/typed_config.rs
@@ -1,6 +1,6 @@
 //! ADR-0090 c1 (issue 1256) integration coverage for the typed
 //! `WasmActor::Config` path. Loads the `ProbeWithConfig` actor from the
-//! `probe` bundle (issue 1994, ADR-0096) via `export: Some("test_fixtures_probe_with_config")`
+//! `probe` bundle (issue 1994, ADR-0096) via `export: Some("test.probe_with_config")`
 //! through a [`TestBench`] and asserts the wasm guest's
 //! `init_with_config_p32` decode-error surfaces in `LoadResult::Err` when the
 //! load mail carries no config bytes — c1 wires the host probe and
@@ -55,7 +55,7 @@ fn typed_config_guest_without_config_bytes_surfaces_decode_error() {
                     wasm,
                     name: Some("probe_with_config".to_owned()),
                     config: Vec::new(),
-                    export: Some("test_fixtures_probe_with_config".to_owned()),
+                    export: Some("test.probe_with_config".to_owned()),
                 },
             ),
         )])
@@ -111,7 +111,7 @@ fn typed_config_guest_with_config_bytes_round_trips() {
                         wasm,
                         name: Some("probe_with_config".to_owned()),
                         config: config_bytes,
-                        export: Some("test_fixtures_probe_with_config".to_owned()),
+                        export: Some("test.probe_with_config".to_owned()),
                     },
                 ),
             ),

--- a/crates/aether-substrate-bundle/tests/widget_actor_cost.rs
+++ b/crates/aether-substrate-bundle/tests/widget_actor_cost.rs
@@ -115,7 +115,7 @@ fn load_widgets(
                         name: Some(format!("ui-widget-{i}")),
                         config: config.clone(),
                         // `UiWidget` is a non-entry actor in the bundle.
-                        export: Some("test_fixtures_ui_widget".to_owned()),
+                        export: Some("test.ui_widget".to_owned()),
                     },
                 ),
             )])

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/cube.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/cube.rs
@@ -128,7 +128,7 @@ impl Cube {
 
 #[actor]
 impl WasmActor for Cube {
-    const NAMESPACE: &'static str = "cube";
+    const NAMESPACE: &'static str = "test.cube";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Cube {

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -10,7 +10,7 @@
 //! - `GET /` → 200 `hello from aether`
 //! - Anything else → 404 `not found`
 //!
-//! Registered at `aether.component/aether.embedded:web` after load.
+//! Registered at `aether.component/aether.embedded:test.web` after load.
 //! The e2e test configures `HttpServerConfig.handler_mailbox` to that
 //! address and then fires real `TcpStream` requests at the bound port.
 
@@ -35,7 +35,7 @@ pub struct HttpHandler;
 
 #[actor]
 impl WasmActor for HttpHandler {
-    const NAMESPACE: &'static str = "web";
+    const NAMESPACE: &'static str = "test.web";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(HttpHandler)
@@ -48,7 +48,7 @@ impl WasmActor for HttpHandler {
     /// # Agent
     /// Not sent manually — the `aether.http.server` cap dispatches it
     /// on every inbound request. Configure `HttpServerConfig.handler_mailbox`
-    /// to `"aether.component/aether.embedded:web"` to route here.
+    /// to `"aether.component/aether.embedded:test.web"` to route here.
     #[handler]
     fn on_request(&mut self, _ctx: &mut WasmCtx<'_>, req: HttpServerRequest) -> HttpServerResponse {
         let (status, body): (u16, &[u8]) = match req.path.as_str() {
@@ -74,7 +74,7 @@ const STREAM_CHUNK_COUNT: u32 = 20;
 /// `HttpResponseStreamEnd`. Each chunk is `"chunk-{i}\n"`, so the client
 /// reassembles a deterministic body.
 ///
-/// Registered at `aether.component/aether.embedded:web_stream` after load.
+/// Registered at `aether.component/aether.embedded:test.web_stream` after load.
 pub struct StreamingHttpHandler {
     /// The stream this handler is feeding (ADR-0133), captured from the
     /// first credit mail — the counterparty that dispatched it plus the
@@ -88,7 +88,7 @@ pub struct StreamingHttpHandler {
 
 #[actor]
 impl WasmActor for StreamingHttpHandler {
-    const NAMESPACE: &'static str = "web_stream";
+    const NAMESPACE: &'static str = "test.web_stream";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(StreamingHttpHandler {
@@ -105,7 +105,7 @@ impl WasmActor for StreamingHttpHandler {
     /// Not sent manually — the `aether.http.server` cap dispatches it on
     /// every inbound request. Route here by pointing
     /// `HttpServerConfig.handler_mailbox` at
-    /// `"aether.component/aether.embedded:web_stream"`.
+    /// `"aether.component/aether.embedded:test.web_stream"`.
     #[handler]
     fn on_request(
         &mut self,
@@ -165,7 +165,7 @@ impl WasmActor for StreamingHttpHandler {
 /// can assert the cap drops an unknown-stream send without tearing the
 /// connection down.
 ///
-/// Registered at `aether.component/aether.embedded:web_socket` after load.
+/// Registered at `aether.component/aether.embedded:test.web_socket` after load.
 pub struct WebSocketHandler {
     /// The upgraded connection (ADR-0133), captured from the first credit
     /// grant. `None` until that accept-time grant arms it.
@@ -175,7 +175,7 @@ pub struct WebSocketHandler {
 
 #[actor]
 impl WasmActor for WebSocketHandler {
-    const NAMESPACE: &'static str = "web_socket";
+    const NAMESPACE: &'static str = "test.web_socket";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(WebSocketHandler {
@@ -278,7 +278,7 @@ pub struct RoutedHttpHandler;
 #[http::router]
 #[actor]
 impl WasmActor for RoutedHttpHandler {
-    const NAMESPACE: &'static str = "routed_web";
+    const NAMESPACE: &'static str = "test.routed_web";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(RoutedHttpHandler)

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/mat4_source.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/mat4_source.rs
@@ -25,7 +25,7 @@ pub struct MatSource;
 
 #[actor]
 impl WasmActor for MatSource {
-    const NAMESPACE: &'static str = "mat4_source";
+    const NAMESPACE: &'static str = "test.mat4_source";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(MatSource)

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/multi_actor.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/multi_actor.rs
@@ -33,7 +33,7 @@ pub struct RootManager;
 
 #[actor]
 impl WasmActor for RootManager {
-    const NAMESPACE: &'static str = "ui.root";
+    const NAMESPACE: &'static str = "test.ui.root";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(RootManager)
@@ -54,7 +54,7 @@ impl WasmActor for RootManager {
     }
 }
 
-/// Sibling export — selectable at load via `export: "ui.panel"`
+/// Sibling export — selectable at load via `export: "test.ui.panel"`
 /// (ADR-0096) and spawnable at runtime by `RootManager` (ADR-0097).
 /// `Instanced` so it satisfies the `spawn_child` bound. Carries a
 /// `#[fallback]` so its capability group is observably distinct from the
@@ -63,7 +63,7 @@ pub struct Panel;
 
 #[actor(instanced)]
 impl WasmActor for Panel {
-    const NAMESPACE: &'static str = "ui.panel";
+    const NAMESPACE: &'static str = "test.ui.panel";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Panel)

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/probe.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/probe.rs
@@ -51,7 +51,7 @@
 //! sibling `Probe` covers that.
 //!
 //! Consumers load it from the `probe` bundle stem with
-//! `export: Some("test_fixtures_probe_with_config")` (ADR-0096).
+//! `export: Some("test.probe_with_config")` (ADR-0096).
 
 // `on_key` only re-broadcasts the inbound payload, so it doesn't touch
 // `self`; it keeps `&mut self` to match the `#[handler]` dispatch ABI.
@@ -78,7 +78,7 @@ pub struct Probe {
 
 #[actor]
 impl WasmActor for Probe {
-    const NAMESPACE: &'static str = "test_fixture_probe";
+    const NAMESPACE: &'static str = "test.probe";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Probe {
@@ -175,7 +175,7 @@ impl WasmActor for Probe {
 /// `WasmActor::Config = ProbeConfig` path end-to-end.
 ///
 /// Consumers load this actor from the `probe` bundle with
-/// `export: Some("test_fixtures_probe_with_config")`.
+/// `export: Some("test.probe_with_config")`.
 pub struct ProbeWithConfig {
     seed: u32,
     label: String,
@@ -184,7 +184,7 @@ pub struct ProbeWithConfig {
 #[actor]
 impl WasmActor for ProbeWithConfig {
     type Config = ProbeConfig;
-    const NAMESPACE: &'static str = "test_fixtures_probe_with_config";
+    const NAMESPACE: &'static str = "test.probe_with_config";
 
     fn init(config: ProbeConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(ProbeWithConfig {

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/stateful_replace.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/stateful_replace.rs
@@ -34,7 +34,7 @@ pub struct Counter {
 
 #[actor]
 impl WasmActor for Counter {
-    const NAMESPACE: &'static str = "stateful.counter";
+    const NAMESPACE: &'static str = "test.stateful.counter";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Counter { count: 0 })
@@ -79,7 +79,7 @@ pub struct Sidecar;
 
 #[actor(instanced)]
 impl WasmActor for Sidecar {
-    const NAMESPACE: &'static str = "stateful.sidecar";
+    const NAMESPACE: &'static str = "test.stateful.sidecar";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Sidecar)

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/ui_widget.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/ui_widget.rs
@@ -37,7 +37,7 @@ pub struct UiWidget {
 #[actor]
 impl WasmActor for UiWidget {
     type Config = UiWidgetConfig;
-    const NAMESPACE: &'static str = "test_fixtures_ui_widget";
+    const NAMESPACE: &'static str = "test.ui_widget";
 
     fn init(config: UiWidgetConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(UiWidget { config })

--- a/crates/aether-test-fixtures/aether-test-fixtures-stateful-reshaped/Cargo.toml
+++ b/crates/aether-test-fixtures/aether-test-fixtures-stateful-reshaped/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 # ADR-0113 decode-miss companion / replace TARGET: same
-# `NAMESPACE = "stateful.typed"` and `CounterState` kind name as the typed
+# `NAMESPACE = "test.stateful.typed"` and `CounterState` kind name as the typed
 # satellite, but a reshaped state shape (an added `generation` field
 # changes `Kind::ID`). Replacing the typed fixture with this one makes the
 # generated `on_rehydrate` decode-miss and boot fresh. Standalone for the

--- a/crates/aether-test-fixtures/aether-test-fixtures-stateful-reshaped/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-stateful-reshaped/src/lib.rs
@@ -37,7 +37,7 @@ pub struct Counter {
 
 #[actor]
 impl WasmActor for Counter {
-    const NAMESPACE: &'static str = "stateful.typed";
+    const NAMESPACE: &'static str = "test.stateful.typed";
 
     type State = CounterState;
 

--- a/crates/aether-test-fixtures/aether-test-fixtures-stateful-typed/Cargo.toml
+++ b/crates/aether-test-fixtures/aether-test-fixtures-stateful-typed/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 # ADR-0113 declarative-state replace SOURCE: a single-actor `Counter`
-# (`NAMESPACE = "stateful.typed"`) that declares `type State = CounterState`
+# (`NAMESPACE = "test.stateful.typed"`) that declares `type State = CounterState`
 # plus the dehydrate / rehydrate accessors, so `#[actor]` generates the
 # hot-swap hooks. Standalone (not in the bundle) because the decode-miss
 # test entry-loads it and replaces it with the reshaped satellite — a

--- a/crates/aether-test-fixtures/aether-test-fixtures-stateful-typed/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-stateful-typed/src/lib.rs
@@ -40,7 +40,7 @@ pub struct Counter {
 
 #[actor]
 impl WasmActor for Counter {
-    const NAMESPACE: &'static str = "stateful.typed";
+    const NAMESPACE: &'static str = "test.stateful.typed";
 
     /// ADR-0113: the durable shape. Declaring it plus the accessors below
     /// is enough — `#[actor]` generates the `on_dehydrate` /


### PR DESCRIPTION
Closes #2592.

## Summary

Test-fixture actor `NAMESPACE` consts used three inconsistent styles (`test.`-dotted, `test_fixture(s)_`-underscored, and fully unprefixed like `web`/`cube`). Because these values are live mailbox load-addresses / `export:` selectors in a shared substrate during integration tests, an unprefixed `web`/`cube` can collide with or be mistaken for a real loaded component. This fences every fixture into its own `test.` namespace via a prefix-only transform (prepend `test.` / de-mangle the underscore form; internal segments unchanged):

- `web → test.web`, `web_stream → test.web_stream`, `web_socket → test.web_socket`, `routed_web → test.routed_web`, `cube → test.cube`, `mat4_source → test.mat4_source`, `ui.root → test.ui.root`, `ui.panel → test.ui.panel`, `stateful.* → test.stateful.*`
- `test_fixture_probe → test.probe`, `test_fixtures_probe_with_config → test.probe_with_config`, `test_fixtures_ui_widget → test.ui_widget`
- The 11 already-conformant `test.inline.*` / `test.matrix.*` / `test.source_observer` / `test.split_cap` consts are left as-is.

Each const moved in lockstep with its `export: Some(...)` selectors and every `aether.component/aether.embedded:<name>` call site that addresses it. The typed↔reshaped `replace_component` pair keeps an identical shared `NAMESPACE` (`test.stateful.typed` on both satellite crates). Occurrences of `test_fixture_probe` / `ui.root` / `ui.panel` that appear as synthetic sample data in unrelated crates' unit tests were left untouched — per-site judgment, since a blind global replace would corrupt them.

## Test plan

No new tests — a namespace rename is proven by the fixture-addressing integration suites continuing to pass. `cargo nextest run --workspace` (1799 passed, 0 failed) drives the TestBench / FleetBench suites that instantiate fixtures by `export:` selector and address them by mailbox name — green is the proof the const, selector, and call-site renames landed in lockstep. `cargo clippy --workspace --all-targets -- -D warnings` and the `wasm32-unknown-unknown` cross-build of the fixture bundle also pass.

## Generated by

`/implement` — agent execution of [scoped issue #2592](https://github.com/iamacoffeepot/aether/issues/2592).
