### PR TITLE
fix(substrate): acquire pid lock with an atomic hard_link

### DIFF
--- a/crates/aether-substrate/src/pid_lock.rs
+++ b/crates/aether-substrate/src/pid_lock.rs
@@ -8,11 +8,12 @@
 //! own divergent live-holder policy.
 
 use std::fs;
+use std::fs::OpenOptions;
 use std::io::Error as IoError;
+use std::io::{ErrorKind, Write as _};
 use std::path::{Path, PathBuf};
 use std::process;
-
-use crate::atomic_write::atomic_write;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Whether `pid` names a live process. Unix: `kill(pid, 0)` returns 0
 /// for a live process, `ESRCH` for a dead one, `EPERM` for a live one
@@ -64,34 +65,104 @@ pub enum LockAcquisition {
     WriteFailed(IoError),
 }
 
+/// Bound on the reclaim-and-retry loop: each pass reclaims one stale lock
+/// and re-attempts the atomic link, so exhaustion means a pathological
+/// reclaim war rather than an unbounded spin (CLAUDE.md loop-budget rule).
+const RECLAIM_ATTEMPTS: u32 = 8;
+
+/// Per-process counter that makes each acquisition's staging temp file name
+/// unique, so concurrent threads acquiring different (or the same) paths
+/// never collide on the sibling temp.
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
 /// Acquire (or reclaim) the `lock.pid` at `path`.
 ///
-/// Performs read → trim → parse → classify → (reclaim and) write:
+/// Publishes the lock atomically in *content*, not just in file creation:
+/// write `process::id()` to a per-call-unique sibling temp file, then
+/// `hard_link` that temp onto `path`. The link is a single atomic step, so
+/// the lock never exists at `path` empty and no concurrent acquirer can
+/// observe a zero-length lock mid-write.
 ///
-/// - If the file holds a parseable, positive, live pid: return
-///   [`LockAcquisition::Held`] — the caller decides the live-holder policy.
-/// - Otherwise (file absent, dead pid, garbage): emit one `tracing::warn!`
-///   on the reclaim path, then write `process::id()` via atomic tmp+rename.
-///   On success return [`LockAcquisition::Acquired`]; on write failure
-///   return [`LockAcquisition::WriteFailed`].
+/// - On a successful link the lock is published carrying our pid: return
+///   [`LockAcquisition::Acquired`].
+/// - `AlreadyExists` means the path is taken; read + classify it. A
+///   parseable, positive, live pid → [`LockAcquisition::Held`] (the caller
+///   decides the live-holder policy). An unreadable / dead-pid / garbage
+///   lock → emit one `tracing::warn!`, remove the stale lock, and retry the
+///   link, bounded by `RECLAIM_ATTEMPTS`.
+/// - Any other IO error (staging or linking) → [`LockAcquisition::WriteFailed`].
 pub fn acquire_lock_pid(path: &Path) -> LockAcquisition {
-    if let Ok(raw) = fs::read_to_string(path) {
-        match raw.trim().parse::<i32>() {
-            Ok(pid) if pid > 0 && is_pid_alive(pid) => return LockAcquisition::Held(pid),
-            _ => {
+    // Stage our pid into a per-call-unique sibling temp file. A sibling
+    // shares the filesystem with `path`, which `hard_link` requires.
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let name = path.file_name().map_or_else(
+        || "lock.pid".to_string(),
+        |n| n.to_string_lossy().to_string(),
+    );
+    let pid = process::id();
+    let temp = loop {
+        let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+        let candidate = dir.join(format!("{name}.tmp-{pid}-{seq}"));
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(mut file) => {
+                if let Err(e) = file.write_all(pid.to_string().as_bytes()) {
+                    let _ = fs::remove_file(&candidate);
+                    return LockAcquisition::WriteFailed(e);
+                }
+                break candidate;
+            }
+            // A leftover temp from a prior crashed acquisition reused our
+            // (pid, seq) name: fall through to bump seq and retry.
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {}
+            Err(e) => return LockAcquisition::WriteFailed(e),
+        }
+    };
+
+    let mut last_exists = None;
+    for _ in 0..RECLAIM_ATTEMPTS {
+        match fs::hard_link(&temp, path) {
+            Ok(()) => {
+                let _ = fs::remove_file(&temp);
+                return LockAcquisition::Acquired(LockGuard {
+                    path: path.to_path_buf(),
+                });
+            }
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+                if let Ok(raw) = fs::read_to_string(path)
+                    && let Ok(held) = raw.trim().parse::<i32>()
+                    && held > 0
+                    && is_pid_alive(held)
+                {
+                    let _ = fs::remove_file(&temp);
+                    return LockAcquisition::Held(held);
+                }
                 tracing::warn!(
                     path = %path.display(),
                     "reclaiming stale or garbage lock.pid",
                 );
+                // A NotFound here means another process already reclaimed;
+                // ignore and retry the link.
+                let _ = fs::remove_file(path);
+                last_exists = Some(e);
+            }
+            Err(e) => {
+                let _ = fs::remove_file(&temp);
+                return LockAcquisition::WriteFailed(e);
             }
         }
     }
-    match atomic_write(path, process::id().to_string().as_bytes()) {
-        Ok(()) => LockAcquisition::Acquired(LockGuard {
-            path: path.to_path_buf(),
-        }),
-        Err(e) => LockAcquisition::WriteFailed(e),
-    }
+
+    let _ = fs::remove_file(&temp);
+    LockAcquisition::WriteFailed(last_exists.unwrap_or_else(|| {
+        IoError::new(
+            ErrorKind::AlreadyExists,
+            "lock.pid reclaim attempts exhausted",
+        )
+    }))
 }
 
 #[cfg(test)]
@@ -173,6 +244,66 @@ mod tests {
             LockAcquisition::Acquired(_) => panic!("expected Held, got Acquired"),
             LockAcquisition::WriteFailed(e) => panic!("expected Held, got WriteFailed({e})"),
         }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // Tripwire: mutual exclusion — of N concurrent acquirers of one absent
+    // lock, exactly one wins Acquired and the rest see Held. The atomic
+    // hard_link publishes the winner's live pid in one step, so no loser can
+    // observe an empty lock and reclaim it into a second win. The predecessor
+    // create_new + write_all form (empty file, pid a syscall later) failed
+    // this 32/60.
+    #[cfg(unix)]
+    #[test]
+    fn concurrent_acquirers_yield_exactly_one_winner() {
+        use std::sync::Arc;
+        use std::sync::Barrier;
+        use std::thread;
+
+        const K: usize = 16;
+
+        let dir = temp_dir("concurrent");
+        let path = dir.join("lock.pid");
+        let our_pid = i32::try_from(process::id()).expect("pid fits i32");
+
+        let barrier = Arc::new(Barrier::new(K));
+        let handles: Vec<_> = (0..K)
+            .map(|_| {
+                let path = path.clone();
+                let barrier = Arc::clone(&barrier);
+                // A raw thread is the test's own concurrency harness, not an
+                // engine actor, so it needs no settlement/trace umbrella.
+                #[allow(
+                    clippy::disallowed_methods,
+                    reason = "test-only concurrency harness thread"
+                )]
+                thread::spawn(move || {
+                    barrier.wait();
+                    acquire_lock_pid(&path)
+                })
+            })
+            .collect();
+
+        let mut acquired = 0;
+        let mut held = 0;
+        let mut guards = Vec::new();
+        for handle in handles {
+            match handle.join().expect("acquirer thread joins") {
+                LockAcquisition::Acquired(g) => {
+                    acquired += 1;
+                    guards.push(g);
+                }
+                LockAcquisition::Held(p) => {
+                    assert_eq!(p, our_pid, "loser reads the winner's live pid");
+                    held += 1;
+                }
+                LockAcquisition::WriteFailed(e) => panic!("unexpected WriteFailed({e})"),
+            }
+        }
+
+        assert_eq!(acquired, 1, "exactly one acquirer wins the lock");
+        assert_eq!(held, K - 1, "every other acquirer sees Held");
+        drop(guards);
         let _ = fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
Closes #2502.

## Summary

`acquire_lock_pid` acquired the `lock.pid` in two independent steps — a read-then-classify followed by an unconditional `atomic_write` (tmp + rename) that overwrote whatever was at the path — so two processes that both observed an absent, dead-pid, or garbage lock both wrote their own pid and both received `Acquired`. Two holders then believed they owned the same lock, the exact mutual-exclusion failure the lock exists to prevent.

This makes acquisition atomic in *content*, not just in file creation, via `std::fs::hard_link`. The pid is written to a per-call-unique sibling temp file (`<name>.tmp-<pid>-<seq>`, `<seq>` from a process-static `AtomicU64` so concurrent threads never collide), then `hard_link`ed onto the path — an atomic step that fails with `AlreadyExists` when the path is taken. The lock therefore appears already carrying its pid and never exists empty, so no acquirer can observe a zero-length lock mid-write. On `AlreadyExists` the existing lock is read and classified exactly as before (live pid → `Held`; dead/garbage → warn, reclaim, retry), bounded by a small fixed attempt budget; the temp is removed on every exit path.

The public signature, the `LockAcquisition` enum, and `LockGuard` are unchanged, so the sole consumer (the ADR-0115 binary store's `acquire_lock`) needs no edit. The change stays inside the ADR-0049 §7 / ADR-0115 best-effort lock contract — no wire or ADR change.

## Test plan

- The four existing branch tests (`absent_lock_is_acquired`, `garbage_lock_is_reclaimed`, `dead_pid_lock_is_reclaimed`, `live_pid_yields_held`) are kept verbatim and pass through the new path.
- New concurrency tripwire `concurrent_acquirers_yield_exactly_one_winner`: 16 barrier-gated threads call `acquire_lock_pid` on one initially-absent path and assert exactly one returns `Acquired`, the rest `Held` reading the winner's live pid. Ran 40× with zero double-wins — deterministic under the atomic-link design, where the predecessor `create_new` + `write_all` form failed 32/60.
- Full preflight green (fmt, clippy `-D warnings`, workspace nextest, strict rustdoc, wasm32 component cross-build, diff-scoped Qodana — 0 problems).

## Generated by

`/implement` — agent execution of [scoped issue #2502](https://github.com/iamacoffeepot/aether/issues/2502).
