### PR TITLE
docs(guide): fill the serving-http recipe gaps for the over-mcp and external-caller path

### DIFF
--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -47,6 +47,7 @@
   - [Adding a chassis capability](recipes/adding-a-chassis-capability.md)
   - [Wiring an MCP tool](recipes/wiring-an-mcp-tool.md)
   - [Writing a component](recipes/writing-a-component.md)
+  - [Serving HTTP from a component](recipes/serving-http.md)
   - [Debugging a hung settlement](recipes/debugging-a-hung-settlement.md)
 
 # Testing

--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -63,6 +63,8 @@ example.
 - **Wiring an MCP tool** (recompile) — args → tool → wire-kind round-trip.
 - **Writing a component** (the middle) — `#[actor]`, handlers, `export!`,
   loading it, and talking to it.
+- **Serving HTTP from a component** (recompile) — the `aether.http.server`
+  capability, the request/response handler, and claiming a route.
 - **Debugging a hung settlement** (drive-only) — reading a stuck mail chain
   with the trace tools.
 

--- a/docs/guide/recipes/serving-http.md
+++ b/docs/guide/recipes/serving-http.md
@@ -24,6 +24,27 @@ let the OS pick a free port. `AETHER_HTTP_SERVER_HANDLER_MAILBOX` is the late-
 bound mailbox name (ADR-0108 §3): the server resolves it at dispatch time, so
 the handler component can load or reload without restarting the server.
 
+### Over MCP (`spawn_substrate`)
+
+`spawn_substrate` forwards its `args` array to the substrate's argv, with no
+env field — so the MCP-spawn path configures the server with flags instead of
+the env vars above. The `#[derive(Config)]` on `HttpServerConfig` is tagged
+`cli_prefix = "http-server"` (ADR-0090), which mints one flag per field —
+`enabled` becomes the bare presence flag `--http-server-enabled`, and every
+other field becomes `--http-server-<field>=<value>`:
+
+```jsonc
+// spawn_substrate
+{
+  "binary_path": "/path/to/aether-substrate-headless",
+  "args": [
+    "--http-server-enabled",
+    "--http-server-bind-addr=127.0.0.1:8080",
+    "--http-server-handler-mailbox=aether.component/aether.embedded:web"
+  ]
+}
+```
+
 ## 2. Set up the crate
 
 The http server cap needs **no marker feature** — unlike `render` / `audio` /
@@ -181,6 +202,51 @@ kind — a struct with `aether.http.server.request`'s fields under its own
 `#[kind(name = …)]` — routes each prefix to its own `#[handler]`, with its own
 `describe_component` entry and `actor_cost` row; the payload bytes are always
 request-shaped, so the route kind decodes them directly.
+
+### Registering a route for another mailbox
+
+`register_route_self` resolves the registrant from the sender's in-process
+`Source`; an MCP session or a test has no such source, so it uses the named
+form instead — `register_route` / `unregister_route`, which take the target
+`mailbox` explicitly. `RegisterRoute` carries `prefix`
+(`String`), `method` (`Option<HttpMethod>` — a bare variant string like
+`"Get"`, or `null` to match every method; the seven variants are `Get`,
+`Post`, `Put`, `Delete`, `Patch`, `Head`, `Options`), `kind` (the route's
+request `KindId`), and `mailbox` (the handler's `MailboxId`). Over the MCP
+wire both tagged ids render as ADR-0064 strings — `knd-…` and `mbx-…` — so
+the values below come from `describe_kinds` (the `kind` for
+`aether.http.server.request`, or a route-specific kind's own id) and from
+`load_component`'s `LoadResult.name` (the `mailbox`, once resolved through
+`describe_component` or the same tagged form it's already returned in):
+
+```jsonc
+// send_mail → aether.http.server  (kind: aether.http.server.register_route)
+{
+  "prefix": "/api",
+  "method": "Get",
+  "kind": "knd-…",     // aether.http.server.request's id, from describe_kinds
+  "mailbox": "mbx-…"   // the handler's mailbox, from load_component's LoadResult
+}
+```
+
+The reply is `aether.http.server.register_route_result` — `"Ok"` or
+`{ "Err": { "error": "…" } }` — the same shape `register_route_self` replies,
+which is *why* the named form exists: an external caller (an MCP session, a
+test) has no in-process `Source` to resolve, so `register_route_self` always
+answers it `Err`.
+
+Releasing the route mirrors the registration, dropping `kind` (a release
+doesn't need it) and keeping `method` so a method-specific route and a
+method-agnostic route at the same prefix release independently:
+
+```jsonc
+// send_mail → aether.http.server  (kind: aether.http.server.unregister_route)
+{
+  "prefix": "/api",
+  "method": "Get",
+  "mailbox": "mbx-…"
+}
+```
 
 ## Typed route authoring
 
@@ -406,7 +472,9 @@ reply shapes; return from a bare `#[handler]` otherwise.
 
 This recipe names the env keys and kind names live in the source. Before
 following it, confirm `AETHER_HTTP_SERVER_ENABLED`, `HttpServerRequest`,
-`HttpServerResponse`, `HttpServerConfig`, the `http::{router, route,
-FromRequest, Ctx}` authoring surface, and `http::ResponseStream` still exist
-where named — grep the crates, and if a name has drifted, fix the recipe as part
-of your work.
+`HttpServerResponse`, `HttpServerConfig`, the `--http-server-*` argv flags
+(`cli_prefix = "http-server"` on `HttpServerConfig`), `RegisterRoute` /
+`UnregisterRoute` / `HttpMethod`, the `http::{router, route, FromRequest,
+Ctx}` authoring surface, and `http::ResponseStream` still exist where named —
+grep the crates, and if a name has drifted, fix the recipe as part of your
+work.


### PR DESCRIPTION
## Summary

Fills the three doc gaps a drive-medium dogfood trial hit while standing up the HTTP server over MCP:

- Links `recipes/serving-http.md` from `SUMMARY.md`'s Recipes block and `recipes.md`'s planned-recipes list, so the HTTP ingress surface is reachable from the guide's navigation.
- Adds an "Over MCP (`spawn_substrate`)" subsection under the recipe's server-configuration step, giving the `--http-server-*` argv flags (`cli_prefix = "http-server"` on `HttpServerConfig`) for the spawn path, which forwards only argv, not env.
- Promotes the one-sentence external `register_route` / `unregister_route` mention under "Claiming routes" into a worked `send_mail` example with the full `RegisterRoute` field list (`prefix`, `method`, `kind`, `mailbox`), pointing at `describe_kinds` / `load_component`'s `LoadResult` as the source of the tagged `knd-…` / `mbx-…` values rather than freezing fake ones.

Docs-only; verified with a local `mdbook build` (clean, no broken-link warnings).

Closes #2601

🤖 Generated with [Claude Code](https://claude.com/claude-code)
