### PR TITLE
fix(test-fixtures): serve concurrent websocket connections and non-root buffered paths in the reference http fixtures

### DIFF
--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -81,6 +81,11 @@ const WS_HANDLER_MAILBOX: &str = "aether.component/aether.embedded:test.web_sock
 const WS_TEST_KEY: &str = "dGhlIHNhbXBsZSBub25jZQ==";
 const WS_TEST_ACCEPT: &str = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
 
+/// A second, distinct handshake key for the concurrent-connection case.
+/// Its `Sec-WebSocket-Accept` isn't asserted — only that the connection
+/// upgrades and gets its own per-connection greeting/echoes.
+const WS_TEST_KEY_2: &str = "AQIDBAUGBwgJCgsMDQ4PEA==";
+
 /// Slice of `response` after the HTTP head's blank line, or empty if absent.
 fn body_after_head(response: &[u8]) -> &[u8] {
     response
@@ -232,8 +237,10 @@ mod tests {
     /// path. Once the guest trampoline is live, send two real HTTP/1.1
     /// requests over a `TcpStream` and assert:
     ///
-    /// - `GET /` → `200 OK` with body `hello from aether`
-    /// - `GET /missing` → `404 Not Found`
+    /// - `GET /` → `200 OK` echoing `/` in the body
+    /// - `GET /missing` → `200 OK` echoing `/missing` in the body — a
+    ///   non-root path serves a success body rather than a `404`
+    ///   (tripwire for issue 2603 finding 2).
     #[test]
     fn wasm_handler_serves_http_requests() {
         let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
@@ -331,19 +338,20 @@ mod tests {
             "GET / body should contain 'hello from aether', got: {root_str:?}",
         );
 
-        // GET /missing → 404
+        // GET /missing → 200, echoing the path (a non-root path serves
+        // success, not a 404 trap).
         let miss_response = round_trip(
             port,
             b"GET /missing HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
         );
         let miss_str = String::from_utf8_lossy(&miss_response);
         assert!(
-            miss_str.starts_with("HTTP/1.1 404 "),
-            "GET /missing should reply 404, got: {miss_str:?}",
+            miss_str.starts_with("HTTP/1.1 200 "),
+            "GET /missing should reply 200, got: {miss_str:?}",
         );
         assert!(
-            miss_str.contains("not found"),
-            "GET /missing body should contain 'not found', got: {miss_str:?}",
+            miss_str.contains("/missing"),
+            "GET /missing body should echo the request path, got: {miss_str:?}",
         );
     }
 
@@ -590,7 +598,11 @@ mod tests {
     /// fragmented message to exercise continuation reassembly), prove an
     /// unknown-stream send is dropped without teardown, and close cleanly —
     /// the end-to-end proof that a wasm handler serves a live bidirectional
-    /// websocket.
+    /// websocket. Also opens a second, concurrent connection and asserts it
+    /// gets its own greeting and its own echoes with no cross-talk against
+    /// the first connection — the tripwire for issue 2603 finding 1 (the
+    /// fixture used to key its greeted flag and captured stream per actor,
+    /// not per connection).
     #[test]
     #[allow(clippy::too_many_lines)]
     fn wasm_handler_serves_a_websocket_round_trip() {
@@ -706,6 +718,91 @@ mod tests {
         assert_eq!(
             payload, b"server greeting",
             "the fixture's unsolicited push should arrive before any client frame",
+        );
+
+        // Concurrent second connection: the fixture keys its greeting +
+        // captured stream per connection (`stream_id`), not per actor, so a
+        // second concurrent client must get its own greeting and its own
+        // echoes with no cross-talk against the first connection (issue
+        // 2603 finding 1).
+        let mut stream2 =
+            TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect second ws client");
+        stream2
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .expect("set_read_timeout for second connection");
+        let handshake2 = format!(
+            "GET /ws HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\n\
+             Connection: Upgrade\r\nSec-WebSocket-Version: 13\r\n\
+             Sec-WebSocket-Key: {WS_TEST_KEY_2}\r\n\r\n"
+        );
+        stream2
+            .write_all(handshake2.as_bytes())
+            .expect("write second handshake");
+        stream2.flush().expect("flush second handshake");
+
+        let head2 = read_http_head(&mut stream2);
+        assert!(
+            head2.starts_with("HTTP/1.1 101 "),
+            "second connection's upgrade should reply 101, got: {head2:?}",
+        );
+
+        // Its own accept-time greeting, distinct from the first
+        // connection's — proves the greet-once behavior is per connection.
+        let (opcode, payload) = read_server_frame(&mut stream2);
+        assert_eq!(
+            opcode, WS_OPCODE_TEXT,
+            "second connection's greeting should be a text frame"
+        );
+        assert_eq!(
+            payload, b"server greeting",
+            "the second connection should get its own greeting",
+        );
+
+        // Interleave a send on each connection, then read the echoes back
+        // in reverse order: if the fixture still tracked a single captured
+        // stream instead of a per-connection map, one of these echoes
+        // would either go missing or land on the wrong socket.
+        stream
+            .write_all(&ws_client_frame(WS_OPCODE_TEXT, b"hello from conn1", true))
+            .expect("write conn1 frame");
+        stream.flush().expect("flush conn1 frame");
+        stream2
+            .write_all(&ws_client_frame(WS_OPCODE_TEXT, b"hello from conn2", true))
+            .expect("write conn2 frame");
+        stream2.flush().expect("flush conn2 frame");
+
+        let (opcode2, payload2) = read_server_frame(&mut stream2);
+        assert_eq!(
+            opcode2, WS_OPCODE_TEXT,
+            "conn2's echo should be a text frame"
+        );
+        assert_eq!(
+            payload2, b"hello from conn2",
+            "conn2's echo must not cross-talk with conn1",
+        );
+
+        let (opcode1, payload1) = read_server_frame(&mut stream);
+        assert_eq!(
+            opcode1, WS_OPCODE_TEXT,
+            "conn1's echo should be a text frame"
+        );
+        assert_eq!(
+            payload1, b"hello from conn1",
+            "conn1's echo must not cross-talk with conn2",
+        );
+
+        // Close the second connection cleanly so it doesn't linger for the
+        // rest of the single-connection assertions below.
+        let mut close_payload2 = Vec::new();
+        close_payload2.extend_from_slice(&1000u16.to_be_bytes());
+        stream2
+            .write_all(&ws_client_frame(WS_OPCODE_CLOSE, &close_payload2, true))
+            .expect("write second close frame");
+        stream2.flush().expect("flush second close frame");
+        let (opcode, _payload) = read_server_frame(&mut stream2);
+        assert_eq!(
+            opcode, WS_OPCODE_CLOSE,
+            "the cap should echo a close frame for the second connection",
         );
 
         // A single-frame message echoes back verbatim.
@@ -910,12 +1007,14 @@ mod tests {
             "drop bridge should acknowledge, got: {drop_str:?}",
         );
 
-        // The purge rides the drop fan-out; once it lands, /routed
-        // falls back to the `web` fixture, which answers 404.
+        // The purge rides the drop fan-out; once it lands, /routed falls
+        // back to the `web` fixture, which echoes the path in its 200 body
+        // — distinct from the routed component's fixed "routed handler"
+        // body, so this still discriminates route-live from route-purged.
         poll_body_contains(
             port,
             b"GET /routed HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
-            "not found",
+            "hello from aether: /routed",
         );
     }
 }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -7,8 +7,8 @@
 //!
 //! Behaviour:
 //!
-//! - `GET /` → 200 `hello from aether`
-//! - Anything else → 404 `not found`
+//! - Any request → 200, echoing the request path in the body
+//!   (`hello from aether: {path}`)
 //!
 //! Registered at `aether.component/aether.embedded:test.web` after load.
 //! The e2e test configures `HttpServerConfig.handler_mailbox` to that
@@ -19,6 +19,8 @@
 // bytes so callers can't see references. A stateless handler that
 // ignores `self` is correct but triggers `unused_self`.
 #![allow(clippy::needless_pass_by_value, clippy::unused_self)]
+
+use std::collections::BTreeMap;
 
 use aether_actor::{ActorInitError, Manual, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::ComponentHostCapability;
@@ -52,14 +54,10 @@ impl WasmActor for HttpHandler {
     /// to `"aether.component/aether.embedded:test.web"` to route here.
     #[handler]
     fn on_request(&mut self, _ctx: &mut WasmCtx<'_>, req: HttpServerRequest) -> HttpServerResponse {
-        let (status, body): (u16, &[u8]) = match req.path.as_str() {
-            "/" => (200, b"hello from aether"),
-            _ => (404, b"not found"),
-        };
         HttpServerResponse {
-            status,
+            status: 200,
             headers: Vec::new(),
-            body: body.to_vec(),
+            body: format!("hello from aether: {}", req.path).into_bytes(),
         }
     }
 }
@@ -168,10 +166,11 @@ impl WasmActor for StreamingHttpHandler {
 ///
 /// Registered at `aether.component/aether.embedded:test.web_socket` after load.
 pub struct WebSocketHandler {
-    /// The upgraded connection (ADR-0133), captured from the first credit
-    /// grant. `None` until that accept-time grant arms it.
-    stream: Option<WebSocketStream>,
-    greeted: bool,
+    /// Per-connection upgraded streams (ADR-0133), keyed by `stream_id` and
+    /// inserted on that connection's accept-time credit grant. Map
+    /// membership is the greeted flag: a `stream_id` present here has
+    /// already received its greeting.
+    connections: BTreeMap<u64, WebSocketStream>,
 }
 
 #[actor]
@@ -180,8 +179,7 @@ impl WasmActor for WebSocketHandler {
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(WebSocketHandler {
-            stream: None,
-            greeted: false,
+            connections: BTreeMap::new(),
         })
     }
 
@@ -209,9 +207,10 @@ impl WasmActor for WebSocketHandler {
     /// websocket message on the upgraded connection.
     #[handler]
     fn on_message(&mut self, ctx: &mut WasmCtx<'_>, msg: WebSocketMessage) {
-        // The connection handle was captured on the accept-time credit
-        // grant (ADR-0132/ADR-0133), which always precedes peer traffic.
-        let Some(stream) = self.stream else {
+        // The connection handle was captured on this connection's
+        // accept-time credit grant (ADR-0132/ADR-0133), which always
+        // precedes peer traffic on that connection.
+        let Some(stream) = self.connections.get(&msg.stream_id).copied() else {
             return;
         };
         if !msg.binary && msg.data == b"misroute" {
@@ -240,27 +239,30 @@ impl WasmActor for WebSocketHandler {
     #[handler::manual]
     fn on_credit(&mut self, ctx: &mut WasmCtx<'_, Manual>, credit: HttpStreamCredit) {
         // ADR-0133: capture the connection handle from the accept-time
-        // credit grant — its counterparty is whoever owns the socket.
-        let stream = match self.stream {
-            Some(stream) => stream,
-            None => match WebSocketStream::from_credit(ctx, &credit) {
-                Some(stream) => *self.stream.insert(stream),
-                None => return,
-            },
-        };
-        if !self.greeted {
-            self.greeted = true;
-            stream.message(ctx, false, b"server greeting".to_vec());
+        // credit grant — its counterparty is whoever owns the socket. A
+        // repeat grant for a known stream_id is a no-op: this connection
+        // has already been greeted.
+        if self.connections.contains_key(&credit.stream_id) {
+            return;
         }
+        let Some(stream) = WebSocketStream::from_credit(ctx, &credit) else {
+            return;
+        };
+        self.connections.insert(credit.stream_id, stream);
+        stream.message(ctx, false, b"server greeting".to_vec());
     }
 
-    /// A peer-initiated close (ADR-0129 §5). Nothing to do — the cap has
-    /// already echoed the close frame and is tearing the connection down.
+    /// A peer-initiated close (ADR-0129 §5). Evict the connection's state so
+    /// a long-lived reference handler does not leak per-connection state as
+    /// sockets churn — the cap has already echoed the close frame and is
+    /// tearing the connection down.
     ///
     /// # Agent
     /// Not sent manually — the cap reports a peer close here.
     #[handler]
-    fn on_close(&mut self, _ctx: &mut WasmCtx<'_>, _close: WebSocketClose) {}
+    fn on_close(&mut self, _ctx: &mut WasmCtx<'_>, close: WebSocketClose) {
+        self.connections.remove(&close.stream_id);
+    }
 }
 
 /// Routed sibling of [`HttpHandler`] for the ADR-0130 drop-purge e2e


### PR DESCRIPTION
## Summary

Two rough edges in `aether-test-fixtures-bundle`'s copy-from HTTP fixtures:

- `WebSocketHandler` keyed its greeted flag and captured stream per actor (a single `Option<WebSocketStream>` + `greeted: bool`), so a second concurrent websocket client got no greeting and its echoes cross-talked against the first connection's `stream_id`. Replaced with `connections: BTreeMap<u64, WebSocketStream>` keyed by `stream_id` — map membership is the greeted flag, `on_close` evicts the entry.
- The buffered `HttpHandler` (`test.web`) answered `200` only for the exact path `/` and `404` for anything else, so a copied handler serving a non-root route read as a failure. It now always replies `200`, echoing the request path in the body.

`crates/aether-substrate-bundle/tests/http_serving.rs` is updated accordingly: `wasm_handler_serves_http_requests`'s `/missing` case now asserts `200` with the echoed path, `dropped_component_routes_are_purged`'s post-purge fallback check polls for the echoed-path marker instead of `404`, and `wasm_handler_serves_a_websocket_round_trip` gains a second concurrent connection asserting its own greeting and echo with no cross-talk against the first — the tripwire for the websocket fix.

Closes #2603

## Test plan

- [x] `cargo check -p aether-test-fixtures-bundle`
- [x] `cargo build -p aether-test-fixtures-bundle --target wasm32-unknown-unknown`
- [x] `cargo test -p aether-substrate-bundle --test http_serving` (all 4 tests pass locally, including the new concurrent-websocket assertions)
- [x] `cargo clippy -p aether-test-fixtures-bundle -p aether-substrate-bundle --tests -- -D warnings`
- [x] `cargo fmt -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
