### PR TITLE
fix(capabilities): grant initial response-stream credit for streaming handlers reached via an external route

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/streaming.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/streaming.rs
@@ -134,19 +134,18 @@ impl HttpServerCapabilityState {
         open: &HttpResponseStreamOpen,
     ) {
         // The stream chain settles here; the request is no longer in-flight
-        // (ADR-0128 §4), so `on_settled` won't `502` it. Resolve the handler
-        // once here (it just replied, so it is live) and store it on the
-        // stream for credit grants; a missing handler leaves the sentinel and
-        // credit sends drop harmlessly, the pre-store no-op behavior.
-        let keep_alive = self
+        // (ADR-0128 §4), so `on_settled` won't `502` it. The handler is carried
+        // out of the in-flight dispatch record — whichever mailbox actually
+        // replied, be it the configured default `handler_mailbox` or an
+        // externally-registered route (ADR-0131) — so credit grants reach the
+        // real replier regardless of dispatch path. A missing in-flight entry
+        // leaves the sentinel and credit sends drop harmlessly, the pre-store
+        // no-op behavior.
+        let (keep_alive, handler) = self
             .in_flight
             .remove(&stream_id)
-            .is_some_and(|pending| pending.keep_alive);
-        let handler = self
-            .mailer
-            .registry()
-            .lookup(&self.handler_mailbox)
-            .unwrap_or(MailboxId(0));
+            .map(|pending| (pending.keep_alive, pending.handler))
+            .unwrap_or((false, MailboxId(0)));
         let head = render_stream_head(open, keep_alive);
         self.write_raw_to(conn_id, &head);
 

--- a/crates/aether-capabilities/src/http/server/runtime/streaming.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/streaming.rs
@@ -144,8 +144,9 @@ impl HttpServerCapabilityState {
         let (keep_alive, handler) = self
             .in_flight
             .remove(&stream_id)
-            .map(|pending| (pending.keep_alive, pending.handler))
-            .unwrap_or((false, MailboxId(0)));
+            .map_or((false, MailboxId(0)), |pending| {
+                (pending.keep_alive, pending.handler)
+            });
         let head = render_stream_head(open, keep_alive);
         self.write_raw_to(conn_id, &head);
 

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -62,6 +62,12 @@ const STREAM_HANDLER_MAILBOX: &str = "aether.component/aether.embedded:test.web_
 /// fixture's own `STREAM_CHUNK_COUNT`.
 const STREAM_CHUNK_COUNT: u32 = 20;
 
+/// The `RoutedStreamingHttpHandler` fixture's `NAMESPACE` const — a
+/// response-streaming handler reached through an externally-registered
+/// route (`register_route_self` in `wire`) rather than the configured
+/// default `handler_mailbox` (ADR-0128 × ADR-0131).
+const ROUTED_STREAM_HANDLER_NAMESPACE: &str = "test.web_stream_routed";
+
 /// The `WebSocketHandler` fixture's `NAMESPACE` const (ADR-0129).
 const WS_HANDLER_NAMESPACE: &str = "test.web_socket";
 
@@ -451,6 +457,128 @@ mod tests {
             "reassembled stream body: {:?}",
             String::from_utf8_lossy(&reassembled),
         );
+    }
+
+    /// Regression for issue 2600: a response-streaming handler reached
+    /// through an externally-registered route (ADR-0131) — not the configured
+    /// default `handler_mailbox` — must still be granted its initial
+    /// response-stream credit window (ADR-0128), so it emits its body chunks
+    /// rather than opening the stream and hanging (`curl` error 18).
+    ///
+    /// The `RoutedStreamingHttpHandler` fixture claims `/routed-stream` for
+    /// its own mailbox in `wire`; `HttpServerConfig.handler_mailbox` is bound
+    /// to a mailbox that does **not** resolve to it, so the default-handler
+    /// dispatch cannot mask the route path. On today's bug `open_stream`
+    /// re-resolves the (unresolvable) default handler and drops the initial
+    /// credit grant, so zero chunks arrive; after the fix the grant reaches
+    /// the route's handler and the client reassembles the same body the
+    /// default-handler streaming test asserts.
+    #[test]
+    fn wasm_handler_streams_chunked_response_via_registered_route() {
+        let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+        let Some(wasm_path) = locate_component_wasm("aether_test_fixtures_bundle") else {
+            assert!(
+                !strict,
+                "AETHER_REQUIRE_RUNTIME set but http_handler.wasm not pre-built; \
+                 CI's `Pre-build component wasm for scenario tests` step is missing it",
+            );
+            eprintln!(
+                "skipping: http_handler.wasm not built; \
+                 run `cargo build --target wasm32-unknown-unknown \
+                 -p aether-test-fixtures --examples`",
+            );
+            return;
+        };
+        let wasm = fs::read(&wasm_path).expect("read http_handler wasm");
+
+        let server_config = HttpServerConfig {
+            enabled: true,
+            bind_addr: "127.0.0.1:0".to_string(),
+            // Deliberately unresolvable: the streaming handler is reachable
+            // only through the route it registers, so the default-handler
+            // dispatch cannot mask the bug (issue 2600 negative control).
+            handler_mailbox: "aether.component/aether.embedded:test.web_absent_default".to_string(),
+            max_request_bytes: 65_536,
+            max_header_bytes: 8_192,
+            request_timeout_millis: 10_000,
+            keep_alive_timeout_millis: 5_000,
+            max_connections: 1024,
+            // Window below the chunk count so the round trip must replenish.
+            response_stream_window: 8,
+            request_stream_window: 16,
+            websocket_idle_timeout_millis: 300_000,
+        };
+
+        let sandbox = init_save_sandbox("http-serving-stream-route");
+        let env = HeadlessEnv {
+            namespace_roots: test_namespace_roots(sandbox),
+            http: HttpConfig::default(),
+            http_server: Some(server_config),
+            anthropic: AnthropicConfig::default(),
+            gemini: GeminiConfig::default(),
+            contentgen: ContentGenConfig::default(),
+            tick_period: Duration::from_millis(100),
+            rpc_addr: None,
+            workers: None,
+            ring_caps: aether_substrate_bundle::RingCapacities::default(),
+            scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
+            lifecycle_advance_timeout_millis: 1_000,
+            autoload: vec![AutoloadComponent {
+                wasm,
+                config: Vec::new(),
+                name: Some(ROUTED_STREAM_HANDLER_NAMESPACE.to_owned()),
+                export: Some(ROUTED_STREAM_HANDLER_NAMESPACE.to_owned()),
+            }],
+        };
+
+        let built = HeadlessChassis::build(env).expect("build headless chassis with http server");
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if built
+                .resolve_actor::<WasmTrampoline>(ROUTED_STREAM_HANDLER_NAMESPACE)
+                .is_some()
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "routed streaming trampoline did not register within 30s; \
+                 live trampolines: {:?}",
+                built.resolve_actors::<WasmTrampoline>(),
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+
+        let port = built
+            .handle::<HttpServerHandle>()
+            .expect("HttpServerHandle published by HttpServerCapability")
+            .local_port;
+        assert!(port > 0, "bound to an OS-assigned port");
+
+        // Route registration is async mail — poll until the streamed body
+        // reassembles rather than racing the `register_route_self`.
+        let expected: Vec<u8> = (0..STREAM_CHUNK_COUNT)
+            .flat_map(|i| format!("chunk-{i}\n").into_bytes())
+            .collect();
+        let request =
+            b"GET /routed-stream HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            let response = round_trip(port, request);
+            let head = String::from_utf8_lossy(&response);
+            if head.starts_with("HTTP/1.1 200 ")
+                && head.contains("Transfer-Encoding: chunked")
+                && dechunk(body_after_head(&response)) == expected
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "routed streaming response did not reassemble within 30s; last: {head:?}",
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
     }
 
     /// Boot a headless chassis with `HttpServerCapability` bound and the

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -370,11 +370,12 @@ impl WasmActor for RoutedStreamingHttpHandler {
     /// cap by type, so the send reads exactly as the `#[http::route]` macro's
     /// injected registration does.
     fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
-        ctx.actor::<HttpServerCapability>().send(&RegisterRouteSelf {
-            prefix: "/routed-stream".to_string(),
-            method: None,
-            kind: <HttpServerRequest as Kind>::ID,
-        });
+        ctx.actor::<HttpServerCapability>()
+            .send(&RegisterRouteSelf {
+                prefix: "/routed-stream".to_string(),
+                method: None,
+                kind: <HttpServerRequest as Kind>::ID,
+            });
     }
 
     /// Open a streamed `200` response. Dispatched here through the registered

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -23,12 +23,13 @@
 use aether_actor::{ActorInitError, Manual, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::ComponentHostCapability;
 use aether_capabilities::http;
+use aether_capabilities::http::HttpServerCapability;
 use aether_capabilities::http::kinds::{
     HttpResponseStreamOpen, HttpServerRequest, HttpServerResponse, HttpStreamCredit,
-    WebSocketAccept, WebSocketClose, WebSocketMessage,
+    RegisterRouteSelf, WebSocketAccept, WebSocketClose, WebSocketMessage,
 };
 use aether_capabilities::http::{ResponseStream, WebSocketStream};
-use aether_data::MailboxId;
+use aether_data::{Kind, MailboxId};
 use aether_kinds::DropComponent;
 
 pub struct HttpHandler;
@@ -324,6 +325,104 @@ impl WasmActor for RoutedHttpHandler {
             status: 200,
             headers: Vec::new(),
             body: b"routed handler".to_vec(),
+        }
+    }
+}
+
+/// Response-streaming handler reached through an **externally-registered
+/// route** rather than the configured default `handler_mailbox` (ADR-0128
+/// streaming × ADR-0131 route dispatch). It claims `/routed-stream` for its
+/// own mailbox with a raw `RegisterRouteSelf` from `wire`, then behaves
+/// exactly like [`StreamingHttpHandler`]: replies `HttpResponseStreamOpen`
+/// and emits `STREAM_CHUNK_COUNT` credit-paced `"chunk-{i}\n"` chunks. The
+/// e2e test points `HttpServerConfig.handler_mailbox` at a *different*
+/// mailbox, so the default-handler dispatch cannot mask the route path — the
+/// initial response-stream credit grant must reach this handler via the route
+/// it registered, not the configured default.
+///
+/// Registered at `aether.component/aether.embedded:test.web_stream_routed`
+/// after load.
+pub struct RoutedStreamingHttpHandler {
+    /// The stream this handler is feeding (ADR-0133), captured from the first
+    /// credit mail. `None` until that first grant arms it.
+    stream: Option<ResponseStream>,
+    /// Index of the next chunk to emit.
+    next_index: u32,
+    /// Whether the terminator has been sent.
+    ended: bool,
+}
+
+#[actor]
+impl WasmActor for RoutedStreamingHttpHandler {
+    const NAMESPACE: &'static str = "test.web_stream_routed";
+
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(RoutedStreamingHttpHandler {
+            stream: None,
+            next_index: 0,
+            ended: false,
+        })
+    }
+
+    /// Claim `/routed-stream` for this actor's own mailbox through the raw
+    /// reflexive route form (ADR-0131). Registering from `wire` is the
+    /// common "route to me" case; `ctx` resolves the `aether.http.server`
+    /// cap by type, so the send reads exactly as the `#[http::route]` macro's
+    /// injected registration does.
+    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+        ctx.actor::<HttpServerCapability>().send(&RegisterRouteSelf {
+            prefix: "/routed-stream".to_string(),
+            method: None,
+            kind: <HttpServerRequest as Kind>::ID,
+        });
+    }
+
+    /// Open a streamed `200` response. Dispatched here through the registered
+    /// route, not the default `handler_mailbox`.
+    ///
+    /// # Agent
+    /// Not sent manually — the `aether.http.server` cap dispatches it on a
+    /// request matching the `/routed-stream` route this actor claimed in
+    /// `wire`.
+    #[handler]
+    fn on_request(
+        &mut self,
+        _ctx: &mut WasmCtx<'_>,
+        _req: HttpServerRequest,
+    ) -> HttpResponseStreamOpen {
+        self.next_index = 0;
+        self.ended = false;
+        HttpResponseStreamOpen {
+            status: 200,
+            headers: Vec::new(),
+        }
+    }
+
+    /// Spend the granted credit exactly as [`StreamingHttpHandler`] does. On
+    /// today's bug the initial grant never arrives for a route-dispatched
+    /// stream, so this never fires and no chunk is emitted.
+    ///
+    /// # Agent
+    /// Not sent manually — the cap sends one `HttpStreamCredit` per freed
+    /// window slot.
+    #[handler::manual]
+    fn on_credit(&mut self, ctx: &mut WasmCtx<'_, Manual>, credit: HttpStreamCredit) {
+        let stream = match self.stream {
+            Some(stream) => stream,
+            None => match ResponseStream::from_credit(ctx, &credit) {
+                Some(stream) => *self.stream.insert(stream),
+                None => return,
+            },
+        };
+        let mut budget = credit.credit;
+        while budget > 0 && self.next_index < STREAM_CHUNK_COUNT {
+            stream.chunk(ctx, format!("chunk-{}\n", self.next_index).into_bytes());
+            self.next_index += 1;
+            budget -= 1;
+        }
+        if self.next_index >= STREAM_CHUNK_COUNT && !self.ended {
+            stream.end(ctx);
+            self.ended = true;
         }
     }
 }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
@@ -25,7 +25,10 @@ mod stateful_replace;
 mod ui_widget;
 
 pub use cube::Cube;
-pub use http_handler::{HttpHandler, RoutedHttpHandler, StreamingHttpHandler, WebSocketHandler};
+pub use http_handler::{
+    HttpHandler, RoutedHttpHandler, RoutedStreamingHttpHandler, StreamingHttpHandler,
+    WebSocketHandler,
+};
 pub use inline_child::{
     InlineDespawnParent, InlineParent, InlineStatefulChild, InlineStatefulParent,
 };
@@ -52,6 +55,7 @@ aether_actor::export!(
     HttpHandler,
     StreamingHttpHandler,
     RoutedHttpHandler,
+    RoutedStreamingHttpHandler,
     WebSocketHandler,
     SourceObserver,
     MatrixParent,


### PR DESCRIPTION
## What

A response-streaming HTTP handler reached through an externally-registered route (ADR-0131) opened its response stream (`200` + `Transfer-Encoding: chunked`) but was never granted the initial `HttpStreamCredit` window, so its credit handler never fired and it emitted zero body chunks — the external client hung (`curl` error 18). The buffered path over a route and the streaming path over the default handler both worked; the defect was the streaming × external-route intersection only.

## Why

`HttpServerCapabilityState::open_stream` re-resolved the configured default `handler_mailbox` to address credit grants, ignoring the route that actually replied. When the default is unresolvable it collapsed to the `MailboxId(0)` sentinel and the grant silently dropped.

The fix carries the dispatched handler out of the removed in-flight record (`PendingRequest.handler`, already the source of truth threaded through the buffered and websocket paths) and stores it on `StreamState`, so the initial grant and every replenishment reach whichever mailbox handled the request — the same pattern `accept_websocket` already uses. This removes `open_stream`'s dependency on `handler_mailbox` for the stream case entirely.

## Test

Adds a `RoutedStreamingHttpHandler` fixture that claims its own route via `register_route_self` and streams like `StreamingHttpHandler`, plus `wasm_handler_streams_chunked_response_via_registered_route`, which binds `handler_mailbox` to a mailbox that cannot resolve to the fixture so the default-handler path cannot mask the bug. The test hangs (times out) on the old code and reassembles the full chunked body after the fix — verified locally both ways.

Closes #2600

🤖 Generated with [Claude Code](https://claude.com/claude-code)
