### PR TITLE
feat(capabilities): split the http server into a supervisor and dispatch shards

### DIFF
--- a/crates/aether-capabilities/src/http/server/config.rs
+++ b/crates/aether-capabilities/src/http/server/config.rs
@@ -94,6 +94,13 @@ pub struct HttpServerConfig {
     /// [`HttpRequestCredit`]: crate::http::kinds::HttpRequestCredit
     #[cfg_attr(feature = "runtime", config(default = 16))]
     pub request_stream_window: u32,
+    /// Dispatch-shard count (ADR-0135): how many instanced dispatch actors
+    /// the supervisor spawns to run the per-connection request machinery in
+    /// parallel. `0` (the default) sizes automatically to the scheduler
+    /// pool's worker count. A count, not a byte or time quantity, so it
+    /// carries no unit suffix.
+    #[cfg_attr(feature = "runtime", config(default = 0))]
+    pub dispatch_shards: usize,
     /// Websocket idle timeout in milliseconds ([`DEFAULT_WS_IDLE_TIMEOUT_MILLIS`],
     /// ADR-0129): the read deadline between frames on an upgraded websocket
     /// connection. Distinct from `request_timeout_millis` (the slow-loris
@@ -117,6 +124,7 @@ impl Default for HttpServerConfig {
             max_connections: DEFAULT_MAX_CONNECTIONS,
             response_stream_window: DEFAULT_RESPONSE_STREAM_WINDOW,
             request_stream_window: DEFAULT_REQUEST_STREAM_WINDOW,
+            dispatch_shards: 0,
             websocket_idle_timeout_millis: DEFAULT_WS_IDLE_TIMEOUT_MILLIS,
         }
     }

--- a/crates/aether-capabilities/src/http/server/mod.rs
+++ b/crates/aether-capabilities/src/http/server/mod.rs
@@ -37,21 +37,15 @@
 
 // Handler-signature kinds resolve at file root through these imports —
 // `#[actor]` emits the `HandlesKind<K>` markers always-on against the
-// identity, and the `init` / handler bodies name these kinds. The
-// response-stream inbound kinds (`HttpResponseChunk` / `HttpResponseStreamEnd`)
-// and the request-stream credit grant (`HttpRequestCredit`) are `#[handler]`
-// kinds so a streaming handler can address them at `HttpServerCapability`
-// type-safely; the route-registration kinds (ADR-0130) are `#[handler]` kinds
-// likewise.
-use crate::http::kinds::{
-    HttpInboundReady, HttpRequestCredit, HttpResponseChunk, HttpResponseStreamEnd, WebSocketClose,
-    WebSocketMessage,
-};
+// identity, and the `init` / handler bodies name these kinds. Post-ADR-0135
+// the supervisor's surface is the sidecar wake plus route registration
+// (ADR-0130); the per-request kinds (streaming, websocket, settlement,
+// reply interception) live on the dispatch shard identity in `shard`.
+use crate::http::kinds::HttpInboundReady;
 use crate::http::kinds::{
     RegisterRoute, RegisterRouteResult, RegisterRouteSelf, UnregisterRoute, UnregisterRouteSelf,
     UnregisterRoutesAll,
 };
-use aether_kinds::trace::Settled;
 
 // Default bind address. Loopback per ADR-0108 §6 — binding a public
 // interface is an explicit operator choice.
@@ -94,6 +88,7 @@ pub const DEFAULT_REQUEST_STREAM_WINDOW: u32 = 16;
 pub const DEFAULT_WS_IDLE_TIMEOUT_MILLIS: u64 = 300_000;
 
 mod config;
+mod shard;
 
 pub use config::HttpServerConfig;
 // The `Config` derive on `HttpServerConfig` emits these native-only sibling
@@ -120,10 +115,10 @@ pub struct HttpServerHandle {
 /// ZST carrying only the addressing — `Addressable`, the per-handler
 /// `HandlesKind` markers, the `#[fallback]` reply-interception marker, and the
 /// name-inventory entry, all emitted always-on by `#[actor]`. The
-/// state-bearing runtime (`HttpServerCapabilityState`, which owns the
-/// listener + accept thread + connection table) lives behind the one
-/// `feature = "runtime"` gate, so a transport-only build never names the state
-/// type nor pulls `aether_substrate` through this cap.
+/// state-bearing runtime (`HttpSupervisorState`, which owns the listener +
+/// accept thread + shared route table + shard sinks, ADR-0135) lives behind
+/// the one `feature = "runtime"` gate, so a transport-only build never names
+/// the state type nor pulls `aether_substrate` through this cap.
 #[actor(singleton)]
 pub struct HttpServerCapability;
 

--- a/crates/aether-capabilities/src/http/server/runtime/mod.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/mod.rs
@@ -3,17 +3,18 @@
 //! in the parent carries the gate), so a transport-only build of the
 //! `HttpServerCapability` identity never names these types nor pulls
 //! `aether_substrate`. The substrate-typed imports are gated once by this
-//! module rather than line-by-line; the `#[actor] impl` in the parent reaches
-//! the state, ctx, and helper types through the single `use runtime::*` glob.
+//! module rather than line-by-line; the `#[actor] impl` in the parent (and
+//! the shard's, in `super::shard::runtime`) reach the state, ctx, and helper
+//! types through a single `use …::*` glob.
 //!
-//! Holds the state-bearing `HttpServerCapabilityState` (the 11 fields: the
-//! listener port, the accept thread, the per-connection table, the internal
-//! mpsc, and the in-flight correlation table), its helper-method impl, the
-//! reader/accept sidecar free functions, and the parse/render support types.
-//! The reader and accept threads capture only `Arc` / channel / id clones
-//! built from locals in `init` (parent) and `spawn_reader_for_peer` (here) —
-//! never the cap struct — so the field-home move into this state does not
-//! change what the threads capture.
+//! Post-ADR-0135 this module hosts *both* halves of the sharded cap: the
+//! supervisor's `#[runtime] impl` below (listener + accept thread, shard
+//! spawn/assignment, the ADR-0130 route-registration surface over the shared
+//! table) and, in the concern submodules, the whole per-connection machine
+//! the dispatch shards run — [`HttpShardState`] and its reader/writer
+//! sidecars, parse/render, streaming, and websocket support. The sidecar
+//! threads capture only `Arc` / channel / id clones — never an actor struct —
+//! so the supervisor/shard split does not change what any thread captures.
 
 // `#[handler]` methods take their decoded payload by value per the ADR-0033
 // dispatch ABI; the macro-generated trampoline owns the decoded bytes so
@@ -23,14 +24,13 @@
 // Parent-level items this module names. `HttpServerConfig` is named by
 // `init`'s signature, `HttpServerCapability` is the impl's `Self` type, and
 // `HttpServerHandle` is the boot artifact `init` publishes.
-use super::{HttpInboundReady, HttpServerCapability, HttpServerConfig, HttpServerHandle, Settled};
+use super::{HttpInboundReady, HttpServerCapability, HttpServerConfig, HttpServerHandle};
 use aether_actor::runtime;
 
 pub use std::collections::HashMap;
 pub use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
-pub use std::sync::Arc;
-pub use std::sync::atomic::{AtomicBool, Ordering};
-pub use std::sync::mpsc;
+pub use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+pub use std::sync::{Arc, RwLock, mpsc};
 pub use std::thread;
 pub use std::time::Duration;
 
@@ -41,20 +41,24 @@ pub use aether_substrate::chassis::error::BootError;
 pub use aether_substrate::mail::mailer::Mailer;
 pub use aether_substrate::mail::registry::{MailboxEntry, Registry};
 
-// The parent `#[actor] impl` writes the `502` reply path, so it names
-// `HttpServerResponse`; the rest of the kind vocabulary is used only here.
-pub use crate::http::kinds::HttpServerResponse;
-use crate::http::kinds::{
+// The shard's `#[runtime] impl` (super::shard::runtime) reaches the kind
+// vocabulary its moved handler bodies name through this module's glob, so
+// the kinds the shard shares with the concern submodules stay `pub use`.
+pub use crate::http::kinds::{
     HttpHeader, HttpMethod, HttpRequestChunk, HttpRequestCredit, HttpRequestStreamEnd,
     HttpRequestStreamOpen, HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen,
-    HttpServerRequest, HttpStreamCredit, RegisterRoute, RegisterRouteResult, RegisterRouteSelf,
-    UnregisterRoute, UnregisterRouteSelf, UnregisterRoutesAll, WebSocketAccept, WebSocketClose,
+    HttpServerRequest, HttpServerResponse, HttpStreamCredit, WebSocketAccept, WebSocketClose,
     WebSocketMessage,
 };
+use crate::http::kinds::{
+    RegisterRoute, RegisterRouteResult, RegisterRouteSelf, UnregisterRoute, UnregisterRouteSelf,
+    UnregisterRoutesAll,
+};
+pub use aether_kinds::trace::Settled;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 
-use aether_substrate::Mail;
+pub use aether_substrate::Mail;
 use std::io::{self, Read, Write};
 use std::mem;
 use std::str::from_utf8;
@@ -81,10 +85,11 @@ mod unit_tests;
 
 #[runtime]
 impl NativeActor for HttpServerCapability {
-    /// The runtime state this identity boots into (ADR-0122 split): the
-    /// listener port, the accept thread, the connection table, and the
-    /// in-flight correlation table.
-    type State = HttpServerCapabilityState;
+    /// The runtime state this identity boots into (ADR-0122 split,
+    /// ADR-0135): the listener port, the accept thread, the shared route
+    /// table, and the dispatch-shard sinks. The per-connection machine
+    /// lives in the shards ([`HttpShardState`]).
+    type State = HttpSupervisorState;
 
     type Config = HttpServerConfig;
 
@@ -93,7 +98,7 @@ impl NativeActor for HttpServerCapability {
     fn init(
         config: HttpServerConfig,
         ctx: &mut NativeInitCtx<'_>,
-    ) -> Result<HttpServerCapabilityState, BootError> {
+    ) -> Result<HttpSupervisorState, BootError> {
         let listener =
             TcpListener::bind(&config.bind_addr).map_err(|e| BootError::Other(Box::new(e)))?;
         let local_addr = listener
@@ -113,7 +118,7 @@ impl NativeActor for HttpServerCapability {
         let wake_kind = KindId(<HttpInboundReady as Kind>::ID.0);
 
         let accept_sink = WakeSink {
-            inbound_tx: inbound_tx.clone(),
+            inbound_tx,
             mailer: Arc::clone(&mailer),
             self_id,
             wake_kind,
@@ -157,62 +162,32 @@ impl NativeActor for HttpServerCapability {
 
         ctx.publish_handle(HttpServerHandle { local_port: port });
 
-        Ok(HttpServerCapabilityState {
-            handler_mailbox: config.handler_mailbox,
-            routes: Vec::new(),
-            max_request_bytes: config.max_request_bytes,
-            max_header_bytes: config.max_header_bytes,
-            max_connections: config.max_connections,
-            request_timeout: Duration::from_millis(config.request_timeout_millis),
-            keep_alive_timeout: Duration::from_millis(config.keep_alive_timeout_millis),
-            self_mailbox: self_id,
+        Ok(HttpSupervisorState {
+            config,
+            routes: Arc::new(RwLock::new(Vec::new())),
+            live_connections: Arc::new(AtomicUsize::new(0)),
             mailer,
             listener_port: port,
             accept_shutdown,
             accept_thread: Some(accept_thread),
             inbound_rx,
-            inbound_tx,
-            connections: HashMap::new(),
-            next_conn_id: 0,
-            in_flight: HashMap::new(),
-            response_stream_window: config.response_stream_window,
-            streams: HashMap::new(),
-            request_stream_window: config.request_stream_window,
-            request_streams: HashMap::new(),
-            next_stream_id: 0,
-            ws_idle_timeout: Duration::from_millis(config.websocket_idle_timeout_millis),
+            shards: Vec::new(),
+            next_shard: 0,
+            next_stream_id: Arc::new(AtomicU64::new(0)),
         })
     }
 
     fn unwire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {
-        // Stop the accept thread; self-connect to unblock its
-        // blocking `accept()`.
+        // Stop the accept thread; self-connect to unblock its blocking
+        // `accept()`. The shards join their own reader/writer sidecars in
+        // their own `unwire` (the chassis tears instanced actors down
+        // alongside the caps).
         state.accept_shutdown.store(true, Ordering::Release);
         if let Ok(addr) = format!("127.0.0.1:{}", state.listener_port).parse::<SocketAddr>() {
             let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
         }
         if let Some(thread) = state.accept_thread.take() {
             let _ = thread.join();
-        }
-        // Stop every per-connection reader. Shutting the socket down
-        // wakes the blocked `read()`; the reader sees the flag and exits.
-        for conn in state.connections.values_mut() {
-            conn.shutdown.store(true, Ordering::Release);
-            let _ = conn.write_half.shutdown(Shutdown::Both);
-            if let Some(thread) = conn.reader_thread.take() {
-                let _ = thread.join();
-            }
-        }
-        // Stop every response-stream writer (ADR-0128). The socket shutdown
-        // above unblocks a write-blocked writer; dropping the sender unblocks
-        // a recv-blocked one, so drop it before joining to keep `unwire`
-        // prompt (never waiting out the idle-write deadline).
-        for (_, mut stream) in state.streams.drain() {
-            let writer = stream.writer_thread.take();
-            drop(stream);
-            if let Some(thread) = writer {
-                let _ = thread.join();
-            }
         }
         tracing::info!(
             target: "aether_substrate::http_server",
@@ -221,137 +196,31 @@ impl NativeActor for HttpServerCapability {
         );
     }
 
-    /// Sidecar wake. Drain every pending inbound event.
+    /// Sidecar wake. Drain every pending accepted connection and assign
+    /// each to a dispatch shard (ADR-0135).
     ///
     /// # Agent
     /// Internal wake mail — not part of the cap's external surface. The
-    /// accept / reader sidecars fire this; the handler drains the mpsc
-    /// and acts per item.
+    /// accept sidecar fires this; the handler drains the mpsc and assigns
+    /// per item.
     #[handler]
     fn on_inbound_ready(state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: HttpInboundReady) {
         while let Ok(event) = state.inbound_rx.try_recv() {
             match event {
                 InboundEvent::PeerAccepted { stream, peer } => {
-                    state.spawn_reader_for_peer(stream, peer);
+                    state.assign_peer(ctx, stream, peer);
                 }
-                InboundEvent::RequestHeadParsed { conn_id, head } => {
-                    state.decide_request_head(ctx, conn_id, head);
-                }
-                InboundEvent::RequestParsed { conn_id, request } => {
-                    state.dispatch_request(ctx, conn_id, request);
-                }
-                InboundEvent::RequestBodyChunk { conn_id, body } => {
-                    state.forward_request_chunk(ctx, conn_id, body);
-                }
-                InboundEvent::RequestBodyEnd { conn_id } => {
-                    state.end_request_stream(ctx, conn_id);
-                }
-                InboundEvent::RequestRejected {
-                    conn_id,
-                    status,
-                    message,
-                } => {
-                    state.write_status_response(conn_id, status, message);
-                    state.close_connection(conn_id, "request rejected");
-                }
-                InboundEvent::ReaderClosed { conn_id, reason } => {
-                    state.close_connection(conn_id, &reason);
-                }
-                InboundEvent::RequestTimedOut { conn_id } => {
-                    // A streaming connection's writer thread owns the
-                    // idle-write deadline (ADR-0128 §4), so the reader's
-                    // response-deadline timeout must not tear an active
-                    // stream down — a stream making progress isn't stalled.
-                    let streaming = state.streams.values().any(|s| s.conn_id == conn_id);
-                    if !streaming {
-                        if state.in_flight.values().any(|p| p.conn_id == conn_id) {
-                            state.write_status_response(conn_id, 504, "gateway timeout");
-                        }
-                        state.close_connection(conn_id, "request timeout");
-                    }
-                }
-                InboundEvent::StreamSlotFreed { stream_id } => {
-                    state.replenish_credit(ctx, stream_id);
-                }
-                InboundEvent::StreamFinished { stream_id } => {
-                    state.finish_stream(stream_id);
-                }
-                InboundEvent::WebSocketMessage {
-                    conn_id,
-                    binary,
-                    data,
-                } => {
-                    state.dispatch_ws_message(ctx, conn_id, binary, data);
-                }
-                InboundEvent::WebSocketPing { conn_id, payload } => {
-                    state.send_ws_pong(conn_id, &payload);
-                }
-                InboundEvent::WebSocketClose {
-                    conn_id,
-                    code,
-                    reason,
-                } => {
-                    // Report the close to the handler on its own root, echo the
-                    // close frame on the writer (its final write finishes the
-                    // stream, tearing the connection down, ADR-0129 §5).
-                    state.report_ws_close(ctx, conn_id, code, &reason);
-                    state.send_ws_close(conn_id, code, &reason);
+                // Only the accept thread feeds the supervisor's channel;
+                // every other event species is posted by a shard's own
+                // sidecars to that shard's channel.
+                _ => {
+                    tracing::debug!(
+                        target: "aether_substrate::http_server",
+                        "unexpected non-accept event at supervisor dropped",
+                    );
                 }
             }
         }
-    }
-
-    /// One streamed response body chunk from the handler (ADR-0128).
-    /// Matched by the payload's `stream_id` against the `streams` table —
-    /// not by envelope correlation, since a handler's `ctx.send` mints a
-    /// fresh correlation the request's in-flight key would not match.
-    ///
-    /// # Agent
-    /// Not user-callable — a streaming handler sends this after replying
-    /// [`HttpResponseStreamOpen`], paced by the cap's
-    /// [`HttpStreamCredit`](crate::http::kinds::HttpStreamCredit) grants.
-    #[handler]
-    fn on_response_chunk(
-        state: &mut Self::State,
-        _ctx: &mut NativeCtx<'_>,
-        chunk: HttpResponseChunk,
-    ) {
-        state.push_chunk(chunk.stream_id, chunk.body);
-    }
-
-    /// The handler's stream terminator (ADR-0128). Matched by the payload's
-    /// `stream_id` like [`Self::on_response_chunk`].
-    ///
-    /// # Agent
-    /// Not user-callable — a streaming handler sends this once after its
-    /// final [`HttpResponseChunk`] to close the stream.
-    #[handler]
-    fn on_response_stream_end(
-        state: &mut Self::State,
-        _ctx: &mut NativeCtx<'_>,
-        end: HttpResponseStreamEnd,
-    ) {
-        state.end_stream(end.stream_id);
-    }
-
-    /// A streaming handler's inbound-body credit grant (ADR-0128), the inverse
-    /// of the cap → handler [`HttpStreamCredit`]. Matched by the payload's
-    /// `stream_id` against the `request_streams` table — a typed handler, not
-    /// the reply-interception fallback, so a credit grant is never mistaken for
-    /// the handler's final `HttpServerResponse`.
-    ///
-    /// # Agent
-    /// Not user-callable — a streaming handler sends this after receiving
-    /// [`HttpRequestStreamOpen`](crate::http::kinds::HttpRequestStreamOpen), as
-    /// it drains [`HttpRequestChunk`](crate::http::kinds::HttpRequestChunk)
-    /// mails, to let the cap deliver more of the request body.
-    #[handler]
-    fn on_request_credit(
-        state: &mut Self::State,
-        _ctx: &mut NativeCtx<'_>,
-        credit: HttpRequestCredit,
-    ) {
-        state.replenish_reader_credit(credit.stream_id, credit.credit);
     }
 
     /// Claim a route for an explicitly named mailbox (ADR-0130).
@@ -458,149 +327,6 @@ impl NativeActor for HttpServerCapability {
         _ctx: &mut NativeCtx<'_>,
         payload: UnregisterRoutesAll,
     ) {
-        state.routes.retain(|r| r.mailbox != payload.mailbox);
-    }
-
-    /// Settlement notice. The root corresponds to a dispatched request
-    /// we subscribed to; if it settled with no [`HttpServerResponse`]
-    /// written, answer `502` (ADR-0108 §5) and clear the entry.
-    ///
-    /// # Agent
-    /// Internal — fires from the settlement registry, not external mail.
-    #[handler]
-    fn on_settled(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: Settled) {
-        let correlation = mail.root.correlation_id;
-        let Some(pending) = state.in_flight.remove(&correlation) else {
-            // Already answered (the reply landed first) or never ours.
-            return;
-        };
-        state.write_status_response(pending.conn_id, 502, "no response from handler");
-        state.close_connection(pending.conn_id, "settled without response");
-    }
-
-    /// An outbound websocket message from the handler (ADR-0129 §3), routed by
-    /// the payload's `stream_id` through the stream table like
-    /// [`Self::on_response_chunk`] (ADR-0132) — so the send routes identically
-    /// from any causal chain, and a handler can push with no inbound message
-    /// in flight. An unknown or torn-down stream drops the message.
-    ///
-    /// # Agent
-    /// Not user-callable — an upgraded connection's handler sends this to
-    /// speak to the peer; the cap frames it and drains it under the credit
-    /// window.
-    #[handler]
-    fn on_websocket_message(
-        state: &mut Self::State,
-        _ctx: &mut NativeCtx<'_>,
-        msg: WebSocketMessage,
-    ) {
-        if let Some(conn_id) = state.streams.get(&msg.stream_id).map(|s| s.conn_id) {
-            state.send_ws_message(conn_id, msg.binary, &msg.data);
-        } else {
-            tracing::debug!(
-                target: "aether_substrate::http_server",
-                stream = msg.stream_id,
-                "outbound websocket message for unknown stream dropped",
-            );
-        }
-    }
-
-    /// A handler-initiated websocket close (ADR-0129 §5), routed by the
-    /// payload's `stream_id` like [`Self::on_websocket_message`] (ADR-0132):
-    /// the cap writes the close frame on the connection's writer and tears it
-    /// down. An unknown or torn-down stream drops the close.
-    ///
-    /// # Agent
-    /// Not user-callable — an upgraded connection's handler sends this to close
-    /// the socket.
-    #[handler]
-    fn on_websocket_close(
-        state: &mut Self::State,
-        _ctx: &mut NativeCtx<'_>,
-        close: WebSocketClose,
-    ) {
-        if let Some(conn_id) = state.streams.get(&close.stream_id).map(|s| s.conn_id) {
-            state.send_ws_close(conn_id, close.code, &close.reason);
-        } else {
-            tracing::debug!(
-                target: "aether_substrate::http_server",
-                stream = close.stream_id,
-                "outbound websocket close for unknown stream dropped",
-            );
-        }
-    }
-
-    /// Reply interception. Any mail addressed at this cap that isn't one
-    /// of the typed wake / settlement kinds is treated as the handler's
-    /// reply; if its `correlation_id` matches an in-flight request and
-    /// it is an [`HttpServerResponse`], format the HTTP/1.1 response,
-    /// write it to the held socket, and close.
-    ///
-    /// # Agent
-    /// Not user-callable — this is the cap's reply-interception path. A
-    /// by-value `#[handler]` can't read the inbound `sender.correlation_id`,
-    /// so reply correlation goes through this envelope fallback
-    /// (ADR-0108 §5). The handler's one-shot reply is either an
-    /// [`HttpServerResponse`] (buffered, ADR-0108) or an
-    /// [`HttpResponseStreamOpen`] (streamed, ADR-0128); both key on the
-    /// request's in-flight correlation id. The mid-stream chunk / end mails
-    /// carry a fresh send-correlation and are routed to their own
-    /// `#[handler]`s ([`Self::on_response_chunk`] / [`Self::on_response_stream_end`]
-    /// / [`Self::on_websocket_message`]), keyed by their explicit `stream_id`
-    /// payload — a second correlation regime living beside this one.
-    #[fallback]
-    fn on_any(state: &mut Self::State, ctx: &mut NativeCtx<'_>, env: &Envelope) {
-        let correlation = env.sender.correlation_id;
-        let Some(pending) = state.in_flight.get(&correlation).copied() else {
-            return;
-        };
-        // ADR-0129: the handler accepted the upgrade. `WebSocketAccept` is a
-        // one-shot reply (correlation-echoed) keyed on the handshake request's
-        // in-flight correlation, like `HttpResponseStreamOpen`.
-        if env.kind == <WebSocketAccept as Kind>::ID {
-            if let Some(accept) = WebSocketAccept::decode_from_bytes(env.payload.bytes()) {
-                state.accept_websocket(ctx, correlation, pending.conn_id, pending.handler, &accept);
-            } else {
-                state.in_flight.remove(&correlation);
-                state.write_status_response(pending.conn_id, 502, "malformed websocket accept");
-                state.close_connection(pending.conn_id, "malformed websocket accept");
-            }
-            return;
-        }
-        if env.kind == <HttpResponseStreamOpen as Kind>::ID {
-            if let Some(open) = HttpResponseStreamOpen::decode_from_bytes(env.payload.bytes()) {
-                state.open_stream(ctx, correlation, pending.conn_id, &open);
-            } else {
-                state.in_flight.remove(&correlation);
-                state.write_status_response(pending.conn_id, 502, "malformed stream open");
-                state.close_connection(pending.conn_id, "malformed stream open");
-            }
-            return;
-        }
-        if env.kind != <HttpServerResponse as Kind>::ID {
-            // Unexpected kind with a matching correlation — leave the
-            // in-flight entry for the settlement / timeout safety net.
-            return;
-        }
-        if let Some(response) = HttpServerResponse::decode_from_bytes(env.payload.bytes()) {
-            let is_head = pending.method == HttpMethod::Head;
-            state.write_handler_response(pending.conn_id, &response, is_head, pending.keep_alive);
-            state.in_flight.remove(&correlation);
-            // A successful keep-alive response holds the connection and
-            // releases the reader for the next request; otherwise the
-            // connection closes (HTTP/1.0, or `Connection: close`).
-            if pending.keep_alive {
-                state.resume_connection(pending.conn_id);
-            } else {
-                state.close_connection(pending.conn_id, "response written");
-            }
-        } else {
-            // A cap-level error ends the connection (canned responses stay
-            // `Connection: close`), which keeps the keep-alive path scoped to
-            // the normal success round-trip.
-            state.write_status_response(pending.conn_id, 502, "malformed handler response");
-            state.in_flight.remove(&correlation);
-            state.close_connection(pending.conn_id, "malformed handler response");
-        }
+        state.unregister_routes_all(payload.mailbox);
     }
 }

--- a/crates/aether-capabilities/src/http/server/runtime/state.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/state.rs
@@ -4,27 +4,71 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
 
-/// `aether.http.server` runtime state. Owns one TCP listener + per-connection
-/// state + the in-flight correlation table. The dispatcher holds this as the
-/// cap's state and routes envelopes through the macro-emitted `Dispatch`
-/// impl; the addressing identity is the distinct ZST `HttpServerCapability`.
-/// Living in this private module keeps it `pub`-enough to satisfy the
-/// `NativeActor::State` interface without exposing it as crate-public API.
-pub struct HttpServerCapabilityState {
+use crate::http::server::shard::HttpDispatchShard;
+use aether_substrate::Subname;
+
+/// `aether.http.server` supervisor state (ADR-0135). Owns the TCP listener +
+/// accept thread, the shared route table, the global live-connection ceiling,
+/// and the dispatch-shard sinks. Per-request work never runs here — the
+/// supervisor's steady-state job is assigning each accepted connection to a
+/// shard and serving the route-registration surface (ADR-0130).
+pub struct HttpSupervisorState {
+    /// The resolved boot config, kept whole: the tuning fields seed each
+    /// shard at spawn, and `max_connections` backs the assignment-time
+    /// ceiling check.
+    pub config: HttpServerConfig,
+    /// Registered routes (ADR-0130), shared with every shard (and, in later
+    /// stages, the readers): the supervisor's registration handlers write
+    /// under the lock, dispatch-time resolution reads. Unordered —
+    /// resolution picks the winner per request by `(prefix length, method
+    /// specificity)`, which is deterministic without a sort: two distinct
+    /// equal-length prefixes cannot both match one path, and duplicate
+    /// `(prefix, method)` keys are rejected at registration. Route counts
+    /// are tens per substrate, so the linear scan is dwarfed by the header
+    /// parse that precedes it (ADR-0130).
+    pub routes: SharedRoutes,
+    /// Global live-connection count backing the `max_connections` ceiling
+    /// (ADR-0108 §6): incremented here at assignment, decremented by the
+    /// owning shard on connection close. An atomic rather than a table —
+    /// the connections themselves live sharded.
+    pub live_connections: Arc<AtomicUsize>,
+    /// Cached `Arc<Mailer>` for registry validation in the registration
+    /// handlers and for building each shard's wake sink.
+    pub mailer: Arc<Mailer>,
+    pub listener_port: u16,
+    pub accept_shutdown: Arc<AtomicBool>,
+    pub accept_thread: Option<JoinHandle<()>>,
+    /// The supervisor's own sidecar channel: the accept thread posts
+    /// [`InboundEvent::PeerAccepted`] here; nothing else feeds it.
+    pub inbound_rx: mpsc::Receiver<InboundEvent>,
+    /// One wake sink per spawned dispatch shard, in spawn order; empty until
+    /// the first accepted connection forces the spawn (the dispatcher ctx is
+    /// not available at `init`).
+    pub shards: Vec<WakeSink>,
+    /// Round-robin cursor over `shards`.
+    pub next_shard: usize,
+    /// Cap-global stream-id source, cloned into every shard's seed
+    /// (ADR-0135) — see [`HttpShardState::next_stream_id`].
+    pub next_stream_id: Arc<AtomicU64>,
+}
+
+/// Dispatch-shard state (ADR-0135): today's whole per-connection machine —
+/// connection table, in-flight correlation table, response/request stream
+/// tables, websocket state — over the 1/N slice of connections the
+/// supervisor assigned here. The dispatcher holds this as the shard actor's
+/// state; the addressing identity is the distinct ZST
+/// [`HttpDispatchShard`](crate::http::server::shard::HttpDispatchShard).
+pub struct HttpShardState {
     pub handler_mailbox: String,
-    /// Registered routes (ADR-0130), unordered — [`Self::resolve_route`]
-    /// picks the winner per request by `(prefix length, method
-    /// specificity)`, which is deterministic without a sort: two
-    /// distinct equal-length prefixes cannot both match one path, and
-    /// duplicate `(prefix, method)` keys are rejected at registration.
-    /// Route counts are tens per substrate, so the linear scan is
-    /// dwarfed by the header parse that precedes it (ADR-0130).
-    pub routes: Vec<Route>,
+    /// The supervisor's shared route table (ADR-0130/0135); this shard only
+    /// reads it, at request-dispatch time.
+    pub routes: SharedRoutes,
+    /// The global live-connection count (ADR-0135): the supervisor
+    /// increments at assignment; this shard decrements when it closes (or
+    /// fails to adopt) one of its connections.
+    pub live_connections: Arc<AtomicUsize>,
     pub max_request_bytes: usize,
     pub max_header_bytes: usize,
-    /// Live-connection-table ceiling (ADR-0108 §6); a peer accepted past
-    /// this is refused `503` before a reader thread is spawned.
-    pub max_connections: usize,
     pub request_timeout: Duration,
     /// Idle timeout between requests on a kept-alive connection (and for a
     /// fresh connection that never sends its first byte). Distinct from
@@ -32,14 +76,11 @@ pub struct HttpServerCapabilityState {
     /// deadline.
     pub keep_alive_timeout: Duration,
     pub self_mailbox: MailboxId,
-    /// Cached `Arc<Mailer>` so the dispatcher can fire wake mails into
-    /// the cap, resolve the handler mailbox by name at dispatch time,
-    /// and subscribe to settlement. The cap is single-threaded
-    /// post-ADR-0038 so direct storage is fine.
+    /// Cached `Arc<Mailer>` so the shard can fire wake mails into itself,
+    /// resolve the handler mailbox by name at dispatch time, and subscribe
+    /// to settlement. The shard is single-threaded post-ADR-0038 so direct
+    /// storage is fine.
     pub mailer: Arc<Mailer>,
-    pub listener_port: u16,
-    pub accept_shutdown: Arc<AtomicBool>,
-    pub accept_thread: Option<JoinHandle<()>>,
     pub inbound_rx: mpsc::Receiver<InboundEvent>,
     pub inbound_tx: mpsc::Sender<InboundEvent>,
     pub connections: HashMap<ConnId, ConnState>,
@@ -66,23 +107,135 @@ pub struct HttpServerCapabilityState {
     /// `HttpRequestStreamEnd` dispatch through `in_flight`) or on connection
     /// close.
     pub request_streams: HashMap<u64, RequestStreamState>,
-    /// Monotonic source of inbound request-stream ids. Distinct from response
-    /// stream ids (those reuse the request's dispatch correlation), so the two
-    /// tables never collide.
-    pub next_stream_id: u64,
+    /// Monotonic source of cap-minted stream ids (inbound request streams
+    /// and websocket outbound streams), shared across every shard
+    /// (ADR-0135): a handler identifies a connection by its `stream_id`
+    /// alone (ADR-0132), so ids must stay unique across the whole cap, not
+    /// per shard. Distinct from response stream ids (those reuse the
+    /// request's dispatch correlation, unique substrate-wide already), so
+    /// the tables never collide.
+    pub next_stream_id: Arc<AtomicU64>,
     /// Read deadline between frames on an upgraded websocket connection
     /// (ADR-0129), from `websocket_idle_timeout_millis` — longer than
     /// `request_timeout`, since an idle websocket is normal.
     pub ws_idle_timeout: Duration,
 }
 
-impl HttpServerCapabilityState {
+/// Write a canned refusal to a just-accepted socket and shut it down —
+/// the pre-adoption reject (no `ConnState` exists yet), used by the
+/// supervisor's ceiling check and its no-shard fallback.
+fn refuse_connection(mut stream: TcpStream, status: u16, message: &str) {
+    let bytes = render_status_response(status, message);
+    let _ = stream.write_all(&bytes).and_then(|()| stream.flush());
+    let _ = stream.shutdown(Shutdown::Both);
+}
+
+impl HttpSupervisorState {
+    /// Spawn the dispatch shards (ADR-0135) — deferred to the first accepted
+    /// connection because `init` has no dispatcher ctx to spawn children
+    /// from. `dispatch_shards == 0` sizes automatically, mirroring the
+    /// scheduler pool's worker default (`available_parallelism - 1`).
+    pub fn ensure_shards(&mut self, ctx: &mut NativeCtx<'_>) {
+        if !self.shards.is_empty() {
+            return;
+        }
+        let count = if self.config.dispatch_shards == 0 {
+            thread::available_parallelism().map_or(2, |n| n.get().saturating_sub(1).max(1))
+        } else {
+            self.config.dispatch_shards
+        };
+        for index in 0..count {
+            let (inbound_tx, inbound_rx) = mpsc::channel::<InboundEvent>();
+            let seed = HttpShardSeed {
+                inbound_rx: Some(inbound_rx),
+                inbound_tx: inbound_tx.clone(),
+                routes: Arc::clone(&self.routes),
+                live_connections: Arc::clone(&self.live_connections),
+                handler_mailbox: self.config.handler_mailbox.clone(),
+                max_request_bytes: self.config.max_request_bytes,
+                max_header_bytes: self.config.max_header_bytes,
+                request_timeout: Duration::from_millis(self.config.request_timeout_millis),
+                keep_alive_timeout: Duration::from_millis(self.config.keep_alive_timeout_millis),
+                ws_idle_timeout: Duration::from_millis(self.config.websocket_idle_timeout_millis),
+                response_stream_window: self.config.response_stream_window,
+                request_stream_window: self.config.request_stream_window,
+                next_stream_id: Arc::clone(&self.next_stream_id),
+            };
+            let subname = format!("shard-{index}");
+            match ctx
+                .spawn_child::<HttpDispatchShard>(Subname::Named(&subname), seed)
+                .finish()
+            {
+                Ok(mailbox) => self.shards.push(WakeSink {
+                    inbound_tx,
+                    mailer: Arc::clone(&self.mailer),
+                    self_id: mailbox,
+                    wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
+                }),
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aether_substrate::http_server",
+                        shard = %subname,
+                        error = ?e,
+                        "http dispatch shard spawn failed",
+                    );
+                }
+            }
+        }
+        tracing::info!(
+            target: "aether_substrate::http_server",
+            port = self.listener_port,
+            shards = self.shards.len(),
+            "http dispatch shards spawned",
+        );
+    }
+
+    /// Adopt one accepted connection: enforce the global ceiling, pick the
+    /// next shard round-robin, and hand the socket over. Refuses `503`
+    /// before any reader thread exists (ADR-0108 §6) when the table is at
+    /// capacity or no shard came up.
+    pub fn assign_peer(&mut self, ctx: &mut NativeCtx<'_>, stream: TcpStream, peer: SocketAddr) {
+        self.ensure_shards(ctx);
+        if self.shards.is_empty() {
+            refuse_connection(stream, 503, "no dispatch shards");
+            tracing::warn!(
+                target: "aether_substrate::http_server",
+                %peer,
+                "http conn refused: no dispatch shards",
+            );
+            return;
+        }
+        if self.live_connections.load(Ordering::Acquire) >= self.config.max_connections {
+            refuse_connection(stream, 503, "server at connection capacity");
+            tracing::warn!(
+                target: "aether_substrate::http_server",
+                %peer,
+                live = self.live_connections.load(Ordering::Acquire),
+                "http conn refused: at capacity",
+            );
+            return;
+        }
+        self.live_connections.fetch_add(1, Ordering::AcqRel);
+        let index = self.next_shard % self.shards.len();
+        self.next_shard = self.next_shard.wrapping_add(1);
+        if !self.shards[index].post(InboundEvent::PeerAccepted { stream, peer }) {
+            // The shard's receiver is gone — teardown is in progress; the
+            // socket just dropped with the event.
+            self.live_connections.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+
     /// Claim `(prefix, method)` for `mailbox`, dispatching as `kind`
     /// (ADR-0130). A key held by a different mailbox is answered
     /// `Err`; the same mailbox re-claiming its own key is an
     /// idempotent `Ok` that updates `kind` — so a component
     /// re-running `wire` after `replace_component` re-registers
     /// cleanly (its `MailboxId` is stable).
+    ///
+    /// # Panics
+    /// Panics if the route-table `RwLock` is poisoned — fail-fast per
+    /// ADR-0063 (a poisoned table means a supervisor or shard already
+    /// panicked mid-read/write).
     pub fn register_route(
         &mut self,
         prefix: &str,
@@ -94,8 +247,8 @@ impl HttpServerCapabilityState {
             Ok(prefix) => prefix,
             Err(error) => return RegisterRouteResult::Err { error },
         };
-        if let Some(existing) = self
-            .routes
+        let mut routes = self.routes.write().expect("route table lock poisoned");
+        if let Some(existing) = routes
             .iter_mut()
             .find(|r| r.prefix == prefix && r.method == method)
         {
@@ -110,7 +263,7 @@ impl HttpServerCapabilityState {
                 ),
             };
         }
-        self.routes.push(Route {
+        routes.push(Route {
             prefix,
             method,
             kind,
@@ -123,6 +276,10 @@ impl HttpServerCapabilityState {
     /// Idempotent — releasing a route that isn't held (or is held by
     /// someone else) is still `Ok`, mirroring the input cap's
     /// unsubscribe semantics.
+    ///
+    /// # Panics
+    /// Panics if the route-table `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
     pub fn unregister_route(
         &mut self,
         prefix: &str,
@@ -134,41 +291,59 @@ impl HttpServerCapabilityState {
             Err(error) => return RegisterRouteResult::Err { error },
         };
         self.routes
+            .write()
+            .expect("route table lock poisoned")
             .retain(|r| !(r.prefix == prefix && r.method == method && r.mailbox == mailbox));
         RegisterRouteResult::Ok
     }
 
+    /// Release every route held by `mailbox` (ADR-0130's
+    /// `UnregisterRoutesAll`).
+    ///
+    /// # Panics
+    /// Panics if the route-table `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
+    pub fn unregister_routes_all(&mut self, mailbox: MailboxId) {
+        self.routes
+            .write()
+            .expect("route table lock poisoned")
+            .retain(|r| r.mailbox != mailbox);
+    }
+}
+
+impl HttpShardState {
     /// The longest segment-boundary prefix match among
     /// method-compatible routes, with a method-specific route beating
-    /// a method-agnostic one at equal prefix (ADR-0130). `None` ⇒ the
+    /// a method-agnostic one at equal prefix (ADR-0130), copied out
+    /// from under the shared table's read lock. `None` ⇒ the
     /// configured `handler_mailbox` fallback.
-    fn resolve_route(&self, path: &str, method: HttpMethod) -> Option<&Route> {
+    ///
+    /// # Panics
+    /// Panics if the route-table `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
+    fn resolve_route(&self, path: &str, method: HttpMethod) -> Option<(MailboxId, KindId)> {
         self.routes
+            .read()
+            .expect("route table lock poisoned")
             .iter()
             .filter(|r| r.method.is_none_or(|m| m == method) && route_matches(&r.prefix, path))
             .max_by_key(|r| (r.prefix.len(), r.method.is_some()))
+            .map(|r| (r.mailbox, r.kind))
+    }
+
+    /// Release this connection's slot in the global live count (ADR-0135).
+    /// Paired with the supervisor's assignment-time increment; called
+    /// exactly once per assigned connection — on close, or on an adoption
+    /// failure before any `ConnState` exists.
+    fn release_connection_slot(&self) {
+        self.live_connections.fetch_sub(1, Ordering::AcqRel);
     }
 
     /// Allocate a fresh `ConnId`, store the connection's write half, and
-    /// spin a reader thread for the read half. Refuses `503` and closes
-    /// without spawning a reader when the live connection table is
-    /// already at `max_connections` (ADR-0108 §6) — `connections` is the
-    /// single authoritative live-connection count, so no separate
-    /// counter is kept.
-    pub fn spawn_reader_for_peer(&mut self, mut stream: TcpStream, peer: SocketAddr) {
-        if self.connections.len() >= self.max_connections {
-            let bytes = render_status_response(503, "server at connection capacity");
-            let _ = stream.write_all(&bytes).and_then(|()| stream.flush());
-            let _ = stream.shutdown(Shutdown::Both);
-            tracing::warn!(
-                target: "aether_substrate::http_server",
-                %peer,
-                live = self.connections.len(),
-                "http conn refused: at capacity",
-            );
-            return;
-        }
-
+    /// spin a reader thread for the read half. The global `max_connections`
+    /// ceiling was already enforced at assignment by the supervisor
+    /// (ADR-0135); an adoption failure here releases the slot it charged.
+    pub fn spawn_reader_for_peer(&mut self, stream: TcpStream, peer: SocketAddr) {
         let conn_id = self.next_conn_id;
         self.next_conn_id += 1;
 
@@ -181,6 +356,7 @@ impl HttpServerCapabilityState {
                     error = %e,
                     "http conn: try_clone failed; dropping",
                 );
+                self.release_connection_slot();
                 return;
             }
         };
@@ -193,6 +369,7 @@ impl HttpServerCapabilityState {
                 error = %e,
                 "http conn: set_read_timeout failed; dropping",
             );
+            self.release_connection_slot();
             return;
         }
         let write_half = stream;
@@ -241,6 +418,7 @@ impl HttpServerCapabilityState {
                     error = %e,
                     "http reader thread spawn failed",
                 );
+                self.release_connection_slot();
                 return;
             }
         };
@@ -289,9 +467,7 @@ impl HttpServerCapabilityState {
         // `handler_mailbox` by name at dispatch time through the
         // registry — the sanctioned runtime-name path — dispatching
         // the generic request kind. Nothing live either way → `503`.
-        let routed = self
-            .resolve_route(&request.path, method)
-            .map(|route| (route.mailbox, route.kind));
+        let routed = self.resolve_route(&request.path, method);
         let (handler, dispatch_kind) = if let Some((mailbox, kind)) = routed {
             if validate_route_mailbox(self.mailer.registry(), mailbox).is_err() {
                 self.write_status_response(conn_id, 503, "routed handler gone");
@@ -350,11 +526,11 @@ impl HttpServerCapabilityState {
     /// `None` collapses every "nothing live" case to the `503` the buffered
     /// dispatch answers.
     fn resolved_handler(&self, path: &str, method: HttpMethod) -> Option<(MailboxId, KindId)> {
-        if let Some(route) = self.resolve_route(path, method) {
-            if validate_route_mailbox(self.mailer.registry(), route.mailbox).is_err() {
+        if let Some((mailbox, kind)) = self.resolve_route(path, method) {
+            if validate_route_mailbox(self.mailer.registry(), mailbox).is_err() {
                 return None;
             }
-            return Some((route.mailbox, route.kind));
+            return Some((mailbox, kind));
         }
         self.mailer
             .registry()
@@ -497,6 +673,7 @@ impl HttpServerCapabilityState {
         let Some(mut conn) = self.connections.remove(&conn_id) else {
             return;
         };
+        self.release_connection_slot();
         conn.shutdown.store(true, Ordering::Release);
         let _ = conn.write_half.shutdown(Shutdown::Both);
         // Detach the reader without joining inline — the dispatcher must

--- a/crates/aether-capabilities/src/http/server/runtime/streaming.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/streaming.rs
@@ -4,7 +4,7 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
 
-impl HttpServerCapabilityState {
+impl HttpShardState {
     /// Open an inbound request stream (ADR-0128): mint a `stream_id`, record
     /// the stream, send the handler an `HttpRequestStreamOpen`, and seed the
     /// reader's send window. The handler learns its `stream_id` here and paces
@@ -17,8 +17,7 @@ impl HttpServerCapabilityState {
         method: HttpMethod,
         head: ParsedHead,
     ) {
-        let stream_id = self.next_stream_id;
-        self.next_stream_id += 1;
+        let stream_id = self.next_stream_id.fetch_add(1, Ordering::Relaxed);
         let window = self.request_stream_window.max(1);
         self.request_streams.insert(
             stream_id,

--- a/crates/aether-capabilities/src/http/server/runtime/types.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/types.rs
@@ -4,10 +4,42 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
 
-/// Per-connection identifier, monotonic within this cap. Distinct from
-/// the OS-level peer addr (one peer may reconnect; ids stay unique for
-/// the cap's lifetime).
+/// Per-connection identifier, monotonic within one dispatch shard.
+/// Distinct from the OS-level peer addr (one peer may reconnect; ids stay
+/// unique for the shard's lifetime).
 pub type ConnId = u64;
+
+/// The route table (ADR-0130) shared across the supervisor, its dispatch
+/// shards, and (in later ADR-0135 stages) the reader threads: the
+/// supervisor's registration handlers write, request dispatch reads.
+pub type SharedRoutes = Arc<RwLock<Vec<Route>>>;
+
+/// Boot config the supervisor builds for each dispatch shard it spawns
+/// (ADR-0135): the shard's sidecar channel (receiver consumed at `init`,
+/// sender cloned into every reader the shard spawns), the shared route
+/// table + live-connection count, and the per-connection tuning copied
+/// from [`HttpServerConfig`](crate::http::server::HttpServerConfig).
+pub struct HttpShardSeed {
+    /// The shard's inbound event channel; `Some` exactly until the shard's
+    /// `init` takes it (the `TcpSessionConfig::stream` consume pattern).
+    pub inbound_rx: Option<mpsc::Receiver<InboundEvent>>,
+    /// The matching sender: the supervisor keeps a clone (its assignment
+    /// sink), and the shard clones it into each reader's [`WakeSink`].
+    pub inbound_tx: mpsc::Sender<InboundEvent>,
+    pub routes: SharedRoutes,
+    pub live_connections: Arc<AtomicUsize>,
+    pub handler_mailbox: String,
+    pub max_request_bytes: usize,
+    pub max_header_bytes: usize,
+    pub request_timeout: Duration,
+    pub keep_alive_timeout: Duration,
+    pub ws_idle_timeout: Duration,
+    pub response_stream_window: u32,
+    pub request_stream_window: u32,
+    /// Cap-global stream-id source (ADR-0135) — see
+    /// [`HttpShardState::next_stream_id`](super::HttpShardState).
+    pub next_stream_id: Arc<AtomicU64>,
+}
 
 /// Header-array size for the inbound parse (doubles as the header-count
 /// cap: a request with more headers is answered `431`). ADR-0108 §6.
@@ -220,7 +252,7 @@ pub struct ConnState {
 
 /// Per-connection websocket state (ADR-0129), set on accept. Outbound frames
 /// ride the ADR-0128 writer thread through the [`StreamState`] keyed by
-/// `stream_id` in [`HttpServerCapabilityState::streams`]; `handler` is the
+/// `stream_id` in [`HttpShardState::streams`]; `handler` is the
 /// mailbox each inbound message is dispatched to.
 pub struct WsConn {
     /// The handler mailbox resolved at handshake — inbound messages dispatch
@@ -251,7 +283,7 @@ pub struct PendingRequest {
 }
 
 /// Per-connection response-stream state (ADR-0128), keyed in
-/// [`HttpServerCapabilityState::streams`] by `stream_id` (== the request's
+/// [`HttpShardState::streams`] by `stream_id` (== the request's
 /// dispatch correlation id `C`). The dispatcher owns all of this
 /// single-threaded, exactly like [`PendingRequest`]; the writer thread owns
 /// only the socket write.
@@ -283,14 +315,14 @@ pub struct StreamState {
     pub pending_end: bool,
     /// Whether the connection is kept alive once this stream finishes
     /// (renders `Connection: keep-alive` in the stream head and resumes the
-    /// reader at [`HttpServerCapabilityState::finish_stream`]) rather than
+    /// reader at [`HttpShardState::finish_stream`]) rather than
     /// closing it. Set from the promoted request's [`PendingRequest`] at
     /// stream open, mirroring `PendingRequest::keep_alive`.
     pub keep_alive: bool,
 }
 
 /// Per-connection *inbound* request-stream state (ADR-0128), keyed in
-/// [`HttpServerCapabilityState::request_streams`] by a cap-minted `stream_id`.
+/// [`HttpShardState::request_streams`] by a cap-minted `stream_id`.
 /// The dispatcher owns it single-threaded; the reader thread owns only the
 /// socket read and the credit wait. The mirror of [`StreamState`] with the
 /// data flowing the other way — the cap produces credit-paced chunks *to* the

--- a/crates/aether-capabilities/src/http/server/runtime/websocket.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/websocket.rs
@@ -485,7 +485,7 @@ pub fn run_ws_reader_loop(
     }
 }
 
-impl HttpServerCapabilityState {
+impl HttpShardState {
     /// Accept a websocket upgrade (ADR-0129 §1): the handler replied
     /// `WebSocketAccept` to a stashed-key upgrade request. Compute
     /// `Sec-WebSocket-Accept`, write the `101 Switching Protocols` head
@@ -534,8 +534,7 @@ impl HttpServerCapabilityState {
             }
         };
 
-        let stream_id = self.next_stream_id;
-        self.next_stream_id += 1;
+        let stream_id = self.next_stream_id.fetch_add(1, Ordering::Relaxed);
         let window = self.response_stream_window.max(1);
         let (tx, rx) = mpsc::sync_channel::<WriterMsg>(window as usize);
         let sink = WakeSink {

--- a/crates/aether-capabilities/src/http/server/shard/mod.rs
+++ b/crates/aether-capabilities/src/http/server/shard/mod.rs
@@ -1,0 +1,38 @@
+//! `aether.http.server.shard` — instanced dispatch shard of the HTTP server
+//! (ADR-0135). The supervisor (`aether.http.server`) assigns each accepted
+//! connection to one shard round-robin; from then on the connection lives
+//! entirely here — this actor spawns and controls the per-connection reader,
+//! owns the connection / in-flight / stream / websocket tables for its slice,
+//! dispatches requests to the handler, and intercepts the replies. N shards
+//! run as independent actors on the worker pool, so the per-request dispatch
+//! work parallelizes across cores instead of serializing through the one
+//! supervisor actor.
+//!
+//! The external mail surface (route registration, ADR-0130) stays on the
+//! supervisor; nothing addresses a shard by name. Handler replies and
+//! stream-phase mails arrive here because the shard is the dispatch source
+//! (reply correlation and the ADR-0133 handles both follow the dispatching
+//! mailbox).
+
+// Handler-signature kinds resolve at file root through these imports —
+// `#[actor]` emits the `HandlesKind<K>` markers always-on against the
+// identity, and the handler bodies in `runtime` name these kinds.
+use crate::http::kinds::{
+    HttpInboundReady, HttpRequestCredit, HttpResponseChunk, HttpResponseStreamEnd, WebSocketClose,
+    WebSocketMessage,
+};
+use aether_kinds::trace::Settled;
+
+/// `aether.http.server.shard` **identity** (ADR-0122 identity/runtime split,
+/// ADR-0135). A ZST carrying only the addressing — `Addressable`, the
+/// per-handler `HandlesKind` markers, the `#[fallback]` reply-interception
+/// marker, and the instanced name-inventory entry, all emitted always-on by
+/// `#[actor]`. The state-bearing runtime (`HttpShardState`, the
+/// per-connection machine) lives behind the one `feature = "runtime"` gate.
+#[actor(instanced)]
+pub struct HttpDispatchShard;
+
+use aether_actor::actor;
+
+#[cfg(feature = "runtime")]
+mod runtime;

--- a/crates/aether-capabilities/src/http/server/shard/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/shard/runtime.rs
@@ -1,0 +1,370 @@
+//! The `aether.http.server.shard` runtime half (ADR-0122 identity/runtime
+//! split, ADR-0135). The state type and the whole per-connection machine —
+//! reader/writer sidecars, parse/render, streaming, websocket — live in the
+//! server's shared `runtime` module; this file carries only the shard's
+//! `#[runtime] impl`: boot from the supervisor-built [`HttpShardSeed`], the
+//! sidecar drain, the stream/websocket/credit handlers, settlement, and the
+//! reply-interception fallback.
+
+// `#[handler]` methods take their decoded payload by value per the ADR-0033
+// dispatch ABI; the macro-generated trampoline owns the decoded bytes so
+// callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
+// The shard shares the server runtime's one import surface (ADR-0122):
+// state + event + helper types come through this glob rather than a
+// bespoke list.
+#[allow(clippy::wildcard_imports)]
+use crate::http::server::runtime::*;
+
+use crate::http::kinds::HttpInboundReady;
+use aether_actor::runtime;
+
+use super::HttpDispatchShard;
+
+#[runtime]
+impl NativeActor for HttpDispatchShard {
+    /// The runtime state this shard boots into (ADR-0135): the connection
+    /// table, the in-flight correlation table, and the stream/websocket
+    /// tables for this shard's slice of the connections.
+    type State = HttpShardState;
+
+    type Config = HttpShardSeed;
+
+    const NAMESPACE: &'static str = "aether.http.server.shard";
+
+    fn init(
+        mut seed: HttpShardSeed,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<HttpShardState, BootError> {
+        let inbound_rx = seed
+            .inbound_rx
+            .take()
+            .expect("HttpShardSeed::inbound_rx consumed exactly once");
+        Ok(HttpShardState {
+            handler_mailbox: seed.handler_mailbox,
+            routes: seed.routes,
+            live_connections: seed.live_connections,
+            max_request_bytes: seed.max_request_bytes,
+            max_header_bytes: seed.max_header_bytes,
+            request_timeout: seed.request_timeout,
+            keep_alive_timeout: seed.keep_alive_timeout,
+            self_mailbox: ctx.self_id(),
+            mailer: ctx.mailer(),
+            inbound_rx,
+            inbound_tx: seed.inbound_tx,
+            connections: HashMap::new(),
+            next_conn_id: 0,
+            in_flight: HashMap::new(),
+            response_stream_window: seed.response_stream_window,
+            streams: HashMap::new(),
+            request_stream_window: seed.request_stream_window,
+            request_streams: HashMap::new(),
+            next_stream_id: seed.next_stream_id,
+            ws_idle_timeout: seed.ws_idle_timeout,
+        })
+    }
+
+    fn unwire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {
+        // Stop every per-connection reader. Shutting the socket down
+        // wakes the blocked `read()`; the reader sees the flag and exits.
+        for conn in state.connections.values_mut() {
+            conn.shutdown.store(true, Ordering::Release);
+            let _ = conn.write_half.shutdown(Shutdown::Both);
+            if let Some(thread) = conn.reader_thread.take() {
+                let _ = thread.join();
+            }
+        }
+        // Stop every response-stream writer (ADR-0128). The socket shutdown
+        // above unblocks a write-blocked writer; dropping the sender unblocks
+        // a recv-blocked one, so drop it before joining to keep `unwire`
+        // prompt (never waiting out the idle-write deadline).
+        for (_, mut stream) in state.streams.drain() {
+            let writer = stream.writer_thread.take();
+            drop(stream);
+            if let Some(thread) = writer {
+                let _ = thread.join();
+            }
+        }
+    }
+
+    /// Sidecar wake. Drain every pending inbound event — connection
+    /// assignments from the supervisor, plus everything this shard's own
+    /// reader / writer sidecars post.
+    ///
+    /// # Agent
+    /// Internal wake mail — not part of the cap's external surface. The
+    /// supervisor and this shard's reader sidecars fire this; the handler
+    /// drains the mpsc and acts per item.
+    #[handler]
+    fn on_inbound_ready(state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: HttpInboundReady) {
+        while let Ok(event) = state.inbound_rx.try_recv() {
+            match event {
+                InboundEvent::PeerAccepted { stream, peer } => {
+                    state.spawn_reader_for_peer(stream, peer);
+                }
+                InboundEvent::RequestHeadParsed { conn_id, head } => {
+                    state.decide_request_head(ctx, conn_id, head);
+                }
+                InboundEvent::RequestParsed { conn_id, request } => {
+                    state.dispatch_request(ctx, conn_id, request);
+                }
+                InboundEvent::RequestBodyChunk { conn_id, body } => {
+                    state.forward_request_chunk(ctx, conn_id, body);
+                }
+                InboundEvent::RequestBodyEnd { conn_id } => {
+                    state.end_request_stream(ctx, conn_id);
+                }
+                InboundEvent::RequestRejected {
+                    conn_id,
+                    status,
+                    message,
+                } => {
+                    state.write_status_response(conn_id, status, message);
+                    state.close_connection(conn_id, "request rejected");
+                }
+                InboundEvent::ReaderClosed { conn_id, reason } => {
+                    state.close_connection(conn_id, &reason);
+                }
+                InboundEvent::RequestTimedOut { conn_id } => {
+                    // A streaming connection's writer thread owns the
+                    // idle-write deadline (ADR-0128 §4), so the reader's
+                    // response-deadline timeout must not tear an active
+                    // stream down — a stream making progress isn't stalled.
+                    let streaming = state.streams.values().any(|s| s.conn_id == conn_id);
+                    if !streaming {
+                        if state.in_flight.values().any(|p| p.conn_id == conn_id) {
+                            state.write_status_response(conn_id, 504, "gateway timeout");
+                        }
+                        state.close_connection(conn_id, "request timeout");
+                    }
+                }
+                InboundEvent::StreamSlotFreed { stream_id } => {
+                    state.replenish_credit(ctx, stream_id);
+                }
+                InboundEvent::StreamFinished { stream_id } => {
+                    state.finish_stream(stream_id);
+                }
+                InboundEvent::WebSocketMessage {
+                    conn_id,
+                    binary,
+                    data,
+                } => {
+                    state.dispatch_ws_message(ctx, conn_id, binary, data);
+                }
+                InboundEvent::WebSocketPing { conn_id, payload } => {
+                    state.send_ws_pong(conn_id, &payload);
+                }
+                InboundEvent::WebSocketClose {
+                    conn_id,
+                    code,
+                    reason,
+                } => {
+                    // Report the close to the handler on its own root, echo the
+                    // close frame on the writer (its final write finishes the
+                    // stream, tearing the connection down, ADR-0129 §5).
+                    state.report_ws_close(ctx, conn_id, code, &reason);
+                    state.send_ws_close(conn_id, code, &reason);
+                }
+            }
+        }
+    }
+
+    /// One streamed response body chunk from the handler (ADR-0128).
+    /// Matched by the payload's `stream_id` against the `streams` table —
+    /// not by envelope correlation, since a handler's `ctx.send` mints a
+    /// fresh correlation the request's in-flight key would not match.
+    ///
+    /// # Agent
+    /// Not user-callable — a streaming handler sends this after replying
+    /// [`HttpResponseStreamOpen`], paced by the cap's
+    /// [`HttpStreamCredit`](crate::http::kinds::HttpStreamCredit) grants.
+    #[handler]
+    fn on_response_chunk(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        chunk: HttpResponseChunk,
+    ) {
+        state.push_chunk(chunk.stream_id, chunk.body);
+    }
+
+    /// The handler's stream terminator (ADR-0128). Matched by the payload's
+    /// `stream_id` like [`Self::on_response_chunk`].
+    ///
+    /// # Agent
+    /// Not user-callable — a streaming handler sends this once after its
+    /// final [`HttpResponseChunk`] to close the stream.
+    #[handler]
+    fn on_response_stream_end(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        end: HttpResponseStreamEnd,
+    ) {
+        state.end_stream(end.stream_id);
+    }
+
+    /// A streaming handler's inbound-body credit grant (ADR-0128), the inverse
+    /// of the cap → handler [`HttpStreamCredit`]. Matched by the payload's
+    /// `stream_id` against the `request_streams` table — a typed handler, not
+    /// the reply-interception fallback, so a credit grant is never mistaken for
+    /// the handler's final `HttpServerResponse`.
+    ///
+    /// # Agent
+    /// Not user-callable — a streaming handler sends this after receiving
+    /// [`HttpRequestStreamOpen`](crate::http::kinds::HttpRequestStreamOpen), as
+    /// it drains [`HttpRequestChunk`](crate::http::kinds::HttpRequestChunk)
+    /// mails, to let the cap deliver more of the request body.
+    ///
+    /// [`HttpStreamCredit`]: crate::http::kinds::HttpStreamCredit
+    #[handler]
+    fn on_request_credit(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        credit: HttpRequestCredit,
+    ) {
+        state.replenish_reader_credit(credit.stream_id, credit.credit);
+    }
+
+    /// Settlement notice. The root corresponds to a dispatched request
+    /// we subscribed to; if it settled with no [`HttpServerResponse`]
+    /// written, answer `502` (ADR-0108 §5) and clear the entry.
+    ///
+    /// # Agent
+    /// Internal — fires from the settlement registry, not external mail.
+    #[handler]
+    fn on_settled(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: Settled) {
+        let correlation = mail.root.correlation_id;
+        let Some(pending) = state.in_flight.remove(&correlation) else {
+            // Already answered (the reply landed first) or never ours.
+            return;
+        };
+        state.write_status_response(pending.conn_id, 502, "no response from handler");
+        state.close_connection(pending.conn_id, "settled without response");
+    }
+
+    /// An outbound websocket message from the handler (ADR-0129 §3), routed by
+    /// the payload's `stream_id` through the stream table like
+    /// [`Self::on_response_chunk`] (ADR-0132) — so the send routes identically
+    /// from any causal chain, and a handler can push with no inbound message
+    /// in flight. An unknown or torn-down stream drops the message.
+    ///
+    /// # Agent
+    /// Not user-callable — an upgraded connection's handler sends this to
+    /// speak to the peer; the cap frames it and drains it under the credit
+    /// window.
+    #[handler]
+    fn on_websocket_message(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        msg: WebSocketMessage,
+    ) {
+        if let Some(conn_id) = state.streams.get(&msg.stream_id).map(|s| s.conn_id) {
+            state.send_ws_message(conn_id, msg.binary, &msg.data);
+        } else {
+            tracing::debug!(
+                target: "aether_substrate::http_server",
+                stream = msg.stream_id,
+                "outbound websocket message for unknown stream dropped",
+            );
+        }
+    }
+
+    /// A handler-initiated websocket close (ADR-0129 §5), routed by the
+    /// payload's `stream_id` like [`Self::on_websocket_message`] (ADR-0132):
+    /// the cap writes the close frame on the connection's writer and tears it
+    /// down. An unknown or torn-down stream drops the close.
+    ///
+    /// # Agent
+    /// Not user-callable — an upgraded connection's handler sends this to close
+    /// the socket.
+    #[handler]
+    fn on_websocket_close(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        close: WebSocketClose,
+    ) {
+        if let Some(conn_id) = state.streams.get(&close.stream_id).map(|s| s.conn_id) {
+            state.send_ws_close(conn_id, close.code, &close.reason);
+        } else {
+            tracing::debug!(
+                target: "aether_substrate::http_server",
+                stream = close.stream_id,
+                "outbound websocket close for unknown stream dropped",
+            );
+        }
+    }
+
+    /// Reply interception. Any mail addressed at this shard that isn't one
+    /// of the typed wake / settlement kinds is treated as the handler's
+    /// reply; if its `correlation_id` matches an in-flight request and
+    /// it is an [`HttpServerResponse`], format the HTTP/1.1 response,
+    /// write it to the held socket, and close.
+    ///
+    /// # Agent
+    /// Not user-callable — this is the cap's reply-interception path. A
+    /// by-value `#[handler]` can't read the inbound `sender.correlation_id`,
+    /// so reply correlation goes through this envelope fallback
+    /// (ADR-0108 §5). The handler's one-shot reply is either an
+    /// [`HttpServerResponse`] (buffered, ADR-0108) or an
+    /// [`HttpResponseStreamOpen`] (streamed, ADR-0128); both key on the
+    /// request's in-flight correlation id. The mid-stream chunk / end mails
+    /// carry a fresh send-correlation and are routed to their own
+    /// `#[handler]`s ([`Self::on_response_chunk`] / [`Self::on_response_stream_end`]
+    /// / [`Self::on_websocket_message`]), keyed by their explicit `stream_id`
+    /// payload — a second correlation regime living beside this one.
+    #[fallback]
+    fn on_any(state: &mut Self::State, ctx: &mut NativeCtx<'_>, env: &Envelope) {
+        let correlation = env.sender.correlation_id;
+        let Some(pending) = state.in_flight.get(&correlation).copied() else {
+            return;
+        };
+        // ADR-0129: the handler accepted the upgrade. `WebSocketAccept` is a
+        // one-shot reply (correlation-echoed) keyed on the handshake request's
+        // in-flight correlation, like `HttpResponseStreamOpen`.
+        if env.kind == <WebSocketAccept as Kind>::ID {
+            if let Some(accept) = WebSocketAccept::decode_from_bytes(env.payload.bytes()) {
+                state.accept_websocket(ctx, correlation, pending.conn_id, pending.handler, &accept);
+            } else {
+                state.in_flight.remove(&correlation);
+                state.write_status_response(pending.conn_id, 502, "malformed websocket accept");
+                state.close_connection(pending.conn_id, "malformed websocket accept");
+            }
+            return;
+        }
+        if env.kind == <HttpResponseStreamOpen as Kind>::ID {
+            if let Some(open) = HttpResponseStreamOpen::decode_from_bytes(env.payload.bytes()) {
+                state.open_stream(ctx, correlation, pending.conn_id, &open);
+            } else {
+                state.in_flight.remove(&correlation);
+                state.write_status_response(pending.conn_id, 502, "malformed stream open");
+                state.close_connection(pending.conn_id, "malformed stream open");
+            }
+            return;
+        }
+        if env.kind != <HttpServerResponse as Kind>::ID {
+            // Unexpected kind with a matching correlation — leave the
+            // in-flight entry for the settlement / timeout safety net.
+            return;
+        }
+        if let Some(response) = HttpServerResponse::decode_from_bytes(env.payload.bytes()) {
+            let is_head = pending.method == HttpMethod::Head;
+            state.write_handler_response(pending.conn_id, &response, is_head, pending.keep_alive);
+            state.in_flight.remove(&correlation);
+            // A successful keep-alive response holds the connection and
+            // releases the reader for the next request; otherwise the
+            // connection closes (HTTP/1.0, or `Connection: close`).
+            if pending.keep_alive {
+                state.resume_connection(pending.conn_id);
+            } else {
+                state.close_connection(pending.conn_id, "response written");
+            }
+        } else {
+            // A cap-level error ends the connection (canned responses stay
+            // `Connection: close`), which keeps the keep-alive path scoped to
+            // the normal success round-trip.
+            state.write_status_response(pending.conn_id, 502, "malformed handler response");
+            state.in_flight.remove(&correlation);
+            state.close_connection(pending.conn_id, "malformed handler response");
+        }
+    }
+}

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -29,17 +29,18 @@ mod test_handlers {
     //! component author writes. The conflict-`Err` and idempotent
     //! double-claim handlers stay on the raw registration surface, so a
     //! macro regression cannot mask a registration-semantics one.
-    use aether_actor::actor;
+    use aether_actor::{Manual, actor};
     use aether_data::Kind;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
 
+    use crate::http::{RequestStream, ResponseStream};
+
     use crate::http;
     use crate::http::kinds::{
-        HttpHeader, HttpRequestChunk, HttpRequestCredit, HttpRequestStreamEnd,
-        HttpRequestStreamOpen, HttpResponseChunk, HttpResponseStreamEnd, HttpResponseStreamOpen,
-        HttpServerRequest, HttpServerResponse, HttpStreamCredit, RegisterRouteSelf,
-        UnregisterRouteSelf,
+        HttpHeader, HttpRequestChunk, HttpRequestStreamEnd, HttpRequestStreamOpen,
+        HttpResponseStreamOpen, HttpServerRequest, HttpServerResponse, HttpStreamCredit,
+        RegisterRouteSelf, UnregisterRouteSelf,
     };
     use crate::http::server::HttpServerCapability;
 
@@ -495,7 +496,6 @@ mod test_handlers {
 
     /// Per-stream progress for [`StreamHttpHandler`].
     pub struct StreamHttpHandlerState {
-        stream_id: u64,
         next_index: u32,
         ended: bool,
     }
@@ -508,7 +508,6 @@ mod test_handlers {
 
         fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<StreamHttpHandlerState, BootError> {
             Ok(StreamHttpHandlerState {
-                stream_id: 0,
                 next_index: 0,
                 ended: false,
             })
@@ -533,24 +532,26 @@ mod test_handlers {
 
         /// Spend the granted credit: send up to `credit.credit` more chunks,
         /// then terminate once all [`STREAM_CHUNK_COUNT`] have gone out.
-        #[handler]
-        fn on_credit(state: &mut Self::State, ctx: &mut NativeCtx<'_>, credit: HttpStreamCredit) {
-            state.stream_id = credit.stream_id;
+        /// Addressed through the ADR-0133 [`ResponseStream`] handle — the
+        /// data phase goes to whichever dispatch shard granted the credit,
+        /// never to the supervisor by type (ADR-0135).
+        #[handler::manual]
+        fn on_credit(
+            state: &mut Self::State,
+            ctx: &mut NativeCtx<'_, Manual>,
+            credit: HttpStreamCredit,
+        ) {
+            let Some(stream) = ResponseStream::from_credit(ctx, &credit) else {
+                return;
+            };
             let mut budget = credit.credit;
             while budget > 0 && state.next_index < STREAM_CHUNK_COUNT {
-                ctx.actor::<HttpServerCapability>()
-                    .send(&HttpResponseChunk {
-                        stream_id: state.stream_id,
-                        body: stream_chunk_body(state.next_index),
-                    });
+                stream.chunk(ctx, stream_chunk_body(state.next_index));
                 state.next_index += 1;
                 budget -= 1;
             }
             if state.next_index >= STREAM_CHUNK_COUNT && !state.ended {
-                ctx.actor::<HttpServerCapability>()
-                    .send(&HttpResponseStreamEnd {
-                        stream_id: state.stream_id,
-                    });
+                stream.end(ctx);
                 state.ended = true;
             }
         }
@@ -594,18 +595,21 @@ mod test_handlers {
             }
         }
 
-        #[handler]
-        fn on_credit(state: &mut Self::State, ctx: &mut NativeCtx<'_>, credit: HttpStreamCredit) {
+        #[handler::manual]
+        fn on_credit(
+            state: &mut Self::State,
+            ctx: &mut NativeCtx<'_, Manual>,
+            credit: HttpStreamCredit,
+        ) {
             if state.flooded {
                 return;
             }
             state.flooded = true;
+            let Some(stream) = ResponseStream::from_credit(ctx, &credit) else {
+                return;
+            };
             for _ in 0..FLOOD_CHUNK_COUNT {
-                ctx.actor::<HttpServerCapability>()
-                    .send(&HttpResponseChunk {
-                        stream_id: credit.stream_id,
-                        body: vec![b'x'; 8],
-                    });
+                stream.chunk(ctx, vec![b'x'; 8]);
             }
         }
     }
@@ -622,6 +626,11 @@ mod test_handlers {
     /// Per-upload progress for [`StreamingUploadHandler`].
     pub struct StreamingUploadHandlerState {
         received: usize,
+        /// The ADR-0133 inbound-stream handle captured at
+        /// `HttpRequestStreamOpen` — credit grants go to whichever dispatch
+        /// shard opened the stream (ADR-0135), never to the supervisor by
+        /// type.
+        stream: Option<RequestStream>,
     }
 
     #[actor(singleton)]
@@ -634,16 +643,20 @@ mod test_handlers {
             (): (),
             _ctx: &mut NativeInitCtx<'_>,
         ) -> Result<StreamingUploadHandlerState, BootError> {
-            Ok(StreamingUploadHandlerState { received: 0 })
+            Ok(StreamingUploadHandlerState {
+                received: 0,
+                stream: None,
+            })
         }
 
-        #[handler]
+        #[handler::manual]
         fn on_stream_open(
             state: &mut Self::State,
-            _ctx: &mut NativeCtx<'_>,
-            _open: HttpRequestStreamOpen,
+            ctx: &mut NativeCtx<'_, Manual>,
+            open: HttpRequestStreamOpen,
         ) {
             state.received = 0;
+            state.stream = RequestStream::from_open(ctx, &open);
         }
 
         /// Count the piece and grant one credit back so the cap delivers the
@@ -651,11 +664,9 @@ mod test_handlers {
         #[handler]
         fn on_chunk(state: &mut Self::State, ctx: &mut NativeCtx<'_>, chunk: HttpRequestChunk) {
             state.received += chunk.body.len();
-            ctx.actor::<HttpServerCapability>()
-                .send(&HttpRequestCredit {
-                    stream_id: chunk.stream_id,
-                    credit: 1,
-                });
+            if let Some(stream) = &state.stream {
+                stream.credit(ctx, 1);
+            }
         }
 
         #[handler]
@@ -1095,11 +1106,16 @@ fn head_response_suppresses_body() {
 
 /// A peer accepted past `max_connections` is refused a canned `503`
 /// and closed before a reader thread is spawned; it never reaches the
-/// handler.
+/// handler. `dispatch_shards` is pinned above one so the ceiling is
+/// provably global across shards (ADR-0135) — the two held connections
+/// land on different shards round-robin, and the supervisor still
+/// refuses the third against the shared live count.
 ///
-/// Tripwire: without the capacity guard in `spawn_reader_for_peer`,
-/// this connection is accepted and dispatched (or hangs waiting on
-/// the handler) instead of being refused.
+/// Tripwire: without the assignment-time capacity guard in
+/// `HttpSupervisorState::assign_peer`, this connection is accepted and
+/// dispatched (or hangs waiting on the handler) instead of being
+/// refused; with a per-shard rather than global count, it is accepted
+/// because no single shard is at the ceiling.
 #[test]
 fn over_capacity_connection_is_503() {
     let (registry, mailer) = fresh_substrate();
@@ -1111,6 +1127,7 @@ fn over_capacity_connection_is_503() {
             handler_mailbox: <EchoHttpHandler as Addressable>::NAMESPACE.to_string(),
             request_timeout_millis: 5_000,
             max_connections,
+            dispatch_shards: 2,
             ..HttpServerConfig::default()
         })
         .build_passive()
@@ -1143,6 +1160,70 @@ fn over_capacity_connection_is_503() {
     );
 
     drop(held);
+}
+
+/// Concurrent connections under a pinned multi-shard config (ADR-0135) are
+/// all served, including keep-alive reuse: four connections land on two
+/// shards round-robin, each serves two sequential requests, every reply
+/// routes back through the owning shard. Pinned to `dispatch_shards: 2`
+/// rather than the auto worker-count sizing so the multi-shard path is
+/// exercised even on a low-core CI runner where auto sizing collapses to
+/// one shard.
+///
+/// Tripwire: a shard-assignment bug (posting to a never-spawned shard, a
+/// round-robin index error, a reply intercepted by the wrong actor)
+/// surfaces here as a hung read or a `502`/`503` on some subset of the
+/// connections.
+#[test]
+fn connections_distribute_across_shards() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<EchoHttpHandler>(())
+        .with_actor::<HttpServerCapability>(HttpServerConfig {
+            bind_addr: "127.0.0.1:0".to_string(),
+            handler_mailbox: <EchoHttpHandler as Addressable>::NAMESPACE.to_string(),
+            request_timeout_millis: 5_000,
+            dispatch_shards: 2,
+            ..HttpServerConfig::default()
+        })
+        .build_passive()
+        .expect("caps boot");
+
+    let port = port_of(&chassis);
+
+    let mut streams: Vec<(TcpStream, Vec<u8>)> = (0..4)
+        .map(|_| {
+            let stream =
+                TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to http server");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .expect("set_read_timeout");
+            (stream, Vec::new())
+        })
+        .collect();
+
+    for round in 0..2 {
+        // Write this round's request on every connection first, then read
+        // every response — so all four connections are in flight across
+        // both shards at once, not serialized one connection at a time.
+        for (index, (stream, _)) in streams.iter_mut().enumerate() {
+            let request =
+                format!("GET /conn{index}/round{round} HTTP/1.1\r\nHost: localhost\r\n\r\n");
+            stream.write_all(request.as_bytes()).expect("write request");
+            stream.flush().expect("flush request");
+        }
+        for (index, (stream, carry)) in streams.iter_mut().enumerate() {
+            let response = read_one_response(stream, carry);
+            assert!(
+                response.starts_with("HTTP/1.1 200 "),
+                "conn {index} round {round}: expected 200, got: {response:?}",
+            );
+            assert!(
+                response.contains(&format!("x-aether-path: /conn{index}/round{round}")),
+                "conn {index} round {round}: reply correlated to the wrong request: {response:?}",
+            );
+        }
+    }
 }
 
 /// A streaming handler (ADR-0128) emits its body across more chunks than the

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -270,6 +270,7 @@ mod tests {
             max_connections: 1024,
             response_stream_window: 16,
             request_stream_window: 16,
+            dispatch_shards: 0,
             websocket_idle_timeout_millis: 300_000,
         };
 
@@ -391,6 +392,7 @@ mod tests {
             // Window below the chunk count so the round trip must replenish.
             response_stream_window: 8,
             request_stream_window: 16,
+            dispatch_shards: 0,
             websocket_idle_timeout_millis: 300_000,
         };
 
@@ -514,6 +516,7 @@ mod tests {
             // Window below the chunk count so the round trip must replenish.
             response_stream_window: 8,
             request_stream_window: 16,
+            dispatch_shards: 0,
             websocket_idle_timeout_millis: 300_000,
         };
 
@@ -633,6 +636,7 @@ mod tests {
             max_connections: 1024,
             response_stream_window: 8,
             request_stream_window: 16,
+            dispatch_shards: 0,
             websocket_idle_timeout_millis: 10_000,
         };
 
@@ -926,6 +930,7 @@ mod tests {
             max_connections: 1024,
             response_stream_window: 16,
             request_stream_window: 16,
+            dispatch_shards: 0,
             websocket_idle_timeout_millis: 300_000,
         };
 


### PR DESCRIPTION
Phase 1 of the ADR-0135 arc (#2610): the `aether.http.server` cap splits into a supervisor plus N connection-affine dispatch shards.

- **Supervisor** (existing `HttpServerCapability` identity): listener + accept thread, shared route table (ADR-0130 registration surface, supervisor-written / shard-read `RwLock`), global `max_connections` ceiling (shared atomic live count, `503` refusal at assignment), round-robin connection assignment to shards.
- **`HttpDispatchShard`** (new `Instanced` actor, spawned via `ctx.spawn_child` on first accept, `dispatch_shards` knob, default = pool worker count): the whole per-connection machine — reader spawn/control, in-flight correlation, response/request streams, websocket state, dispatch, reply interception — over its slice of the connections. Replies and stream-phase mails land at the shard because it is the dispatch source (ADR-0133).
- **Cap-global stream ids**: cap-minted stream ids (inbound request streams, websocket streams) move to one shared counter — a handler identifies a connection by `stream_id` alone (ADR-0132), so per-shard counters collide (caught live by the websocket e2e test: two connections on two shards both minted `stream_id 0` and the handler conflated them).
- **Test handlers on the sanctioned handles**: the streaming/upload native test handlers move from `ctx.actor::<HttpServerCapability>().send(...)` to the ADR-0133 `ResponseStream` / `RequestStream` handles, so they address whichever shard granted credit — and the tests now exercise what a component author writes.

No kind, wire, or handler-visible semantics changes. All 49 in-crate server tests + the 5 wasm-fixture `http_serving` e2e tests pass, including two new ones: multi-shard connection distribution (pinned `dispatch_shards: 2` so low-core CI still exercises the multi-shard path) and the global ceiling across shards.

Throughput measurements against `spike/http-stress` follow in a comment once the stack lands together (this PR is the parallelism structure; the per-request cost cuts are #2613/#2614/#2615).

Part of #2610. Design: ADR-0135 (#2611). Closes #2612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
