### PR TITLE
perf(capabilities): coalesce the http server inbound wake mail

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/mod.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/mod.rs
@@ -117,11 +117,13 @@ impl NativeActor for HttpServerCapability {
         let self_id = ctx.self_id();
         let wake_kind = KindId(<HttpInboundReady as Kind>::ID.0);
 
+        let wake_dirty = Arc::new(AtomicBool::new(false));
         let accept_sink = WakeSink {
             inbound_tx,
             mailer: Arc::clone(&mailer),
             self_id,
             wake_kind,
+            dirty: Arc::clone(&wake_dirty),
         };
 
         // Transport thread below the mail layer — it accepts sockets
@@ -171,6 +173,7 @@ impl NativeActor for HttpServerCapability {
             accept_shutdown,
             accept_thread: Some(accept_thread),
             inbound_rx,
+            wake_dirty,
             shards: Vec::new(),
             next_shard: 0,
             next_stream_id: Arc::new(AtomicU64::new(0)),
@@ -205,6 +208,7 @@ impl NativeActor for HttpServerCapability {
     /// per item.
     #[handler]
     fn on_inbound_ready(state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: HttpInboundReady) {
+        WakeSink::arm_for_drain(&state.wake_dirty);
         while let Ok(event) = state.inbound_rx.try_recv() {
             match event {
                 InboundEvent::PeerAccepted { stream, peer } => {

--- a/crates/aether-capabilities/src/http/server/runtime/state.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/state.rs
@@ -41,6 +41,10 @@ pub struct HttpSupervisorState {
     /// The supervisor's own sidecar channel: the accept thread posts
     /// [`InboundEvent::PeerAccepted`] here; nothing else feeds it.
     pub inbound_rx: mpsc::Receiver<InboundEvent>,
+    /// The supervisor drain loop's wake-coalescing flag (ADR-0135 §4),
+    /// shared with the accept sink; cleared at the top of
+    /// `on_inbound_ready`.
+    pub wake_dirty: Arc<AtomicBool>,
     /// One wake sink per spawned dispatch shard, in spawn order; empty until
     /// the first accepted connection forces the spawn (the dispatcher ctx is
     /// not available at `init`).
@@ -83,6 +87,11 @@ pub struct HttpShardState {
     pub mailer: Arc<Mailer>,
     pub inbound_rx: mpsc::Receiver<InboundEvent>,
     pub inbound_tx: mpsc::Sender<InboundEvent>,
+    /// This shard's wake-coalescing flag (ADR-0135 §4), shared by every
+    /// sink targeting this shard (the supervisor's assignment sink and
+    /// each reader/writer sidecar); cleared at the top of the shard's
+    /// `on_inbound_ready`.
+    pub wake_dirty: Arc<AtomicBool>,
     pub connections: HashMap<ConnId, ConnState>,
     pub next_conn_id: ConnId,
     /// Dispatch-correlation → open response socket. Populated on
@@ -146,9 +155,11 @@ impl HttpSupervisorState {
         };
         for index in 0..count {
             let (inbound_tx, inbound_rx) = mpsc::channel::<InboundEvent>();
+            let wake_dirty = Arc::new(AtomicBool::new(false));
             let seed = HttpShardSeed {
                 inbound_rx: Some(inbound_rx),
                 inbound_tx: inbound_tx.clone(),
+                wake_dirty: Arc::clone(&wake_dirty),
                 routes: Arc::clone(&self.routes),
                 live_connections: Arc::clone(&self.live_connections),
                 handler_mailbox: self.config.handler_mailbox.clone(),
@@ -171,6 +182,7 @@ impl HttpSupervisorState {
                     mailer: Arc::clone(&self.mailer),
                     self_id: mailbox,
                     wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
+                    dirty: wake_dirty,
                 }),
                 Err(e) => {
                     tracing::warn!(
@@ -385,6 +397,7 @@ impl HttpShardState {
             mailer: Arc::clone(&self.mailer),
             self_id: self.self_mailbox,
             wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
+            dirty: Arc::clone(&self.wake_dirty),
         };
         let tuning = ReaderTuning {
             request_timeout: self.request_timeout,

--- a/crates/aether-capabilities/src/http/server/runtime/streaming.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/streaming.rs
@@ -174,6 +174,7 @@ impl HttpShardState {
             mailer: Arc::clone(&self.mailer),
             self_id: self.self_mailbox,
             wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
+            dirty: Arc::clone(&self.wake_dirty),
         };
         let idle_deadline = self.request_timeout;
 

--- a/crates/aether-capabilities/src/http/server/runtime/types.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/types.rs
@@ -26,6 +26,9 @@ pub struct HttpShardSeed {
     /// The matching sender: the supervisor keeps a clone (its assignment
     /// sink), and the shard clones it into each reader's [`WakeSink`].
     pub inbound_tx: mpsc::Sender<InboundEvent>,
+    /// The shard's wake-coalescing flag (ADR-0135 §4), shared between
+    /// the supervisor's assignment sink and every sink the shard builds.
+    pub wake_dirty: Arc<AtomicBool>,
     pub routes: SharedRoutes,
     pub live_connections: Arc<AtomicUsize>,
     pub handler_mailbox: String,
@@ -346,26 +349,49 @@ pub struct RequestStreamState {
 /// Wake sink shared with the accept + reader sidecar threads: push an
 /// [`InboundEvent`] over the mpsc, then fire an [`HttpInboundReady`]
 /// wake mail at the cap so the dispatcher drains.
+///
+/// The wake mail coalesces behind `dirty` (ADR-0135 §4): every sink
+/// targeting one drain loop shares the same flag, a post only fires the
+/// wake when it flips the flag clear → set, and the drain handler clears
+/// the flag *before* draining ([`WakeSink::arm_for_drain`]). A burst of
+/// events costs one wake instead of one per event; an event posted
+/// mid-drain re-arms the flag, so the follow-up wake is at most one
+/// spurious drain, never a lost event. The clear-before-drain /
+/// send-before-swap order is the load-bearing part of that guarantee.
 pub struct WakeSink {
     pub inbound_tx: mpsc::Sender<InboundEvent>,
     pub mailer: Arc<Mailer>,
     pub self_id: MailboxId,
     pub wake_kind: KindId,
+    /// Shared per-drain-target coalescing flag: `true` while a fired
+    /// wake mail has not yet begun its drain.
+    pub dirty: Arc<AtomicBool>,
 }
 
 impl WakeSink {
-    /// Post one event + wake. Returns `false` when the receiver is gone
-    /// (the cap tore down) so the caller stops.
+    /// Post one event, waking the drain loop only if no wake is already
+    /// pending for it. Returns `false` when the receiver is gone (the
+    /// cap tore down) so the caller stops.
     pub fn post(&self, event: InboundEvent) -> bool {
         if self.inbound_tx.send(event).is_err() {
             return false;
         }
-        self.mailer.push(Mail::new(
-            self.self_id,
-            self.wake_kind,
-            HttpInboundReady::default().encode_into_bytes(),
-            1,
-        ));
+        if !self.dirty.swap(true, Ordering::AcqRel) {
+            self.mailer.push(Mail::new(
+                self.self_id,
+                self.wake_kind,
+                HttpInboundReady::default().encode_into_bytes(),
+                1,
+            ));
+        }
         true
+    }
+
+    /// Drain-side arm: clear the coalescing flag. Must run *before* the
+    /// first `try_recv` of the drain loop — an event posted after the
+    /// clear re-fires the wake, an event posted before it is already in
+    /// the channel this drain is about to empty.
+    pub fn arm_for_drain(dirty: &AtomicBool) {
+        dirty.store(false, Ordering::Release);
     }
 }

--- a/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
@@ -358,3 +358,81 @@ fn config_layer_defaults_match_the_named_consts() {
         DEFAULT_WS_IDLE_TIMEOUT_MILLIS
     );
 }
+
+mod wake_coalescing {
+    //! ADR-0135 §4 — the wake-mail coalescing protocol on [`WakeSink`].
+
+    use super::super::{InboundEvent, WakeSink};
+    use crate::http::kinds::HttpInboundReady;
+    use aether_data::{Kind, KindId};
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::registry::{InboxHandler, OwnedDispatch, Registry};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::mpsc;
+
+    struct CountingInbox(AtomicUsize);
+    impl InboxHandler for CountingInbox {
+        fn enqueue(&self, _dispatch: OwnedDispatch) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn sink_with_counter() -> (WakeSink, mpsc::Receiver<InboundEvent>, Arc<CountingInbox>) {
+        let registry = Arc::new(Registry::new());
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry)));
+        let counter = Arc::new(CountingInbox(AtomicUsize::new(0)));
+        let self_id = registry.register_inbox(
+            "test.wake_target",
+            Arc::clone(&counter) as Arc<dyn InboxHandler>,
+        );
+        let (inbound_tx, inbound_rx) = mpsc::channel();
+        let sink = WakeSink {
+            inbound_tx,
+            mailer,
+            self_id,
+            wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
+            dirty: Arc::new(AtomicBool::new(false)),
+        };
+        (sink, inbound_rx, counter)
+    }
+
+    fn probe_event() -> InboundEvent {
+        InboundEvent::RequestTimedOut { conn_id: 0 }
+    }
+
+    /// Tripwire: a burst of posts between drains fires exactly one wake
+    /// mail — without the dirty-flag swap, every post fires one (the
+    /// pre-ADR-0135 per-event wake volume this optimization exists to
+    /// remove).
+    #[test]
+    fn burst_fires_one_wake() {
+        let (sink, _rx, counter) = sink_with_counter();
+        for _ in 0..16 {
+            assert!(sink.post(probe_event()));
+        }
+        assert_eq!(counter.0.load(Ordering::SeqCst), 1);
+    }
+
+    /// Tripwire: the drain-side arm order (clear the flag *before*
+    /// draining) means a post landing mid-drain re-fires the wake —
+    /// clearing after the drain instead would swallow it and strand the
+    /// event until the next unrelated wake. `_dead_mailbox_id` never
+    /// aliases; the second wake is observable as a second count.
+    #[test]
+    fn post_after_arm_refires_wake() {
+        let (sink, rx, counter) = sink_with_counter();
+        assert!(sink.post(probe_event()));
+        assert_eq!(counter.0.load(Ordering::SeqCst), 1);
+
+        // Drain begins: arm first (the load-bearing order), then empty
+        // the channel.
+        WakeSink::arm_for_drain(&sink.dirty);
+        while rx.try_recv().is_ok() {}
+
+        // A post after the arm — even mid-drain — must fire a fresh
+        // wake, or the event would sit undelivered.
+        assert!(sink.post(probe_event()));
+        assert_eq!(counter.0.load(Ordering::SeqCst), 2);
+    }
+}

--- a/crates/aether-capabilities/src/http/server/runtime/websocket.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/websocket.rs
@@ -542,6 +542,7 @@ impl HttpShardState {
             mailer: Arc::clone(&self.mailer),
             self_id: self.self_mailbox,
             wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
+            dirty: Arc::clone(&self.wake_dirty),
         };
         // The writer's idle deadline is the websocket idle timeout: an upgraded
         // socket with nothing to write for minutes is normal, unlike a stalled

--- a/crates/aether-capabilities/src/http/server/shard/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/shard/runtime.rs
@@ -53,6 +53,7 @@ impl NativeActor for HttpDispatchShard {
             mailer: ctx.mailer(),
             inbound_rx,
             inbound_tx: seed.inbound_tx,
+            wake_dirty: seed.wake_dirty,
             connections: HashMap::new(),
             next_conn_id: 0,
             in_flight: HashMap::new(),
@@ -98,6 +99,7 @@ impl NativeActor for HttpDispatchShard {
     /// drains the mpsc and acts per item.
     #[handler]
     fn on_inbound_ready(state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: HttpInboundReady) {
+        WakeSink::arm_for_drain(&state.wake_dirty);
         while let Ok(event) = state.inbound_rx.try_recv() {
             match event {
                 InboundEvent::PeerAccepted { stream, peer } => {


### PR DESCRIPTION
Phase 2c of #2610 (ADR-0135 §4), stacked on #2617 (`feat/http-shard-dispatch` base — retarget to `main` after that PR lands).

`WakeSink::post` fired one `HttpInboundReady` per posted event (~2 wake mails per request), and the per-actor trace-ring push funded by that mail volume was the top CPU sink in the stress profile. Each drain target (the supervisor and each dispatch shard) now shares one atomic dirty flag across every sink pointing at it: a post fires the wake only on the clear→set flip; the drain handler clears the flag before its first `try_recv`, so an event posted mid-drain re-arms and re-fires — a burst costs one wake, and no event is ever stranded.

Two unit tests pin the invariants: a 16-post burst fires exactly one wake, and a post landing after the drain-side arm fires a fresh one (the clear-before-drain order is the load-bearing part).

Part of #2610. Design: ADR-0135 (#2611). Closes #2615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
