### PR TITLE
feat(capabilities): route target sets to spread one route across handler mailboxes

### DIFF
--- a/crates/aether-capabilities-derive/src/lib.rs
+++ b/crates/aether-capabilities-derive/src/lib.rs
@@ -525,6 +525,7 @@ fn registration_send(routed: &Routed, ctx: &Ident) -> TokenStream2 {
                 prefix: #prefix.to_string(),
                 method: #method_expr,
                 kind: <#kind_struct as ::aether_data::Kind>::ID,
+                shared: false,
             });
     }
 }

--- a/crates/aether-capabilities/src/http/kinds.rs
+++ b/crates/aether-capabilities/src/http/kinds.rs
@@ -399,6 +399,14 @@ pub struct WebSocketClose {
 /// method)` key already claimed by a *different* mailbox is answered
 /// `Err`; the same mailbox re-claiming its own key is an idempotent
 /// `Ok` (and updates `kind`). Reply: `RegisterRouteResult`.
+///
+/// `shared` (ADR-0136) opts the registration into the key's member
+/// *set*: N handler instances that all register `shared: true` with the
+/// same dispatch `kind` jointly serve the route, each request picked
+/// round-robin across live members. `false` is the exclusive claim
+/// described above. Mixing the two on one key, or joining with a
+/// different `kind`, is a conflict `Err` — spreading is something
+/// instances opt into together, never an accident.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.http.server.register_route")]
 pub struct RegisterRoute {
@@ -406,6 +414,7 @@ pub struct RegisterRoute {
     pub method: Option<HttpMethod>,
     pub kind: aether_data::KindId,
     pub mailbox: aether_data::MailboxId,
+    pub shared: bool,
 }
 
 /// `aether.http.server.register_route_self` — reflexive counterpart of
@@ -417,12 +426,18 @@ pub struct RegisterRoute {
 /// an `Err` reply, pushing it onto the named [`RegisterRoute`] form.
 /// This is the common "route to me" case, sent from `wire`. Reply:
 /// `RegisterRouteResult`.
+///
+/// `shared` (ADR-0136) opts into the key's member set exactly as on
+/// [`RegisterRoute`]: instanced handlers that all register `shared:
+/// true` jointly serve the route round-robin; `false` is the exclusive
+/// claim.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.http.server.register_route_self")]
 pub struct RegisterRouteSelf {
     pub prefix: String,
     pub method: Option<HttpMethod>,
     pub kind: aether_data::KindId,
+    pub shared: bool,
 }
 
 /// `aether.http.server.unregister_route` — release the `(prefix,

--- a/crates/aether-capabilities/src/http/server/runtime/mod.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/mod.rs
@@ -248,6 +248,7 @@ impl NativeActor for HttpServerCapability {
             payload.method,
             payload.kind,
             payload.mailbox,
+            payload.shared,
         )
     }
 
@@ -268,9 +269,13 @@ impl NativeActor for HttpServerCapability {
         payload: RegisterRouteSelf,
     ) -> RegisterRouteResult {
         match ctx.source_mailbox() {
-            Some(mailbox) => {
-                state.register_route(&payload.prefix, payload.method, payload.kind, mailbox)
-            }
+            Some(mailbox) => state.register_route(
+                &payload.prefix,
+                payload.method,
+                payload.kind,
+                mailbox,
+                payload.shared,
+            ),
             None => RegisterRouteResult::Err {
                 error: "aether.http.server.register_route_self requires a local sender; an \
                         external session or remote engine must use \

--- a/crates/aether-capabilities/src/http/server/runtime/routing.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/routing.rs
@@ -4,17 +4,24 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
 
-/// One registered route (ADR-0130): requests whose path matches
-/// `prefix` on a segment boundary (and whose method passes `method`)
-/// dispatch to `mailbox` as kind `kind`. The table keys the route by
-/// the registrant's `MailboxId`, so a route survives
-/// `replace_component` (the id is stable) and dispatch skips name
-/// resolution.
+/// One registered route (ADR-0130 / ADR-0136): requests whose path
+/// matches `prefix` on a segment boundary (and whose method passes
+/// `method`) dispatch as kind `kind` to one of `members`. An exclusive
+/// registration is the one-member set; a shared set (ADR-0136) holds
+/// every instance that opted in, picked round-robin per request. The
+/// table keys targets by stable `MailboxId`, so a route survives
+/// `replace_component` and dispatch skips name resolution.
 pub struct Route {
     pub prefix: String,
     pub method: Option<HttpMethod>,
     pub kind: KindId,
-    pub mailbox: MailboxId,
+    /// Whether this key was registered `shared` (ADR-0136). An
+    /// exclusive route never grows a second member; a shared route
+    /// only admits further `shared` registrations of the same `kind`.
+    pub shared: bool,
+    /// The target set, in registration order. Never empty — the last
+    /// member's unregistration drops the whole route.
+    pub members: Vec<MailboxId>,
 }
 
 /// Segment-boundary prefix match (ADR-0130): `/api` matches `/api` and

--- a/crates/aether-capabilities/src/http/server/runtime/state.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/state.rs
@@ -92,6 +92,10 @@ pub struct HttpShardState {
     /// each reader/writer sidecar); cleared at the top of the shard's
     /// `on_inbound_ready`.
     pub wake_dirty: Arc<AtomicBool>,
+    /// Round-robin cursor over shared route member sets (ADR-0136),
+    /// shard-local by design — a global cursor would be a cross-shard
+    /// contention point for marginal balance.
+    pub route_cursor: usize,
     pub connections: HashMap<ConnId, ConnState>,
     pub next_conn_id: ConnId,
     /// Dispatch-correlation → open response socket. Populated on
@@ -238,11 +242,16 @@ impl HttpSupervisorState {
     }
 
     /// Claim `(prefix, method)` for `mailbox`, dispatching as `kind`
-    /// (ADR-0130). A key held by a different mailbox is answered
-    /// `Err`; the same mailbox re-claiming its own key is an
-    /// idempotent `Ok` that updates `kind` — so a component
-    /// re-running `wire` after `replace_component` re-registers
-    /// cleanly (its `MailboxId` is stable).
+    /// (ADR-0130), or join its shared member set (ADR-0136). Exclusive
+    /// (`shared: false`): a key held by anyone else is answered `Err`;
+    /// the same sole mailbox re-claiming its own key is an idempotent
+    /// `Ok` that updates `kind` — so a component re-running `wire`
+    /// after `replace_component` re-registers cleanly (its `MailboxId`
+    /// is stable). Shared (`shared: true`): joins the key's member set
+    /// when the set is shared and the `kind` matches; re-registering an
+    /// existing membership is an idempotent `Ok`. Mixing exclusive and
+    /// shared on one key, or joining with a different `kind`, is a
+    /// conflict `Err` either way.
     ///
     /// # Panics
     /// Panics if the route-table `RwLock` is poisoned — fail-fast per
@@ -254,6 +263,7 @@ impl HttpSupervisorState {
         method: Option<HttpMethod>,
         kind: KindId,
         mailbox: MailboxId,
+        shared: bool,
     ) -> RegisterRouteResult {
         let prefix = match normalize_prefix(prefix) {
             Ok(prefix) => prefix,
@@ -264,29 +274,62 @@ impl HttpSupervisorState {
             .iter_mut()
             .find(|r| r.prefix == prefix && r.method == method)
         {
-            if existing.mailbox == mailbox {
+            // Exclusive re-claim by the sole holder stays the idempotent
+            // kind-updating Ok it always was.
+            if !shared && !existing.shared && existing.members == [mailbox] {
                 existing.kind = kind;
                 return RegisterRouteResult::Ok;
             }
-            return RegisterRouteResult::Err {
-                error: format!(
-                    "route ({prefix:?}, {method:?}) already claimed by mailbox {:?}",
-                    existing.mailbox,
-                ),
-            };
+            if shared != existing.shared {
+                return RegisterRouteResult::Err {
+                    error: format!(
+                        "route ({prefix:?}, {method:?}) is {}; a {} registration cannot \
+                         join it (ADR-0136: spreading is a joint opt-in)",
+                        if existing.shared {
+                            "a shared member set"
+                        } else {
+                            "exclusively claimed"
+                        },
+                        if shared { "shared" } else { "exclusive" },
+                    ),
+                };
+            }
+            if !shared {
+                return RegisterRouteResult::Err {
+                    error: format!(
+                        "route ({prefix:?}, {method:?}) already claimed by mailbox {:?}",
+                        existing.members[0],
+                    ),
+                };
+            }
+            if existing.kind != kind {
+                return RegisterRouteResult::Err {
+                    error: format!(
+                        "route ({prefix:?}, {method:?}) member set dispatches kind {:?}; a \
+                         member registering kind {kind:?} cannot join (ADR-0136)",
+                        existing.kind,
+                    ),
+                };
+            }
+            if !existing.members.contains(&mailbox) {
+                existing.members.push(mailbox);
+            }
+            return RegisterRouteResult::Ok;
         }
         routes.push(Route {
             prefix,
             method,
             kind,
-            mailbox,
+            shared,
+            members: vec![mailbox],
         });
         RegisterRouteResult::Ok
     }
 
-    /// Release the `(prefix, method)` route held by `mailbox`.
-    /// Idempotent — releasing a route that isn't held (or is held by
-    /// someone else) is still `Ok`, mirroring the input cap's
+    /// Release `mailbox`'s membership in the `(prefix, method)` route
+    /// (ADR-0136); the last member's release drops the route.
+    /// Idempotent — releasing a route that isn't held (or a set the
+    /// mailbox never joined) is still `Ok`, mirroring the input cap's
     /// unsubscribe semantics.
     ///
     /// # Panics
@@ -302,45 +345,79 @@ impl HttpSupervisorState {
             Ok(prefix) => prefix,
             Err(error) => return RegisterRouteResult::Err { error },
         };
-        self.routes
-            .write()
-            .expect("route table lock poisoned")
-            .retain(|r| !(r.prefix == prefix && r.method == method && r.mailbox == mailbox));
+        let mut routes = self.routes.write().expect("route table lock poisoned");
+        for route in routes.iter_mut() {
+            if route.prefix == prefix && route.method == method {
+                route.members.retain(|m| *m != mailbox);
+            }
+        }
+        routes.retain(|r| !r.members.is_empty());
         RegisterRouteResult::Ok
     }
 
-    /// Release every route held by `mailbox` (ADR-0130's
-    /// `UnregisterRoutesAll`).
+    /// Release every route membership held by `mailbox` (ADR-0130's
+    /// `UnregisterRoutesAll`, ADR-0136 set semantics); sets it empties
+    /// drop entirely.
     ///
     /// # Panics
     /// Panics if the route-table `RwLock` is poisoned — fail-fast per
     /// ADR-0063.
     pub fn unregister_routes_all(&mut self, mailbox: MailboxId) {
-        self.routes
-            .write()
-            .expect("route table lock poisoned")
-            .retain(|r| r.mailbox != mailbox);
+        let mut routes = self.routes.write().expect("route table lock poisoned");
+        for route in routes.iter_mut() {
+            route.members.retain(|m| *m != mailbox);
+        }
+        routes.retain(|r| !r.members.is_empty());
     }
 }
 
 impl HttpShardState {
     /// The longest segment-boundary prefix match among
     /// method-compatible routes, with a method-specific route beating
-    /// a method-agnostic one at equal prefix (ADR-0130), copied out
-    /// from under the shared table's read lock. `None` ⇒ the
-    /// configured `handler_mailbox` fallback.
+    /// a method-agnostic one at equal prefix (ADR-0130), then one live
+    /// member picked round-robin from the winning route's set
+    /// (ADR-0136) — copied out from under the shared table's read
+    /// lock. [`RouteResolution::NoRoute`] ⇒ the configured
+    /// `handler_mailbox` fallback; [`RouteResolution::Dead`] ⇒ the
+    /// route exists but no member is live, the `503` surface (falling
+    /// back instead would silently reroute a claimed path family).
     ///
     /// # Panics
     /// Panics if the route-table `RwLock` is poisoned — fail-fast per
     /// ADR-0063.
-    fn resolve_route(&self, path: &str, method: HttpMethod) -> Option<(MailboxId, KindId)> {
-        self.routes
-            .read()
-            .expect("route table lock poisoned")
+    /// `advance: false` is the peek form for the pre-dispatch head
+    /// decision (ADR-0128 §4): it reads the member the next dispatch
+    /// would pick without consuming a cursor tick, so the decision +
+    /// dispatch pair of resolutions per request advances the
+    /// round-robin exactly once.
+    // The read guard spans member validation by design: a route emptied
+    // concurrently must not be picked from a stale copy, and the
+    // registry probe under it takes no lock that ever holds this one.
+    #[allow(clippy::significant_drop_tightening)]
+    fn resolve_route(&mut self, path: &str, method: HttpMethod, advance: bool) -> RouteResolution {
+        let routes = self.routes.read().expect("route table lock poisoned");
+        let Some(route) = routes
             .iter()
             .filter(|r| r.method.is_none_or(|m| m == method) && route_matches(&r.prefix, path))
             .max_by_key(|r| (r.prefix.len(), r.method.is_some()))
-            .map(|r| (r.mailbox, r.kind))
+        else {
+            return RouteResolution::NoRoute;
+        };
+        // Shard-local round-robin over the member set, skipping members
+        // the registry no longer reports live (the single-member case
+        // degenerates to today's validate-the-one-target check).
+        let start = self.route_cursor;
+        if advance {
+            self.route_cursor = self.route_cursor.wrapping_add(1);
+        }
+        let len = route.members.len();
+        for offset in 0..len {
+            let member = route.members[(start + offset) % len];
+            if validate_route_mailbox(self.mailer.registry(), member).is_ok() {
+                return RouteResolution::Live(member, route.kind);
+            }
+        }
+        RouteResolution::Dead
     }
 
     /// Release this connection's slot in the global live count (ADR-0135).
@@ -480,20 +557,22 @@ impl HttpShardState {
         // `handler_mailbox` by name at dispatch time through the
         // registry — the sanctioned runtime-name path — dispatching
         // the generic request kind. Nothing live either way → `503`.
-        let routed = self.resolve_route(&request.path, method);
-        let (handler, dispatch_kind) = if let Some((mailbox, kind)) = routed {
-            if validate_route_mailbox(self.mailer.registry(), mailbox).is_err() {
+        let (handler, dispatch_kind) = match self.resolve_route(&request.path, method, true) {
+            RouteResolution::Live(mailbox, kind) => (mailbox, kind),
+            RouteResolution::Dead => {
                 self.write_status_response(conn_id, 503, "routed handler gone");
                 self.close_connection(conn_id, "routed mailbox dead");
                 return;
             }
-            (mailbox, kind)
-        } else if let Some(handler) = self.mailer.registry().lookup(&self.handler_mailbox) {
-            (handler, <HttpServerRequest as Kind>::ID)
-        } else {
-            self.write_status_response(conn_id, 503, "no handler registered");
-            self.close_connection(conn_id, "handler unresolved");
-            return;
+            RouteResolution::NoRoute => {
+                if let Some(handler) = self.mailer.registry().lookup(&self.handler_mailbox) {
+                    (handler, <HttpServerRequest as Kind>::ID)
+                } else {
+                    self.write_status_response(conn_id, 503, "no handler registered");
+                    self.close_connection(conn_id, "handler unresolved");
+                    return;
+                }
+            }
         };
         let peer_addr = self
             .connections
@@ -538,17 +617,16 @@ impl HttpShardState {
     /// can consult the resolved handler's accept-set before the body is read.
     /// `None` collapses every "nothing live" case to the `503` the buffered
     /// dispatch answers.
-    fn resolved_handler(&self, path: &str, method: HttpMethod) -> Option<(MailboxId, KindId)> {
-        if let Some((mailbox, kind)) = self.resolve_route(path, method) {
-            if validate_route_mailbox(self.mailer.registry(), mailbox).is_err() {
-                return None;
-            }
-            return Some((mailbox, kind));
+    fn resolved_handler(&mut self, path: &str, method: HttpMethod) -> Option<(MailboxId, KindId)> {
+        match self.resolve_route(path, method, false) {
+            RouteResolution::Live(mailbox, kind) => Some((mailbox, kind)),
+            RouteResolution::Dead => None,
+            RouteResolution::NoRoute => self
+                .mailer
+                .registry()
+                .lookup(&self.handler_mailbox)
+                .map(|handler| (handler, <HttpServerRequest as Kind>::ID)),
         }
-        self.mailer
-            .registry()
-            .lookup(&self.handler_mailbox)
-            .map(|handler| (handler, <HttpServerRequest as Kind>::ID))
     }
 
     /// Decide a parsed request head's body path (ADR-0128): resolve the

--- a/crates/aether-capabilities/src/http/server/runtime/types.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/types.rs
@@ -14,6 +14,19 @@ pub type ConnId = u64;
 /// supervisor's registration handlers write, request dispatch reads.
 pub type SharedRoutes = Arc<RwLock<Vec<Route>>>;
 
+/// Outcome of a shard's route resolution (ADR-0130 / ADR-0136).
+pub enum RouteResolution {
+    /// No registered route matches — dispatch falls back to the
+    /// configured `handler_mailbox`.
+    NoRoute,
+    /// A route matches but no member of its set is live — the `503`
+    /// surface (never the fallback: that would silently reroute a
+    /// claimed path family).
+    Dead,
+    /// The picked live member and the kind its requests dispatch as.
+    Live(MailboxId, KindId),
+}
+
 /// Boot config the supervisor builds for each dispatch shard it spawns
 /// (ADR-0135): the shard's sidecar channel (receiver consumed at `init`,
 /// sender cloned into every reader the shard spawns), the shared route

--- a/crates/aether-capabilities/src/http/server/shard/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/shard/runtime.rs
@@ -54,6 +54,7 @@ impl NativeActor for HttpDispatchShard {
             inbound_rx,
             inbound_tx: seed.inbound_tx,
             wake_dirty: seed.wake_dirty,
+            route_cursor: 0,
             connections: HashMap::new(),
             next_conn_id: 0,
             in_flight: HashMap::new(),

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -11,8 +11,9 @@ use std::time::{Duration, Instant};
 
 use test_handlers::{
     ApiRouteHandler, ApiV2Handler, DupFirstHandler, DupSecondHandler, EchoHttpHandler,
-    ExtractRouteHandler, FixedBodyHttpHandler, FloodHttpHandler, MethodAnyHandler,
-    MethodPostHandler, STREAM_CHUNK_COUNT, SilentHttpHandler, StreamHttpHandler,
+    ExclusivePoolHandler, ExtractRouteHandler, FixedBodyHttpHandler, FloodHttpHandler,
+    MethodAnyHandler, MethodPostHandler, STREAM_CHUNK_COUNT, SharedAlphaHandler, SharedBetaHandler,
+    SharedDupJoinHandler, SharedWrongKindHandler, SilentHttpHandler, StreamHttpHandler,
     StreamingUploadHandler, TmpRouteHandler, WiredRouteHandler, stream_chunk_body,
 };
 
@@ -199,6 +200,7 @@ mod test_handlers {
                     prefix: "/wired-extra".to_string(),
                     method: None,
                     kind: <HttpServerRequest as Kind>::ID,
+                    shared: false,
                 });
         }
 
@@ -318,6 +320,7 @@ mod test_handlers {
                         prefix: $prefix.to_string(),
                         method: $method,
                         kind: <HttpServerRequest as Kind>::ID,
+                        shared: false,
                     });)+
                 }
 
@@ -353,6 +356,94 @@ mod test_handlers {
         "aether.http.test_route_dup_second",
         b"second",
         [(None, "/dup"), (None, "/second")]
+    );
+
+    /// Like [`raw_routed_handler!`] but every claim registers
+    /// `shared: true` with the given dispatch kind (ADR-0136) — the
+    /// member-set opt-in the shared-route tests exercise.
+    macro_rules! shared_routed_handler {
+        ($ty:ident, $state:ident, $namespace:literal, $tag:literal, $kind:ty,
+         [$(($method:expr, $prefix:literal)),+ $(,)?]) => {
+            pub struct $ty;
+            pub struct $state;
+
+            #[actor(singleton)]
+            impl NativeActor for $ty {
+                type State = $state;
+                type Config = ();
+                const NAMESPACE: &'static str = $namespace;
+
+                fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<$state, BootError> {
+                    Ok($state)
+                }
+
+                fn wire(_state: &mut $state, ctx: &mut NativeCtx<'_>) {
+                    $(ctx.actor::<HttpServerCapability>().send(&RegisterRouteSelf {
+                        prefix: $prefix.to_string(),
+                        method: $method,
+                        kind: <$kind as Kind>::ID,
+                        shared: true,
+                    });)+
+                }
+
+                #[handler]
+                fn on_request(
+                    _state: &mut Self::State,
+                    _ctx: &mut NativeCtx<'_>,
+                    _request: HttpServerRequest,
+                ) -> HttpServerResponse {
+                    HttpServerResponse {
+                        status: 200,
+                        headers: Vec::new(),
+                        body: $tag.to_vec(),
+                    }
+                }
+            }
+        };
+    }
+
+    // The /pool member set (ADR-0136): two shared claimants that both
+    // serve, one kind-mismatched shared claimant and one exclusive
+    // claimant that are both rejected without touching their other
+    // routes.
+    shared_routed_handler!(
+        SharedAlphaHandler,
+        SharedAlphaHandlerState,
+        "aether.http.test_route_shared_alpha",
+        b"alpha",
+        HttpServerRequest,
+        [(None, "/pool")]
+    );
+    shared_routed_handler!(
+        SharedBetaHandler,
+        SharedBetaHandlerState,
+        "aether.http.test_route_shared_beta",
+        b"beta",
+        HttpServerRequest,
+        [(None, "/pool")]
+    );
+    shared_routed_handler!(
+        SharedWrongKindHandler,
+        SharedWrongKindHandlerState,
+        "aether.http.test_route_shared_wrong_kind",
+        b"wrong-kind",
+        HttpRequestChunk,
+        [(None, "/pool")]
+    );
+    shared_routed_handler!(
+        SharedDupJoinHandler,
+        SharedDupJoinHandlerState,
+        "aether.http.test_route_shared_dup_join",
+        b"shared-dup",
+        HttpServerRequest,
+        [(None, "/dup"), (None, "/shared-ok")]
+    );
+    raw_routed_handler!(
+        ExclusivePoolHandler,
+        ExclusivePoolHandlerState,
+        "aether.http.test_route_excl_pool",
+        b"excl-pool",
+        [(None, "/pool"), (None, "/excl-ok")]
     );
 
     /// Replies `200` and echoes the request's method / path / query /
@@ -1607,6 +1698,128 @@ fn conflicting_claim_is_rejected_first_claimant_keeps_route() {
 
     let dup = round_trip(port, b"GET /dup HTTP/1.1\r\nHost: localhost\r\n\r\n");
     assert_eq!(body_of(&dup), "first", "first claimant keeps the route");
+}
+
+/// A shared member set (ADR-0136) spreads requests across its members
+/// round-robin: alpha and beta both register `/pool` shared, and with
+/// `dispatch_shards` pinned to 1 (one cursor) sequential requests
+/// alternate between them — both bodies observed, nothing else.
+///
+/// Tripwire: without member sets the second shared claim is rejected
+/// and every request serves "alpha"; with a broken cursor (never
+/// advancing) likewise.
+#[test]
+fn shared_route_spreads_across_members() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<HttpServerCapability>(HttpServerConfig {
+            bind_addr: "127.0.0.1:0".to_string(),
+            handler_mailbox: <FixedBodyHttpHandler as Addressable>::NAMESPACE.to_string(),
+            request_timeout_millis: 5_000,
+            dispatch_shards: 1,
+            ..HttpServerConfig::default()
+        })
+        .with_actor::<FixedBodyHttpHandler>(())
+        .with_actor::<SharedAlphaHandler>(())
+        .with_actor::<SharedBetaHandler>(())
+        .build_passive()
+        .expect("caps boot");
+    let port = port_of(&chassis);
+
+    // Wait until both registrations are live: with the set complete a
+    // pair of consecutive requests serves both bodies.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let first = round_trip(port, b"GET /pool HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        let second = round_trip(port, b"GET /pool HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        let pair = [body_of(&first).to_string(), body_of(&second).to_string()];
+        if pair.contains(&"alpha".to_string()) && pair.contains(&"beta".to_string()) {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected alpha+beta across a request pair within 10s; got {pair:?}",
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    // Steady state: six more requests keep alternating — both members
+    // serve, and only members serve.
+    let mut alpha = 0;
+    let mut beta = 0;
+    for _ in 0..6 {
+        let response = round_trip(port, b"GET /pool HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        match body_of(&response) {
+            "alpha" => alpha += 1,
+            "beta" => beta += 1,
+            other => panic!("unexpected /pool body {other:?}"),
+        }
+    }
+    assert_eq!(
+        (alpha, beta),
+        (3, 3),
+        "round-robin alternation over 6 requests"
+    );
+}
+
+/// The ADR-0136 conflict matrix: a shared claim cannot join an
+/// exclusively-held key, an exclusive claim cannot take a shared set,
+/// and a kind-mismatched shared claim cannot join — each rejection
+/// leaves the loser's other routes serving and the contested route
+/// unchanged.
+#[test]
+fn mixed_and_mismatched_claims_are_rejected() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<HttpServerCapability>(HttpServerConfig {
+            bind_addr: "127.0.0.1:0".to_string(),
+            handler_mailbox: <FixedBodyHttpHandler as Addressable>::NAMESPACE.to_string(),
+            request_timeout_millis: 5_000,
+            dispatch_shards: 1,
+            ..HttpServerConfig::default()
+        })
+        .with_actor::<FixedBodyHttpHandler>(())
+        // Boot order fixes who holds what: /dup exclusive first; the
+        // /pool shared pair before the wrong-kind and exclusive
+        // challengers.
+        .with_actor::<DupFirstHandler>(())
+        .with_actor::<SharedAlphaHandler>(())
+        .with_actor::<SharedBetaHandler>(())
+        .with_actor::<SharedWrongKindHandler>(())
+        .with_actor::<SharedDupJoinHandler>(())
+        .with_actor::<ExclusivePoolHandler>(())
+        .build_passive()
+        .expect("caps boot");
+    let port = port_of(&chassis);
+
+    // The last-booted challenger's accepted route being live proves
+    // every earlier registration (including the rejected ones) has
+    // been processed.
+    poll_body(
+        port,
+        b"GET /excl-ok HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        "excl-pool",
+    );
+    poll_body(
+        port,
+        b"GET /shared-ok HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        "shared-dup",
+    );
+
+    // Shared join on the exclusive /dup: rejected, holder keeps it.
+    let dup = round_trip(port, b"GET /dup HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    assert_eq!(body_of(&dup), "first", "exclusive holder keeps /dup");
+
+    // Wrong-kind shared join and exclusive take of /pool: rejected —
+    // only alpha/beta ever serve it.
+    for _ in 0..6 {
+        let response = round_trip(port, b"GET /pool HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        let body = body_of(&response);
+        assert!(
+            body == "alpha" || body == "beta",
+            "/pool must stay with the shared pair; got {body:?}",
+        );
+    }
 }
 
 /// A macro route composes with a hand-written `wire`: the macro appends

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -377,6 +377,7 @@ impl WasmActor for RoutedStreamingHttpHandler {
                 prefix: "/routed-stream".to_string(),
                 method: None,
                 kind: <HttpServerRequest as Kind>::ID,
+                shared: false,
             });
     }
 


### PR DESCRIPTION
Implements ADR-0136 (#2621): a route target becomes an opt-in member set.

- `RegisterRoute` / `RegisterRouteSelf` gain `shared: bool` (positional wire append, in-repo lockstep — the `peer_addr` precedent; the ADR-0131 macro emits `shared: false`).
- Shared registrations of the same dispatch kind join the key`s member set; exclusive semantics unchanged; exclusive-vs-shared and kind-mismatch claims stay conflict `Err`s (ADR-0130`s accidental-claim guard survives).
- Per-shard round-robin selection with dead-member skip (all dead = `503`, unchanged surface); the head decision peeks without advancing the cursor so decision+dispatch consumes one tick; sessions pin their member through the existing handler carry.
- Tests: shared pair alternates deterministically at `dispatch_shards: 1`; the conflict matrix (shared-on-exclusive, exclusive-on-shared, kind mismatch) each rejected without touching the loser`s other routes. 53 in-crate + 5 e2e green.

Part of #2610. Depends on ADR-0136 (#2621) merging first. Closes #2616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
