### PR TITLE
perf(capabilities): decide the http request path at the reader

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/reader.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/reader.rs
@@ -188,6 +188,9 @@ pub struct ReaderTuning {
     pub request_timeout: Duration,
     pub idle_timeout: Duration,
     pub max_header_bytes: usize,
+    /// Cap on a buffered request body (ADR-0108 §6); the reader answers
+    /// `413` itself past it (ADR-0135 §2).
+    pub max_request_bytes: usize,
     /// Read deadline between frames once the connection upgrades to a websocket
     /// (ADR-0129). The frame loop reads under this rather than `request_timeout`.
     pub ws_idle_timeout: Duration,
@@ -277,19 +280,113 @@ const MAX_CHUNK_LINE_BYTES: usize = 256;
 /// stream unbounded trailers.
 const MAX_CHUNK_TRAILERS: usize = MAX_HEADER_COUNT;
 
+/// Reader-side handler resolution (ADR-0135 §2): the winning route's
+/// next live member by this reader's round-robin cursor (seeded from
+/// the connection id so concurrent connections start spread across a
+/// shared set, ADR-0136), or the late-bound `handler_mailbox`
+/// fallback. `streaming` is the resolved handler's accept-set verdict
+/// on [`HttpRequestStreamOpen`] — the same structural opt-in the
+/// dispatcher used to read.
+enum ReaderResolution {
+    /// A live handler: the dispatch target, its dispatch kind, and
+    /// whether it takes the streamed body path.
+    Live {
+        handler: MailboxId,
+        kind: KindId,
+        streaming: bool,
+    },
+    /// A route matched but no member of its set is live — `503`, never
+    /// the fallback (that would silently reroute a claimed family).
+    Dead,
+    /// No route and no resolvable fallback — `503`.
+    NoHandler,
+}
+
+fn resolve_at_reader(
+    shared: &ReaderShared,
+    sink: &WakeSink,
+    cursor: &mut usize,
+    path: &str,
+    method: HttpMethod,
+) -> ReaderResolution {
+    let registry = sink.mailer.registry();
+    let picked = {
+        let routes = shared.routes.read().expect("route table lock poisoned");
+        match best_route(&routes, path, method) {
+            Some(route) => {
+                let start = *cursor;
+                *cursor = cursor.wrapping_add(1);
+                let len = route.members.len();
+                let mut live = None;
+                for offset in 0..len {
+                    let member = route.members[(start + offset) % len];
+                    if validate_route_mailbox(registry, member).is_ok() {
+                        live = Some((member, route.kind));
+                        break;
+                    }
+                }
+                let Some(found) = live else {
+                    return ReaderResolution::Dead;
+                };
+                Some(found)
+            }
+            None => registry
+                .lookup(&shared.handler_mailbox)
+                .map(|handler| (handler, <HttpServerRequest as Kind>::ID)),
+        }
+    };
+    match picked {
+        Some((handler, kind)) => ReaderResolution::Live {
+            handler,
+            kind,
+            streaming: sink
+                .mailer
+                .capability_registry()
+                .accepts(handler, <HttpRequestStreamOpen as Kind>::ID),
+        },
+        None => ReaderResolution::NoHandler,
+    }
+}
+
+/// Reader-written reject (ADR-0135 §2): write the canned status on the
+/// reader's own full-duplex clone — no response can be in flight at a
+/// pre-dispatch reject — and post `ReaderClosed` so the shard reaps the
+/// connection state.
+fn reject_and_close(
+    stream: &mut TcpStream,
+    sink: &WakeSink,
+    conn_id: ConnId,
+    status: u16,
+    message: &'static str,
+) {
+    let bytes = render_status_response(status, message);
+    let _ = stream.write_all(&bytes).and_then(|()| stream.flush());
+    sink.post(InboundEvent::ReaderClosed {
+        conn_id,
+        reason: message.to_string(),
+    });
+}
+
 /// Per-connection reader thread body. An outer per-request loop reads one
-/// HTTP/1.1 request head, posts it for the dispatcher's streaming decision,
-/// then reads the body either buffered (`Content-Length` into one
-/// [`InboundEvent::RequestParsed`]) or streamed (credit-paced
-/// [`InboundEvent::RequestBodyChunk`] mails, ADR-0128), then waits on the
-/// per-connection control channel: on a keep-alive response the dispatcher
-/// signals [`ReaderControl::Resume`] and the loop reads the next request off
-/// the same socket (carrying any over-read pipelined bytes forward); on a
-/// close response the dispatcher drops the sender and the reader exits. A fresh
-/// / idle connection between requests reads under `idle_timeout`; once a
-/// request's bytes start arriving the in-flight `request_timeout` (slow-loris)
-/// governs, and the handler-response deadline is the control wait.
-#[allow(clippy::too_many_lines)]
+/// HTTP/1.1 request head and makes the request-path decision itself
+/// (ADR-0135 §2): it resolves the handler against the shared route
+/// table + registry, writes every pre-dispatch reject on its own
+/// socket clone, and — the common buffered case — reads the body,
+/// encodes the request payload, and posts one ready-to-dispatch
+/// [`InboundEvent::RequestParsed`]. Only a streaming-handler body
+/// takes the head round trip ([`InboundEvent::RequestHeadParsed`] →
+/// [`ReaderControl::Stream`], ADR-0128); a websocket handshake is
+/// validated here and rides the buffered path with its key attached.
+/// After dispatch the reader parks on the control channel: on a
+/// keep-alive response the dispatcher signals [`ReaderControl::Resume`]
+/// and the loop reads the next request off the same socket (carrying
+/// any over-read pipelined bytes forward); on a close response the
+/// dispatcher drops the sender and the reader exits. A fresh / idle
+/// connection between requests reads under `idle_timeout`; once a
+/// request's bytes start arriving the in-flight `request_timeout`
+/// (slow-loris) governs, and the handler-response deadline is the
+/// control wait.
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 pub fn run_reader_loop(
     read_half: TcpStream,
     conn_id: ConnId,
@@ -297,16 +394,22 @@ pub fn run_reader_loop(
     sink: &WakeSink,
     control_rx: &mpsc::Receiver<ReaderControl>,
     tuning: ReaderTuning,
+    shared: &ReaderShared,
 ) {
     let ReaderTuning {
         request_timeout,
         idle_timeout,
         max_header_bytes,
+        max_request_bytes,
         ..
     } = tuning;
     let mut stream = read_half;
     let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
     let mut chunk = [0u8; 8 * 1024];
+    // Round-robin cursor over shared route member sets (ADR-0136),
+    // seeded from the connection id so concurrent connections start
+    // spread across a set rather than all on member 0.
+    let mut route_cursor = usize::try_from(conn_id).unwrap_or(0);
     // `spawn_reader_for_peer` set the socket read timeout to `request_timeout`
     // before spawning; track it so a read only re-issues `set_read_timeout`
     // when the desired timeout actually changes.
@@ -326,11 +429,7 @@ pub fn run_reader_loop(
             match parse_head(&buf, max_header_bytes) {
                 HeadParse::Complete(head) => break head,
                 HeadParse::Reject { status, message } => {
-                    sink.post(InboundEvent::RequestRejected {
-                        conn_id,
-                        status,
-                        message,
-                    });
+                    reject_and_close(&mut stream, sink, conn_id, status, message);
                     return;
                 }
                 HeadParse::NeedMore => {}
@@ -401,40 +500,76 @@ pub fn run_reader_loop(
 
         let keep_alive = request_keeps_alive(head.version, &head.headers);
 
-        // Post the head and await the dispatcher's streaming decision (ADR-0128).
-        // The dispatcher owns registry access, so it resolves the handler,
-        // reads its accept-set, and replies `Buffered` / `Stream` — or rejects
-        // (`411` / `413` / `501` / `503`) and closes, surfacing here as a
-        // disconnect. Reject decisions (including the body-cap `413` that used
-        // to live in this reader) now belong to the dispatcher, which has the
-        // handler's streaming disposition.
-        let parsed_head = ParsedHead {
-            method: head.method.clone(),
-            path: head.path.clone(),
-            query: head.query.clone(),
-            headers: head.headers.clone(),
-            framing: head.framing,
-            keep_alive,
-        };
-        if !sink.post(InboundEvent::RequestHeadParsed {
-            conn_id,
-            head: parsed_head,
-        }) {
+        // The request-path decision, made here (ADR-0135 §2): map the
+        // method, resolve the handler against the shared route table +
+        // registry, and reject — writing the canned status on this
+        // reader's own socket clone — without waking the shard.
+        let Some(method) = parse_http_method(&head.method) else {
+            reject_and_close(&mut stream, sink, conn_id, 501, "method not implemented");
             return;
+        };
+        let resolution = resolve_at_reader(shared, sink, &mut route_cursor, &head.path, method);
+        let (handler, dispatch_kind, streaming) = match resolution {
+            ReaderResolution::Live {
+                handler,
+                kind,
+                streaming,
+            } => (handler, kind, streaming),
+            ReaderResolution::Dead => {
+                reject_and_close(&mut stream, sink, conn_id, 503, "routed handler gone");
+                return;
+            }
+            ReaderResolution::NoHandler => {
+                reject_and_close(&mut stream, sink, conn_id, 503, "no handler registered");
+                return;
+            }
+        };
+        // ADR-0129: a websocket upgrade handshake, validated here; a
+        // valid one rides the buffered path with the key attached (the
+        // shard stashes it pre-dispatch). Checked before framing,
+        // matching the pre-fast-path decision order — an upgrade
+        // request always buffers.
+        let ws_key = if header_has_token(&head.headers, "upgrade", "websocket") {
+            match validate_ws_handshake(&head.headers) {
+                Ok(key) => Some(key),
+                Err((status, message)) => {
+                    reject_and_close(&mut stream, sink, conn_id, status, message);
+                    return;
+                }
+            }
+        } else {
+            None
+        };
+        if ws_key.is_none() {
+            // Framing rejects for the buffered path (ADR-0128): smuggling
+            // / non-`chunked` codings always, a lone `chunked` body to a
+            // buffered handler (no length to buffer under), and the body
+            // cap.
+            match (head.framing, streaming) {
+                (BodyFraming::Invalid, _) | (BodyFraming::Chunked, false) => {
+                    reject_and_close(&mut stream, sink, conn_id, 411, "length required");
+                    return;
+                }
+                (BodyFraming::Length(n), false) if n > max_request_bytes => {
+                    reject_and_close(
+                        &mut stream,
+                        sink,
+                        conn_id,
+                        413,
+                        "request body exceeds limit",
+                    );
+                    return;
+                }
+                _ => {}
+            }
         }
-        // A timeout means the dispatcher never answered (a wedged / torn-down
-        // cap); a disconnect means it rejected the request and closed. Either
-        // way there is nothing more this reader can write.
-        let Ok(mode) = control_rx.recv_timeout(request_timeout) else {
-            return;
-        };
 
-        // `Expect: 100-continue`: written only once the dispatcher has accepted
-        // the body (a rejected request never prompts a body send). The reader
-        // owns a full-duplex clone of the socket, so it writes the interim
-        // response inline, strictly before the body read — the final response
-        // still goes out the dispatcher's `write_half`, so the two writes never
-        // interleave on the shared fd.
+        // `Expect: 100-continue`: written only once the request is
+        // accepted (every reject above returned already). The reader
+        // owns a full-duplex clone of the socket, so it writes the
+        // interim response inline, strictly before the body read — the
+        // final response still goes out the dispatcher's `write_half`,
+        // so the two writes never interleave on the shared fd.
         let expects_continue = head.headers.iter().any(|header| {
             header.name.eq_ignore_ascii_case("expect")
                 && header.value.to_ascii_lowercase().contains("100-continue")
@@ -448,51 +583,81 @@ pub fn run_reader_loop(
             );
         }
 
-        // Phase 2: read the body per the decision, then Phase 3: wait for the
-        // response deadline. Both paths leave the reader ready to loop with the
+        // Phase 2: read the body — buffered inline (the fast path: one
+        // event per request, encoded here), or streamed under the
+        // shard-seated session (the head round trip survives only for
+        // streaming handlers). Then Phase 3: wait for the response
+        // deadline. Both paths leave the reader ready to loop with the
         // over-read (pipelined) bytes in `next_buf`, or return to close.
-        let next_buf = match mode {
-            ReaderControl::Buffered => {
-                match read_buffered_body(&mut stream, conn_id, shutdown, sink, &head, &buf) {
-                    Some((body, next_buf)) => {
-                        let request = ParsedRequest {
-                            method: head.method,
-                            path: head.path,
-                            query: head.query,
-                            headers: head.headers,
-                            body,
-                            keep_alive,
-                        };
-                        if !sink.post(InboundEvent::RequestParsed { conn_id, request }) {
-                            return;
-                        }
-                        next_buf
+        let next_buf = if streaming && ws_key.is_none() {
+            let parsed_head = ParsedHead {
+                method: head.method.clone(),
+                path: head.path.clone(),
+                query: head.query.clone(),
+                headers: head.headers.clone(),
+                framing: head.framing,
+                keep_alive,
+            };
+            if !sink.post(InboundEvent::RequestHeadParsed {
+                conn_id,
+                head: parsed_head,
+                handler,
+            }) {
+                return;
+            }
+            // A timeout means the shard never answered (wedged / torn
+            // down); a disconnect means it closed. Either way there is
+            // nothing more this reader can write.
+            let Ok(mode) = control_rx.recv_timeout(request_timeout) else {
+                return;
+            };
+            let ReaderControl::Stream { credit } = mode else {
+                // A bare credit / resume / upgrade as the first control
+                // after a streaming head means a torn-down connection.
+                return;
+            };
+            let leftover = buf[head.head_len..].to_vec();
+            match stream_request_body(
+                &mut stream,
+                conn_id,
+                shutdown,
+                sink,
+                control_rx,
+                head.framing,
+                leftover,
+                credit,
+                request_timeout,
+            ) {
+                StreamOutcome::Complete { next_buf } => next_buf,
+                StreamOutcome::Closed => return,
+            }
+        } else {
+            match read_buffered_body(&mut stream, conn_id, shutdown, sink, &head, &buf) {
+                Some((body, next_buf)) => {
+                    let payload = HttpServerRequest {
+                        method,
+                        path: head.path,
+                        query: head.query,
+                        headers: head.headers,
+                        body,
+                        peer_addr: shared.peer.clone(),
                     }
-                    None => return,
+                    .encode_into_bytes();
+                    if !sink.post(InboundEvent::RequestParsed {
+                        conn_id,
+                        payload,
+                        handler,
+                        kind: dispatch_kind,
+                        method,
+                        keep_alive,
+                        ws_key,
+                    }) {
+                        return;
+                    }
+                    next_buf
                 }
+                None => return,
             }
-            ReaderControl::Stream { credit } => {
-                let leftover = buf[head.head_len..].to_vec();
-                match stream_request_body(
-                    &mut stream,
-                    conn_id,
-                    shutdown,
-                    sink,
-                    control_rx,
-                    head.framing,
-                    leftover,
-                    credit,
-                    request_timeout,
-                ) {
-                    StreamOutcome::Complete { next_buf } => next_buf,
-                    StreamOutcome::Closed => return,
-                }
-            }
-            // The dispatcher never sends a bare credit / resume / upgrade as
-            // the first control after a head (an upgrade rides the Buffered
-            // dispatch, then arrives at the response wait) — treat it as a
-            // torn-down connection.
-            ReaderControl::Credit { .. } | ReaderControl::Resume | ReaderControl::Upgrade => return,
         };
 
         // Phase 3: response deadline. Wait for the dispatcher's resume signal
@@ -733,9 +898,9 @@ impl BodyStreamer<'_> {
                 Ok(ReaderControl::Credit { credit } | ReaderControl::Stream { credit }) => {
                     self.credit = self.credit.saturating_add(credit);
                 }
-                // A bare buffered / resume / upgrade mid-stream, or the control
+                // A bare resume / upgrade mid-stream, or the control
                 // channel dropped, means a torn-down connection — stop.
-                Ok(ReaderControl::Buffered | ReaderControl::Resume | ReaderControl::Upgrade)
+                Ok(ReaderControl::Resume | ReaderControl::Upgrade)
                 | Err(mpsc::RecvTimeoutError::Disconnected) => return Err(()),
                 Err(mpsc::RecvTimeoutError::Timeout) => {
                     self.post_closed("stream credit timeout");

--- a/crates/aether-capabilities/src/http/server/runtime/routing.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/routing.rs
@@ -24,6 +24,19 @@ pub struct Route {
     pub members: Vec<MailboxId>,
 }
 
+/// The winning route for `(path, method)` (ADR-0130): the longest
+/// segment-boundary prefix among method-compatible routes, a
+/// method-specific route beating a method-agnostic one at equal
+/// prefix. Shared by the shard's streaming-path resolution and the
+/// reader's fast-path decision (ADR-0135 §2), so the two sides cannot
+/// drift.
+pub fn best_route<'a>(routes: &'a [Route], path: &str, method: HttpMethod) -> Option<&'a Route> {
+    routes
+        .iter()
+        .filter(|r| r.method.is_none_or(|m| m == method) && route_matches(&r.prefix, path))
+        .max_by_key(|r| (r.prefix.len(), r.method.is_some()))
+}
+
 /// Segment-boundary prefix match (ADR-0130): `/api` matches `/api` and
 /// `/api/…`, never `/apiary`; `/` is the catch-all. Prefixes are
 /// normalized at registration ([`normalize_prefix`]), so no trailing

--- a/crates/aether-capabilities/src/http/server/runtime/state.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/state.rs
@@ -92,10 +92,6 @@ pub struct HttpShardState {
     /// each reader/writer sidecar); cleared at the top of the shard's
     /// `on_inbound_ready`.
     pub wake_dirty: Arc<AtomicBool>,
-    /// Round-robin cursor over shared route member sets (ADR-0136),
-    /// shard-local by design — a global cursor would be a cross-shard
-    /// contention point for marginal balance.
-    pub route_cursor: usize,
     pub connections: HashMap<ConnId, ConnState>,
     pub next_conn_id: ConnId,
     /// Dispatch-correlation → open response socket. Populated on
@@ -372,54 +368,6 @@ impl HttpSupervisorState {
 }
 
 impl HttpShardState {
-    /// The longest segment-boundary prefix match among
-    /// method-compatible routes, with a method-specific route beating
-    /// a method-agnostic one at equal prefix (ADR-0130), then one live
-    /// member picked round-robin from the winning route's set
-    /// (ADR-0136) — copied out from under the shared table's read
-    /// lock. [`RouteResolution::NoRoute`] ⇒ the configured
-    /// `handler_mailbox` fallback; [`RouteResolution::Dead`] ⇒ the
-    /// route exists but no member is live, the `503` surface (falling
-    /// back instead would silently reroute a claimed path family).
-    ///
-    /// # Panics
-    /// Panics if the route-table `RwLock` is poisoned — fail-fast per
-    /// ADR-0063.
-    /// `advance: false` is the peek form for the pre-dispatch head
-    /// decision (ADR-0128 §4): it reads the member the next dispatch
-    /// would pick without consuming a cursor tick, so the decision +
-    /// dispatch pair of resolutions per request advances the
-    /// round-robin exactly once.
-    // The read guard spans member validation by design: a route emptied
-    // concurrently must not be picked from a stale copy, and the
-    // registry probe under it takes no lock that ever holds this one.
-    #[allow(clippy::significant_drop_tightening)]
-    fn resolve_route(&mut self, path: &str, method: HttpMethod, advance: bool) -> RouteResolution {
-        let routes = self.routes.read().expect("route table lock poisoned");
-        let Some(route) = routes
-            .iter()
-            .filter(|r| r.method.is_none_or(|m| m == method) && route_matches(&r.prefix, path))
-            .max_by_key(|r| (r.prefix.len(), r.method.is_some()))
-        else {
-            return RouteResolution::NoRoute;
-        };
-        // Shard-local round-robin over the member set, skipping members
-        // the registry no longer reports live (the single-member case
-        // degenerates to today's validate-the-one-target check).
-        let start = self.route_cursor;
-        if advance {
-            self.route_cursor = self.route_cursor.wrapping_add(1);
-        }
-        let len = route.members.len();
-        for offset in 0..len {
-            let member = route.members[(start + offset) % len];
-            if validate_route_mailbox(self.mailer.registry(), member).is_ok() {
-                return RouteResolution::Live(member, route.kind);
-            }
-        }
-        RouteResolution::Dead
-    }
-
     /// Release this connection's slot in the global live count (ADR-0135).
     /// Paired with the supervisor's assignment-time increment; called
     /// exactly once per assigned connection — on close, or on an adoption
@@ -480,8 +428,14 @@ impl HttpShardState {
             request_timeout: self.request_timeout,
             idle_timeout: self.keep_alive_timeout,
             max_header_bytes: self.max_header_bytes,
+            max_request_bytes: self.max_request_bytes,
             ws_idle_timeout: self.ws_idle_timeout,
             ws_max_message_bytes: self.max_request_bytes,
+        };
+        let shared = ReaderShared {
+            routes: Arc::clone(&self.routes),
+            handler_mailbox: Arc::from(self.handler_mailbox.as_str()),
+            peer: peer.to_string(),
         };
 
         // Per-connection transport reader below the mail layer — carries
@@ -498,6 +452,7 @@ impl HttpShardState {
                     &sink,
                     &control_rx,
                     tuning,
+                    &shared,
                 );
             }) {
             Ok(thread) => thread,
@@ -534,61 +489,31 @@ impl HttpShardState {
         );
     }
 
-    /// Map the method, resolve the handler, dispatch the request, and
-    /// record the in-flight entry. Answers `501` / `503` inline.
-    pub fn dispatch_request(
+    /// Dispatch a reader-prepared buffered request (ADR-0135 §2): the
+    /// reader resolved the handler, validated it live, and encoded the
+    /// payload; this side stashes a websocket handshake key when one
+    /// rode along (ADR-0129), sends, subscribes settlement, and records
+    /// the in-flight entry. A handler that died since the reader's
+    /// check is caught by the settlement `502` net — the same net that
+    /// covers the dispatch-to-delivery gap.
+    #[allow(clippy::too_many_arguments)]
+    pub fn dispatch_prepared(
         &mut self,
         ctx: &mut NativeCtx<'_>,
         conn_id: ConnId,
-        request: ParsedRequest,
+        payload: &[u8],
+        handler: MailboxId,
+        kind: KindId,
+        method: HttpMethod,
+        keep_alive: bool,
+        ws_key: Option<String>,
     ) {
-        let Some(method) = parse_http_method(&request.method) else {
-            self.write_status_response(conn_id, 501, "method not implemented");
-            self.close_connection(conn_id, "unsupported method");
-            return;
-        };
-        let keep_alive = request.keep_alive;
-        // Route resolution (ADR-0130): a registered route names its
-        // handler by stable `MailboxId` and the kind its requests
-        // dispatch as; a dead routed mailbox is answered `503`, the
-        // same surface as an unresolved fallback (falling back instead
-        // would silently reroute a claimed path family). No route ⇒
-        // the ADR-0108 §3 late-binding fallback: resolve the configured
-        // `handler_mailbox` by name at dispatch time through the
-        // registry — the sanctioned runtime-name path — dispatching
-        // the generic request kind. Nothing live either way → `503`.
-        let (handler, dispatch_kind) = match self.resolve_route(&request.path, method, true) {
-            RouteResolution::Live(mailbox, kind) => (mailbox, kind),
-            RouteResolution::Dead => {
-                self.write_status_response(conn_id, 503, "routed handler gone");
-                self.close_connection(conn_id, "routed mailbox dead");
-                return;
-            }
-            RouteResolution::NoRoute => {
-                if let Some(handler) = self.mailer.registry().lookup(&self.handler_mailbox) {
-                    (handler, <HttpServerRequest as Kind>::ID)
-                } else {
-                    self.write_status_response(conn_id, 503, "no handler registered");
-                    self.close_connection(conn_id, "handler unresolved");
-                    return;
-                }
-            }
-        };
-        let peer_addr = self
-            .connections
-            .get(&conn_id)
-            .map(|c| c.peer.to_string())
-            .unwrap_or_default();
-        let payload = HttpServerRequest {
-            method,
-            path: request.path,
-            query: request.query,
-            headers: request.headers,
-            body: request.body,
-            peer_addr,
+        if ws_key.is_some()
+            && let Some(conn) = self.connections.get_mut(&conn_id)
+        {
+            conn.ws_pending_key = ws_key;
         }
-        .encode_into_bytes();
-        let mail_id = ctx.send_envelope_detached(handler, dispatch_kind, &payload);
+        let mail_id = ctx.send_envelope_detached(handler, kind, payload);
         // Safety net (ADR-0108 §5): if the chain settles with no
         // response, `on_settled` answers `502`. Best-effort — a chassis
         // without the settlement registry still serves the reply path.
@@ -611,93 +536,27 @@ impl HttpShardState {
         );
     }
 
-    /// Resolve the handler a request head dispatches to — a matching ADR-0130
-    /// route (its stable mailbox validated live, no fallback if it is dead) or
-    /// the late-bound `handler_mailbox` — read-only, so the streaming decision
-    /// can consult the resolved handler's accept-set before the body is read.
-    /// `None` collapses every "nothing live" case to the `503` the buffered
-    /// dispatch answers.
-    fn resolved_handler(&mut self, path: &str, method: HttpMethod) -> Option<(MailboxId, KindId)> {
-        match self.resolve_route(path, method, false) {
-            RouteResolution::Live(mailbox, kind) => Some((mailbox, kind)),
-            RouteResolution::Dead => None,
-            RouteResolution::NoRoute => self
-                .mailer
-                .registry()
-                .lookup(&self.handler_mailbox)
-                .map(|handler| (handler, <HttpServerRequest as Kind>::ID)),
-        }
-    }
-
-    /// Decide a parsed request head's body path (ADR-0128): resolve the
-    /// handler, read its accept-set, and either signal the parked reader to
-    /// buffer or stream the body, or reject and close. A handler whose
-    /// accept-set carries `HttpRequestStreamOpen` takes the streamed path
-    /// structurally — the cap cannot stream chunk kinds to a handler that does
-    /// not handle them — so no per-request opt-in is needed.
-    pub fn decide_request_head(
+    /// Open the inbound request stream for a reader-posted head bound
+    /// for a streaming handler (ADR-0128 / ADR-0135 §2). The reader
+    /// resolved `handler` and made every reject decision; the shard
+    /// seats the session — minting the stream id and seeding credit —
+    /// because the stream tables live here. The method re-parses from
+    /// the head's raw string; the reader already rejected
+    /// non-enumerated verbs, so the defensive arm only fires on a
+    /// torn-down race.
+    pub fn open_requested_stream(
         &mut self,
         ctx: &mut NativeCtx<'_>,
         conn_id: ConnId,
         head: ParsedHead,
+        handler: MailboxId,
     ) {
         let Some(method) = parse_http_method(&head.method) else {
             self.write_status_response(conn_id, 501, "method not implemented");
             self.close_connection(conn_id, "unsupported method");
             return;
         };
-        let Some((handler, _kind)) = self.resolved_handler(&head.path, method) else {
-            self.write_status_response(conn_id, 503, "no handler registered");
-            self.close_connection(conn_id, "handler unresolved");
-            return;
-        };
-        // ADR-0129: a websocket upgrade handshake. The cap validates the
-        // protocol layer (`426`/`400`, cap-owned) before dispatch; on a valid
-        // handshake it stashes the `Sec-WebSocket-Key` and dispatches the
-        // request as an ordinary buffered `HttpServerRequest` the handler
-        // answers with `WebSocketAccept` (accept) or `HttpServerResponse`
-        // (decline). An upgrade request carries no body, so it always buffers.
-        if header_has_token(&head.headers, "upgrade", "websocket") {
-            match validate_ws_handshake(&head.headers) {
-                Ok(key) => {
-                    if let Some(conn) = self.connections.get_mut(&conn_id) {
-                        conn.ws_pending_key = Some(key);
-                    }
-                    self.signal_reader(conn_id, ReaderControl::Buffered);
-                }
-                Err((status, message)) => {
-                    self.write_status_response(conn_id, status, message);
-                    self.close_connection(conn_id, "invalid websocket handshake");
-                }
-            }
-            return;
-        }
-        let streaming = self
-            .mailer
-            .capability_registry()
-            .accepts(handler, <HttpRequestStreamOpen as Kind>::ID);
-        match (head.framing, streaming) {
-            // Smuggling (`Content-Length` + `Transfer-Encoding`) and a
-            // non-`chunked` coding are always `411`; a lone `chunked` body to a
-            // buffered handler has no length to buffer under, also `411`
-            // (relaxing #2545's guard only for a streaming handler).
-            (BodyFraming::Invalid, _) | (BodyFraming::Chunked, false) => {
-                self.write_status_response(conn_id, 411, "length required");
-                self.close_connection(conn_id, "unbufferable request framing");
-            }
-            (BodyFraming::Length(n), false) if n > self.max_request_bytes => {
-                self.write_status_response(conn_id, 413, "request body exceeds limit");
-                self.close_connection(conn_id, "body exceeds limit");
-            }
-            (_, false) => {
-                // Buffered handler: the reader reads the `Content-Length` body
-                // into one `RequestParsed`, then `dispatch_request` runs.
-                self.signal_reader(conn_id, ReaderControl::Buffered);
-            }
-            (_, true) => {
-                self.start_request_stream(ctx, conn_id, handler, method, head);
-            }
-        }
+        self.start_request_stream(ctx, conn_id, handler, method, head);
     }
 
     /// Send a control message to a connection's parked reader; a send failure

--- a/crates/aether-capabilities/src/http/server/runtime/types.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/types.rs
@@ -14,17 +14,15 @@ pub type ConnId = u64;
 /// supervisor's registration handlers write, request dispatch reads.
 pub type SharedRoutes = Arc<RwLock<Vec<Route>>>;
 
-/// Outcome of a shard's route resolution (ADR-0130 / ADR-0136).
-pub enum RouteResolution {
-    /// No registered route matches — dispatch falls back to the
-    /// configured `handler_mailbox`.
-    NoRoute,
-    /// A route matches but no member of its set is live — the `503`
-    /// surface (never the fallback: that would silently reroute a
-    /// claimed path family).
-    Dead,
-    /// The picked live member and the kind its requests dispatch as.
-    Live(MailboxId, KindId),
+/// Read-mostly state a reader thread consults to make the fast-path
+/// decision itself (ADR-0135 §2): the shared route table, the
+/// late-bound fallback handler name, and the connection's peer string
+/// (captured once at adoption; every request's `peer_addr` clones it
+/// on the reader thread rather than the shard).
+pub struct ReaderShared {
+    pub routes: SharedRoutes,
+    pub handler_mailbox: Arc<str>,
+    pub peer: String,
 }
 
 /// Boot config the supervisor builds for each dispatch shard it spawns
@@ -98,9 +96,6 @@ pub struct ParsedHead {
 /// dropping the control sender, which surfaces at the reader as a disconnect —
 /// so there is no reject variant here.
 pub enum ReaderControl {
-    /// Read the `Content-Length` body into one [`InboundEvent::RequestParsed`]
-    /// (today's buffered path).
-    Buffered,
     /// Stream the body incrementally, seeded with `credit` initial send-window
     /// units (one per [`InboundEvent::RequestBodyChunk`]).
     Stream { credit: u32 },
@@ -118,24 +113,6 @@ pub enum ReaderControl {
     Upgrade,
 }
 
-/// One parsed inbound HTTP/1.1 request the reader hands to the
-/// dispatcher. The method stays a raw `String` here; the dispatcher
-/// maps it to [`HttpMethod`] and answers `501` for a non-enumerated
-/// verb before any dispatch.
-pub struct ParsedRequest {
-    pub method: String,
-    pub path: String,
-    pub query: String,
-    pub headers: Vec<HttpHeader>,
-    pub body: Vec<u8>,
-    /// Whether this request wants the connection kept alive after its
-    /// response (HTTP/1.1 default, or HTTP/1.0 with `Connection:
-    /// keep-alive`), computed by [`request_keeps_alive`]. Carried to the
-    /// dispatcher so it renders `Connection: keep-alive` vs `close` and
-    /// either resumes the reader or closes the socket.
-    pub keep_alive: bool,
-}
-
 /// Internal event the accept / reader sidecar threads push to the cap
 /// dispatcher via an mpsc. The matching wake-mail kind is
 /// [`HttpInboundReady`] (empty payload) — `on_inbound_ready` drains the
@@ -143,17 +120,31 @@ pub struct ParsedRequest {
 pub enum InboundEvent {
     /// The accept thread took a new connection.
     PeerAccepted { stream: TcpStream, peer: SocketAddr },
-    /// A reader parsed a request head and needs the dispatcher's streaming
-    /// decision before it reads the body (ADR-0128): the dispatcher resolves
-    /// the handler, checks its accept-set, and replies down the connection's
-    /// control channel with either [`ReaderControl::Buffered`] (read the body
-    /// into one [`Self::RequestParsed`]) or [`ReaderControl::Stream`] (deliver
-    /// it incrementally), or rejects the request and closes.
-    RequestHeadParsed { conn_id: ConnId, head: ParsedHead },
-    /// A reader parsed a complete, size-bounded request (buffered path).
+    /// A reader parsed a request head bound for a *streaming* handler
+    /// (ADR-0128 / ADR-0135 §2): the reader already resolved `handler`
+    /// and read its accept-set; the shard opens the inbound request
+    /// stream and replies [`ReaderControl::Stream`] down the control
+    /// channel. Buffered requests never take this round trip.
+    RequestHeadParsed {
+        conn_id: ConnId,
+        head: ParsedHead,
+        handler: MailboxId,
+    },
+    /// A complete, size-bounded buffered request, resolved and encoded
+    /// at the reader (ADR-0135 §2): `payload` is the ready-to-send
+    /// `HttpServerRequest` (or routed-kind) wire image; the shard's
+    /// dispatch is send + settlement-subscribe + in-flight insert.
     RequestParsed {
         conn_id: ConnId,
-        request: ParsedRequest,
+        payload: Vec<u8>,
+        handler: MailboxId,
+        kind: KindId,
+        method: HttpMethod,
+        keep_alive: bool,
+        /// `Some` on a websocket upgrade handshake (ADR-0129) the
+        /// reader validated: the `Sec-WebSocket-Key` the shard stashes
+        /// before dispatching, consumed if the handler accepts.
+        ws_key: Option<String>,
     },
     /// A streaming reader delivered one inbound body piece (ADR-0128); the
     /// dispatcher forwards it to the handler as an [`HttpRequestChunk`] on the
@@ -164,13 +155,6 @@ pub enum InboundEvent {
     /// The dispatcher sends the handler an [`HttpRequestStreamEnd`] and awaits
     /// its buffered response on that mail's correlation.
     RequestBodyEnd { conn_id: ConnId },
-    /// A reader hit a trust cap or a parse error before any dispatch;
-    /// the dispatcher writes the canned status response and closes.
-    RequestRejected {
-        conn_id: ConnId,
-        status: u16,
-        message: &'static str,
-    },
     /// A reader saw EOF / a read error / a slow-loris timeout; the
     /// dispatcher tears the connection down.
     ReaderClosed { conn_id: ConnId, reason: String },

--- a/crates/aether-capabilities/src/http/server/shard/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/shard/runtime.rs
@@ -54,7 +54,6 @@ impl NativeActor for HttpDispatchShard {
             inbound_rx,
             inbound_tx: seed.inbound_tx,
             wake_dirty: seed.wake_dirty,
-            route_cursor: 0,
             connections: HashMap::new(),
             next_conn_id: 0,
             in_flight: HashMap::new(),
@@ -106,25 +105,31 @@ impl NativeActor for HttpDispatchShard {
                 InboundEvent::PeerAccepted { stream, peer } => {
                     state.spawn_reader_for_peer(stream, peer);
                 }
-                InboundEvent::RequestHeadParsed { conn_id, head } => {
-                    state.decide_request_head(ctx, conn_id, head);
+                InboundEvent::RequestHeadParsed {
+                    conn_id,
+                    head,
+                    handler,
+                } => {
+                    state.open_requested_stream(ctx, conn_id, head, handler);
                 }
-                InboundEvent::RequestParsed { conn_id, request } => {
-                    state.dispatch_request(ctx, conn_id, request);
+                InboundEvent::RequestParsed {
+                    conn_id,
+                    payload,
+                    handler,
+                    kind,
+                    method,
+                    keep_alive,
+                    ws_key,
+                } => {
+                    state.dispatch_prepared(
+                        ctx, conn_id, &payload, handler, kind, method, keep_alive, ws_key,
+                    );
                 }
                 InboundEvent::RequestBodyChunk { conn_id, body } => {
                     state.forward_request_chunk(ctx, conn_id, body);
                 }
                 InboundEvent::RequestBodyEnd { conn_id } => {
                     state.end_request_stream(ctx, conn_id);
-                }
-                InboundEvent::RequestRejected {
-                    conn_id,
-                    status,
-                    message,
-                } => {
-                    state.write_status_response(conn_id, status, message);
-                    state.close_connection(conn_id, "request rejected");
                 }
                 InboundEvent::ReaderClosed { conn_id, reason } => {
                     state.close_connection(conn_id, &reason);

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -1,6 +1,10 @@
 use super::{HttpServerCapability, HttpServerConfig, HttpServerHandle};
+use crate::http::kinds::{HttpServerRequest as RequestKind, RegisterRoute};
 use crate::trace::TraceDispatchCapability;
 use aether_actor::Addressable;
+use aether_data::Kind as KindTrait;
+use aether_data::KindId;
+use aether_substrate::Mail;
 use aether_substrate::chassis::builder::{Builder, PassiveChassis};
 use aether_substrate::testing::{TestChassis, fresh_substrate};
 use std::io::{self, Read, Write};
@@ -1698,6 +1702,88 @@ fn conflicting_claim_is_rejected_first_claimant_keeps_route() {
 
     let dup = round_trip(port, b"GET /dup HTTP/1.1\r\nHost: localhost\r\n\r\n");
     assert_eq!(body_of(&dup), "first", "first claimant keeps the route");
+}
+
+/// A route registered mid-connection is visible to the very next
+/// request on an already-kept-alive socket (ADR-0135 §2): the reader
+/// re-reads the shared route table per request head, so registration
+/// granularity is next-request, not next-connection.
+///
+/// Tripwire: a reader-side route *snapshot* taken at connection
+/// adoption would serve the fallback forever on a long-lived
+/// connection; this test's second-phase request would never flip to
+/// the routed body.
+#[test]
+fn route_registered_mid_connection_serves_next_request() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<EchoHttpHandler>(())
+        .with_actor::<FixedBodyHttpHandler>(())
+        .with_actor::<HttpServerCapability>(keep_alive_config_for(
+            <EchoHttpHandler as Addressable>::NAMESPACE,
+            5_000,
+        ))
+        .build_passive()
+        .expect("caps boot");
+    let port = port_of(&chassis);
+
+    let mut stream =
+        TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to http server");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set_read_timeout");
+    let mut carry = Vec::new();
+
+    // Pre-registration: /late falls back to the echo handler.
+    stream
+        .write_all(b"GET /late HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .expect("write request");
+    let first = read_one_response(&mut stream, &mut carry);
+    assert!(
+        first.contains("x-aether-path: /late"),
+        "pre-registration request falls back to echo: {first:?}",
+    );
+
+    // Register /late at the fixed-body handler while the connection is
+    // parked between keep-alive requests.
+    let supervisor = registry
+        .lookup(<HttpServerCapability as Addressable>::NAMESPACE)
+        .expect("http server registered");
+    let target = registry
+        .lookup(<FixedBodyHttpHandler as Addressable>::NAMESPACE)
+        .expect("fixed-body handler registered");
+    let payload = RegisterRoute {
+        prefix: "/late".to_string(),
+        method: None,
+        kind: <RequestKind as KindTrait>::ID,
+        mailbox: target,
+        shared: false,
+    }
+    .encode_into_bytes();
+    mailer.push(Mail::new(
+        supervisor,
+        KindId(<RegisterRoute as KindTrait>::ID.0),
+        payload,
+        1,
+    ));
+
+    // The registration lands asynchronously; poll on the SAME socket.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        stream
+            .write_all(b"GET /late HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .expect("write request");
+        let response = read_one_response(&mut stream, &mut carry);
+        if body_of(&response) == "fixed body" {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "mid-connection registration should reach the next request within 10s; \
+             last: {response:?}",
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
 }
 
 /// A shared member set (ADR-0136) spreads requests across its members


### PR DESCRIPTION
Phase 2a of #2610 (ADR-0135 §2), stacked on #2622 — retarget to main after it lands.

The reader makes the request-path decision itself: it resolves the handler against the shared route table + registries (round-robin over ADR-0136 member sets, cursor seeded from the connection id), writes every pre-dispatch reject (400/411/413/431/501/503) on its own socket clone, validates websocket handshakes (the key rides the buffered dispatch), and — the common case — reads the body, encodes the `HttpServerRequest` payload, and posts one ready-to-dispatch event. The shard dispatch shrinks to send + settlement subscribe + in-flight insert; the ADR-0128 head round trip survives only for streaming-handler bodies. New test: a route registered mid-connection reaches the very next request on a kept-alive socket.

Part of #2610. Design: ADR-0135 (§2). Closes #2613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
