### PR TITLE
perf(capabilities): write buffered http responses from the reader

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/reader.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/reader.rs
@@ -4,6 +4,8 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
 
+use std::time::Instant;
+
 /// Outcome of [`read_more`].
 pub enum ReadStep {
     Filled(usize),
@@ -660,28 +662,79 @@ pub fn run_reader_loop(
             }
         };
 
-        // Phase 3: response deadline. Wait for the dispatcher's resume signal
-        // (a keep-alive response was written — loop to the next request), the
-        // handler-response timeout (`504`), or the sender being dropped (the
-        // dispatcher took the close path — the connection is torn down).
-        match control_rx.recv_timeout(request_timeout) {
-            Ok(ReaderControl::Resume) => {
-                buf = next_buf;
-            }
-            Ok(ReaderControl::Upgrade) => {
-                // ADR-0129: the handshake was accepted (`101` written) — leave
-                // the HTTP request lifecycle for the RFC 6455 frame loop,
-                // carrying any bytes over-read past the handshake head.
-                run_ws_reader_loop(&mut stream, conn_id, shutdown, sink, next_buf, tuning);
-                return;
-            }
-            Ok(_) => return,
-            Err(mpsc::RecvTimeoutError::Timeout) => {
+        // Phase 3: response deadline. Wait for the response bytes to
+        // write ourselves (ADR-0135 §3), the streamed-response resume,
+        // the handler-response timeout (`504`), or the sender being
+        // dropped (the dispatcher took the close path — the connection
+        // is torn down).
+        let response_deadline = Instant::now() + request_timeout;
+        // Wrapped so the loop can hand the pipelined carry-over to
+        // exactly one consuming arm (the borrow checker cannot see that
+        // every consumer exits the loop).
+        let mut next_buf = Some(next_buf);
+        loop {
+            let now = Instant::now();
+            let Some(remaining) = response_deadline.checked_duration_since(now) else {
                 sink.post(InboundEvent::RequestTimedOut { conn_id });
                 return;
-            }
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                return;
+            };
+            match control_rx.recv_timeout(remaining) {
+                Ok(ReaderControl::Respond { bytes, resume }) => {
+                    if let Err(e) = stream.write_all(&bytes).and_then(|()| stream.flush()) {
+                        tracing::debug!(
+                            target: "aether_substrate::http_server",
+                            conn = conn_id,
+                            error = %e,
+                            "http response write failed",
+                        );
+                        sink.post(InboundEvent::ReaderClosed {
+                            conn_id,
+                            reason: "response write failed".to_string(),
+                        });
+                        return;
+                    }
+                    if resume {
+                        buf = next_buf.take().unwrap_or_default();
+                        break;
+                    }
+                    sink.post(InboundEvent::ReaderClosed {
+                        conn_id,
+                        reason: "response written".to_string(),
+                    });
+                    return;
+                }
+                Ok(ReaderControl::Resume) => {
+                    buf = next_buf.take().unwrap_or_default();
+                    break;
+                }
+                Ok(ReaderControl::Upgrade) => {
+                    // ADR-0129: the handshake was accepted (`101` written) — leave
+                    // the HTTP request lifecycle for the RFC 6455 frame loop,
+                    // carrying any bytes over-read past the handshake head.
+                    run_ws_reader_loop(
+                        &mut stream,
+                        conn_id,
+                        shutdown,
+                        sink,
+                        next_buf.take().unwrap_or_default(),
+                        tuning,
+                    );
+                    return;
+                }
+                // A late credit grant for the just-finished request stream
+                // (the handler's replenishment racing the RequestBodyEnd
+                // drain) is benign — keep waiting out the same deadline.
+                Ok(ReaderControl::Credit { .. }) => {}
+                // A fresh Stream decision with no head posted means a
+                // torn-down connection.
+                Ok(ReaderControl::Stream { .. }) => return,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    sink.post(InboundEvent::RequestTimedOut { conn_id });
+                    return;
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    return;
+                }
             }
         }
     }
@@ -898,9 +951,12 @@ impl BodyStreamer<'_> {
                 Ok(ReaderControl::Credit { credit } | ReaderControl::Stream { credit }) => {
                     self.credit = self.credit.saturating_add(credit);
                 }
-                // A bare resume / upgrade mid-stream, or the control
-                // channel dropped, means a torn-down connection — stop.
-                Ok(ReaderControl::Resume | ReaderControl::Upgrade)
+                // A bare resume / respond / upgrade mid-stream, or the
+                // control channel dropped, means a torn-down connection
+                // — stop.
+                Ok(
+                    ReaderControl::Resume | ReaderControl::Respond { .. } | ReaderControl::Upgrade,
+                )
                 | Err(mpsc::RecvTimeoutError::Disconnected) => return Err(()),
                 Err(mpsc::RecvTimeoutError::Timeout) => {
                     self.post_closed("stream credit timeout");

--- a/crates/aether-capabilities/src/http/server/runtime/state.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/state.rs
@@ -571,19 +571,15 @@ impl HttpShardState {
         }
     }
 
-    /// Format + write the handler's [`HttpServerResponse`]. `is_head`
-    /// suppresses the response body per HEAD semantics (headers,
-    /// including `Content-Length`, still describe what the body would
-    /// have been).
-    pub fn write_handler_response(
-        &mut self,
-        conn_id: ConnId,
-        response: &HttpServerResponse,
-        is_head: bool,
-        keep_alive: bool,
-    ) {
-        let bytes = render_handler_response(response, is_head, keep_alive);
-        self.write_raw_to(conn_id, &bytes);
+    /// Hand a fully rendered response to the connection's parked reader
+    /// (ADR-0135 §3): the reader performs the socket write on its own
+    /// clone and either loops into the next request (`resume`) or exits
+    /// into the normal `ReaderClosed` teardown. The shard's dispatch
+    /// never blocks on a peer's receive window — a stalled peer stalls
+    /// only its own reader thread. A send failure means the reader
+    /// already exited, so the connection closes instead.
+    pub fn respond_and_finish(&mut self, conn_id: ConnId, bytes: Vec<u8>, resume: bool) {
+        self.signal_reader(conn_id, ReaderControl::Respond { bytes, resume });
     }
 
     /// Release the reader for the next request on a kept-alive connection by

--- a/crates/aether-capabilities/src/http/server/runtime/types.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/types.rs
@@ -102,8 +102,16 @@ pub enum ReaderControl {
     /// Replenish the streaming reader's send window by `credit` — the handler
     /// drained chunks and granted more.
     Credit { credit: u32 },
-    /// Keep-alive resume: the response was written; read the next request on
-    /// the same socket.
+    /// The rendered response bytes for the request this reader has in
+    /// flight (ADR-0135 §3): the reader writes them on its own socket
+    /// clone — the write syscall never runs on the shard's dispatch —
+    /// then loops into the next request (`resume: true`, keep-alive) or
+    /// exits posting `ReaderClosed` (`resume: false`, close-mode and
+    /// every canned terminal status).
+    Respond { bytes: Vec<u8>, resume: bool },
+    /// Keep-alive resume with nothing to write: a streamed response
+    /// finished on the writer thread (ADR-0128); read the next request
+    /// on the same socket.
     Resume,
     /// Websocket upgrade accepted (ADR-0129): the `101` was written and the
     /// connection is now in websocket mode. The parked reader leaves the

--- a/crates/aether-capabilities/src/http/server/runtime/websocket.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/websocket.rs
@@ -509,9 +509,13 @@ impl HttpShardState {
             .and_then(|conn| conn.ws_pending_key.take())
         else {
             // A `WebSocketAccept` with no stashed key — the handler replied it
-            // to a non-upgrade request. Cap-level error, close the connection.
-            self.write_status_response(conn_id, 500, "websocket accept without upgrade");
-            self.close_connection(conn_id, "websocket accept without upgrade");
+            // to a non-upgrade request. Cap-level error; the parked reader
+            // writes the canned status and exits (ADR-0135 §3).
+            self.respond_and_finish(
+                conn_id,
+                render_status_response(500, "websocket accept without upgrade"),
+                false,
+            );
             return;
         };
         let head = render_ws_accept(&key, accept);

--- a/crates/aether-capabilities/src/http/server/shard/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/shard/runtime.rs
@@ -246,8 +246,11 @@ impl NativeActor for HttpDispatchShard {
             // Already answered (the reply landed first) or never ours.
             return;
         };
-        state.write_status_response(pending.conn_id, 502, "no response from handler");
-        state.close_connection(pending.conn_id, "settled without response");
+        state.respond_and_finish(
+            pending.conn_id,
+            render_status_response(502, "no response from handler"),
+            false,
+        );
     }
 
     /// An outbound websocket message from the handler (ADR-0129 §3), routed by
@@ -334,8 +337,11 @@ impl NativeActor for HttpDispatchShard {
                 state.accept_websocket(ctx, correlation, pending.conn_id, pending.handler, &accept);
             } else {
                 state.in_flight.remove(&correlation);
-                state.write_status_response(pending.conn_id, 502, "malformed websocket accept");
-                state.close_connection(pending.conn_id, "malformed websocket accept");
+                state.respond_and_finish(
+                    pending.conn_id,
+                    render_status_response(502, "malformed websocket accept"),
+                    false,
+                );
             }
             return;
         }
@@ -344,8 +350,11 @@ impl NativeActor for HttpDispatchShard {
                 state.open_stream(ctx, correlation, pending.conn_id, &open);
             } else {
                 state.in_flight.remove(&correlation);
-                state.write_status_response(pending.conn_id, 502, "malformed stream open");
-                state.close_connection(pending.conn_id, "malformed stream open");
+                state.respond_and_finish(
+                    pending.conn_id,
+                    render_status_response(502, "malformed stream open"),
+                    false,
+                );
             }
             return;
         }
@@ -356,23 +365,23 @@ impl NativeActor for HttpDispatchShard {
         }
         if let Some(response) = HttpServerResponse::decode_from_bytes(env.payload.bytes()) {
             let is_head = pending.method == HttpMethod::Head;
-            state.write_handler_response(pending.conn_id, &response, is_head, pending.keep_alive);
+            let bytes = render_handler_response(&response, is_head, pending.keep_alive);
             state.in_flight.remove(&correlation);
-            // A successful keep-alive response holds the connection and
-            // releases the reader for the next request; otherwise the
-            // connection closes (HTTP/1.0, or `Connection: close`).
-            if pending.keep_alive {
-                state.resume_connection(pending.conn_id);
-            } else {
-                state.close_connection(pending.conn_id, "response written");
-            }
+            // The parked reader writes the bytes (ADR-0135 §3): on
+            // keep-alive it loops into the next request; otherwise it
+            // exits into the normal ReaderClosed teardown (HTTP/1.0, or
+            // `Connection: close`).
+            state.respond_and_finish(pending.conn_id, bytes, pending.keep_alive);
         } else {
             // A cap-level error ends the connection (canned responses stay
             // `Connection: close`), which keeps the keep-alive path scoped to
             // the normal success round-trip.
-            state.write_status_response(pending.conn_id, 502, "malformed handler response");
             state.in_flight.remove(&correlation);
-            state.close_connection(pending.conn_id, "malformed handler response");
+            state.respond_and_finish(
+                pending.conn_id,
+                render_status_response(502, "malformed handler response"),
+                false,
+            );
         }
     }
 }

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -1704,6 +1704,60 @@ fn conflicting_claim_is_rejected_first_claimant_keeps_route() {
     assert_eq!(body_of(&dup), "first", "first claimant keeps the route");
 }
 
+/// A peer that stalls its receive window blocks only its own reader
+/// thread, never the dispatch shard (ADR-0135 §3): with one shard
+/// pinned, connection A parks a 16 MiB echo response against a client
+/// that refuses to read while connection B's small request round-trips
+/// promptly through the same shard.
+///
+/// Tripwire: with the response write back on the shard's dispatch (the
+/// pre-ADR-0135 §3 shape), A's blocked `write_all` freezes the shard
+/// and B times out empty.
+#[test]
+fn stalled_peer_does_not_block_sibling_connections() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<EchoHttpHandler>(())
+        .with_actor::<HttpServerCapability>(HttpServerConfig {
+            bind_addr: "127.0.0.1:0".to_string(),
+            handler_mailbox: <EchoHttpHandler as Addressable>::NAMESPACE.to_string(),
+            // Short: the stalled write parks within milliseconds, and
+            // teardown waits out at most one response deadline.
+            request_timeout_millis: 2_000,
+            max_request_bytes: 32 * 1024 * 1024,
+            dispatch_shards: 1,
+            ..HttpServerConfig::default()
+        })
+        .build_passive()
+        .expect("caps boot");
+    let port = port_of(&chassis);
+
+    // Connection A: a 16 MiB echo whose response the client never
+    // reads — far past loopback socket buffering, so the reader's
+    // write_all parks against A's receive window.
+    let body_len = 16 * 1024 * 1024;
+    let mut stalled =
+        TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect stalled peer");
+    let mut request =
+        format!("POST /stall HTTP/1.1\r\nHost: localhost\r\nContent-Length: {body_len}\r\n\r\n")
+            .into_bytes();
+    request.resize(request.len() + body_len, b'a');
+    stalled.write_all(&request).expect("write stalled request");
+    stalled.flush().expect("flush stalled request");
+
+    // Give the echo time to dispatch and its response write to park.
+    thread::sleep(Duration::from_millis(300));
+
+    // Connection B on the same (sole) shard round-trips promptly.
+    let response = round_trip(port, b"GET /probe HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    assert!(
+        response.starts_with("HTTP/1.1 200 "),
+        "sibling connection must be served while a peer stalls; got: {response:?}",
+    );
+
+    drop(stalled);
+}
+
 /// A route registered mid-connection is visible to the very next
 /// request on an already-kept-alive socket (ADR-0135 §2): the reader
 /// re-reads the shared route table per request head, so registration


### PR DESCRIPTION
Phase 2b of #2610 (ADR-0135 §3), stacked on the #2613 PR — retarget to main as the stack lands.

The shard renders the response and hands the bytes to the connection`s parked reader (`ReaderControl::Respond`): the reader writes on its own socket clone, loops on keep-alive, or exits into the normal `ReaderClosed` teardown for close-mode + every canned terminal status. Removes the response syscall from the dispatch and the head-of-line hazard (a stalled peer now blocks only its own reader — pinned by a new one-shard isolation test with a 16 MiB stalled response). The response deadline becomes an absolute-deadline loop tolerating a late stream-credit grant racing the `RequestBodyEnd` drain (a latent ADR-0128 race the tighter timing surfaced). Also retires the #2610 side finding: a failed response write now closes instead of silently resuming keep-alive.

Part of #2610. Design: ADR-0135 (§3). Closes #2614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
