### PR TITLE
feat(capabilities): shared opt-in on the router macro

### DIFF
--- a/crates/aether-capabilities-derive/src/lib.rs
+++ b/crates/aether-capabilities-derive/src/lib.rs
@@ -11,6 +11,10 @@
 //! route, rewrites each routed method into a `#[handler]` glue method
 //! driven by `FromRequest` extraction, injects the `RegisterRouteSelf`
 //! registration into `wire`, and hands `#[actor]` an ordinary impl block.
+//! Bare `#[http::router]` registers every route exclusively (today's
+//! default); `#[http::router(shared)]` registers them all `shared: true`
+//! instead (ADR-0136) — the impl-level opt-in for a component built to
+//! run as N interchangeable instances of one round-robin member set.
 //!
 //! The macros only emit token paths at the runtime vocabulary
 //! (`::aether_capabilities::http::…`, `::aether_data::…`, `::serde::…`);
@@ -46,13 +50,40 @@ pub fn route(_args: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /// `#[http::router]` — the impl-block attribute that expands the typed
-/// route-authoring surface (ADR-0131). Written above `#[actor]`.
+/// route-authoring surface (ADR-0131). Written above `#[actor]`. Takes no
+/// arguments (today's exclusive registration) or the bare ident `shared`
+/// (ADR-0136 joint opt-in — every route on the impl registers
+/// `shared: true`, so N instances of the component join one round-robin
+/// member set).
 #[proc_macro_attribute]
-pub fn router(_args: TokenStream, item: TokenStream) -> TokenStream {
+pub fn router(args: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemImpl);
-    match expand_router(item) {
+    let shared = match parse_router_args(TokenStream2::from(args)) {
+        Ok(shared) => shared,
+        Err(err) => return err.into_compile_error().into(),
+    };
+    match expand_router(item, shared) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.into_compile_error().into(),
+    }
+}
+
+/// Parse `#[http::router(...)]`'s optional argument: absent (`shared =
+/// false`, today's exclusive semantics) or the bare ident `shared`
+/// (`shared = true`, ADR-0136 joint opt-in). Anything else — a different
+/// ident, a value, more than one token — is a spanned `compile_error!`
+/// naming the two accepted forms.
+fn parse_router_args(args: TokenStream2) -> syn::Result<bool> {
+    if args.is_empty() {
+        return Ok(false);
+    }
+    match syn::parse2::<Ident>(args.clone()) {
+        Ok(ident) if ident == "shared" => Ok(true),
+        _ => Err(syn::Error::new_spanned(
+            args,
+            "#[http::router] accepts no arguments, or the bare ident `shared` \
+             (ADR-0136 joint opt-in)",
+        )),
     }
 }
 
@@ -109,7 +140,7 @@ enum CallStyle {
     State(Box<Type>),
 }
 
-fn expand_router(mut item: ItemImpl) -> syn::Result<TokenStream2> {
+fn expand_router(mut item: ItemImpl, shared: bool) -> syn::Result<TokenStream2> {
     if !item.generics.params.is_empty() {
         return Err(syn::Error::new(
             item.generics.span(),
@@ -145,7 +176,7 @@ fn expand_router(mut item: ItemImpl) -> syn::Result<TokenStream2> {
         item.items.push(parse_quote!(#handler));
     }
 
-    inject_registration(&mut item, &routed)?;
+    inject_registration(&mut item, &routed, shared)?;
 
     Ok(quote! {
         #(#minted)*
@@ -511,8 +542,10 @@ fn emit_glue_handler(routed: &Routed) -> TokenStream2 {
 }
 
 /// Build the `RegisterRouteSelf` send for one route, addressed with the
-/// given `wire` ctx binding.
-fn registration_send(routed: &Routed, ctx: &Ident) -> TokenStream2 {
+/// given `wire` ctx binding. `shared` carries the impl-level
+/// `#[http::router(shared)]` opt-in (ADR-0136) straight into the wire
+/// field — every route on a `shared` impl registers `shared: true`.
+fn registration_send(routed: &Routed, ctx: &Ident, shared: bool) -> TokenStream2 {
     let Routed {
         method_expr,
         prefix,
@@ -525,7 +558,7 @@ fn registration_send(routed: &Routed, ctx: &Ident) -> TokenStream2 {
                 prefix: #prefix.to_string(),
                 method: #method_expr,
                 kind: <#kind_struct as ::aether_data::Kind>::ID,
-                shared: false,
+                shared: #shared,
             });
     }
 }
@@ -534,7 +567,9 @@ fn registration_send(routed: &Routed, ctx: &Ident) -> TokenStream2 {
 /// appended to an author-written `wire` body, or synthesized as a new
 /// `wire` when the impl has none. Receiver and ctx shapes are copied
 /// from the routed methods, so one rewrite serves both transports.
-fn inject_registration(item: &mut ItemImpl, routed: &[Routed]) -> syn::Result<()> {
+/// `shared` is the impl-level `#[http::router(shared)]` flag (ADR-0136),
+/// applied uniformly to every route registration this impl emits.
+fn inject_registration(item: &mut ItemImpl, routed: &[Routed], shared: bool) -> syn::Result<()> {
     let existing = item.items.iter_mut().find_map(|impl_item| match impl_item {
         ImplItem::Fn(method) if method.sig.ident == "wire" => Some(method),
         _ => None,
@@ -543,7 +578,7 @@ fn inject_registration(item: &mut ItemImpl, routed: &[Routed]) -> syn::Result<()
     if let Some(wire) = existing {
         let ctx = wire_ctx_ident(wire)?;
         for route in routed {
-            let send = registration_send(route, &ctx);
+            let send = registration_send(route, &ctx, shared);
             wire.block.stmts.push(parse_quote!(#send));
         }
         return Ok(());
@@ -557,7 +592,7 @@ fn inject_registration(item: &mut ItemImpl, routed: &[Routed]) -> syn::Result<()
     let ctx = format_ident!("__aether_ctx");
     let sends = routed
         .iter()
-        .map(|route| registration_send(route, &ctx))
+        .map(|route| registration_send(route, &ctx, shared))
         .collect::<Vec<_>>();
     let wire: ImplItemFn = parse_quote! {
         fn wire(#first_arg, #ctx: &mut #ctx_c) {

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -5,6 +5,7 @@ use aether_actor::Addressable;
 use aether_data::Kind as KindTrait;
 use aether_data::KindId;
 use aether_substrate::Mail;
+use aether_substrate::Subname;
 use aether_substrate::chassis::builder::{Builder, PassiveChassis};
 use aether_substrate::testing::{TestChassis, fresh_substrate};
 use std::io::{self, Read, Write};
@@ -15,10 +16,12 @@ use std::time::{Duration, Instant};
 
 use test_handlers::{
     ApiRouteHandler, ApiV2Handler, DupFirstHandler, DupSecondHandler, EchoHttpHandler,
-    ExclusivePoolHandler, ExtractRouteHandler, FixedBodyHttpHandler, FloodHttpHandler,
-    MethodAnyHandler, MethodPostHandler, STREAM_CHUNK_COUNT, SharedAlphaHandler, SharedBetaHandler,
-    SharedDupJoinHandler, SharedWrongKindHandler, SilentHttpHandler, StreamHttpHandler,
-    StreamingUploadHandler, TmpRouteHandler, WiredRouteHandler, stream_chunk_body,
+    ExclusiveMacroFirstHandler, ExclusiveMacroSecondHandler, ExclusivePoolHandler,
+    ExtractRouteHandler, FixedBodyHttpHandler, FloodHttpHandler, MethodAnyHandler,
+    MethodPostHandler, STREAM_CHUNK_COUNT, SharedAlphaHandler, SharedBetaHandler,
+    SharedDupJoinHandler, SharedMacroPoolHandler, SharedWrongKindHandler, SilentHttpHandler,
+    StreamHttpHandler, StreamingUploadHandler, TmpRouteHandler, WiredRouteHandler,
+    stream_chunk_body,
 };
 
 mod test_handlers {
@@ -449,6 +452,147 @@ mod test_handlers {
         b"excl-pool",
         [(None, "/pool"), (None, "/excl-ok")]
     );
+
+    /// A `#[http::router(shared)]` handler (issue 2625) — the typed
+    /// author-facing surface a scaled component actually writes, as opposed
+    /// to [`shared_routed_handler!`]'s hand-written
+    /// `RegisterRouteSelf { shared: true, .. }` send. `#[actor(instanced)]`
+    /// so a test can spawn two independently-named live instances of this
+    /// exact compiled type under `/macro-pool` — the accurate analog of
+    /// loading one wasm component `replicas: 2` times (#2626): both
+    /// instances' `wire` runs the identical macro-emitted registration send,
+    /// so they carry the same minted `Kind::ID` (derived from the compiled
+    /// `NAMESPACE` + method name, not the runtime instance name) and can
+    /// actually join one member set — two *different* actor types can't,
+    /// since each mints its own kind. `Config` is each instance's reply
+    /// tag, so the test can tell which instance served a request.
+    pub struct SharedMacroPoolHandler;
+    pub struct SharedMacroPoolHandlerState {
+        tag: &'static [u8],
+    }
+
+    #[http::router(shared)]
+    #[actor(instanced)]
+    impl NativeActor for SharedMacroPoolHandler {
+        type State = SharedMacroPoolHandlerState;
+        type Config = &'static [u8];
+        const NAMESPACE: &'static str = "aether.http.test_route_shared_macro_pool";
+
+        fn init(
+            tag: &'static [u8],
+            _ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<SharedMacroPoolHandlerState, BootError> {
+            Ok(SharedMacroPoolHandlerState { tag })
+        }
+
+        // Hand-written (empty) so `#[http::router]` appends its
+        // registration send here rather than synthesizing its own `wire`
+        // by copying `on_route`'s first-arg pattern verbatim — a
+        // synthesized copy would never touch `state`, so whichever name
+        // `on_route` uses would either warn unused (a plain `state`) or
+        // trip `clippy::used_underscore_binding` (an `_`-prefixed one
+        // `on_route` still reads). An author-written `wire` sidesteps
+        // both: its own unused first arg is independently `_`-prefixed
+        // and never read, and `on_route`'s `state` is read and plain.
+        fn wire(_state: &mut SharedMacroPoolHandlerState, ctx: &mut NativeCtx<'_>) {
+            // Body is otherwise empty — `#[http::router]` appends this
+            // impl's `RegisterRouteSelf` send here, which is what actually
+            // uses `ctx` (a plain, non-underscore name since it must be
+            // usable by the injected statement).
+        }
+
+        #[http::route(any, "/macro-pool")]
+        fn on_route(
+            state: &mut SharedMacroPoolHandlerState,
+            _ctx: http::Ctx<'_, NativeCtx<'_>>,
+        ) -> HttpServerResponse {
+            HttpServerResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: state.tag.to_vec(),
+            }
+        }
+    }
+
+    /// A bare `#[http::router]` handler used by the regression guard
+    /// proving the default flag stays `shared: false` through the new
+    /// argument-parsing path (issue 2625): claims the contested
+    /// `/macro-excl` prefix.
+    pub struct ExclusiveMacroFirstHandler;
+    pub struct ExclusiveMacroFirstHandlerState;
+
+    #[http::router]
+    #[actor(singleton)]
+    impl NativeActor for ExclusiveMacroFirstHandler {
+        type State = ExclusiveMacroFirstHandlerState;
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.http.test_route_excl_macro_first";
+
+        fn init(
+            (): (),
+            _ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<ExclusiveMacroFirstHandlerState, BootError> {
+            Ok(ExclusiveMacroFirstHandlerState)
+        }
+
+        #[http::route(any, "/macro-excl")]
+        fn on_excl(
+            _state: &mut ExclusiveMacroFirstHandlerState,
+            _ctx: http::Ctx<'_, NativeCtx<'_>>,
+        ) -> HttpServerResponse {
+            HttpServerResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: b"excl-macro-first".to_vec(),
+            }
+        }
+    }
+
+    /// The second bare `#[http::router]` claimant of `/macro-excl`: its
+    /// own distinct `/macro-excl-second-ok` route proves this handler's
+    /// registrations were processed even though its `/macro-excl` claim
+    /// is rejected (the first claimant keeps it).
+    pub struct ExclusiveMacroSecondHandler;
+    pub struct ExclusiveMacroSecondHandlerState;
+
+    #[http::router]
+    #[actor(singleton)]
+    impl NativeActor for ExclusiveMacroSecondHandler {
+        type State = ExclusiveMacroSecondHandlerState;
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.http.test_route_excl_macro_second";
+
+        fn init(
+            (): (),
+            _ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<ExclusiveMacroSecondHandlerState, BootError> {
+            Ok(ExclusiveMacroSecondHandlerState)
+        }
+
+        #[http::route(any, "/macro-excl")]
+        fn on_excl(
+            _state: &mut ExclusiveMacroSecondHandlerState,
+            _ctx: http::Ctx<'_, NativeCtx<'_>>,
+        ) -> HttpServerResponse {
+            HttpServerResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: b"excl-macro-second".to_vec(),
+            }
+        }
+
+        #[http::route(any, "/macro-excl-second-ok")]
+        fn on_ok(
+            _state: &mut ExclusiveMacroSecondHandlerState,
+            _ctx: http::Ctx<'_, NativeCtx<'_>>,
+        ) -> HttpServerResponse {
+            HttpServerResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: b"excl-macro-second-ok".to_vec(),
+            }
+        }
+    }
 
     /// Replies `200` and echoes the request's method / path / query /
     /// peer address (as headers) and body (verbatim), so a test can
@@ -1702,6 +1846,109 @@ fn conflicting_claim_is_rejected_first_claimant_keeps_route() {
 
     let dup = round_trip(port, b"GET /dup HTTP/1.1\r\nHost: localhost\r\n\r\n");
     assert_eq!(body_of(&dup), "first", "first claimant keeps the route");
+}
+
+/// A bare `#[http::router]` impl still registers exclusive (issue 2625
+/// regression guard on the default): `ExclusiveMacroFirstHandler` and
+/// `ExclusiveMacroSecondHandler` both claim `/macro-excl` through the
+/// typed macro surface with no `shared` argument, so the second
+/// claimant's registration must conflict and lose — proving the new
+/// argument-parsing path still defaults `shared` to `false` rather than
+/// letting every bare `#[http::router]` impl accidentally join a member
+/// set.
+#[test]
+fn bare_router_stays_exclusive_second_claim_rejected() {
+    let chassis = routed_chassis!(ExclusiveMacroFirstHandler, ExclusiveMacroSecondHandler);
+    let port = port_of(&chassis);
+
+    // The second handler's own distinct route being live proves its
+    // rejected `/macro-excl` claim was processed too.
+    poll_body(
+        port,
+        b"GET /macro-excl-second-ok HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        "excl-macro-second-ok",
+    );
+
+    let contested = round_trip(port, b"GET /macro-excl HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    assert_eq!(
+        body_of(&contested),
+        "excl-macro-first",
+        "bare #[http::router] must stay exclusive: first claimant keeps the route",
+    );
+}
+
+/// `#[http::router(shared)]` (issue 2625) threads the flag from the
+/// attribute all the way into the wire `RegisterRouteSelf` send: two
+/// instances of a component built with the opt-in join one round-robin
+/// member set and both serve — the bug this catches is the flag failing
+/// to thread, which would make the second instance's registration a
+/// conflict `Err` instead of a join (only one tag would ever serve).
+#[test]
+fn macro_router_shared_opt_in_joins_a_member_set() {
+    // Pinned to one dispatch shard, like `shared_route_spreads_across_members`:
+    // round-robin state is per-shard, so alternation across a request
+    // sequence is only deterministic with a single shard.
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<HttpServerCapability>(HttpServerConfig {
+            bind_addr: "127.0.0.1:0".to_string(),
+            handler_mailbox: <FixedBodyHttpHandler as Addressable>::NAMESPACE.to_string(),
+            request_timeout_millis: 5_000,
+            dispatch_shards: 1,
+            ..HttpServerConfig::default()
+        })
+        .with_actor::<FixedBodyHttpHandler>(())
+        .build_passive()
+        .expect("caps boot");
+    // Two named instances of the exact same `SharedMacroPoolHandler` type
+    // (the accurate replica analog, per the type's own doc comment): each
+    // instance's `wire` runs the identical macro-emitted `shared: true`
+    // registration, so both carry the same minted `Kind::ID` and can join
+    // one member set.
+    chassis
+        .spawn_actor::<SharedMacroPoolHandler>(Subname::Named("alpha"), b"macro-alpha")
+        .finish()
+        .expect("spawn alpha");
+    chassis
+        .spawn_actor::<SharedMacroPoolHandler>(Subname::Named("beta"), b"macro-beta")
+        .finish()
+        .expect("spawn beta");
+    let port = port_of(&chassis);
+
+    // Wait until both registrations are live: with the set complete a
+    // pair of consecutive requests serves both bodies.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let first = round_trip(port, b"GET /macro-pool HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        let second = round_trip(port, b"GET /macro-pool HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        let pair = [body_of(&first).to_string(), body_of(&second).to_string()];
+        if pair.contains(&"macro-alpha".to_string()) && pair.contains(&"macro-beta".to_string()) {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected macro-alpha+macro-beta across a request pair within 10s; got {pair:?}",
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    // Steady state: six more requests keep alternating — both members
+    // serve, and only members serve.
+    let mut alpha = 0;
+    let mut beta = 0;
+    for _ in 0..6 {
+        let response = round_trip(port, b"GET /macro-pool HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        match body_of(&response) {
+            "macro-alpha" => alpha += 1,
+            "macro-beta" => beta += 1,
+            other => panic!("unexpected /macro-pool body {other:?}"),
+        }
+    }
+    assert_eq!(
+        (alpha, beta),
+        (3, 3),
+        "round-robin alternation over 6 requests"
+    );
 }
 
 /// A peer that stalls its receive window blocks only its own reader

--- a/docs/guide/recipes/serving-http.md
+++ b/docs/guide/recipes/serving-http.md
@@ -323,6 +323,17 @@ Drop to the raw `register_route_self` surface above for a streaming route
 (`HttpResponseStreamOpen`) — the typed surface returns `HttpServerResponse`, so
 a streamed response keeps its own hand-written `#[handler]`.
 
+### Scaling one handler to N instances
+
+`#[http::router(shared)]` — the bare ident `shared` in place of no argument —
+registers every route on the impl `shared: true` instead of the default
+exclusive claim. Load N instances of a component written this way and they
+join one round-robin member set on their shared prefixes, so "scale this
+handler to 4" is one attribute plus a `replicas: 4` on the load spec, with no
+hand-written `register_route_self` sends. Any argument other than the bare
+`shared` ident is a compile error naming the two accepted forms (no argument,
+or `shared`).
+
 ## What happens when the handler doesn't reply
 
 If the handler receives the request but returns without calling `ctx.reply`, the


### PR DESCRIPTION
Closes #2625.

## Summary

The ADR-0131 typed route macro emitted `shared: false` unconditionally, so a handler wanting to join an ADR-0136 shared member set had to abandon the macro and hand-write its `RegisterRouteSelf` sends. This adds an impl-level `#[router(shared)]` opt-in that emits every route registration with `shared: true`, keeping the full typed surface for a component built for N-instance scaling.

- `router` parses its attribute args: empty -> exclusive (today's default), the bare ident `shared` -> shared, anything else a spanned `compile_error!`. The `bool` threads through `expand_router` -> `inject_registration` -> `registration_send`, which emits `shared: #shared`.
- No runtime change — `register_route`'s joint-opt-in conflict checks stay the enforcement layer. No wire-format change (`RegisterRouteSelf.shared` already exists), no new ADR.

Hoop 1 of 2 (with #2626) in the ergonomic HTTP-scaling story.

## Test plan

- `cargo nextest run --workspace`: 1811 passed, 0 failed — includes `macro_router_shared_opt_in_joins_a_member_set` (one `#[actor(instanced)]` + `#[http::router(shared)]` type spawned as two live instances joins one member set — the accurate `replicas: N` analog) and `bare_router_stays_exclusive_second_claim_rejected` (default still conflicts on the second claim).
- clippy `-D warnings`, strict rustdoc, and the wasm32 component cross-build all pass.

## Generated by

`/implement` — agent execution of scoped issue #2625.
