### PR TITLE
fix(capabilities): handle the websocket read-timeout set failure

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/websocket.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/websocket.rs
@@ -412,8 +412,17 @@ pub fn run_ws_reader_loop(
         ws_max_message_bytes,
         ..
     } = tuning;
-    // An idle websocket is normal — read under the (longer) idle deadline.
-    let _ = stream.set_read_timeout(Some(ws_idle_timeout));
+    // An idle websocket is normal — read under the (longer) idle deadline. If the
+    // setsockopt itself fails, the reader has no idle bound to enforce; close
+    // rather than enter the frame loop with an unbounded blocking read.
+    if stream.set_read_timeout(Some(ws_idle_timeout)).is_err() {
+        sink.post(InboundEvent::WebSocketClose {
+            conn_id,
+            code: 1011,
+            reason: "failed to arm websocket idle timeout".to_string(),
+        });
+        return;
+    }
     let mut buf = leftover;
     let mut msg: Vec<u8> = Vec::new();
     let mut msg_binary = false;


### PR DESCRIPTION
Closes #2632.

## Summary

`run_ws_reader_loop` dropped the result of `stream.set_read_timeout(Some(ws_idle_timeout))`; on failure the reader looped with no idle bound, silently degrading to an unbounded blocking read. It now checks the result and, on `Err`, posts `InboundEvent::WebSocketClose { conn_id, code: 1011, reason }` and returns before entering the frame loop — matching the sibling close-and-return sites in the same function. Code 1011 (internal error) is used because the cap failed to honor its own idle-timeout invariant.

## Test plan

The `Err` branch is not cleanly unit-testable (provoking a setsockopt failure on a live `TcpStream` needs a fault-injection seam that would test the seam, not owned logic), so no dedicated test is added per the scoped plan. Covered by `cargo check` / `clippy` and the existing http server suite (`cargo nextest run -p aether-capabilities`, 233 tests green).

## Generated by

`/implement` — agent execution of [scoped issue #2632](https://github.com/iamacoffeepot/aether/issues/2632).
