### PR TITLE
fix(capabilities): cap http request body allocation on the websocket-upgrade path

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/reader.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/reader.rs
@@ -544,26 +544,34 @@ pub fn run_reader_loop(
         };
         if ws_key.is_none() {
             // Framing rejects for the buffered path (ADR-0128): smuggling
-            // / non-`chunked` codings always, a lone `chunked` body to a
-            // buffered handler (no length to buffer under), and the body
-            // cap.
+            // / non-`chunked` codings always, and a lone `chunked` body to
+            // a buffered handler (no length to buffer under).
             match (head.framing, streaming) {
                 (BodyFraming::Invalid, _) | (BodyFraming::Chunked, false) => {
                     reject_and_close(&mut stream, sink, conn_id, 411, "length required");
                     return;
                 }
-                (BodyFraming::Length(n), false) if n > max_request_bytes => {
-                    reject_and_close(
-                        &mut stream,
-                        sink,
-                        conn_id,
-                        413,
-                        "request body exceeds limit",
-                    );
-                    return;
-                }
                 _ => {}
             }
+        }
+        // The body-size cap applies whenever the request will be buffered
+        // — a websocket upgrade always buffers (line ~594 forces the
+        // `else`-branch) regardless of the `streaming` flag, so the cap
+        // must not be gated on `ws_key.is_none()`. A non-upgrade request
+        // still keeps the ADR-0128 streaming exemption: only the
+        // `streaming && ws_key.is_none()` combination skips this check.
+        if (ws_key.is_some() || !streaming)
+            && let BodyFraming::Length(n) = head.framing
+            && n > max_request_bytes
+        {
+            reject_and_close(
+                &mut stream,
+                sink,
+                conn_id,
+                413,
+                "request body exceeds limit",
+            );
+            return;
         }
 
         // `Expect: 100-continue`: written only once the request is
@@ -634,7 +642,15 @@ pub fn run_reader_loop(
                 StreamOutcome::Closed => return,
             }
         } else {
-            match read_buffered_body(&mut stream, conn_id, shutdown, sink, &head, &buf) {
+            match read_buffered_body(
+                &mut stream,
+                conn_id,
+                shutdown,
+                sink,
+                &head,
+                &buf,
+                max_request_bytes,
+            ) {
                 Some((body, next_buf)) => {
                     let payload = HttpServerRequest {
                         method,
@@ -752,8 +768,13 @@ fn read_buffered_body(
     sink: &WakeSink,
     head: &RequestHead,
     buf: &[u8],
+    max_request_bytes: usize,
 ) -> Option<(Vec<u8>, Vec<u8>)> {
-    let mut body: Vec<u8> = Vec::with_capacity(head.content_length);
+    // Defense-in-depth (the primary guard is the 413 reject above, hoisted
+    // out of the `ws_key.is_none()` gate): even if some future path ever
+    // reaches this read without the cap having fired, the upfront
+    // allocation can never exceed it.
+    let mut body: Vec<u8> = Vec::with_capacity(head.content_length.min(max_request_bytes));
     let mut next_buf: Vec<u8> = Vec::new();
     let after_head = &buf[head.head_len..];
     if after_head.len() >= head.content_length {

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -1152,6 +1152,39 @@ fn oversize_body_is_413() {
     );
 }
 
+/// A websocket-upgrade request that also declares an oversized
+/// `Content-Length` is answered `413` before any dispatch or buffered-body
+/// allocation. A valid upgrade handshake always buffers (never streams),
+/// so the body-size cap must apply to it the same as any other buffered
+/// request rather than being skipped because `ws_key.is_some()`.
+#[test]
+fn oversize_body_on_ws_upgrade_is_413() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<EchoHttpHandler>(())
+        .with_actor::<HttpServerCapability>(config_for(
+            <EchoHttpHandler as Addressable>::NAMESPACE,
+            8,
+        ))
+        .build_passive()
+        .expect("caps boot");
+
+    let response = round_trip(
+        port_of(&chassis),
+        b"GET /ws HTTP/1.1\r\n\
+          Host: localhost\r\n\
+          Upgrade: websocket\r\n\
+          Connection: Upgrade\r\n\
+          Sec-WebSocket-Version: 13\r\n\
+          Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+          Content-Length: 100\r\n\r\n",
+    );
+    assert!(
+        response.starts_with("HTTP/1.1 413 "),
+        "expected 413, got: {response:?}",
+    );
+}
+
 /// A non-enumerated method is answered `501` before any dispatch.
 #[test]
 fn unknown_method_is_501() {


### PR DESCRIPTION
Closes #2630.

## Summary

A websocket-upgrade request could drive an unbounded upfront heap allocation on the buffered read path: the `n > max_request_bytes` → 413 body-size reject sat inside the `if ws_key.is_none()` gate, so a request presenting a valid `Upgrade: websocket` handshake skipped the cap and reached `read_buffered_body`, whose `Vec::with_capacity(head.content_length)` pre-allocated the full attacker-declared `Content-Length` before reading a byte — a one-request OOM DoS.

This hoists the 413 reject out of the `ws_key.is_none()` gate so it fires for any buffered `BodyFraming::Length(n)` with `n > max_request_bytes` regardless of upgrade status, and clamps the pre-allocation to `Vec::with_capacity(head.content_length.min(max_request_bytes))` as defense-in-depth. The 411 framing rejects and the ADR-0128 streaming-upload exemption are unchanged.

## Test plan

New `oversize_body_on_ws_upgrade_is_413` in `crates/aether-capabilities/src/http/server/tests.rs` (modeled on `oversize_body_is_413`) — a real tripwire: it fails on pre-change code (`expected 413, got ""`) and passes after the hoist. `cargo nextest run -p aether-capabilities` — 234 passed, including the new test; clippy/check clean.

## Generated by

`/implement` — agent execution of [scoped issue #2630](https://github.com/iamacoffeepot/aether/issues/2630).
