### PR TITLE
refactor(capabilities): tighten http server runtime economy

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/mod.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/mod.rs
@@ -135,7 +135,7 @@ impl NativeActor for HttpServerCapability {
         let (inbound_tx, inbound_rx) = mpsc::channel::<InboundEvent>();
         let mailer: Arc<Mailer> = ctx.mailer();
         let self_id = ctx.self_id();
-        let wake_kind = KindId(<HttpInboundReady as Kind>::ID.0);
+        let wake_kind = <HttpInboundReady as Kind>::ID;
 
         let wake_dirty = Arc::new(AtomicBool::new(false));
         let accept_sink = WakeSink {

--- a/crates/aether-capabilities/src/http/server/runtime/reader.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/reader.rs
@@ -206,15 +206,7 @@ pub struct ReaderTuning {
 /// comma-separated values and repeated header lines (`Connection: keep-alive,
 /// Upgrade`).
 fn connection_has_token(headers: &[HttpHeader], token: &str) -> bool {
-    headers
-        .iter()
-        .filter(|header| header.name.eq_ignore_ascii_case("connection"))
-        .any(|header| {
-            header
-                .value
-                .split(',')
-                .any(|value| value.trim().eq_ignore_ascii_case(token))
-        })
+    header_has_token(headers, "connection", token)
 }
 
 /// First value of the header named `name` (case-insensitive), or `None` if the
@@ -350,6 +342,31 @@ fn resolve_at_reader(
     }
 }
 
+/// Re-arm the socket read timeout to `want` if it differs from `current`,
+/// posting `ReaderClosed` and returning `false` on a `set_read_timeout`
+/// failure (the caller must bail); returns `true` otherwise, with
+/// `current` updated to `want` when a change was made.
+fn ensure_read_timeout(
+    stream: &mut TcpStream,
+    sink: &WakeSink,
+    conn_id: ConnId,
+    current: &mut Duration,
+    want: Duration,
+) -> bool {
+    if want == *current {
+        return true;
+    }
+    if stream.set_read_timeout(Some(want)).is_err() {
+        sink.post(InboundEvent::ReaderClosed {
+            conn_id,
+            reason: "set read timeout failed".to_string(),
+        });
+        return false;
+    }
+    *current = want;
+    true
+}
+
 /// Reader-written reject (ADR-0135 §2): write the canned status on the
 /// reader's own full-duplex clone — no response can be in flight at a
 /// pre-dispatch reject — and post `ReaderClosed` so the shard reaps the
@@ -441,15 +458,14 @@ pub fn run_reader_loop(
             } else {
                 request_timeout
             };
-            if want_timeout != current_timeout {
-                if stream.set_read_timeout(Some(want_timeout)).is_err() {
-                    sink.post(InboundEvent::ReaderClosed {
-                        conn_id,
-                        reason: "set read timeout failed".to_string(),
-                    });
-                    return;
-                }
-                current_timeout = want_timeout;
+            if !ensure_read_timeout(
+                &mut stream,
+                sink,
+                conn_id,
+                &mut current_timeout,
+                want_timeout,
+            ) {
+                return;
             }
             match read_more(&mut stream, &mut chunk) {
                 ReadStep::Filled(n) => buf.extend_from_slice(&chunk[..n]),
@@ -489,15 +505,14 @@ pub fn run_reader_loop(
 
         // The body read and the `Expect: 100-continue` write run under the
         // in-flight timeout — a request has started arriving.
-        if current_timeout != request_timeout {
-            if stream.set_read_timeout(Some(request_timeout)).is_err() {
-                sink.post(InboundEvent::ReaderClosed {
-                    conn_id,
-                    reason: "set read timeout failed".to_string(),
-                });
-                return;
-            }
-            current_timeout = request_timeout;
+        if !ensure_read_timeout(
+            &mut stream,
+            sink,
+            conn_id,
+            &mut current_timeout,
+            request_timeout,
+        ) {
+            return;
         }
 
         let keep_alive = request_keeps_alive(head.version, &head.headers);

--- a/crates/aether-capabilities/src/http/server/runtime/render.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/render.rs
@@ -101,13 +101,12 @@ pub fn render_stream_head(open: &HttpResponseStreamOpen, keep_alive: bool) -> Ve
 /// `idle_deadline` is the idle-write / no-progress deadline: a handler that
 /// stalled mid-stream tears the stream down.
 pub fn run_writer_loop(
-    write_half: TcpStream,
+    mut write_half: TcpStream,
     stream_id: u64,
     rx: &mpsc::Receiver<WriterMsg>,
     sink: &WakeSink,
     idle_deadline: Duration,
 ) {
-    let mut write_half = write_half;
     loop {
         match rx.recv_timeout(idle_deadline) {
             Ok(WriterMsg::Chunk(body)) => {

--- a/crates/aether-capabilities/src/http/server/runtime/state.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/state.rs
@@ -217,12 +217,13 @@ impl HttpSupervisorState {
             );
             return;
         }
-        if self.live_connections.load(Ordering::Acquire) >= self.config.max_connections {
+        let live = self.live_connections.load(Ordering::Acquire);
+        if live >= self.config.max_connections {
             refuse_connection(stream, 503, "server at connection capacity");
             tracing::warn!(
                 target: "aether_substrate::http_server",
                 %peer,
-                live = self.live_connections.load(Ordering::Acquire),
+                live,
                 "http conn refused: at capacity",
             );
             return;

--- a/crates/aether-capabilities/src/http/server/runtime/websocket.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/websocket.rs
@@ -614,6 +614,16 @@ impl HttpShardState {
         );
     }
 
+    /// The websocket-upgraded connection's dispatch handler + `stream_id`
+    /// (ADR-0132), or `None` if `conn_id` names no such connection — the
+    /// shared lookup behind every ws dispatch/close/send site.
+    fn ws_target(&self, conn_id: ConnId) -> Option<(MailboxId, u64)> {
+        self.connections
+            .get(&conn_id)
+            .and_then(|conn| conn.websocket.as_ref())
+            .map(|ws| (ws.handler, ws.stream_id))
+    }
+
     /// Deliver one reassembled inbound websocket message to the handler
     /// (ADR-0129 §4) as a `WebSocketMessage` on its own fresh causal root,
     /// stamped with the connection's `stream_id` (ADR-0132) so the handler
@@ -626,12 +636,7 @@ impl HttpShardState {
         binary: bool,
         data: Vec<u8>,
     ) {
-        let Some((handler, stream_id)) = self
-            .connections
-            .get(&conn_id)
-            .and_then(|conn| conn.websocket.as_ref())
-            .map(|ws| (ws.handler, ws.stream_id))
-        else {
+        let Some((handler, stream_id)) = self.ws_target(conn_id) else {
             return;
         };
         let payload = WebSocketMessage {
@@ -653,12 +658,7 @@ impl HttpShardState {
         code: u16,
         reason: &str,
     ) {
-        let Some((handler, stream_id)) = self
-            .connections
-            .get(&conn_id)
-            .and_then(|conn| conn.websocket.as_ref())
-            .map(|ws| (ws.handler, ws.stream_id))
-        else {
+        let Some((handler, stream_id)) = self.ws_target(conn_id) else {
             return;
         };
         let payload = WebSocketClose {
@@ -676,12 +676,7 @@ impl HttpShardState {
     /// the connection down; otherwise it spends one credit and queues the
     /// serialized frame.
     pub fn send_ws_message(&mut self, conn_id: ConnId, binary: bool, data: &[u8]) {
-        let Some(stream_id) = self
-            .connections
-            .get(&conn_id)
-            .and_then(|conn| conn.websocket.as_ref())
-            .map(|ws| ws.stream_id)
-        else {
+        let Some((_, stream_id)) = self.ws_target(conn_id) else {
             return;
         };
         let opcode = if binary { OPCODE_BINARY } else { OPCODE_TEXT };
@@ -716,12 +711,7 @@ impl HttpShardState {
     /// connection's writer thread. Uncredited and best-effort — a full writer
     /// channel drops the pong rather than blocking or tearing down.
     pub fn send_ws_pong(&mut self, conn_id: ConnId, payload: &[u8]) {
-        let Some(stream_id) = self
-            .connections
-            .get(&conn_id)
-            .and_then(|conn| conn.websocket.as_ref())
-            .map(|ws| ws.stream_id)
-        else {
+        let Some((_, stream_id)) = self.ws_target(conn_id) else {
             return;
         };
         let frame = serialize_ws_frame(OPCODE_PONG, payload, None);
@@ -735,12 +725,7 @@ impl HttpShardState {
     /// which tears the connection down). Serves both a handler-initiated close
     /// and the echo of a peer close frame.
     pub fn send_ws_close(&mut self, conn_id: ConnId, code: u16, reason: &str) {
-        let Some(stream_id) = self
-            .connections
-            .get(&conn_id)
-            .and_then(|conn| conn.websocket.as_ref())
-            .map(|ws| ws.stream_id)
-        else {
+        let Some((_, stream_id)) = self.ws_target(conn_id) else {
             return;
         };
         let frame = serialize_ws_close_frame(code, reason);


### PR DESCRIPTION
Closes #2633.

## Summary

Six economy cleanups in the http server runtime, no behavior change (a pure refactor — the existing http server suite is the behavior-preservation gate):

1. `reader.rs` `connection_has_token` folds to delegate to the existing `header_has_token(headers, "connection", token)`.
2. `reader.rs` extracts `ensure_read_timeout(stream, sink, conn_id, current, want) -> bool`; both timeout-set guards become `if !ensure_read_timeout(...) { return; }`.
3. `websocket.rs` extracts a private `ws_target(&self, conn_id) -> Option<(MailboxId, u64)>`; the five `HttpShardState` ws sites call it (the three send sites destructure `(_, stream_id)`).
4. `state.rs` `assign_peer` hoists the doubled `live_connections.load(Acquire)` into one local.
5. `render.rs` `run_writer_loop` takes `mut write_half: TcpStream`, dropping the redundant rebind.
6. `runtime/mod.rs` `wake_kind` simplifies to `<HttpInboundReady as Kind>::ID`.

All new helpers stay private — no public API or wire-format change. Net char delta negative (2273 added / 2420 removed).

## Test plan

`cargo nextest run -p aether-capabilities` — 233 passed (the full http server suite unchanged), clippy/check/fmt clean. No new tests: this is behavior-preserving extraction, gated by the existing suite staying green.

## Note

Overlaps #2630 (`reader.rs`), #2631 (`runtime/mod.rs`), #2632 (`websocket.rs`) — intended land order is those three first, then this rebased last.

## Generated by

`/implement` — agent execution of [scoped issue #2633](https://github.com/iamacoffeepot/aether/issues/2633).
