### PR TITLE
fix(capabilities): harden the http accept-thread error and teardown paths

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/mod.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/mod.rs
@@ -28,7 +28,7 @@ use super::{HttpInboundReady, HttpServerCapability, HttpServerConfig, HttpServer
 use aether_actor::runtime;
 
 pub use std::collections::HashMap;
-pub use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, TcpListener, TcpStream};
 pub use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 pub use std::sync::{Arc, RwLock, mpsc};
 pub use std::thread;
@@ -82,6 +82,26 @@ pub use websocket::*;
 
 #[cfg(test)]
 mod unit_tests;
+
+/// Reconstructs the teardown self-connect target (see `unwire` below)
+/// from state the runtime already holds — no new state field. The
+/// listener's bound IP equals the configured `bind_addr`'s IP (`bind`
+/// only resolves the *port* when it is `0`), so this pairs that IP with
+/// the resolved `listener_port`. A wildcard bind (`0.0.0.0` / `::`) has
+/// no address a self-connect can land on, so it maps to the matching
+/// loopback instead; an unparseable `bind_addr` falls back to IPv4
+/// loopback.
+fn teardown_connect_addr(bind_addr: &str, listener_port: u16) -> SocketAddr {
+    let ip = bind_addr
+        .parse::<SocketAddr>()
+        .map_or(IpAddr::V4(Ipv4Addr::LOCALHOST), |addr| addr.ip());
+    let ip = match ip {
+        IpAddr::V4(v4) if v4.is_unspecified() => IpAddr::V4(Ipv4Addr::LOCALHOST),
+        IpAddr::V6(v6) if v6.is_unspecified() => IpAddr::V6(Ipv6Addr::LOCALHOST),
+        other => other,
+    };
+    SocketAddr::new(ip, listener_port)
+}
 
 #[runtime]
 impl NativeActor for HttpServerCapability {
@@ -144,10 +164,17 @@ impl NativeActor for HttpServerCapability {
                                 break;
                             }
                         }
-                        Err(_) => {
+                        Err(error) => {
                             if accept_shutdown_for_thread.load(Ordering::Acquire) {
                                 break;
                             }
+                            tracing::warn!(
+                                target: "aether_substrate::http_server",
+                                port,
+                                %error,
+                                "http accept() failed; backing off before retry",
+                            );
+                            thread::sleep(Duration::from_millis(100));
                         }
                     }
                 }
@@ -186,8 +213,15 @@ impl NativeActor for HttpServerCapability {
         // their own `unwire` (the chassis tears instanced actors down
         // alongside the caps).
         state.accept_shutdown.store(true, Ordering::Release);
-        if let Ok(addr) = format!("127.0.0.1:{}", state.listener_port).parse::<SocketAddr>() {
-            let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
+        let wake_addr = teardown_connect_addr(&state.config.bind_addr, state.listener_port);
+        if let Err(error) = TcpStream::connect_timeout(&wake_addr, Duration::from_millis(100)) {
+            tracing::warn!(
+                target: "aether_substrate::http_server",
+                port = state.listener_port,
+                addr = %wake_addr,
+                %error,
+                "http server teardown wake self-connect failed; accept-thread join may stall",
+            );
         }
         if let Some(thread) = state.accept_thread.take() {
             let _ = thread.join();

--- a/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
@@ -2,9 +2,10 @@ use super::{
     HttpResponseStreamOpen, OPCODE_BINARY, OPCODE_CONTINUATION, OPCODE_TEXT, WsFrameParse,
     http_date, normalize_prefix, parse_http_method, parse_ws_frame, percent_decode_path,
     reason_phrase, render_stream_head, request_keeps_alive, route_matches, sec_websocket_accept,
-    serialize_ws_frame, sha1, validate_ws_handshake,
+    serialize_ws_frame, sha1, teardown_connect_addr, validate_ws_handshake,
 };
 use crate::http::kinds::{HttpHeader, HttpMethod};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::{Duration, UNIX_EPOCH};
 
 fn conn_header(value: &str) -> Vec<HttpHeader> {
@@ -356,6 +357,51 @@ fn config_layer_defaults_match_the_named_consts() {
     assert_eq!(
         default.websocket_idle_timeout_millis,
         DEFAULT_WS_IDLE_TIMEOUT_MILLIS
+    );
+}
+
+/// Tripwire: a wildcard bind (`0.0.0.0` / `::`, no routable self-connect
+/// target) maps to the matching loopback family — this is the actual bug
+/// fix (issue #2631), not a mirror of the input.
+#[test]
+fn teardown_connect_addr_maps_wildcard_to_loopback() {
+    assert_eq!(
+        teardown_connect_addr("0.0.0.0:8080", 8080),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
+    );
+    assert_eq!(
+        teardown_connect_addr("[::]:8080", 8080),
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080)
+    );
+}
+
+/// A specific bind IP (not wildcard) is preserved as-is, paired with the
+/// resolved listener port rather than whatever port `bind_addr` named
+/// (e.g. `0` for an OS-assigned port).
+#[test]
+fn teardown_connect_addr_preserves_specific_ip() {
+    assert_eq!(
+        teardown_connect_addr("192.168.1.5:0", 41_234),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5)), 41_234)
+    );
+    assert_eq!(
+        teardown_connect_addr("127.0.0.1:8080", 8080),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
+    );
+}
+
+/// An unparseable `bind_addr` (e.g. a hostname `TcpListener::bind` would
+/// resolve via DNS, which this pure helper does not do) falls back to
+/// IPv4 loopback rather than panicking or propagating the parse error.
+#[test]
+fn teardown_connect_addr_unparseable_falls_back_to_loopback() {
+    assert_eq!(
+        teardown_connect_addr("not-an-address", 9090),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9090)
+    );
+    assert_eq!(
+        teardown_connect_addr("localhost:9090", 9090),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9090)
     );
 }
 


### PR DESCRIPTION
Closes #2631.

## Summary

Two swallowed-error gaps in the http accept-thread lifecycle in `runtime/mod.rs`. At teardown, `unwire` woke the blocked `accept()` by self-connecting to a hardcoded `127.0.0.1:{listener_port}` and discarded the result — but a listener bound to `0.0.0.0`/an external interface can miss that loopback wake, hanging the following `thread.join()` silently. The accept loop's `Err(_)` arm also dropped the `io::Error` unbound and hot-spun straight back into `accept()`.

This adds a private `teardown_connect_addr(bind_addr, listener_port) -> SocketAddr` helper that targets the listener's actual bound address (wildcard/unparseable → loopback, specific IP preserved); `unwire` uses it and `warn!`s on a failed `connect_timeout`. The accept-loop `Err` arm now binds the error, `warn!`s, and backs off ~100ms before retrying.

## Test plan

Three unit tests on `teardown_connect_addr` (wildcard → loopback, specific IP preserved, unparseable → loopback) — the testable tripwire. The two warn paths are log-only and not reliably inducible in CI (stated in the plan; no fabricated fault-injection test). `cargo nextest run -p aether-capabilities` — 236 passed including the new tests; clippy/check/fmt clean.

## Generated by

`/implement` — agent execution of [scoped issue #2631](https://github.com/iamacoffeepot/aether/issues/2631).
