### PR TITLE
feat(kit): chunked world plane stack — underlay, overlay, region planes

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -10,7 +10,11 @@
 //! `.dsl` / `.obj` mesh file and replays it to the render sink,
 //! selected by the `aether_kit@aether.mesh_viewer` export). The
 //! camera's `aether.camera.*` driver kinds live in [`camera`]; the
-//! mesh viewer's `aether.mesh.load` kind lives in [`mesh`].
+//! mesh viewer's `aether.mesh.load` kind lives in [`mesh`]. The
+//! [`world`] module holds the chunked world plane stack — the
+//! `World` / `Chunk` / `Material` data layer and its
+//! `aether.kit.world.{set_chunk,set_region,load}` wire kinds — that a
+//! world-view actor meshes to the render sink.
 //!
 //! # Units
 //!
@@ -32,6 +36,12 @@ use serde::{Deserialize, Serialize};
 
 pub mod camera;
 pub mod mesh;
+pub mod world;
+
+pub use world::{
+    CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk, ChunkPos, Material, Region,
+    SetChunk, SetRegion, World, WorldDecodeError, WorldLoad,
+};
 
 #[cfg(feature = "runtime")]
 pub mod runtime;

--- a/crates/aether-kit/src/world.rs
+++ b/crates/aether-kit/src/world.rs
@@ -1,0 +1,831 @@
+// Serialization casts here are bounded by the fixed plane geometry: a
+// chunk has 256 cells, region ids and plane lengths are small by
+// construction, and `region: Vec<u32>` narrows to the `[u16; 256]`
+// region plane by design (ids past u16 are not addressable). The
+// truncation these lints warn about cannot occur in this domain.
+#![allow(clippy::cast_possible_truncation)]
+// `chunk_index` casts a `rem_euclid` result (always `0..16`) to `usize`;
+// the sign-loss the lint warns about cannot occur.
+#![allow(clippy::cast_sign_loss)]
+
+//! The chunked world plane stack.
+//!
+//! The world is a **cell lattice**: cells are addresses, not objects.
+//! What a cell *is* — its ground fabric, elevation, region membership —
+//! lives in a stack of property planes over that lattice, chunked
+//! `16 × 16` cells (a [`Chunk`]). A [`World`] holds a sparse set of
+//! chunks keyed by [`ChunkPos`] plus a region table.
+//!
+//! # Units
+//!
+//! `1 cell = 1 m = 256 octimeters` (the fixed-point movement quantum).
+//! The chunk a cell sits in is the cell right-shifted by [`CHUNK_BITS`]
+//! — an arithmetic shift, so a negative cell floors toward `-∞` (cell
+//! `-1` is in chunk
+//! `-1`, not `0`), which is the intended lattice tiling. A cell's index
+//! within its chunk is `z.rem_euclid(16) * 16 + x.rem_euclid(16)`
+//! (row-major), so negative cells index their chunk correctly.
+//!
+//! # Ground fabric — underlay / overlay
+//!
+//! Two material planes, RuneScape-style:
+//!
+//! - [`Chunk::underlay`] — the ground fabric. This is what the region
+//!   cascade resolves ([`World::underlay`]): the cell's own underlay if
+//!   non-[`Material::Void`], else the cell's region's `default_material`,
+//!   else `Void`.
+//! - [`Chunk::overlay`] — an optional crisp placed surface (path, water,
+//!   floor). `Void` means no overlay. Never cascade-resolved
+//!   ([`World::overlay`] is a raw plane read).
+//! - [`Chunk::overlay_mask`] — a subcell coverage bitmask per cell. Each
+//!   cell holds a [`SUBCELLS_PER_CELL_EDGE`]² bit grid (bit `z*SUB + x`,
+//!   `1` = the overlay covers that subcell); `0xFFFF` at `SUB = 4` is
+//!   full coverage. The subcell is the finest semantic resolution —
+//!   paint must not out-resolve movement / blocking, which resolve at the
+//!   subcell. Masks OR-compose (bitwise) within the overlay layer;
+//!   painter's order applies across layers. Reserved here — the wire
+//!   layout is final, but mask meshing is a follow-up; nothing in this
+//!   module interprets the bits.
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+/// Cells along one edge of a chunk. Chunks are `16 × 16` cells.
+pub const CELLS_PER_CHUNK: i32 = 16;
+
+/// Right-shift a cell coordinate by this to derive its chunk
+/// (`2^4 = 16` cells per chunk edge). Arithmetic shift — floors on
+/// negatives.
+pub const CHUNK_BITS: u32 = 4;
+
+/// Cells in one chunk: `16 × 16`. The length of every per-chunk plane.
+pub const CELLS_PER_CHUNK_AREA: usize = 256;
+
+/// Subcells along one edge of a cell — the overlay coverage resolution.
+/// A cell's [`Chunk::overlay_mask`] is a `SUB × SUB` bit grid. Raising
+/// this is a single-constant change; the wire mask-plane length is
+/// derived from it ([`OVERLAY_MASK_WIRE_BYTES`]), never hard-coded, so
+/// no wire migration is needed. The in-memory mask is a `u16`, which
+/// holds `SUB = 4` (16 bits).
+pub const SUBCELLS_PER_CELL_EDGE: u32 = 4;
+
+/// Bits in one cell's overlay coverage mask: `SUB²`.
+pub const SUBCELLS_PER_CELL: usize = (SUBCELLS_PER_CELL_EDGE * SUBCELLS_PER_CELL_EDGE) as usize;
+
+/// Wire length in bytes of a chunk's overlay-mask plane:
+/// `CELLS_PER_CHUNK_AREA * SUB² / 8` (= 512 at `SUB = 4`). The plane
+/// travels as little-endian mask words per cell, row-major cell order.
+pub const OVERLAY_MASK_WIRE_BYTES: usize = CELLS_PER_CHUNK_AREA * SUBCELLS_PER_CELL / 8;
+
+/// Octimeters per cell: `1 cell = 1 m = 256 octimeters`.
+const OCTIMETERS_PER_CELL: i32 = 256;
+
+/// Right-shift an octimeter coordinate by this to derive its cell.
+const OCTIMETER_BITS: u32 = 8;
+
+/// A cell address on the world lattice. Cells are addresses; their
+/// properties live in the plane stack.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct CellPos {
+    pub x: i32,
+    pub z: i32,
+}
+
+/// A chunk address — a cell address right-shifted by [`CHUNK_BITS`].
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct ChunkPos {
+    pub x: i32,
+    pub z: i32,
+}
+
+impl CellPos {
+    /// The chunk this cell belongs to. Arithmetic right shift, so
+    /// negative cells floor toward `-∞`.
+    #[must_use]
+    pub fn chunk(self) -> ChunkPos {
+        ChunkPos {
+            x: self.x >> CHUNK_BITS,
+            z: self.z >> CHUNK_BITS,
+        }
+    }
+
+    /// The cell's center in octimeters — cell-center-anchored, so a
+    /// mover placed here sits in the middle of the cell, not on its
+    /// corner. `(x << 8) + 128`.
+    #[must_use]
+    pub fn center_octimeters(self) -> (i32, i32) {
+        (
+            (self.x << OCTIMETER_BITS) + OCTIMETERS_PER_CELL / 2,
+            (self.z << OCTIMETER_BITS) + OCTIMETERS_PER_CELL / 2,
+        )
+    }
+
+    /// The cell an octimeter position sits in. Arithmetic right shift —
+    /// negative positions floor.
+    #[must_use]
+    pub fn from_octimeters(x: i32, z: i32) -> Self {
+        Self {
+            x: x >> OCTIMETER_BITS,
+            z: z >> OCTIMETER_BITS,
+        }
+    }
+
+    /// Index of this cell within its chunk's row-major planes.
+    /// `rem_euclid` so negative cells map into `0..256` correctly.
+    fn chunk_index(self) -> usize {
+        (self.z.rem_euclid(CELLS_PER_CHUNK) * CELLS_PER_CHUNK + self.x.rem_euclid(CELLS_PER_CHUNK))
+            as usize
+    }
+}
+
+/// The ground-material vocabulary. Rides the wire as a raw `u8` inside a
+/// `Bytes` plane, never as a schema enum, so a plane has one canonical
+/// byte-array form. `Void` (`0`) is "nothing here".
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum Material {
+    #[default]
+    Void = 0,
+    Grass = 1,
+    Dirt = 2,
+    Stone = 3,
+    Sand = 4,
+    Water = 5,
+}
+
+impl Material {
+    /// The raw wire byte.
+    #[must_use]
+    pub fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Decode a wire byte, degrading an unknown value to [`Material::Void`]
+    /// rather than erroring — a malformed plane byte becomes empty space,
+    /// not a panic.
+    #[must_use]
+    pub fn from_u8_or_void(byte: u8) -> Self {
+        Self::try_from(byte).unwrap_or(Self::Void)
+    }
+}
+
+impl TryFrom<u8> for Material {
+    type Error = u8;
+
+    fn try_from(byte: u8) -> Result<Self, u8> {
+        match byte {
+            0 => Ok(Self::Void),
+            1 => Ok(Self::Grass),
+            2 => Ok(Self::Dirt),
+            3 => Ok(Self::Stone),
+            4 => Ok(Self::Sand),
+            5 => Ok(Self::Water),
+            other => Err(other),
+        }
+    }
+}
+
+/// A semantic group of cells with a default ground material. Regions are
+/// referenced by 1-based id from the per-cell region plane (`0` = no
+/// region); the region table is positional, so a region's id is its
+/// index in [`World`]'s table plus one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Region {
+    pub name: String,
+    pub default_material: Material,
+}
+
+/// One `16 × 16` block of the world, as a struct-of-arrays: five
+/// property planes, each row-major (`z * 16 + x`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Chunk {
+    /// Ground fabric — cascade-resolved by [`World::underlay`].
+    pub underlay: [Material; CELLS_PER_CHUNK_AREA],
+    /// Placed surface — raw, never cascade-resolved. `Void` = none.
+    pub overlay: [Material; CELLS_PER_CHUNK_AREA],
+    /// Overlay subcell coverage bitmask per cell — a `SUB × SUB` bit grid
+    /// (bit `z*SUB + x`). `0xFFFF` at `SUB = 4` is full coverage; `0` is
+    /// none. Meaningless where `overlay` is `Void`. Reserved; not
+    /// interpreted here.
+    pub overlay_mask: [u16; CELLS_PER_CHUNK_AREA],
+    /// Elevation in octimeters (`0` = flat).
+    pub height: [i32; CELLS_PER_CHUNK_AREA],
+    /// Region id per cell (`0` = no region).
+    pub region: [u16; CELLS_PER_CHUNK_AREA],
+}
+
+impl Chunk {
+    /// An empty chunk — all planes `Void` / zero.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            underlay: [Material::Void; CELLS_PER_CHUNK_AREA],
+            overlay: [Material::Void; CELLS_PER_CHUNK_AREA],
+            overlay_mask: [0; CELLS_PER_CHUNK_AREA],
+            height: [0; CELLS_PER_CHUNK_AREA],
+            region: [0; CELLS_PER_CHUNK_AREA],
+        }
+    }
+}
+
+impl Default for Chunk {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// The world: a sparse set of chunks plus a region table. Cells with no
+/// chunk read as `Void` / `0`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct World {
+    chunks: BTreeMap<ChunkPos, Chunk>,
+    regions: Vec<Region>,
+}
+
+impl World {
+    /// An empty world.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The cascade-resolved ground material at `cell`: the cell's own
+    /// underlay if non-`Void`, else the cell's region's `default_material`,
+    /// else `Void`.
+    #[must_use]
+    pub fn underlay(&self, cell: CellPos) -> Material {
+        let Some(chunk) = self.chunks.get(&cell.chunk()) else {
+            return Material::Void;
+        };
+        let idx = cell.chunk_index();
+        let own = chunk.underlay[idx];
+        if own != Material::Void {
+            return own;
+        }
+        let region_id = chunk.region[idx];
+        if region_id != 0
+            && let Some(region) = self.regions.get(region_id as usize - 1)
+        {
+            return region.default_material;
+        }
+        Material::Void
+    }
+
+    /// The raw overlay material at `cell` — never cascade-resolved.
+    #[must_use]
+    pub fn overlay(&self, cell: CellPos) -> Material {
+        self.chunks
+            .get(&cell.chunk())
+            .map_or(Material::Void, |chunk| chunk.overlay[cell.chunk_index()])
+    }
+
+    /// Elevation at `cell` in octimeters. Unset cells read `0`.
+    #[must_use]
+    pub fn height(&self, cell: CellPos) -> i32 {
+        self.chunks
+            .get(&cell.chunk())
+            .map_or(0, |chunk| chunk.height[cell.chunk_index()])
+    }
+
+    /// The chunk at `at`, if present.
+    #[must_use]
+    pub fn chunk(&self, at: ChunkPos) -> Option<&Chunk> {
+        self.chunks.get(&at)
+    }
+
+    /// Insert (or replace) the chunk at `at`.
+    pub fn insert_chunk(&mut self, at: ChunkPos, chunk: Chunk) {
+        self.chunks.insert(at, chunk);
+    }
+
+    /// Register a region under a 1-based `id`. The table is positional,
+    /// so this grows it (padding intervening slots with empty regions)
+    /// and writes `region` at index `id - 1`. `id == 0` is ignored (`0`
+    /// is the "no region" sentinel).
+    pub fn insert_region(&mut self, id: u32, region: Region) {
+        if id == 0 {
+            return;
+        }
+        let index = id as usize - 1;
+        if index >= self.regions.len() {
+            self.regions.resize(
+                index + 1,
+                Region {
+                    name: String::new(),
+                    default_material: Material::Void,
+                },
+            );
+        }
+        self.regions[index] = region;
+    }
+
+    /// Iterate the chunk set in `ChunkPos` order (deterministic — the
+    /// `BTreeMap` key order).
+    pub fn chunks(&self) -> impl Iterator<Item = (ChunkPos, &Chunk)> {
+        self.chunks.iter().map(|(pos, chunk)| (*pos, chunk))
+    }
+}
+
+/// `aether.kit.world.set_chunk` — write one chunk's planes. The three
+/// ground planes ride as raw `Bytes` (256 material/shape bytes each);
+/// `height` / `region` ride as length-256 vectors. Shorter vectors pad
+/// with `Void` / `0`; longer ones truncate.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.world.set_chunk")]
+pub struct SetChunk {
+    pub chunk_x: i32,
+    pub chunk_z: i32,
+    /// Underlay plane — 256 raw material bytes (`Material as u8`).
+    pub underlay: Vec<u8>,
+    /// Overlay plane — 256 raw material bytes. `0` = no overlay.
+    pub overlay: Vec<u8>,
+    /// Overlay subcell-mask plane — [`OVERLAY_MASK_WIRE_BYTES`] bytes
+    /// (`256 * SUB² / 8`; 512 at `SUB = 4`), one little-endian mask word
+    /// per cell in row-major cell order.
+    pub overlay_mask: Vec<u8>,
+    /// Elevation plane — 256 octimeter values.
+    pub height: Vec<i32>,
+    /// Region-id plane — 256 values. `0` = no region.
+    pub region: Vec<u32>,
+}
+
+impl SetChunk {
+    /// The chunk address this write targets.
+    #[must_use]
+    pub fn chunk_pos(&self) -> ChunkPos {
+        ChunkPos {
+            x: self.chunk_x,
+            z: self.chunk_z,
+        }
+    }
+
+    /// Decode the wire planes into a [`Chunk`]. Material bytes degrade to
+    /// `Void` on an unknown value; every plane pads to 256 / truncates
+    /// past it; `region` casts `u32` down to `u16`.
+    #[must_use]
+    pub fn into_chunk(self) -> Chunk {
+        let mut chunk = Chunk::empty();
+        for (dst, byte) in chunk.underlay.iter_mut().zip(&self.underlay) {
+            *dst = Material::from_u8_or_void(*byte);
+        }
+        for (dst, byte) in chunk.overlay.iter_mut().zip(&self.overlay) {
+            *dst = Material::from_u8_or_void(*byte);
+        }
+        // Mask plane: two little-endian bytes per cell (u16 at SUB=4). A
+        // short plane pads with 0 (no coverage); trailing bytes truncate.
+        for (dst, pair) in chunk
+            .overlay_mask
+            .iter_mut()
+            .zip(self.overlay_mask.chunks_exact(2))
+        {
+            *dst = u16::from_le_bytes([pair[0], pair[1]]);
+        }
+        for (dst, value) in chunk.height.iter_mut().zip(&self.height) {
+            *dst = *value;
+        }
+        for (dst, value) in chunk.region.iter_mut().zip(&self.region) {
+            *dst = *value as u16;
+        }
+        chunk
+    }
+}
+
+/// `aether.kit.world.set_region` — register a region in the table under a
+/// 1-based `region_id`, giving the underlay cascade a default material to
+/// fall through to. `default_material` is a raw `Material` byte.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.world.set_region")]
+pub struct SetRegion {
+    pub region_id: u32,
+    pub name: String,
+    pub default_material: u8,
+}
+
+impl SetRegion {
+    /// The [`Region`] this registers, decoding `default_material`
+    /// (unknown → `Void`).
+    #[must_use]
+    pub fn into_region(self) -> Region {
+        Region {
+            name: self.name,
+            default_material: Material::from_u8_or_void(self.default_material),
+        }
+    }
+}
+
+/// `aether.kit.world.load` — load a serialized world from the substrate's
+/// I/O surface (ADR-0041 namespace + path). The bytes are the
+/// [`World::to_bytes`] format; a decode failure keeps the prior world.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.world.load")]
+pub struct WorldLoad {
+    pub namespace: String,
+    pub path: String,
+}
+
+/// A [`World::from_bytes`] failure — the buffer was truncated or carried
+/// an unknown format version.
+#[derive(Debug, PartialEq, Eq)]
+pub enum WorldDecodeError {
+    /// Ran off the end of the buffer mid-record.
+    Truncated,
+    /// First byte was not a recognized format version.
+    BadVersion(u8),
+    /// A region name was not valid UTF-8.
+    BadName,
+}
+
+const WORLD_FORMAT_VERSION: u8 = 1;
+
+impl World {
+    /// Serialize to the compact `aether.kit.world.load` binary format: a
+    /// version byte, the region table, then per-chunk plane records — all
+    /// little-endian. Region ids are positional (index + 1), so the table
+    /// order is the id order.
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.push(WORLD_FORMAT_VERSION);
+        out.extend_from_slice(&(self.regions.len() as u32).to_le_bytes());
+        for region in &self.regions {
+            let name = region.name.as_bytes();
+            out.extend_from_slice(&(name.len() as u16).to_le_bytes());
+            out.extend_from_slice(name);
+            out.push(region.default_material.to_u8());
+        }
+        out.extend_from_slice(&(self.chunks.len() as u32).to_le_bytes());
+        for (pos, chunk) in &self.chunks {
+            out.extend_from_slice(&pos.x.to_le_bytes());
+            out.extend_from_slice(&pos.z.to_le_bytes());
+            for m in &chunk.underlay {
+                out.push(m.to_u8());
+            }
+            for m in &chunk.overlay {
+                out.push(m.to_u8());
+            }
+            for mask in &chunk.overlay_mask {
+                out.extend_from_slice(&mask.to_le_bytes());
+            }
+            for h in &chunk.height {
+                out.extend_from_slice(&h.to_le_bytes());
+            }
+            for r in &chunk.region {
+                out.extend_from_slice(&r.to_le_bytes());
+            }
+        }
+        out
+    }
+
+    /// Decode the [`World::to_bytes`] format. A truncated buffer or
+    /// unknown version returns `Err` rather than panicking; the caller
+    /// keeps its prior world on any error.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, WorldDecodeError> {
+        let mut reader = Reader::new(bytes);
+        let version = reader.u8()?;
+        if version != WORLD_FORMAT_VERSION {
+            return Err(WorldDecodeError::BadVersion(version));
+        }
+        let region_count = reader.u32()? as usize;
+        let mut regions = Vec::with_capacity(region_count);
+        for _ in 0..region_count {
+            let name_len = reader.u16()? as usize;
+            let name_bytes = reader.take(name_len)?;
+            let name =
+                String::from_utf8(name_bytes.to_vec()).map_err(|_| WorldDecodeError::BadName)?;
+            let default_material = Material::from_u8_or_void(reader.u8()?);
+            regions.push(Region {
+                name,
+                default_material,
+            });
+        }
+        let chunk_count = reader.u32()? as usize;
+        let mut chunks = BTreeMap::new();
+        for _ in 0..chunk_count {
+            let x = reader.i32()?;
+            let z = reader.i32()?;
+            let mut chunk = Chunk::empty();
+            for slot in &mut chunk.underlay {
+                *slot = Material::from_u8_or_void(reader.u8()?);
+            }
+            for slot in &mut chunk.overlay {
+                *slot = Material::from_u8_or_void(reader.u8()?);
+            }
+            for slot in &mut chunk.overlay_mask {
+                *slot = reader.u16()?;
+            }
+            for slot in &mut chunk.height {
+                *slot = reader.i32()?;
+            }
+            for slot in &mut chunk.region {
+                *slot = reader.u16()?;
+            }
+            chunks.insert(ChunkPos { x, z }, chunk);
+        }
+        Ok(Self { chunks, regions })
+    }
+}
+
+/// A bounds-checked little-endian byte cursor for [`World::from_bytes`].
+struct Reader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], WorldDecodeError> {
+        let end = self.pos.checked_add(n).ok_or(WorldDecodeError::Truncated)?;
+        let slice = self
+            .bytes
+            .get(self.pos..end)
+            .ok_or(WorldDecodeError::Truncated)?;
+        self.pos = end;
+        Ok(slice)
+    }
+
+    fn u8(&mut self) -> Result<u8, WorldDecodeError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, WorldDecodeError> {
+        let b = self.take(2)?;
+        Ok(u16::from_le_bytes([b[0], b[1]]))
+    }
+
+    fn u32(&mut self) -> Result<u32, WorldDecodeError> {
+        let b = self.take(4)?;
+        Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+
+    fn i32(&mut self) -> Result<i32, WorldDecodeError> {
+        let b = self.take(4)?;
+        Ok(i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cell(x: i32, z: i32) -> CellPos {
+        CellPos { x, z }
+    }
+
+    #[test]
+    fn chunk_shift_floors_on_negative_cells() {
+        // Cell 0 and 15 are both in chunk 0; cell 16 in chunk 1.
+        assert_eq!(cell(0, 0).chunk(), ChunkPos { x: 0, z: 0 });
+        assert_eq!(cell(15, 15).chunk(), ChunkPos { x: 0, z: 0 });
+        assert_eq!(cell(16, 16).chunk(), ChunkPos { x: 1, z: 1 });
+        // Arithmetic shift floors: cell -1 is in chunk -1, not 0.
+        assert_eq!(cell(-1, -1).chunk(), ChunkPos { x: -1, z: -1 });
+        assert_eq!(cell(-16, -16).chunk(), ChunkPos { x: -1, z: -1 });
+        assert_eq!(cell(-17, -17).chunk(), ChunkPos { x: -2, z: -2 });
+    }
+
+    #[test]
+    fn from_octimeters_floors_on_negative_positions() {
+        // 256 octimeters per cell; cell 0 spans [0,256), cell -1 spans [-256,0).
+        assert_eq!(CellPos::from_octimeters(0, 0), cell(0, 0));
+        assert_eq!(CellPos::from_octimeters(255, 255), cell(0, 0));
+        assert_eq!(CellPos::from_octimeters(256, 256), cell(1, 1));
+        assert_eq!(CellPos::from_octimeters(-1, -1), cell(-1, -1));
+        assert_eq!(CellPos::from_octimeters(-256, -256), cell(-1, -1));
+        assert_eq!(CellPos::from_octimeters(-257, -257), cell(-2, -2));
+    }
+
+    #[test]
+    fn center_octimeters_is_cell_center() {
+        assert_eq!(cell(0, 0).center_octimeters(), (128, 128));
+        assert_eq!(cell(1, 2).center_octimeters(), (384, 640));
+        assert_eq!(cell(-1, -1).center_octimeters(), (-128, -128));
+    }
+
+    #[test]
+    fn negative_cell_indexes_its_chunk_correctly() {
+        // Cell -1 sits at local (15,15) of chunk -1 → index 255.
+        assert_eq!(cell(-1, -1).chunk_index(), 15 * 16 + 15);
+        // Cell -16 sits at local (0,0) of chunk -1 → index 0.
+        assert_eq!(cell(-16, -16).chunk_index(), 0);
+    }
+
+    #[test]
+    fn underlay_cascade_resolves_cell_then_region_then_void() {
+        let mut world = World::new();
+        let mut chunk = Chunk::empty();
+        // Cell (2,3): explicit Stone underlay — cell override wins.
+        chunk.underlay[3 * 16 + 2] = Material::Stone;
+        // Cell (4,5): Void underlay but in region 1 → region default.
+        chunk.region[5 * 16 + 4] = 1;
+        // Cell (6,7): Void underlay, no region → Void.
+        world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
+        world.insert_region(
+            1,
+            Region {
+                name: "meadow".into(),
+                default_material: Material::Grass,
+            },
+        );
+
+        assert_eq!(world.underlay(cell(2, 3)), Material::Stone, "cell override");
+        assert_eq!(
+            world.underlay(cell(4, 5)),
+            Material::Grass,
+            "region default"
+        );
+        assert_eq!(
+            world.underlay(cell(6, 7)),
+            Material::Void,
+            "no cascade source"
+        );
+    }
+
+    #[test]
+    fn overlay_never_cascades() {
+        let mut world = World::new();
+        let mut chunk = Chunk::empty();
+        // Cell in region 1 with a region default, but Void overlay.
+        chunk.region[0] = 1;
+        world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
+        world.insert_region(
+            1,
+            Region {
+                name: "r".into(),
+                default_material: Material::Grass,
+            },
+        );
+        // Underlay cascades to Grass; overlay stays raw Void.
+        assert_eq!(world.underlay(cell(0, 0)), Material::Grass);
+        assert_eq!(world.overlay(cell(0, 0)), Material::Void);
+    }
+
+    #[test]
+    fn sparse_world_reads_void_and_zero() {
+        let world = World::new();
+        assert_eq!(world.underlay(cell(100, -50)), Material::Void);
+        assert_eq!(world.overlay(cell(100, -50)), Material::Void);
+        assert_eq!(world.height(cell(100, -50)), 0);
+        assert!(world.chunk(ChunkPos { x: 3, z: 3 }).is_none());
+    }
+
+    #[test]
+    fn set_chunk_decodes_planes_and_clamps_unknown_material() {
+        let mut underlay = vec![0u8; CELLS_PER_CHUNK_AREA];
+        underlay[3 * 16 + 2] = Material::Water.to_u8();
+        underlay[0] = 99; // unknown byte → Void
+        let mut region = vec![0u32; CELLS_PER_CHUNK_AREA];
+        region[1] = 7;
+        let set = SetChunk {
+            chunk_x: 2,
+            chunk_z: -1,
+            underlay,
+            overlay: vec![0u8; CELLS_PER_CHUNK_AREA],
+            overlay_mask: vec![0u8; OVERLAY_MASK_WIRE_BYTES],
+            height: vec![0i32; CELLS_PER_CHUNK_AREA],
+            region,
+        };
+        assert_eq!(set.chunk_pos(), ChunkPos { x: 2, z: -1 });
+        let chunk = set.into_chunk();
+        assert_eq!(chunk.underlay[3 * 16 + 2], Material::Water);
+        assert_eq!(
+            chunk.underlay[0],
+            Material::Void,
+            "unknown byte clamps to Void"
+        );
+        assert_eq!(chunk.region[1], 7);
+    }
+
+    #[test]
+    fn set_chunk_decodes_overlay_mask_as_le_words() {
+        // 512-byte mask plane; cell 1's word set to 0xBEEF (LE bytes EF BE).
+        let mut overlay_mask = vec![0u8; OVERLAY_MASK_WIRE_BYTES];
+        overlay_mask[2] = 0xEF;
+        overlay_mask[3] = 0xBE;
+        let set = SetChunk {
+            chunk_x: 0,
+            chunk_z: 0,
+            underlay: Vec::new(),
+            overlay: Vec::new(),
+            overlay_mask,
+            height: Vec::new(),
+            region: Vec::new(),
+        };
+        let chunk = set.into_chunk();
+        assert_eq!(chunk.overlay_mask[0], 0);
+        assert_eq!(chunk.overlay_mask[1], 0xBEEF);
+        assert_eq!(OVERLAY_MASK_WIRE_BYTES, 512, "SUB=4 → 256*16/8 bytes");
+    }
+
+    #[test]
+    fn set_chunk_pads_short_planes_and_truncates_long() {
+        let set = SetChunk {
+            chunk_x: 0,
+            chunk_z: 0,
+            underlay: vec![Material::Grass.to_u8(); 2], // short → rest Void
+            overlay: vec![0u8; CELLS_PER_CHUNK_AREA + 10], // long → truncated
+            overlay_mask: Vec::new(),
+            height: vec![5i32; 1],
+            region: Vec::new(),
+        };
+        let chunk = set.into_chunk();
+        assert_eq!(chunk.underlay[0], Material::Grass);
+        assert_eq!(chunk.underlay[1], Material::Grass);
+        assert_eq!(chunk.underlay[2], Material::Void);
+        assert_eq!(chunk.height[0], 5);
+        assert_eq!(chunk.height[1], 0);
+    }
+
+    #[test]
+    fn world_bytes_roundtrip() {
+        let mut world = World::new();
+        world.insert_region(
+            1,
+            Region {
+                name: "meadow".into(),
+                default_material: Material::Grass,
+            },
+        );
+        world.insert_region(
+            2,
+            Region {
+                name: "shore".into(),
+                default_material: Material::Sand,
+            },
+        );
+        let mut a = Chunk::empty();
+        a.underlay[0] = Material::Stone;
+        a.overlay[5] = Material::Water;
+        a.overlay_mask[5] = 0x0F0F;
+        a.height[10] = -42;
+        a.region[20] = 2;
+        world.insert_chunk(ChunkPos { x: 1, z: -3 }, a);
+        let mut b = Chunk::empty();
+        b.underlay[255] = Material::Dirt;
+        world.insert_chunk(ChunkPos { x: -7, z: 4 }, b);
+
+        let bytes = world.to_bytes();
+        let decoded = World::from_bytes(&bytes).expect("roundtrip decodes");
+
+        // Structural equality across the whole world.
+        assert_eq!(decoded.regions, world.regions);
+        assert_eq!(
+            decoded.chunk(ChunkPos { x: 1, z: -3 }),
+            world.chunk(ChunkPos { x: 1, z: -3 })
+        );
+        assert_eq!(
+            decoded.chunk(ChunkPos { x: -7, z: 4 }),
+            world.chunk(ChunkPos { x: -7, z: 4 })
+        );
+    }
+
+    #[test]
+    fn from_bytes_rejects_truncated_and_bad_version() {
+        assert_eq!(World::from_bytes(&[]), Err(WorldDecodeError::Truncated));
+        assert_eq!(
+            World::from_bytes(&[9]),
+            Err(WorldDecodeError::BadVersion(9))
+        );
+        // Version + a region count claiming one region, but no region bytes.
+        let mut buf = vec![WORLD_FORMAT_VERSION];
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        assert_eq!(World::from_bytes(&buf), Err(WorldDecodeError::Truncated));
+    }
+
+    #[test]
+    fn insert_region_ignores_zero_and_grows_table() {
+        let mut world = World::new();
+        world.insert_region(
+            0,
+            Region {
+                name: "ignored".into(),
+                default_material: Material::Grass,
+            },
+        );
+        // id 0 is the no-region sentinel — table stays empty, so a cell
+        // pointing at region 1 finds no default and reads Void.
+        let mut chunk = Chunk::empty();
+        chunk.region[0] = 1;
+        world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
+        assert_eq!(world.underlay(cell(0, 0)), Material::Void);
+
+        // Inserting id 3 grows the table to length 3 (ids 1,2 padded
+        // empty); a cell pointing at region 3 resolves its default.
+        world.insert_region(
+            3,
+            Region {
+                name: "third".into(),
+                default_material: Material::Stone,
+            },
+        );
+        let mut chunk3 = Chunk::empty();
+        chunk3.region[0] = 3;
+        world.insert_chunk(ChunkPos { x: 1, z: 0 }, chunk3);
+        assert_eq!(world.underlay(cell(16, 0)), Material::Stone);
+    }
+}


### PR DESCRIPTION
Closes #2636.

## Summary

Adds the pure data layer for a chunked world in `aether-kit`: cells are addresses, and what a cell *is* lives in a stack of property planes over the cell lattice, chunked 16x16 cells. No actor, no rendering (that is the follow-up #2637).

- `CellPos` / `ChunkPos` with arithmetic-shift chunk derivation (floors on negative cells — the intended lattice tiling), cell-center octimeter anchoring, and `rem_euclid` chunk indexing.
- `Material` — a `#[repr(u8)]` domain enum that rides the wire as a raw byte inside a `Bytes` plane, never as a schema enum (one canonical plane form); unknown bytes degrade to `Void`.
- `Chunk` — struct-of-arrays over five row-major planes: `underlay` (cascade-resolved), `overlay` (raw) + `overlay_mask` (a `SUB x SUB` subcell coverage bitmask, reserved; wire length derived from the `SUB` constant by formula, not hard-coded), `height`, `region`.
- `World` — a sparse `BTreeMap` chunk set plus a positional region table with the underlay cascade (cell underlay -> region default -> Void).
- Wire kinds `aether.kit.world.{set_chunk,set_region,load}` and a hand-rolled compact little-endian world encoding backing `world.load`.

The `set_region` kind (and `World::insert_region`) beyond the original two-kind sketch is a deliberate completion: the underlay cascade needs a region-table default to resolve to, and there was otherwise no mail path to populate it — a region table you cannot populate is dead machinery.

## Test plan

Owned-logic unit tests only (per `docs/guide/testing.md`): underlay cascade resolution (cell override / region default / Void), `overlay` never cascades, negative-coordinate arithmetic-shift math for `chunk` / `from_octimeters` / chunk indexing, cell-center anchoring, sparse-world defaults, `SetChunk` plane decode (material clamp, short/long padding), `overlay_mask` little-endian word decode, `insert_region` (id-0 sentinel + positional growth), and the `to_bytes` / `from_bytes` round-trip plus truncation / bad-version rejection. No derived-constant mirrors, no derive-only round-trips.

## Generated by

`/implement` — agent execution of scoped issue #2636.
