### PR TITLE
docs(kit): describe granularity presets and the plane split in their own terms

### DIFF
--- a/crates/aether-kit/src/runtime/locomotion.rs
+++ b/crates/aether-kit/src/runtime/locomotion.rs
@@ -40,8 +40,8 @@
 //! glides there at `SPEED_OCTIMETERS_PER_TICK`, snaps, and re-commits.
 //! One dial spans the whole feel:
 //!
-//! - `cell = 256` (a full tile) — classic tile-to-tile, `RuneScape`-like
-//!   cadence; the mover rests on tile centers.
+//! - `cell = 256` (a full tile) — classic tile-to-tile cadence; the
+//!   mover rests on tile centers.
 //! - smaller cells — the mover lands on sub-tiles (halves, quarters, …).
 //! - `cell = 8` (one tick of travel) — it re-commits every tick, so
 //!   direction is free and it reads as continuous glide.

--- a/crates/aether-kit/src/world.rs
+++ b/crates/aether-kit/src/world.rs
@@ -28,7 +28,7 @@
 //!
 //! # Ground fabric — underlay / overlay
 //!
-//! Two material planes, RuneScape-style:
+//! Two material planes:
 //!
 //! - [`Chunk::underlay`] — the ground fabric. This is what the region
 //!   cascade resolves ([`World::underlay`]): the cell's own underlay if


### PR DESCRIPTION
Rewrites two rustdoc comments in aether-kit to state their design intrinsically instead of by external comparison: the granularity-preset note in `runtime/locomotion.rs` and the plane-split intro in `world.rs`. Comment-only change, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
