### PR TITLE
feat(kit): widget theme — shared visual tokens without cascade

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -16,7 +16,10 @@
 //! kind lives in [`mesh`]. The [`world`] module holds the chunked world
 //! plane stack — the `World` / `Chunk` / `Material` data layer and its
 //! `aether.kit.world.{set_chunk,set_region,set_smoothing_profile,set_view_mode,load}` wire kinds
-//! — that `WorldView` meshes to the render sink.
+//! — that `WorldView` meshes to the render sink. The [`theme`] module
+//! holds the widget-tier visual tokens — the `Theme` struct,
+//! `WidgetState`, the `Theme::fill` state-overlay compositor, and the
+//! `aether.kit.widget.set_theme` live-restyle kind.
 //!
 //! # Units
 //!
@@ -38,8 +41,10 @@ use serde::{Deserialize, Serialize};
 
 pub mod camera;
 pub mod mesh;
+pub mod theme;
 pub mod world;
 
+pub use theme::{SetTheme, Theme, WidgetState};
 pub use world::{
     CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk, ChunkPos, Material, Region,
     SetChunk, SetRegion, SetSmoothingProfile, SetViewMode, SmoothingProfile, ViewMode, World,

--- a/crates/aether-kit/src/theme.rs
+++ b/crates/aether-kit/src/theme.rs
@@ -1,0 +1,243 @@
+//! Widget theme trunk types: a flat value of named visual tokens the
+//! widget tier draws from instead of per-site color / metric literals.
+//! [`Theme`] carries palette roles, interaction-state overlays, and
+//! spacing/font metrics; it rides data-down through the two channels
+//! the actor model already has — a widget's spawn `Config` embeds it,
+//! and [`SetTheme`] re-fans it down live. There is no cascade, no
+//! selectors, and no ambient ctx-carried theme: a one-off widget look
+//! is an explicit override field in that widget's own config, not a
+//! resolution rule here.
+//!
+//! [`Theme::fill`] is the one piece of owned logic — it composites an
+//! interaction-state overlay over a base role color, so restyling a
+//! role (e.g. `accent`) restyles its hover/pressed looks for free and
+//! no widget invents an ad-hoc pressed color.
+
+use serde::{Deserialize, Serialize};
+
+/// Per-frame local interaction state a widget is in. Never serialized
+/// — it's derived fresh each frame from input, not carried on the
+/// wire. Passed by value to [`Theme::fill`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WidgetState {
+    Normal,
+    Hover,
+    Pressed,
+    Disabled,
+}
+
+/// Convert one 8-bit sRGB channel to a linear-space float via the same
+/// approximate `channel²` transfer the world mesher uses
+/// (`crates/aether-kit/src/runtime/mesher/style.rs`, `hsl_to_linear_rgb`):
+/// `(channel / 255)²`.
+const fn srgb_channel_to_linear(channel: u8) -> f32 {
+    let c = channel as f32 / 255.0;
+    c * c
+}
+
+/// The shared visual language every widget draws from: palette role
+/// tokens, interaction-state overlays, and spacing/font metrics. A
+/// flat value, not a styling system — resolving a widget's actual draw
+/// color is always an explicit `theme.fill(theme.some_role, state)`
+/// call at the draw site, never implicit lookup or cascade.
+///
+/// Schema-only (no `Kind`): `Theme` is only ever a nested field inside
+/// a widget's `Config` or inside [`SetTheme`], never a top-level mail
+/// payload on its own, mirroring the established nested-struct
+/// precedent `SolidQuad`
+/// (`crates/aether-capabilities/src/render/kinds.rs`).
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Theme {
+    /// Base background fill — panel / window backdrop.
+    pub surface: [f32; 4],
+    /// A surface lifted one step above `surface` — cards, rows,
+    /// raised panels within a panel.
+    pub surface_raised: [f32; 4],
+    /// Borders, dividers, and control outlines.
+    pub outline: [f32; 4],
+    /// Primary text and iconography.
+    pub text_primary: [f32; 4],
+    /// De-emphasized text — captions, disabled labels, hints.
+    pub text_muted: [f32; 4],
+    /// The interactive / highlight role — buttons, active track
+    /// fills, selection.
+    pub accent: [f32; 4],
+    /// Text/iconography drawn on top of an `accent`-filled surface.
+    pub accent_text: [f32; 4],
+    /// Role-agnostic lift composited over a base color on
+    /// [`WidgetState::Hover`] — a subtle white brighten.
+    pub hover_overlay: [f32; 4],
+    /// Role-agnostic press composited over a base color on
+    /// [`WidgetState::Pressed`] — a subtle black darken.
+    pub pressed_overlay: [f32; 4],
+    /// Alpha multiplier applied to a base color on
+    /// [`WidgetState::Disabled`].
+    pub disabled_alpha: f32,
+    /// Inner padding, in pixels, a widget reserves between its
+    /// border and its content.
+    pub pad: f32,
+    /// Spacing, in pixels, between sibling widgets in a layout.
+    pub gap: f32,
+    /// Height, in pixels, of one widget row (sliders, buttons,
+    /// labeled rows).
+    pub row_height: f32,
+    /// Font size, in pixels, for a widget's label text.
+    pub label_size_pixels: f32,
+    /// Font size, in pixels, for a widget's value text (e.g. a
+    /// slider's live numeric readout).
+    pub value_size_pixels: f32,
+    /// Session-scoped font id to draw label/value text with.
+    /// Placeholder `0` here — the panel root stamps the real id
+    /// once its `load_font_result` arrives.
+    pub font_id: u32,
+}
+
+impl Theme {
+    /// Resolve a widget's actual draw color: `base` unchanged for
+    /// [`WidgetState::Normal`]; `hover_overlay` / `pressed_overlay`
+    /// alpha-composited over `base` as standard src-over (the overlay
+    /// as source, `base`'s own alpha preserved — overlays shift
+    /// color/luminance, they never punch holes in an opaque surface)
+    /// for `Hover` / `Pressed`; `base`'s alpha scaled by
+    /// `disabled_alpha` for `Disabled`.
+    #[must_use]
+    pub fn fill(&self, base: [f32; 4], state: WidgetState) -> [f32; 4] {
+        match state {
+            WidgetState::Normal => base,
+            WidgetState::Hover => Self::composite_over(base, self.hover_overlay),
+            WidgetState::Pressed => Self::composite_over(base, self.pressed_overlay),
+            WidgetState::Disabled => [base[0], base[1], base[2], base[3] * self.disabled_alpha],
+        }
+    }
+
+    /// Standard src-over blend of `overlay` atop `base`, preserving
+    /// `base`'s own alpha channel: each RGB channel lerps toward the
+    /// overlay's channel by the overlay's alpha.
+    fn composite_over(base: [f32; 4], overlay: [f32; 4]) -> [f32; 4] {
+        let a = overlay[3];
+        [
+            (overlay[0] - base[0]).mul_add(a, base[0]),
+            (overlay[1] - base[1]).mul_add(a, base[1]),
+            (overlay[2] - base[2]).mul_add(a, base[2]),
+            base[3],
+        ]
+    }
+
+    /// The compiled-in default theme, seeded from the settled
+    /// workbench chrome palette (the Moor-family dark UI). Overlay
+    /// and metric defaults are neutral starting points, free to tune
+    /// during widget-set bring-up.
+    pub const DEFAULT: Self = Self {
+        // `#191b15` — workbench `--bg`.
+        surface: [
+            srgb_channel_to_linear(0x19),
+            srgb_channel_to_linear(0x1b),
+            srgb_channel_to_linear(0x15),
+            1.0,
+        ],
+        // `#20231b` — workbench `--panel`.
+        surface_raised: [
+            srgb_channel_to_linear(0x20),
+            srgb_channel_to_linear(0x23),
+            srgb_channel_to_linear(0x1b),
+            1.0,
+        ],
+        // `#32362a` — workbench `--line`.
+        outline: [
+            srgb_channel_to_linear(0x32),
+            srgb_channel_to_linear(0x36),
+            srgb_channel_to_linear(0x2a),
+            1.0,
+        ],
+        // `#e6e4d6` — workbench `--ink`.
+        text_primary: [
+            srgb_channel_to_linear(0xe6),
+            srgb_channel_to_linear(0xe4),
+            srgb_channel_to_linear(0xd6),
+            1.0,
+        ],
+        // `#9aa08c` — workbench `--dim`.
+        text_muted: [
+            srgb_channel_to_linear(0x9a),
+            srgb_channel_to_linear(0xa0),
+            srgb_channel_to_linear(0x8c),
+            1.0,
+        ],
+        // `#a8c97a` — workbench `--accent`.
+        accent: [
+            srgb_channel_to_linear(0xa8),
+            srgb_channel_to_linear(0xc9),
+            srgb_channel_to_linear(0x7a),
+            1.0,
+        ],
+        // `#191b15` — dark ink on the light accent (= `surface`).
+        accent_text: [
+            srgb_channel_to_linear(0x19),
+            srgb_channel_to_linear(0x1b),
+            srgb_channel_to_linear(0x15),
+            1.0,
+        ],
+        hover_overlay: [1.0, 1.0, 1.0, 0.08],
+        pressed_overlay: [0.0, 0.0, 0.0, 0.12],
+        disabled_alpha: 0.4,
+        pad: 8.0,
+        gap: 6.0,
+        row_height: 24.0,
+        label_size_pixels: 14.0,
+        value_size_pixels: 14.0,
+        font_id: 0,
+    };
+}
+
+/// `aether.kit.widget.set_theme` — re-fan a live theme change down to
+/// a panel root's widget children. Fire-and-forget; because the
+/// widget surface redraws every tick (immediate mode), the next frame
+/// draws with the new tokens — one frame of restyle latency, no
+/// invalidation.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.set_theme")]
+pub struct SetTheme {
+    pub theme: Theme,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fill_normal_is_identity() {
+        // Tripwire: Normal must return the base color untouched — no
+        // overlay, no alpha scaling.
+        let theme = Theme::DEFAULT;
+        let base = [0.2, 0.4, 0.6, 0.8];
+        assert_eq!(theme.fill(base, WidgetState::Normal), base);
+    }
+
+    #[test]
+    fn fill_hover_composites_overlay_src_over_preserving_base_alpha() {
+        // Tripwire: Hover blends hover_overlay over base as src-over —
+        // each RGB channel lerps toward the overlay by the overlay's
+        // alpha, and base's own alpha survives untouched.
+        let theme = Theme {
+            hover_overlay: [1.0, 0.0, 0.0, 0.5],
+            ..Theme::DEFAULT
+        };
+        let base = [0.0, 1.0, 0.0, 1.0];
+        assert_eq!(theme.fill(base, WidgetState::Hover), [0.5, 0.5, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn fill_disabled_scales_only_alpha() {
+        // Tripwire: Disabled must scale the alpha channel by
+        // disabled_alpha and leave RGB untouched.
+        let theme = Theme {
+            disabled_alpha: 0.4,
+            ..Theme::DEFAULT
+        };
+        let base = [0.1, 0.2, 0.3, 1.0];
+        assert_eq!(
+            theme.fill(base, WidgetState::Disabled),
+            [0.1, 0.2, 0.3, 0.4]
+        );
+    }
+}


### PR DESCRIPTION
Closes #2661.

## Summary

Widget styling as a theme value, not a styling system: one flat `Theme` struct of named role tokens in `crates/aether-kit/src/theme.rs` — seven palette roles, hover/pressed overlays plus a disabled alpha applied through `Theme::fill(base, state)` (src-over composite preserving base alpha), and spacing/font metrics. `Theme` is Schema-only (it rides nested inside widget configs, the `SolidQuad` precedent); `SetTheme` (`aether.kit.widget.set_theme`) is the Kind the panel root fans down for live restyle. `Theme::DEFAULT` seeds from the settled chrome palette through the same channel-squared sRGB-to-linear transfer the mesher's style path uses. No cascade, no selectors, no ambient inheritance — a one-off widget look is an explicit override field in that widget's own config.

## Test plan

Three tripwires on the one piece of owned logic, `Theme::fill`: normal state is identity, hover composites the overlay src-over while preserving base alpha, disabled scales only alpha. `cargo nextest run -p aether-kit` green (84/84); clippy `-D warnings` clean.

## Generated by

`/implement` — agent execution of [scoped issue #2661](https://github.com/iamacoffeepot/aether/issues/2661).
