### PR TITLE
feat(kinds): mouse button identity, release, and wheel input kinds

### DIFF
--- a/crates/aether-capabilities/src/input/mod.rs
+++ b/crates/aether-capabilities/src/input/mod.rs
@@ -49,7 +49,9 @@ use aether_actor::actor;
 // gate, for every `#[handler]` parameter type the moved `#[runtime] impl`
 // declares — including these five stream-event kinds, not just the
 // subscribe/unsubscribe family.
-use aether_kinds::{Key, KeyRelease, MouseButton, MouseMove, WindowSize};
+use aether_kinds::{
+    Key, KeyRelease, MouseButton, MouseButtonRelease, MouseMove, MouseWheel, WindowSize,
+};
 
 /// `aether.input` cap **identity** (ADR-0122 identity/runtime split). A
 /// ZST carrying only the addressing — the `Addressable` / `HandlesKind`
@@ -66,9 +68,9 @@ use aether_kinds::{Key, KeyRelease, MouseButton, MouseMove, WindowSize};
 ///    table on the runtime state. Reply target: the original sender.
 ///
 /// 2. **Input events** (`Key`, `KeyRelease`, `MouseMove`,
-///    `MouseButton`, `WindowSize`) — pushed by the chassis driver
-///    after each platform event; the cap fans out one mail per
-///    subscriber. Fire-and-forget; no reply.
+///    `MouseButton`, `MouseButtonRelease`, `MouseWheel`, `WindowSize`) —
+///    pushed by the chassis driver after each platform event; the cap
+///    fans out one mail per subscriber. Fire-and-forget; no reply.
 #[actor(singleton)]
 pub struct InputCapability;
 

--- a/crates/aether-capabilities/src/input/runtime.rs
+++ b/crates/aether-capabilities/src/input/runtime.rs
@@ -5,8 +5,9 @@
 //! single `use runtime::*` glob in the parent.
 
 use super::{
-    InputCapability, Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, SubscribeInputSelf,
-    UnsubscribeAll, UnsubscribeInput, UnsubscribeInputSelf, WindowSize,
+    InputCapability, Key, KeyRelease, MouseButton, MouseButtonRelease, MouseMove, MouseWheel,
+    SubscribeInput, SubscribeInputSelf, UnsubscribeAll, UnsubscribeInput, UnsubscribeInputSelf,
+    WindowSize,
 };
 use aether_actor::runtime;
 
@@ -239,9 +240,26 @@ impl NativeActor for InputCapability {
         state.fanout(ctx, &payload);
     }
 
-    /// Mouse-press fan-out. Empty payload.
+    /// Mouse-press fan-out.
     #[handler]
     fn on_mouse_button(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: MouseButton) {
+        state.fanout(ctx, &payload);
+    }
+
+    /// Mouse-release fan-out (paired with [`MouseButton`] for
+    /// press-move-release drag).
+    #[handler]
+    fn on_mouse_button_release(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: MouseButtonRelease,
+    ) {
+        state.fanout(ctx, &payload);
+    }
+
+    /// Mouse-wheel fan-out.
+    #[handler]
+    fn on_mouse_wheel(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: MouseWheel) {
         state.fanout(ctx, &payload);
     }
 

--- a/crates/aether-capabilities/src/ui/mod.rs
+++ b/crates/aether-capabilities/src/ui/mod.rs
@@ -30,7 +30,7 @@ pub use kinds::{UiBar, UiButton, UiClicked, UiLabel, UiPanel};
 // `ui-runtime` runtime gate, so they reference these kinds from here. The
 // widget kinds (`UiPanel` / `UiBar` / `UiLabel`) resolve through the `pub
 // use kinds::{…}` re-export above.
-use aether_kinds::{MouseButton, MouseMove, Tick};
+use aether_kinds::{MouseButton, Tick};
 
 // The struct-hosted `#[actor(singleton)]` below stays always-on (the macro
 // divides what it emits). Everything that names an `aether_substrate` type —

--- a/crates/aether-capabilities/src/ui/runtime.rs
+++ b/crates/aether-capabilities/src/ui/runtime.rs
@@ -49,8 +49,6 @@ pub struct ButtonRect {
 /// within a tick.
 #[derive(Default)]
 pub struct UiCapabilityState {
-    /// Latest cursor position from `MouseMove`, window pixels.
-    pub cursor: [f32; 2],
     /// Buttons recorded during the in-progress frame.
     pub current: Vec<ButtonRect>,
     /// Buttons from the last completed frame — the hit-test set.
@@ -63,12 +61,11 @@ pub struct UiCapabilityState {
 use super::UiCapability;
 use super::kinds::{UiBar, UiButton, UiClicked, UiLabel, UiPanel};
 use aether_actor::runtime;
-use aether_kinds::{MouseButton, MouseMove, Tick};
+use aether_kinds::{MouseButton, Tick, mouse_button};
 #[runtime]
 impl NativeActor for UiCapability {
     /// The runtime state this identity boots into (ADR-0122 split): the
-    /// state-bearing struct holding the cursor position and button-rect
-    /// double-buffer.
+    /// state-bearing struct holding the button-rect double-buffer.
     type State = UiCapabilityState;
 
     type Config = ();
@@ -82,14 +79,14 @@ impl NativeActor for UiCapability {
         Ok(UiCapabilityState::default())
     }
 
-    /// Subscribe the cursor + click streams and the frame edge.
+    /// Subscribe the click stream and the frame edge.
     ///
-    /// Mirrors the kit's input-subscription pattern: `MouseMove` /
-    /// `MouseButton` through `aether.input`, `Tick` through
+    /// Mirrors the kit's input-subscription pattern: `MouseButton`
+    /// through `aether.input` (which now carries the cursor position, so
+    /// no separate `MouseMove` subscription is needed), `Tick` through
     /// `aether.lifecycle`. The subscriptions survive `replace` (the
     /// mailbox id is stable) and clear on drop.
     fn wire(_state: &mut Self::State, ctx: &mut NativeCtx<'_>) {
-        ctx.actor::<InputCapability>().subscribe::<MouseMove>();
         ctx.actor::<InputCapability>().subscribe::<MouseButton>();
         ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
     }
@@ -215,29 +212,21 @@ impl NativeActor for UiCapability {
         ctx.actor::<TextCapability>().send(&label);
     }
 
-    /// Cache the cursor position.
-    ///
-    /// # Agent
-    /// Fire-and-forget. Updates the latest cursor used by the next
-    /// `on_mouse_button` hit-test. No forwarded mail.
-    #[handler]
-    fn on_mouse_move(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: MouseMove) {
-        state.cursor = [mail.x, mail.y];
-    }
-
     /// Hit-test a left-click against the last frame's buttons.
     ///
     /// # Agent
-    /// Fire-and-forget. Tests the cached cursor against the last
-    /// completed frame's button rects, topmost-wins (later-drawn
-    /// buttons paint on top, so it scans in reverse draw order), and
-    /// on a hit sends `UiClicked { id }` to that button's recorded
-    /// owner by id. A click outside every rect does nothing. v1: the
-    /// mouse-button stream has no button discriminant or release, so
-    /// this fires on left-press only.
+    /// Fire-and-forget. Filters to the left button, then tests the
+    /// press position carried on the payload against the last completed
+    /// frame's button rects, topmost-wins (later-drawn buttons paint on
+    /// top, so it scans in reverse draw order), and on a hit sends
+    /// `UiClicked { id }` to that button's recorded owner by id. A click
+    /// outside every rect, or a non-left button, does nothing.
     #[handler]
-    fn on_mouse_button(state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: MouseButton) {
-        let [cursor_x, cursor_y] = state.cursor;
+    fn on_mouse_button(state: &mut Self::State, ctx: &mut NativeCtx<'_>, mail: MouseButton) {
+        if mail.button != mouse_button::LEFT {
+            return;
+        }
+        let (cursor_x, cursor_y) = (mail.x, mail.y);
         let target = state
             .last
             .iter()
@@ -281,7 +270,7 @@ mod tests {
 
     use super::UiCapability;
     use super::UiCapabilityState;
-    use super::{MouseButton, MouseMove, Tick, UiBar, UiButton, UiClicked, UiLabel, UiPanel};
+    use super::{MouseButton, Tick, UiBar, UiButton, UiClicked, UiLabel, UiPanel, mouse_button};
     use crate::render::DrawSolidQuads;
     use crate::text::DrawText;
     use aether_substrate::testing::test_mailer_and_rx;
@@ -548,8 +537,15 @@ mod tests {
         let mut ctx = make_ctx(&binding, component_sender(42));
         UiCapability::on_button(&mut state, &mut ctx, button(7, [10.0, 10.0, 100.0, 40.0]));
         UiCapability::on_tick(&mut state, &mut ctx, Tick);
-        UiCapability::on_mouse_move(&mut state, &mut ctx, MouseMove { x: 50.0, y: 25.0 });
-        UiCapability::on_mouse_button(&mut state, &mut ctx, MouseButton);
+        UiCapability::on_mouse_button(
+            &mut state,
+            &mut ctx,
+            MouseButton {
+                button: mouse_button::LEFT,
+                x: 50.0,
+                y: 25.0,
+            },
+        );
         let (recipient, clicked) = recv_clicked(&binding, &rx);
         assert_eq!(recipient, MailboxId(42), "clicked routes to the owner");
         assert_eq!(clicked.id, 7, "clicked carries the button id");
@@ -562,9 +558,16 @@ mod tests {
         let mut ctx = make_ctx(&binding, component_sender(42));
         UiCapability::on_button(&mut state, &mut ctx, button(7, [10.0, 10.0, 100.0, 40.0]));
         UiCapability::on_tick(&mut state, &mut ctx, Tick);
-        // Cursor outside the rect (right of x + width).
-        UiCapability::on_mouse_move(&mut state, &mut ctx, MouseMove { x: 200.0, y: 25.0 });
-        UiCapability::on_mouse_button(&mut state, &mut ctx, MouseButton);
+        // Press outside the rect (right of x + width).
+        UiCapability::on_mouse_button(
+            &mut state,
+            &mut ctx,
+            MouseButton {
+                button: mouse_button::LEFT,
+                x: 200.0,
+                y: 25.0,
+            },
+        );
         assert_no_clicked(&binding, &rx);
     }
 
@@ -583,9 +586,16 @@ mod tests {
             button(2, [50.0, 50.0, 100.0, 100.0]),
         );
         UiCapability::on_tick(&mut state, &mut ctx_b, Tick);
-        // Cursor inside both rects.
-        UiCapability::on_mouse_move(&mut state, &mut ctx_b, MouseMove { x: 60.0, y: 60.0 });
-        UiCapability::on_mouse_button(&mut state, &mut ctx_b, MouseButton);
+        // Press inside both rects.
+        UiCapability::on_mouse_button(
+            &mut state,
+            &mut ctx_b,
+            MouseButton {
+                button: mouse_button::LEFT,
+                x: 60.0,
+                y: 60.0,
+            },
+        );
         let (recipient, clicked) = recv_clicked(&binding, &rx);
         assert_eq!(
             recipient,

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -15,6 +15,7 @@ extern crate alloc;
 
 pub mod descriptors;
 pub mod keycode;
+pub mod mouse_button;
 pub mod text_metrics;
 pub mod trace;
 // First-party native `#[transform]`s (ADR-0048, issue 1464). Native-only
@@ -433,24 +434,53 @@ pub struct KeyRelease {
     pub code: u32,
 }
 
-/// A mouse-button press. No payload today — which button isn't tracked.
-/// Zero-sized but derives `Pod` / `Zeroable` for the same reason as
-/// `Tick` — see the note on that type.
+/// A mouse-button press. `button` identifies which button via the
+/// `mouse_button` constant space (`LEFT` / `RIGHT` / `MIDDLE` / …);
+/// `x` / `y` carry the cursor position at press time in window
+/// coordinates, matching `MouseMove` — so a click event is
+/// self-contained and needs no external cursor correlation. Omits `Eq`
+/// because the `f32` fields make it non-`Eq`, same as `MouseMove`.
 #[repr(C)]
 #[derive(
-    Copy,
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    Pod,
-    Zeroable,
-    aether_data::Kind,
-    aether_data::Schema,
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_data::Kind, aether_data::Schema,
 )]
 #[kind(name = "aether.mouse_button")]
-pub struct MouseButton;
+pub struct MouseButton {
+    pub button: u32,
+    pub x: f32,
+    pub y: f32,
+}
+
+/// Release counterpart of `MouseButton`. Dispatched once per button
+/// release, carrying the same `button` code the press carried and the
+/// cursor position at release time. Components tracking press-move-release
+/// drag pair subscription to both kinds so they can commit on release.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.mouse_button_release")]
+pub struct MouseButtonRelease {
+    pub button: u32,
+    pub x: f32,
+    pub y: f32,
+}
+
+/// A mouse-wheel scroll. `delta_x` / `delta_y` carry the scroll amount
+/// (line deltas normalized to pixels by the driver); `x` / `y` carry the
+/// cursor position at scroll time in window coordinates, so wheel-zoom-at-
+/// cursor needs no external cursor correlation.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.mouse_wheel")]
+pub struct MouseWheel {
+    pub delta_x: f32,
+    pub delta_y: f32,
+    pub x: f32,
+    pub y: f32,
+}
 
 /// Cursor position in window coordinates, as logical pixels cast to f32.
 #[repr(C)]

--- a/crates/aether-kinds/src/mouse_button.rs
+++ b/crates/aether-kinds/src/mouse_button.rs
@@ -1,0 +1,20 @@
+//! Stable identifiers for mouse buttons, carried in `MouseButton.button`
+//! and `MouseButtonRelease.button`. These are the engine's own named u32
+//! space — decoupled from winit's `MouseButton` discriminants, the same
+//! way `keycode` decouples from winit's `KeyCode`.
+//!
+//! The substrate maps `winit::event::MouseButton → u32` via the constants
+//! below; components match on these constants. Unmapped buttons (winit's
+//! `Other(n)`) produce no mail, mirroring the unmapped-key contract in
+//! `keycode`.
+
+/// Primary button — the left button on a right-handed mouse.
+pub const LEFT: u32 = 0;
+/// Secondary button — the right button on a right-handed mouse.
+pub const RIGHT: u32 = 1;
+/// Middle button — usually the scroll-wheel click.
+pub const MIDDLE: u32 = 2;
+/// Back button — the thumb button that navigates backward.
+pub const BACK: u32 = 3;
+/// Forward button — the thumb button that navigates forward.
+pub const FORWARD: u32 = 4;

--- a/crates/aether-kit/src/runtime/locomotion.rs
+++ b/crates/aether-kit/src/runtime/locomotion.rs
@@ -81,7 +81,9 @@ use aether_capabilities::render::{Camera, DrawTriangle, Vertex};
 use aether_capabilities::{
     InputCapability, LifecycleCapability, RenderCapability, UiBar, UiCapability, UiPanel,
 };
-use aether_kinds::{Key, KeyRelease, MouseButton, MouseMove, Render, Tick, WindowSize, keycode};
+use aether_kinds::{
+    Key, KeyRelease, MouseButton, MouseMove, Render, Tick, WindowSize, keycode, mouse_button,
+};
 use aether_math::{Mat4, Vec3};
 
 use crate::arena::{Arena, HH, HW, SUB, ShapeClass};
@@ -452,8 +454,12 @@ impl WasmActor for Locomotion {
     }
 
     #[handler]
-    fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, _mail: MouseButton) {
-        self.click_to_move();
+    fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, mail: MouseButton) {
+        // Left-click paths the avatar; other buttons are ignored so a
+        // right-click no longer moves it.
+        if mail.button == mouse_button::LEFT {
+            self.click_to_move();
+        }
     }
 
     #[handler]

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -27,8 +27,9 @@ use aether_data::Kind;
 use aether_data::{encode, encode_empty, mailbox_id_from_name};
 use aether_kinds::{
     CaptureFrameResult, FocusWindow, FocusWindowResult, Key, KeyRelease, LifecycleAdvanceComplete,
-    MouseButton, MouseMove, Quit, SetWindowMode, SetWindowModeResult, SetWindowTitle,
-    SetWindowTitleResult, Tick, WindowMode, WindowSize, keycode,
+    MouseButton, MouseButtonRelease, MouseMove, MouseWheel, Quit, SetWindowMode,
+    SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, Tick, WindowMode, WindowSize,
+    keycode, mouse_button,
 };
 use aether_substrate::actor::native::local;
 // Only the unit tests name the `Envelope` (aka `OwnedDispatch`) type now —
@@ -52,7 +53,7 @@ use aether_substrate::{
     mail::{Mail, MailId, MailboxId},
 };
 use winit::application::ApplicationHandler;
-use winit::event::{ElementState, WindowEvent};
+use winit::event::{ElementState, MouseButton as WinitMouseButton, MouseScrollDelta, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use winit::keyboard::{KeyCode, PhysicalKey};
 use winit::monitor::{MonitorHandle, VideoModeHandle};
@@ -103,8 +104,15 @@ pub struct App {
     kind_key: aether_data::KindId,
     kind_key_release: aether_data::KindId,
     kind_mouse_button: aether_data::KindId,
+    kind_mouse_button_release: aether_data::KindId,
+    kind_mouse_wheel: aether_data::KindId,
     kind_mouse_move: aether_data::KindId,
     kind_window_size: aether_data::KindId,
+    /// Last cursor position seen in a `CursorMoved` event, in window
+    /// coordinates. Stamped onto each button / wheel event so a click or
+    /// scroll carries its location without the consumer correlating a
+    /// separate `MouseMove`.
+    last_cursor: (f32, f32),
     /// Cloned out of `RenderCapability::handles()` before the cap
     /// moves into the chassis builder. The app holds a clone so
     /// `Gpu::new` can install wgpu state and the per-frame loop can
@@ -391,6 +399,39 @@ fn parse_wxh(s: &str) -> Result<(u32, u32), String> {
         .parse()
         .map_err(|e| format!("invalid height {h:?}: {e}"))?;
     Ok((w, h))
+}
+
+/// Scroll lines are normalized to pixels at this rate. A tuning knob,
+/// not cap config — the wheel kind carries pixel-space deltas so a
+/// consumer never sees the winit line/pixel distinction.
+const PIXELS_PER_SCROLL_LINE: f32 = 40.0;
+
+/// Map winit's mouse button to the engine's `mouse_button` constant
+/// space. `Other(n)` maps to `None` — the caller pushes no mail,
+/// mirroring the unmapped-key contract in `keycode`.
+fn map_mouse_button(button: WinitMouseButton) -> Option<u32> {
+    match button {
+        WinitMouseButton::Left => Some(mouse_button::LEFT),
+        WinitMouseButton::Right => Some(mouse_button::RIGHT),
+        WinitMouseButton::Middle => Some(mouse_button::MIDDLE),
+        WinitMouseButton::Back => Some(mouse_button::BACK),
+        WinitMouseButton::Forward => Some(mouse_button::FORWARD),
+        WinitMouseButton::Other(_) => None,
+    }
+}
+
+/// Normalize a winit scroll delta to pixel-space `(delta_x, delta_y)`.
+/// Line deltas scale by `PIXELS_PER_SCROLL_LINE`; pixel deltas cast
+/// `f64 → f32` directly, matching the `CursorMoved` position cast.
+fn normalize_wheel(delta: MouseScrollDelta) -> (f32, f32) {
+    match delta {
+        MouseScrollDelta::LineDelta(x, y) => {
+            (x * PIXELS_PER_SCROLL_LINE, y * PIXELS_PER_SCROLL_LINE)
+        }
+        // Realistic scroll deltas stay well inside f32 mantissa.
+        #[allow(clippy::cast_possible_truncation)]
+        MouseScrollDelta::PixelDelta(p) => (p.x as f32, p.y as f32),
+    }
 }
 
 /// Find a `VideoModeHandle` on `monitor` matching the given size +
@@ -1297,26 +1338,50 @@ impl ApplicationHandler<UserEvent> for App {
                     }
                 }
             }
-            WindowEvent::MouseInput {
-                state: ElementState::Pressed,
-                ..
-            } => {
-                self.push_chassis_root(
-                    self.input_mailbox,
-                    self.kind_mouse_button,
-                    encode_empty::<MouseButton>(),
-                    1,
-                );
+            WindowEvent::MouseInput { state, button, .. } => {
+                // winit's `Other(n)` buttons map to no engine constant and
+                // produce no mail, mirroring the unmapped-key contract.
+                if let Some(button) = map_mouse_button(button) {
+                    let (x, y) = self.last_cursor;
+                    match state {
+                        ElementState::Pressed => {
+                            self.push_chassis_root(
+                                self.input_mailbox,
+                                self.kind_mouse_button,
+                                encode(&MouseButton { button, x, y }),
+                                1,
+                            );
+                        }
+                        ElementState::Released => {
+                            self.push_chassis_root(
+                                self.input_mailbox,
+                                self.kind_mouse_button_release,
+                                encode(&MouseButtonRelease { button, x, y }),
+                                1,
+                            );
+                        }
+                    }
+                }
+            }
+            WindowEvent::MouseWheel { delta, .. } => {
+                let (delta_x, delta_y) = normalize_wheel(delta);
+                let (x, y) = self.last_cursor;
+                let payload = encode(&MouseWheel {
+                    delta_x,
+                    delta_y,
+                    x,
+                    y,
+                });
+                self.push_chassis_root(self.input_mailbox, self.kind_mouse_wheel, payload, 1);
             }
             WindowEvent::CursorMoved { position, .. } => {
                 // winit reports cursor position as f64; the input wire
                 // kind carries f32. Realistic window sizes (< 2^20 px)
                 // stay well inside f32 mantissa.
                 #[allow(clippy::cast_possible_truncation)]
-                let payload = encode(&MouseMove {
-                    x: position.x as f32,
-                    y: position.y as f32,
-                });
+                let (x, y) = (position.x as f32, position.y as f32);
+                self.last_cursor = (x, y);
+                let payload = encode(&MouseMove { x, y });
                 self.push_chassis_root(self.input_mailbox, self.kind_mouse_move, payload, 1);
             }
             _ => {}
@@ -1415,6 +1480,14 @@ impl DriverCapability for DesktopDriverCapability {
             .registry
             .kind_id(MouseButton::NAME)
             .expect("MouseButton registered");
+        let kind_mouse_button_release = boot
+            .registry
+            .kind_id(MouseButtonRelease::NAME)
+            .expect("MouseButtonRelease registered");
+        let kind_mouse_wheel = boot
+            .registry
+            .kind_id(MouseWheel::NAME)
+            .expect("MouseWheel registered");
         let kind_mouse_move = boot
             .registry
             .kind_id(MouseMove::NAME)
@@ -1493,8 +1566,11 @@ impl DriverCapability for DesktopDriverCapability {
             kind_key,
             kind_key_release,
             kind_mouse_button,
+            kind_mouse_button_release,
+            kind_mouse_wheel,
             kind_mouse_move,
             kind_window_size,
+            last_cursor: (0.0, 0.0),
             render_handles,
             capture_queue,
             outbound: Arc::clone(&boot.outbound),
@@ -1574,11 +1650,56 @@ mod tests {
     // in fixtures — reference id derivation, not sibling-cap addressing.
     #![allow(clippy::disallowed_methods)]
     use super::*;
+    use winit::dpi::PhysicalPosition;
 
     #[test]
     fn to_boot_title_none_returns_default() {
         // Unset title → "aether" default.
         assert_eq!(WindowConfig::default().to_boot_title(), "aether");
+    }
+
+    #[test]
+    fn map_mouse_button_covers_named_buttons() {
+        assert_eq!(
+            map_mouse_button(WinitMouseButton::Left),
+            Some(mouse_button::LEFT)
+        );
+        assert_eq!(
+            map_mouse_button(WinitMouseButton::Right),
+            Some(mouse_button::RIGHT)
+        );
+        assert_eq!(
+            map_mouse_button(WinitMouseButton::Middle),
+            Some(mouse_button::MIDDLE)
+        );
+        assert_eq!(
+            map_mouse_button(WinitMouseButton::Back),
+            Some(mouse_button::BACK)
+        );
+        assert_eq!(
+            map_mouse_button(WinitMouseButton::Forward),
+            Some(mouse_button::FORWARD)
+        );
+    }
+
+    #[test]
+    fn map_mouse_button_other_produces_no_mail() {
+        assert_eq!(map_mouse_button(WinitMouseButton::Other(9)), None);
+    }
+
+    #[test]
+    fn normalize_wheel_scales_line_delta() {
+        let (x, y) = normalize_wheel(MouseScrollDelta::LineDelta(1.0, -2.0));
+        assert_eq!(x, PIXELS_PER_SCROLL_LINE);
+        assert_eq!(y, -2.0 * PIXELS_PER_SCROLL_LINE);
+    }
+
+    #[test]
+    fn normalize_wheel_passes_pixel_delta_through() {
+        let delta = MouseScrollDelta::PixelDelta(PhysicalPosition::new(12.0, -3.0));
+        let (x, y) = normalize_wheel(delta);
+        assert_eq!(x, 12.0);
+        assert_eq!(y, -3.0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #2657.

## Summary

The mouse vocabulary gains what drag needs: `MouseButton` widens in place to `{ button: u32, x: f32, y: f32 }` (press event, same `aether.mouse_button` name), `MouseButtonRelease` mirrors it the way `KeyRelease` mirrors `Key`, and `MouseWheel { delta_x, delta_y, x, y }` joins in the same PR. Button codes live in a new `mouse_button` const module beside `keycode`; winit `Other(n)` buttons produce no mail, mirroring the unmapped-key contract. Press/release carry the cached cursor position, so click-only consumers no longer subscribe the highest-frequency stream just to learn where the click landed — the ui cap's cursor-cache workaround is retired on exactly that basis, its hit-test now gating on `mouse_button::LEFT` (making the documented left-press-only contract true for right clicks), and kit locomotion's click-to-path gains the same filter. The desktop driver translates both element states plus wheel (line deltas normalized at `PIXELS_PER_SCROLL_LINE`), and the input cap fans the two new kinds out through its existing per-kind handlers.

## Test plan

Unit tests on the two pieces of new owned logic — the winit button map and the wheel normalization (4 driver tests) — plus the ui cap's 3 hit-test tests retargeted to the fielded payload. Deliberate deviation from the scoped plan, flagged for review: the plan's TestBench drag scenario was not added — TestBench injects mail straight to the `aether.input` mailbox, bypassing the driver translation that is the net-new logic, and the fanout path it would re-prove is already covered end-to-end by `input_subscriptions.rs`; adding it would need new fixture kinds to assert what the `Key` round-trip already establishes generically.

## Generated by

`/implement` — agent execution of [scoped issue #2657](https://github.com/iamacoffeepot/aether/issues/2657).
