### PR TITLE
feat(kinds): typed character, ime preedit, and modifier input kinds

### DIFF
--- a/crates/aether-capabilities/src/input/mod.rs
+++ b/crates/aether-capabilities/src/input/mod.rs
@@ -1,6 +1,7 @@
 //! `aether.input` cap. Owns the ADR-0021 publish/subscribe routing
 //! table for substrate input streams (`Key`, `KeyRelease`,
-//! `MouseMove`, `MouseButton`, `WindowSize`).
+//! `MouseMove`, `MouseButton`, `MouseButtonRelease`, `MouseWheel`,
+//! `WindowSize`, `TextInput`, `ImePreedit`, `Modifiers`).
 //!
 //! `Tick` is not an input stream: it is a frame-lifecycle stage
 //! (`aether.lifecycle.tick`) a component subscribes directly on
@@ -47,10 +48,11 @@ use aether_actor::actor;
 // at module root too: `#[actor]` emits `impl HandlesKind<K> for
 // InputCapability {}` markers always-on, outside the `feature = "runtime"`
 // gate, for every `#[handler]` parameter type the moved `#[runtime] impl`
-// declares — including these five stream-event kinds, not just the
+// declares — including these ten stream-event kinds, not just the
 // subscribe/unsubscribe family.
 use aether_kinds::{
-    Key, KeyRelease, MouseButton, MouseButtonRelease, MouseMove, MouseWheel, WindowSize,
+    ImePreedit, Key, KeyRelease, Modifiers, MouseButton, MouseButtonRelease, MouseMove, MouseWheel,
+    TextInput, WindowSize,
 };
 
 /// `aether.input` cap **identity** (ADR-0122 identity/runtime split). A
@@ -68,9 +70,10 @@ use aether_kinds::{
 ///    table on the runtime state. Reply target: the original sender.
 ///
 /// 2. **Input events** (`Key`, `KeyRelease`, `MouseMove`,
-///    `MouseButton`, `MouseButtonRelease`, `MouseWheel`, `WindowSize`) —
-///    pushed by the chassis driver after each platform event; the cap
-///    fans out one mail per subscriber. Fire-and-forget; no reply.
+///    `MouseButton`, `MouseButtonRelease`, `MouseWheel`, `WindowSize`,
+///    `TextInput`, `ImePreedit`, `Modifiers`) — pushed by the chassis
+///    driver after each platform event; the cap fans out one mail per
+///    subscriber. Fire-and-forget; no reply.
 #[actor(singleton)]
 pub struct InputCapability;
 

--- a/crates/aether-capabilities/src/input/runtime.rs
+++ b/crates/aether-capabilities/src/input/runtime.rs
@@ -5,9 +5,9 @@
 //! single `use runtime::*` glob in the parent.
 
 use super::{
-    InputCapability, Key, KeyRelease, MouseButton, MouseButtonRelease, MouseMove, MouseWheel,
-    SubscribeInput, SubscribeInputSelf, UnsubscribeAll, UnsubscribeInput, UnsubscribeInputSelf,
-    WindowSize,
+    ImePreedit, InputCapability, Key, KeyRelease, Modifiers, MouseButton, MouseButtonRelease,
+    MouseMove, MouseWheel, SubscribeInput, SubscribeInputSelf, TextInput, UnsubscribeAll,
+    UnsubscribeInput, UnsubscribeInputSelf, WindowSize,
 };
 use aether_actor::runtime;
 
@@ -266,6 +266,24 @@ impl NativeActor for InputCapability {
     /// Window-resize fan-out.
     #[handler]
     fn on_window_size(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: WindowSize) {
+        state.fanout(ctx, &payload);
+    }
+
+    /// Committed text-input fan-out (layout/IME-resolved characters).
+    #[handler]
+    fn on_text_input(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: TextInput) {
+        state.fanout(ctx, &payload);
+    }
+
+    /// In-flight IME-composition fan-out.
+    #[handler]
+    fn on_ime_preedit(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: ImePreedit) {
+        state.fanout(ctx, &payload);
+    }
+
+    /// Modifier-state fan-out (latest-wins chord state).
+    #[handler]
+    fn on_modifiers(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: Modifiers) {
         state.fanout(ctx, &payload);
     }
 }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -520,6 +520,97 @@ pub struct WindowSize {
     pub height: u32,
 }
 
+/// Committed, layout-resolved text input (`aether.text_input`) — one or
+/// more characters the user typed, already translated through the active
+/// keyboard layout and IME. Published by the desktop chassis from two
+/// winit sources deduped by a composition gate: `KeyEvent.text` when no
+/// IME composition is active, and `Ime::Commit` when one is, so a
+/// character is never delivered twice. Unlike `Key` (a physical-scancode
+/// edge event), this stream forwards key repeats — holding a key types a
+/// run of characters. A text-field widget subscribes this and inserts
+/// `text` at its caret with no guest-side scancode keymap. Headless and
+/// hub chassis never publish — they have no window (same as `Key`).
+///
+/// Carries a `String`, so it rides the structured wire path
+/// (`Kind::encode_into_bytes` → `encode_wire`), not the `#[repr(C)]`
+/// cast path `Key` / `KeyRelease` use.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    aether_data::Kind,
+    aether_data::Schema,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[kind(name = "aether.text_input")]
+pub struct TextInput {
+    pub text: String,
+}
+
+/// In-flight IME composition (`aether.ime_preedit`) — the underlined,
+/// not-yet-committed text a component renders inline while the user
+/// composes. Mirrors winit's `Ime::Preedit(String, Option<(usize,
+/// usize)>)`: `cursor_begin` / `cursor_end` are byte offsets into `text`
+/// marking the cursor/selection span the IME reports (both `None` when
+/// the IME gives no span). Empty `text` means the composition was
+/// cleared — the widget drops any preedit it was showing. Published by
+/// the desktop chassis only. Rides the structured wire path.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    aether_data::Kind,
+    aether_data::Schema,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[kind(name = "aether.ime_preedit")]
+pub struct ImePreedit {
+    pub text: String,
+    pub cursor_begin: Option<u32>,
+    pub cursor_end: Option<u32>,
+}
+
+/// Latest-wins keyboard modifier state (`aether.modifiers`) — the chord
+/// keys currently held. Published by the desktop chassis on every
+/// `WindowEvent::ModifiersChanged`, following the same caching contract
+/// `WindowSize` documents: a component subscribes, caches the latest
+/// value, and consults it when it receives a `Key` (e.g. to tell Ctrl+C
+/// from a bare C). Named bool fields rather than a packed bit mask so a
+/// machine consumer reading the JSON schema sees `{ "shift": true }`
+/// directly. `meta` is the platform "super" key — Command on macOS, the
+/// Windows key elsewhere. A late subscriber holds the all-false default
+/// until the first `ModifiersChanged` arrives — the same warm-up every
+/// stream has. Carries `bool`s, so it rides the structured wire path.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    aether_data::Kind,
+    aether_data::Schema,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[kind(name = "aether.modifiers")]
+// Four named bool fields are the wire contract: a machine consumer reads
+// `{ "shift": true }` off the JSON schema directly rather than decoding a
+// packed bit mask. A two-variant-enum refactor would defeat that.
+#[allow(clippy::struct_excessive_bools)]
+pub struct Modifiers {
+    pub shift: bool,
+    pub ctrl: bool,
+    pub alt: bool,
+    pub meta: bool,
+}
+
 // The render cap's drawing/texture kinds — `Vertex` / `DrawTriangle` /
 // `DRAW_TRIANGLE_BYTES` / `Camera` and the `aether.render.*` texture +
 // quad family — moved to `aether_capabilities::render::kinds` (ADR-0121,

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -26,10 +26,10 @@ use aether_capabilities::RenderHandles;
 use aether_data::Kind;
 use aether_data::{encode, encode_empty, mailbox_id_from_name};
 use aether_kinds::{
-    CaptureFrameResult, FocusWindow, FocusWindowResult, Key, KeyRelease, LifecycleAdvanceComplete,
-    MouseButton, MouseButtonRelease, MouseMove, MouseWheel, Quit, SetWindowMode,
-    SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, Tick, WindowMode, WindowSize,
-    keycode, mouse_button,
+    CaptureFrameResult, FocusWindow, FocusWindowResult, ImePreedit, Key, KeyRelease,
+    LifecycleAdvanceComplete, Modifiers, MouseButton, MouseButtonRelease, MouseMove, MouseWheel,
+    Quit, SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, TextInput,
+    Tick, WindowMode, WindowSize, keycode, mouse_button,
 };
 use aether_substrate::actor::native::local;
 // Only the unit tests name the `Envelope` (aka `OwnedDispatch`) type now —
@@ -53,7 +53,9 @@ use aether_substrate::{
     mail::{Mail, MailId, MailboxId},
 };
 use winit::application::ApplicationHandler;
-use winit::event::{ElementState, MouseButton as WinitMouseButton, MouseScrollDelta, WindowEvent};
+use winit::event::{
+    ElementState, Ime, MouseButton as WinitMouseButton, MouseScrollDelta, WindowEvent,
+};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use winit::keyboard::{KeyCode, PhysicalKey};
 use winit::monitor::{MonitorHandle, VideoModeHandle};
@@ -108,11 +110,21 @@ pub struct App {
     kind_mouse_wheel: aether_data::KindId,
     kind_mouse_move: aether_data::KindId,
     kind_window_size: aether_data::KindId,
+    kind_text_input: aether_data::KindId,
+    kind_ime_preedit: aether_data::KindId,
+    kind_modifiers: aether_data::KindId,
     /// Last cursor position seen in a `CursorMoved` event, in window
     /// coordinates. Stamped onto each button / wheel event so a click or
     /// scroll carries its location without the consumer correlating a
     /// separate `MouseMove`.
     last_cursor: (f32, f32),
+    /// Composition gate for the text-input stream. `true` while an IME
+    /// composition is active (a non-empty `Ime::Preedit` opened it,
+    /// `Ime::Commit` / `Ime::Disabled` / a synthetic empty `Preedit`
+    /// closes it). While composing, raw `KeyEvent.text` is suppressed so
+    /// a committed character is published once (via `Ime::Commit`), never
+    /// doubled. Driven by [`text_input_gate`].
+    composing: bool,
     /// Cloned out of `RenderCapability::handles()` before the cap
     /// moves into the chassis builder. The app holds a clone so
     /// `Gpu::new` can install wgpu state and the per-frame loop can
@@ -283,6 +295,51 @@ fn map_winit_keycode(k: KeyCode) -> Option<u32> {
         KeyCode::AltRight => keycode::KEY_ALT_RIGHT,
         _ => return None,
     })
+}
+
+/// A committed-text / composition signal lifted out of winit's event
+/// types so [`text_input_gate`]'s dedupe logic is unit-testable without
+/// a winit event loop — the same pure-helper factoring as
+/// [`map_winit_keycode`]. The desktop `KeyboardInput` / `Ime` arms
+/// translate their winit events into this before feeding the gate.
+enum TextSource {
+    /// A layout-resolved character run from `KeyEvent.text` on a physical
+    /// key press. Suppressed while an IME composition is active.
+    KeyText(String),
+    /// A `Ime::Preedit`. `active` is `true` for a non-empty preedit
+    /// (composition open) and `false` for the synthetic empty preedit
+    /// winit sends to clear it.
+    Preedit { active: bool },
+    /// A `Ime::Commit` — the composed string is final.
+    Commit(String),
+    /// A `Ime::Disabled` — composition ended without a commit.
+    Disabled,
+}
+
+/// Composition gate for the `TextInput` stream: update `composing` and
+/// return the text to publish (`Some`) or nothing (`None`). The bug it
+/// guards is a character delivered twice — once as `KeyEvent.text`, once
+/// as `Ime::Commit` — when both fire for one keystroke: while a
+/// composition is open, `KeyText` is dropped and the commit is the single
+/// source of truth. `Preedit { active }` opens or closes the gate without
+/// publishing (the in-flight text rides `ImePreedit` instead); `Disabled`
+/// closes it. Winit-free so the dedupe is testable without a winit `App`.
+fn text_input_gate(composing: &mut bool, source: TextSource) -> Option<String> {
+    match source {
+        TextSource::KeyText(text) => (!*composing).then_some(text),
+        TextSource::Preedit { active } => {
+            *composing = active;
+            None
+        }
+        TextSource::Commit(text) => {
+            *composing = false;
+            Some(text)
+        }
+        TextSource::Disabled => {
+            *composing = false;
+            None
+        }
+    }
 }
 
 /// Desktop window boot knobs (ADR-0090 §1/§2 applied to the chassis's
@@ -1072,6 +1129,12 @@ impl ApplicationHandler<UserEvent> for App {
             }
         }
         let window = Arc::new(event_loop.create_window(attrs).expect("create_window"));
+        // Opt this window into IME event delivery. Most platforms send no
+        // `Ime` events (and therefore no composed/committed CJK text)
+        // unless the window has explicitly allowed IME. Candidate-window
+        // placement (`set_ime_cursor_area`) is deferred — its absence only
+        // floats the IME popup at a default position.
+        window.set_ime_allowed(true);
         self.gpu = Some(Gpu::new(
             Arc::clone(&window),
             self.render_handles.clone(),
@@ -1312,31 +1375,100 @@ impl ApplicationHandler<UserEvent> for App {
             }
             WindowEvent::KeyboardInput {
                 event: key_event, ..
-            } if !key_event.repeat => {
-                let Some(code) = (match key_event.physical_key {
-                    PhysicalKey::Code(k) => map_winit_keycode(k),
-                    PhysicalKey::Unidentified(_) => None,
-                }) else {
-                    return;
-                };
-                match key_event.state {
-                    ElementState::Pressed => {
-                        self.push_chassis_root(
-                            self.input_mailbox,
-                            self.kind_key,
-                            encode(&Key { code }),
-                            1,
-                        );
+            } => {
+                // Text path: publish the layout-resolved characters from
+                // `KeyEvent.text` when no IME composition is active. Repeats
+                // are forwarded here (holding a key types a run of
+                // characters), unlike the named-key edge path below.
+                if key_event.state == ElementState::Pressed
+                    && let Some(text) = &key_event.text
+                    && let Some(committed) =
+                        text_input_gate(&mut self.composing, TextSource::KeyText(text.to_string()))
+                {
+                    let payload = TextInput { text: committed }.encode_into_bytes();
+                    self.push_chassis_root(self.input_mailbox, self.kind_text_input, payload, 1);
+                }
+                // Named-key edge path: `Key` / `KeyRelease` keep their
+                // no-repeat contract and their `#[repr(C)]` cast payload.
+                if !key_event.repeat
+                    && let Some(code) = (match key_event.physical_key {
+                        PhysicalKey::Code(k) => map_winit_keycode(k),
+                        PhysicalKey::Unidentified(_) => None,
+                    })
+                {
+                    match key_event.state {
+                        ElementState::Pressed => {
+                            self.push_chassis_root(
+                                self.input_mailbox,
+                                self.kind_key,
+                                encode(&Key { code }),
+                                1,
+                            );
+                        }
+                        ElementState::Released => {
+                            self.push_chassis_root(
+                                self.input_mailbox,
+                                self.kind_key_release,
+                                encode(&KeyRelease { code }),
+                                1,
+                            );
+                        }
                     }
-                    ElementState::Released => {
+                }
+            }
+            WindowEvent::Ime(ime) => match ime {
+                Ime::Preedit(text, cursor) => {
+                    text_input_gate(
+                        &mut self.composing,
+                        TextSource::Preedit {
+                            active: !text.is_empty(),
+                        },
+                    );
+                    // winit reports the cursor span as byte offsets into
+                    // the preedit string (usize); the wire kind carries
+                    // u32. A preedit is a handful of characters, far inside
+                    // u32.
+                    #[allow(clippy::cast_possible_truncation)]
+                    let (cursor_begin, cursor_end) = match cursor {
+                        Some((begin, end)) => (Some(begin as u32), Some(end as u32)),
+                        None => (None, None),
+                    };
+                    let payload = ImePreedit {
+                        text,
+                        cursor_begin,
+                        cursor_end,
+                    }
+                    .encode_into_bytes();
+                    self.push_chassis_root(self.input_mailbox, self.kind_ime_preedit, payload, 1);
+                }
+                Ime::Commit(text) => {
+                    if let Some(committed) =
+                        text_input_gate(&mut self.composing, TextSource::Commit(text))
+                    {
+                        let payload = TextInput { text: committed }.encode_into_bytes();
                         self.push_chassis_root(
                             self.input_mailbox,
-                            self.kind_key_release,
-                            encode(&KeyRelease { code }),
+                            self.kind_text_input,
+                            payload,
                             1,
                         );
                     }
                 }
+                Ime::Disabled => {
+                    text_input_gate(&mut self.composing, TextSource::Disabled);
+                }
+                Ime::Enabled => {}
+            },
+            WindowEvent::ModifiersChanged(modifiers) => {
+                let state = modifiers.state();
+                let payload = Modifiers {
+                    shift: state.shift_key(),
+                    ctrl: state.control_key(),
+                    alt: state.alt_key(),
+                    meta: state.super_key(),
+                }
+                .encode_into_bytes();
+                self.push_chassis_root(self.input_mailbox, self.kind_modifiers, payload, 1);
             }
             WindowEvent::MouseInput { state, button, .. } => {
                 // winit's `Other(n)` buttons map to no engine constant and
@@ -1496,6 +1628,18 @@ impl DriverCapability for DesktopDriverCapability {
             .registry
             .kind_id(WindowSize::NAME)
             .expect("WindowSize registered");
+        let kind_text_input = boot
+            .registry
+            .kind_id(TextInput::NAME)
+            .expect("TextInput registered");
+        let kind_ime_preedit = boot
+            .registry
+            .kind_id(ImePreedit::NAME)
+            .expect("ImePreedit registered");
+        let kind_modifiers = boot
+            .registry
+            .kind_id(Modifiers::NAME)
+            .expect("Modifiers registered");
         let kind_set_window_mode = boot
             .registry
             .kind_id(SetWindowMode::NAME)
@@ -1570,7 +1714,11 @@ impl DriverCapability for DesktopDriverCapability {
             kind_mouse_wheel,
             kind_mouse_move,
             kind_window_size,
+            kind_text_input,
+            kind_ime_preedit,
+            kind_modifiers,
             last_cursor: (0.0, 0.0),
+            composing: false,
             render_handles,
             capture_queue,
             outbound: Arc::clone(&boot.outbound),
@@ -1656,6 +1804,62 @@ mod tests {
     fn to_boot_title_none_returns_default() {
         // Unset title → "aether" default.
         assert_eq!(WindowConfig::default().to_boot_title(), "aether");
+    }
+
+    // Tripwire: the composition gate must never publish a character twice.
+    // A plain keystroke with no IME active publishes its `KeyEvent.text`.
+    #[test]
+    fn gate_publishes_keytext_when_not_composing() {
+        let mut composing = false;
+        let out = text_input_gate(&mut composing, TextSource::KeyText("a".to_owned()));
+        assert_eq!(out.as_deref(), Some("a"));
+        assert!(!composing, "a bare keystroke opens no composition");
+    }
+
+    // Tripwire: while an IME composition is open, raw `KeyEvent.text` is
+    // suppressed — the commit is the single source of truth, so the
+    // committed character is not also emitted from the physical key.
+    #[test]
+    fn gate_suppresses_keytext_during_composition_and_commit_wins() {
+        let mut composing = false;
+        // A non-empty preedit opens the composition.
+        assert_eq!(
+            text_input_gate(&mut composing, TextSource::Preedit { active: true }),
+            None
+        );
+        assert!(composing);
+        // Raw key text arriving mid-composition is dropped.
+        assert_eq!(
+            text_input_gate(&mut composing, TextSource::KeyText("a".to_owned())),
+            None
+        );
+        // The commit publishes the composed text and closes the gate.
+        let out = text_input_gate(&mut composing, TextSource::Commit("\u{5416}".to_owned()));
+        assert_eq!(out.as_deref(), Some("\u{5416}"));
+        assert!(!composing, "commit closes the composition");
+    }
+
+    // Tripwire: text must not stay suppressed after a composition ends.
+    // The synthetic empty preedit and `Disabled` both clear `composing`,
+    // so a subsequent keystroke publishes again.
+    #[test]
+    fn gate_clears_composing_on_empty_preedit_and_disabled() {
+        let mut composing = true;
+        assert_eq!(
+            text_input_gate(&mut composing, TextSource::Preedit { active: false }),
+            None
+        );
+        assert!(!composing, "empty synthetic preedit clears the gate");
+
+        composing = true;
+        assert_eq!(text_input_gate(&mut composing, TextSource::Disabled), None);
+        assert!(!composing, "Disabled clears the gate");
+
+        // A keystroke after the clear publishes normally.
+        assert_eq!(
+            text_input_gate(&mut composing, TextSource::KeyText("z".to_owned())).as_deref(),
+            Some("z"),
+        );
     }
 
     #[test]

--- a/crates/aether-substrate-bundle/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-bundle/tests/input_subscriptions.rs
@@ -21,9 +21,9 @@ use aether_actor::Addressable;
 use aether_capabilities::input::{SubscribeInputResult, UnsubscribeInput};
 use aether_capabilities::{ComponentHostCapability, InputCapability};
 use aether_data::{Kind, KindId, MailboxId};
-use aether_kinds::{DropComponent, DropResult, Key, LoadComponent, LoadResult};
+use aether_kinds::{DropComponent, DropResult, Key, LoadComponent, LoadResult, TextInput};
 use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
-use aether_test_fixtures_kinds::KeyObserved;
+use aether_test_fixtures_kinds::{KeyObserved, TextInputObserved};
 use std::fs;
 
 /// Arbitrary key code for the synthetic `Key` events these tests inject.
@@ -123,6 +123,42 @@ fn empty_subscribers_means_no_delivery() {
         bench.count_observed(KeyObserved::NAME),
         0,
         "no probe loaded but key_observed was broadcast; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}
+
+/// A subscribed probe receives fanned-out `TextInput`. The plausible bug
+/// this guards: a new stream kind whose input-cap fan-out `#[handler]` is
+/// missing warn-drops silently at dispatch (the cap is a strict receiver),
+/// so a `TextInput`-subscribing widget would never see committed text.
+/// Injecting synthetic `TextInput` at `aether.input` and observing the
+/// probe's re-broadcast proves the `on_text_input` fan-out is wired.
+#[test]
+fn subscribed_component_receives_published_text_input() {
+    let Some(wasm_path) = require_runtime("aether_test_fixtures_bundle") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let _mbox = load_probe_named(&mut bench, &wasm_path, "typist");
+    let baseline = bench.count_observed(TextInputObserved::NAME);
+
+    bench
+        .execute(vec![(
+            "text",
+            BenchOp::send_mail(
+                "aether.input",
+                &TextInput {
+                    text: "hi".to_owned(),
+                },
+            ),
+        )])
+        .expect("text send sequence");
+
+    let delta = bench.count_observed(TextInputObserved::NAME) - baseline;
+    assert_eq!(
+        delta,
+        1,
+        "expected 1 text_input_observed broadcast; observed kinds: {:?}",
         bench.observed_kinds(),
     );
 }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/probe.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/probe.rs
@@ -65,10 +65,10 @@ use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::render::{DrawTriangle, Vertex};
 use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
-use aether_kinds::{Key, Tick};
+use aether_kinds::{Key, TextInput, Tick};
 use aether_test_fixtures_kinds::{
     ConfigEcho, ConfigQuery, KeyObserved, ProbeConfig, SetRender, TEST_BENCH_OBSERVER_MAILBOX_NAME,
-    TickObserved,
+    TextInputObserved, TickObserved,
 };
 
 pub struct Probe {
@@ -98,6 +98,7 @@ impl WasmActor for Probe {
     fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
         ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
         ctx.actor::<InputCapability>().subscribe::<Key>();
+        ctx.actor::<InputCapability>().subscribe::<TextInput>();
     }
 
     /// Counts ticks delivered to this mailbox; broadcasts the running
@@ -155,6 +156,22 @@ impl WasmActor for Probe {
         ctx.send_to_named::<KeyObserved>(
             TEST_BENCH_OBSERVER_MAILBOX_NAME,
             &KeyObserved { code: key.code },
+        );
+    }
+
+    /// Broadcasts a `text_input_observed` for each `TextInput` dispatch,
+    /// so the ADR-0021 round-trip scenario can assert the `aether.input`
+    /// cap fanned the committed-text stream out to a subscriber.
+    ///
+    /// # Agent
+    /// Not sent manually; the substrate's input fan-out fires it for
+    /// every `TextInput`-subscribed mailbox when text is committed.
+    /// Watch `receive_mail` for `aether.test_fixture.text_input_observed`.
+    #[handler]
+    fn on_text_input(&mut self, ctx: &mut WasmCtx<'_>, input: TextInput) {
+        ctx.send_to_named::<TextInputObserved>(
+            TEST_BENCH_OBSERVER_MAILBOX_NAME,
+            &TextInputObserved { text: input.text },
         );
     }
 

--- a/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
@@ -48,6 +48,19 @@ pub struct KeyObserved {
     pub code: u32,
 }
 
+/// Broadcast payload the probe emits on each `TextInput` dispatch,
+/// echoing the committed `text`. Lets the ADR-0021 input round-trip
+/// scenario assert the `aether.input` cap fanned a `TextInput` out to a
+/// subscriber — the guard for the new text-stream fan-out handler being
+/// wired up, mirroring how [`KeyObserved`] guards the `Key` fan-out.
+#[derive(
+    aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone,
+)]
+#[kind(name = "aether.test_fixture.text_input_observed")]
+pub struct TextInputObserved {
+    pub text: String,
+}
+
 /// Driver kind: scenarios send this to flip a probe fixture's render
 /// state. `visible == 0` halts the per-tick draw; any other value
 /// enables it. Cast-shape so encoding is just a memcpy of four

--- a/docs/guide/systems/input.md
+++ b/docs/guide/systems/input.md
@@ -51,6 +51,9 @@ the `InputCapability` actor — the sole owner of the subscriber table
 | `aether.mouse_move` | cursor movement |
 | `aether.mouse_button` | a mouse-button press |
 | `aether.window_size` | a resize |
+| `aether.text_input` | committed, layout-resolved characters (typing / IME commit) |
+| `aether.ime_preedit` | in-flight IME composition (the underlined text being composed) |
+| `aether.modifiers` | the held modifier keys changed (Shift / Ctrl / Alt / Meta) |
 
 **`Tick` lives on the lifecycle, not here.** The per-frame advance is the
 substrate's frame-lifecycle state machine (`aether.lifecycle.tick`), so a
@@ -91,6 +94,35 @@ instances.** A `replace_component` keeps the same mailbox id, so the new instanc
 inherits the old one's subscriptions with nothing to redo. A `drop` is the end of
 them — the component host mails `unsubscribe_all`, so a torn-down mailbox can't
 keep receiving fan-out.
+
+**Text entry rides its own streams.** `aether.key` carries a physical scancode —
+which key moved, not which character it produces — so a text field would need a
+keyboard-layout table and its own shift tracking to turn a keypress into a
+character, wrong on every layout but US and impossible for CJK input. The
+substrate already resolves the character through the active layout and IME, so a
+field consumes that directly on three streams:
+
+- **`aether.text_input { text }`** delivers committed characters — the text the
+  user actually entered, one or more per event, already layout- and IME-resolved.
+  A field inserts `text` at its caret. Unlike `Key`, this stream forwards key
+  repeats, so holding a key types a run of characters. The desktop chassis dedupes
+  its two sources (a plain keystroke and an IME commit) behind a composition gate,
+  so a character arrives exactly once.
+- **`aether.ime_preedit { text, cursor_begin, cursor_end }`** carries the in-flight
+  composition an IME is still assembling — the underlined text to render inline
+  while the user composes, with the byte-offset cursor span the IME reports (both
+  offsets `None` when it gives no span). An empty `text` clears the preedit.
+- **`aether.modifiers { shift, ctrl, alt, meta }`** is a latest-wins state stream:
+  it fires whenever the held modifier keys change, and a field caches the last
+  value and consults it on a `Key` (to tell Ctrl+C from a bare C). `meta` is the
+  platform "super" key — Command on macOS, the Windows key elsewhere. This mirrors
+  how a component caches `WindowSize`; a late subscriber holds the all-false
+  default until the first change arrives.
+
+Editing commands — backspace, arrows, enter, home, end — compose from the
+`aether.key` scancodes paired with the cached modifiers; there's no separate kind
+for them. These three streams come from the desktop chassis only; the headless and
+hub chassis have no window and publish none of them, the same as `Key`.
 
 ## How to use it
 


### PR DESCRIPTION
Closes #2658.

## Summary

Text entry becomes expressible: three new input kinds carry what the platform already resolved. `TextInput { text }` (`aether.text_input`) is committed, layout-resolved text — published from winit `KeyEvent.text` when no IME composition is active and from `Ime::Commit` when one is, deduped by a `composing` gate factored as a pure function; key repeats flow here while `Key` keeps its no-repeat contract untouched. `ImePreedit { text, cursor_begin, cursor_end }` mirrors winit's in-flight composition so a text field can render the underlined run. `Modifiers { shift, ctrl, alt, meta }` is a latest-wins state stream on `ModifiersChanged`, following the `WindowSize` caching precedent — named bools over a bitmask so the MCP schema self-describes. The desktop chassis enables IME at window creation; the input cap grows the three per-kind fan-out handlers (it is a strict receiver, so without them the new kinds would warn-drop at dispatch); `Key`/`KeyRelease` stay byte-for-byte untouched. The guide's input page gains the streams table and text-entry consumption contract.

## Test plan

Three unit tests on the composition gate (the owned dedupe logic: commit-vs-KeyEvent.text double-insert, cancelled-preedit text loss), two input-cap unit tests, and a `TextInput` round-trip added to the `input_subscriptions` TestBench harness (subscribe probe → inject at `aether.input` → assert observed broadcast), run end-to-end against the rebuilt wasm fixture. All winit 0.30.13 API names verified against the pinned crate source — no deltas.

## Generated by

`/implement` — agent execution of [scoped issue #2658](https://github.com/iamacoffeepot/aether/issues/2658).
