### PR TITLE
feat(kit): widget set — slider, text field, and radio group inline child actors

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -49,7 +49,11 @@ pub mod widgets;
 pub mod world;
 
 pub use theme::{SetTheme, Theme, WidgetState};
-pub use widgets::{Collect, WidgetChildSpec, WidgetConfig, WidgetDrawItem, WidgetDrawList};
+pub use widgets::{
+    ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, LabelConfig, PanelConfig,
+    RadioConfig, RadioSelected, SliderChanged, SliderConfig, TextCommitted, TextFieldConfig,
+    WidgetChildSpec, WidgetConfig, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+};
 pub use world::{
     CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk, ChunkPos, Material, Region,
     SetChunk, SetRegion, SetSmoothingProfile, SetViewMode, SmoothingProfile, ViewMode, World,

--- a/crates/aether-kit/src/runtime/focus.rs
+++ b/crates/aether-kit/src/runtime/focus.rs
@@ -1,0 +1,277 @@
+//! The focus-and-input routing a panel root embeds (issue 2660).
+//!
+//! [`Focus`] is the plain state the root-owned focus model carries: an
+//! ordered set of child entries (each a hit rect plus whether it can take
+//! keyboard focus), the currently focused child, and the drag-captured child.
+//! It does no mail and holds no capability handle — the root drives it,
+//! mirroring how [`Composite`](crate::runtime::composite::Composite) is the
+//! bookkeeping half of the draw protocol while the actor owns the sends.
+//!
+//! Widgets never subscribe to input themselves. The root subscribes the
+//! pointer and keyboard streams once, then asks [`Focus`] where each event
+//! goes: a pointer event to the drag-captured child if one holds capture, else
+//! to the topmost child under the cursor; a keyboard event to the focused
+//! child. Focus moves on a focusable hit or on Tab, and each move yields the
+//! `(previous, next)` pair the root turns into a `FocusLost` to the old holder
+//! and a `FocusGained` to the new one.
+//!
+//! Rects are window-pixel 2D, carried as a zero-depth [`Aabb`] (`z = 0`) so
+//! the hit test reuses `aether_math::Aabb::contains_point` rather than a
+//! hand-rolled bounds check.
+
+use alloc::vec::Vec;
+
+use aether_data::MailboxId;
+use aether_math::{Aabb, Vec3};
+
+/// The `(previous, next)` focus holders across a focus move: `previous` is the
+/// child that just lost focus (`None` if nothing was focused), `next` the one
+/// that just gained it (`None` if focus cleared). The root sends `FocusLost`
+/// to `previous` and `FocusGained` to `next`.
+pub type FocusTransition = (Option<MailboxId>, Option<MailboxId>);
+
+/// One child's hit rect and focus eligibility. `rect` is the child's
+/// window-pixel bounds (zero-depth), the same rect the root assigned it as a
+/// `WidgetFrame`; `focusable` is `false` for a widget that takes no keyboard
+/// input (a label), which the Tab cycle and focus-on-hit both skip.
+struct Entry {
+    child: MailboxId,
+    rect: Aabb,
+    focusable: bool,
+}
+
+/// The root's focus-and-input routing table: the child entries in registration
+/// (layout / Tab) order, plus the focused and drag-captured children. Rebuilt
+/// each spawn pass with [`Self::clear`] and [`Self::register`]; queried per
+/// input event.
+#[derive(Default)]
+pub struct Focus {
+    entries: Vec<Entry>,
+    focused: Option<MailboxId>,
+    capture: Option<MailboxId>,
+}
+
+impl Focus {
+    /// An empty routing table — no children, nothing focused or captured.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Drop every entry and clear the focused / captured children — the reset
+    /// a root runs before it re-registers its layout (e.g. a respawn).
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.focused = None;
+        self.capture = None;
+    }
+
+    /// Register a child's hit rect in layout order. `(x, y)` is the top-left
+    /// and `(width, height)` the size, in window pixels; `focusable` marks
+    /// whether Tab and focus-on-hit consider it. Registration order is Tab
+    /// order; draw / registration order is also the hit-test stack (a later
+    /// child sits on top of an earlier one where they overlap).
+    pub fn register(
+        &mut self,
+        child: MailboxId,
+        x: f32,
+        y: f32,
+        width: f32,
+        height: f32,
+        focusable: bool,
+    ) {
+        let rect = Aabb::from_min_max(Vec3::new(x, y, 0.0), Vec3::new(x + width, y + height, 0.0));
+        self.entries.push(Entry {
+            child,
+            rect,
+            focusable,
+        });
+    }
+
+    /// The topmost child whose rect contains `(x, y)`, or `None` if the point
+    /// is over no child. Topmost is the last-registered match, since a later
+    /// child draws over an earlier one.
+    #[must_use]
+    pub fn hit_test(&self, x: f32, y: f32) -> Option<MailboxId> {
+        let point = Vec3::new(x, y, 0.0);
+        self.entries
+            .iter()
+            .rev()
+            .find(|entry| entry.rect.contains_point(point))
+            .map(|entry| entry.child)
+    }
+
+    /// Where a pointer event routes: the drag-captured child if one holds
+    /// capture (so a drag that leaves the widget's rect still reaches it),
+    /// else the topmost child under the cursor.
+    #[must_use]
+    pub fn pointer_target(&self, x: f32, y: f32) -> Option<MailboxId> {
+        self.capture.or_else(|| self.hit_test(x, y))
+    }
+
+    /// Where a keyboard event routes: the focused child, or `None` if nothing
+    /// is focused.
+    #[must_use]
+    pub fn keyboard_target(&self) -> Option<MailboxId> {
+        self.focused
+    }
+
+    /// Begin drag capture on `child` — set by the root on a left press that
+    /// hits a widget, so subsequent moves route to it until release.
+    pub fn begin_capture(&mut self, child: MailboxId) {
+        self.capture = Some(child);
+    }
+
+    /// Clear drag capture — the root's response to the matching release.
+    pub fn clear_capture(&mut self) {
+        self.capture = None;
+    }
+
+    /// The drag-captured child, if any.
+    #[must_use]
+    pub fn captured(&self) -> Option<MailboxId> {
+        self.capture
+    }
+
+    /// Set focus to `next`, returning the `(previous, next)` transition when
+    /// it actually changed, or `None` when `next` already held focus (so the
+    /// root sends no redundant `FocusLost` / `FocusGained`).
+    pub fn set_focus(&mut self, next: Option<MailboxId>) -> Option<FocusTransition> {
+        if self.focused == next {
+            return None;
+        }
+        let previous = self.focused;
+        self.focused = next;
+        Some((previous, next))
+    }
+
+    /// Focus the topmost focusable child under `(x, y)`, returning the
+    /// transition when focus moved. A press over empty space or over a
+    /// non-focusable child (a label) leaves the current focus untouched.
+    pub fn focus_hit(&mut self, x: f32, y: f32) -> Option<FocusTransition> {
+        let point = Vec3::new(x, y, 0.0);
+        let hit = self
+            .entries
+            .iter()
+            .rev()
+            .find(|entry| entry.focusable && entry.rect.contains_point(point))
+            .map(|entry| entry.child)?;
+        self.set_focus(Some(hit))
+    }
+
+    /// Advance focus to the next focusable child in registration order,
+    /// wrapping — the Tab cycle. From no focus (or a focused child no longer
+    /// registered) it lands on the first focusable child; returns the
+    /// transition, or `None` when there is no focusable child to move to.
+    pub fn advance_focus(&mut self) -> Option<FocusTransition> {
+        let count = self.entries.len();
+        if count == 0 {
+            return None;
+        }
+        // Start scanning just past the current holder (or before the first
+        // entry when nothing is focused), wrapping once around the ring.
+        let start = self
+            .focused
+            .and_then(|current| self.entries.iter().position(|entry| entry.child == current))
+            .map_or(0, |index| index + 1);
+        for offset in 0..count {
+            let entry = &self.entries[(start + offset) % count];
+            if entry.focusable {
+                return self.set_focus(Some(entry.child));
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn focus_with_three() -> Focus {
+        let mut focus = Focus::new();
+        // Two focusable widgets and one non-focusable label, in Tab order.
+        focus.register(MailboxId(1), 0.0, 0.0, 10.0, 10.0, true);
+        focus.register(MailboxId(2), 0.0, 20.0, 10.0, 10.0, false); // a label
+        focus.register(MailboxId(3), 0.0, 40.0, 10.0, 10.0, true);
+        focus
+    }
+
+    #[test]
+    fn hit_test_picks_topmost_on_overlap() {
+        let mut focus = Focus::new();
+        // Two overlapping rects; the later registration draws on top, so it
+        // wins the hit where they overlap.
+        focus.register(MailboxId(1), 0.0, 0.0, 20.0, 20.0, true);
+        focus.register(MailboxId(2), 10.0, 10.0, 20.0, 20.0, true);
+        assert_eq!(
+            focus.hit_test(15.0, 15.0),
+            Some(MailboxId(2)),
+            "the later-registered (topmost) rect wins the overlap",
+        );
+        assert_eq!(
+            focus.hit_test(2.0, 2.0),
+            Some(MailboxId(1)),
+            "outside the top rect, the lower one is hit",
+        );
+        assert_eq!(focus.hit_test(50.0, 50.0), None, "empty space hits nothing");
+    }
+
+    #[test]
+    fn tab_wraps_in_registration_order_skipping_non_focusable() {
+        let mut focus = focus_with_three();
+        // From nothing, Tab lands on the first focusable.
+        assert_eq!(focus.advance_focus(), Some((None, Some(MailboxId(1)))));
+        // Next Tab skips the non-focusable label (id 2) and lands on id 3.
+        assert_eq!(
+            focus.advance_focus(),
+            Some((Some(MailboxId(1)), Some(MailboxId(3)))),
+        );
+        // Past the last focusable it wraps back to the first.
+        assert_eq!(
+            focus.advance_focus(),
+            Some((Some(MailboxId(3)), Some(MailboxId(1)))),
+        );
+    }
+
+    #[test]
+    fn capture_overrides_hit_for_pointer_routing() {
+        let mut focus = focus_with_three();
+        // With no capture, a pointer routes by hit test — a point over no
+        // child routes nowhere.
+        assert_eq!(focus.pointer_target(100.0, 100.0), None);
+        focus.begin_capture(MailboxId(1));
+        // Captured: every pointer routes to the captor regardless of position.
+        assert_eq!(focus.pointer_target(100.0, 100.0), Some(MailboxId(1)));
+        assert_eq!(focus.pointer_target(5.0, 45.0), Some(MailboxId(1)));
+        focus.clear_capture();
+        // Uncaptured: the point (5, 45) falls in id 3's rect (y 40..50).
+        assert_eq!(focus.pointer_target(5.0, 45.0), Some(MailboxId(3)));
+    }
+
+    #[test]
+    fn focus_hit_ignores_non_focusable_and_reports_the_pair() {
+        let mut focus = focus_with_three();
+        // A hit on the focusable id 1 focuses it.
+        assert_eq!(focus.focus_hit(5.0, 5.0), Some((None, Some(MailboxId(1)))));
+        // A hit on the label (id 2) does not steal focus — no transition.
+        assert_eq!(focus.focus_hit(5.0, 25.0), None);
+        assert_eq!(focus.keyboard_target(), Some(MailboxId(1)));
+        // A hit on the other focusable moves focus, reporting prev + next.
+        assert_eq!(
+            focus.focus_hit(5.0, 45.0),
+            Some((Some(MailboxId(1)), Some(MailboxId(3)))),
+        );
+    }
+
+    #[test]
+    fn set_focus_to_current_holder_is_a_no_op() {
+        let mut focus = focus_with_three();
+        focus.set_focus(Some(MailboxId(1)));
+        assert_eq!(
+            focus.set_focus(Some(MailboxId(1))),
+            None,
+            "re-focusing the current holder yields no transition",
+        );
+    }
+}

--- a/crates/aether-kit/src/runtime/mod.rs
+++ b/crates/aether-kit/src/runtime/mod.rs
@@ -22,17 +22,27 @@
 //!   these draws local and composites up so the whole subtree is one
 //!   render sender in structural draw order; its wire kinds live in
 //!   [`crate::widgets`] and its compositing bookkeeping in [`composite`].
+//! - The **widget set** (issue 2660): the five concrete widgets in
+//!   [`widgets`] ([`widgets::SliderWidget`], [`widgets::TextFieldWidget`],
+//!   [`widgets::RadioGroupWidget`], [`widgets::ButtonWidget`],
+//!   [`widgets::LabelWidget`]) spawned as inline children of the
+//!   reference [`widget_panel::WidgetPanel`] (export
+//!   `aether_kit@aether.kit.widget.panel`), which drives them through the
+//!   [`composite::Composite`] draw protocol and the [`focus::Focus`]
+//!   root-owned input model.
 //!
-//! `export!(Locomotion, CameraComponent, MeshViewer, WorldView, Widget)`
-//! lists the entry first; the macro emits the wasm32 FFI shims and the
-//! `aether.kinds` custom section for all five actors.
+//! `export!(Locomotion, …)` lists the entry first; the macro emits the wasm32
+//! FFI shims and the `aether.kinds` custom section for every listed actor.
 
 pub mod camera;
 pub mod composite;
+pub mod focus;
 pub mod locomotion;
 pub mod mesh_viewer;
 pub mod mesher;
 pub mod widget;
+pub mod widget_panel;
+pub mod widgets;
 pub mod world_view;
 
 pub use camera::CameraComponent;
@@ -40,6 +50,8 @@ pub use locomotion::Locomotion;
 pub use mesh_viewer::MeshViewer;
 pub use mesher::mesh_chunk;
 pub use widget::Widget;
+pub use widget_panel::WidgetPanel;
+pub use widgets::{ButtonWidget, LabelWidget, RadioGroupWidget, SliderWidget, TextFieldWidget};
 pub use world_view::WorldView;
 
 // `arena` (the hazard-field builder) keys its fixed-size scratch on the
@@ -47,4 +59,16 @@ pub use world_view::WorldView;
 // module root where `arena` imports them.
 pub(crate) use locomotion::{GRID_H, GRID_W};
 
-aether_actor::export!(Locomotion, CameraComponent, MeshViewer, WorldView, Widget);
+aether_actor::export!(
+    Locomotion,
+    CameraComponent,
+    MeshViewer,
+    WorldView,
+    Widget,
+    SliderWidget,
+    TextFieldWidget,
+    RadioGroupWidget,
+    ButtonWidget,
+    LabelWidget,
+    WidgetPanel
+);

--- a/crates/aether-kit/src/runtime/widget.rs
+++ b/crates/aether-kit/src/runtime/widget.rs
@@ -131,7 +131,7 @@ impl Widget {
 /// extra hop through the text cap lands its glyphs after the direct quad
 /// batch the same frame — the fills-under-labels layering the shipped
 /// `aether.ui` cap already relies on.
-fn emit(ctx: &mut WasmCtx<'_, Manual>, list: &WidgetDrawList) {
+pub(crate) fn emit(ctx: &mut WasmCtx<'_, Manual>, list: &WidgetDrawList) {
     let quads: Vec<SolidQuad> = list
         .items
         .iter()

--- a/crates/aether-kit/src/runtime/widget_panel.rs
+++ b/crates/aether-kit/src/runtime/widget_panel.rs
@@ -1,0 +1,518 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `runtime/widget.rs`).
+#![allow(clippy::needless_pass_by_value)]
+
+//! The reference panel root (issue 2660): the test vehicle, the copy-paste
+//! template a consumer forks, and the map-editor seam.
+//!
+//! It embeds the two helper structs the widget tier is built from —
+//! [`Composite`] (the ADR-0117 draw protocol's bookkeeping) and [`Focus`] (the
+//! root-owned focus-and-input model) — and ties them together:
+//!
+//! - **Spawn.** On its first frame it spawns a fixed vertical stack of inline
+//!   widgets (a label, a slider, a radio group, a text field, an apply
+//!   button), assigns each a [`WidgetFrame`] rect, and records that rect into
+//!   both [`Composite`] (to offset the child's draws) and [`Focus`] (to
+//!   hit-test and Tab-cycle it).
+//! - **Font.** In `wire` it loads a font through `aether.text` and, when the
+//!   `load_font_result` arrives, stamps the session-scoped `font_id` into its
+//!   [`Theme`] and re-fans it — the inline responsibility the theme module
+//!   hands the panel root.
+//! - **Input.** It subscribes the pointer / keyboard streams once (the input
+//!   cap) and the frame stage once (the lifecycle cap), then routes each event
+//!   through [`Focus`]: keyboard to the focused child, pointer to the hit or
+//!   drag-captured child, Tab to cycle focus, a left press to set focus + drag
+//!   capture. Focus transitions fan `FocusGained` / `FocusLost` down.
+//! - **Draw.** Each frame it drives [`Composite`] — `Collect` down, draw lists
+//!   up — and emits the whole panel as one `DrawSolidQuads` (plus text).
+//! - **Value.** Each value-up event (`SliderChanged` / `TextCommitted` /
+//!   `RadioSelected` / `ButtonClicked`), attributed by `ctx.source_mailbox()`,
+//!   is the seam a real editor translates into world-knob driver mail; the
+//!   reference logs it.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_actor::{
+    ActorInitError, Manual, OutboundReply, Subname, WasmActor, WasmCtx, WasmInitCtx, actor,
+};
+use aether_capabilities::input::InputMailboxExt;
+use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::text::{LoadFont, LoadFontResult};
+use aether_capabilities::{InputCapability, LifecycleCapability, TextCapability};
+use aether_data::MailboxId;
+use aether_kinds::keycode::KEY_TAB;
+use aether_kinds::mouse_button;
+use aether_kinds::{
+    ImePreedit, Key, KeyRelease, Modifiers, MouseButton, MouseButtonRelease, MouseMove, MouseWheel,
+    TextInput, Tick,
+};
+use aether_math::Vec2;
+
+use crate::runtime::composite::Composite;
+use crate::runtime::focus::{Focus, FocusTransition};
+use crate::runtime::widget::emit;
+use crate::runtime::widgets::{
+    ButtonWidget, LabelWidget, RadioGroupWidget, SliderWidget, TextFieldWidget, quad,
+};
+use crate::theme::{SetTheme, Theme};
+use crate::widgets::{
+    ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, LabelConfig, PanelConfig,
+    RadioConfig, RadioSelected, SliderChanged, SliderConfig, TextCommitted, TextFieldConfig,
+    WidgetDrawList, WidgetFrame,
+};
+
+/// One spawned child's alias plus the logical name the panel attributes its
+/// value-up events under (for the map-editor translation / logging).
+struct ChildRef {
+    id: MailboxId,
+    name: &'static str,
+}
+
+/// The reference panel root. Loaded as a component with a [`PanelConfig`]; its
+/// export name is `aether.kit.widget.panel`.
+pub struct WidgetPanel {
+    config: PanelConfig,
+    /// The live theme — `config.theme` with the real `font_id` stamped once
+    /// the font loads. Fanned down to every child on change.
+    theme: Theme,
+    composite: Composite,
+    focus: Focus,
+    children: Vec<ChildRef>,
+    spawned: bool,
+    /// The total stack height, for the background chrome; set at spawn.
+    panel_height: f32,
+}
+
+impl WidgetPanel {
+    /// Spawn the widget stack once (from the first frame — an inline child
+    /// gets no `wire` and `init` cannot spawn, so the root spawns from its
+    /// first send-capable handler). Each widget gets its rect in both the
+    /// composite layout table and the focus table, and its `WidgetFrame`.
+    fn ensure_spawned(&mut self, ctx: &mut WasmCtx<'_, Manual>) {
+        if self.spawned {
+            return;
+        }
+        self.spawned = true;
+
+        let x = self.config.x;
+        let width = self.config.width;
+        let row = self.theme.row_height;
+        let gap = self.theme.gap;
+        let mut y = self.config.y;
+
+        let row_rect = |y: f32, height: f32| WidgetFrame {
+            x,
+            y,
+            width,
+            height,
+        };
+
+        let label = LabelConfig {
+            text: String::from("Controls"),
+            theme: self.theme.clone(),
+        };
+        if let Some(id) = spawn::<LabelWidget>(ctx, "label", &label) {
+            self.place(ctx, id, row_rect(y, row), false, "label");
+        }
+        y += row + gap;
+
+        let slider = SliderConfig {
+            min: 0.0,
+            max: 255.0,
+            step: 1.0,
+            initial: 40.0,
+            theme: self.theme.clone(),
+        };
+        if let Some(id) = spawn::<SliderWidget>(ctx, "slider", &slider) {
+            self.place(ctx, id, row_rect(y, row), true, "slider");
+        }
+        y += row + gap;
+
+        let radio = RadioConfig {
+            options: alloc::vec![
+                String::from("Low"),
+                String::from("Medium"),
+                String::from("High"),
+            ],
+            initial_index: 0,
+            theme: self.theme.clone(),
+        };
+        let radio_height = row * 3.0;
+        if let Some(id) = spawn::<RadioGroupWidget>(ctx, "radio", &radio) {
+            self.place(ctx, id, row_rect(y, radio_height), true, "radio");
+        }
+        y += radio_height + gap;
+
+        let text_field = TextFieldConfig {
+            initial: String::new(),
+            max_chars: 32,
+            theme: self.theme.clone(),
+        };
+        if let Some(id) = spawn::<TextFieldWidget>(ctx, "text_field", &text_field) {
+            self.place(ctx, id, row_rect(y, row), true, "text_field");
+        }
+        y += row + gap;
+
+        let button = ButtonConfig {
+            label: String::from("Apply"),
+            theme: self.theme.clone(),
+        };
+        if let Some(id) = spawn::<ButtonWidget>(ctx, "button", &button) {
+            self.place(ctx, id, row_rect(y, row), true, "button");
+        }
+        y += row;
+
+        self.panel_height = y - self.config.y;
+    }
+
+    /// Record one spawned child's rect into the composite (as its draw offset)
+    /// and the focus table (as its hit rect), send it its `WidgetFrame`, and
+    /// remember it for value-up attribution.
+    fn place(
+        &mut self,
+        ctx: &mut WasmCtx<'_, Manual>,
+        id: MailboxId,
+        frame: WidgetFrame,
+        focusable: bool,
+        name: &'static str,
+    ) {
+        self.composite
+            .register_slot(id, Vec2::new(frame.x, frame.y));
+        self.focus
+            .register(id, frame.x, frame.y, frame.width, frame.height, focusable);
+        ctx.send_to(id, &frame);
+        self.children.push(ChildRef { id, name });
+    }
+
+    /// Discharge a closed frame: flatten the composite and emit it as the
+    /// panel's single render + text output.
+    fn finish(&mut self, ctx: &mut WasmCtx<'_, Manual>) {
+        let list = self.composite.flatten(None);
+        emit(ctx, &list);
+    }
+
+    /// Re-fan the live theme to every child (after a font stamp or a restyle).
+    fn fan_theme(&self, ctx: &mut WasmCtx<'_>) {
+        for child in &self.children {
+            ctx.send_to(
+                child.id,
+                &SetTheme {
+                    theme: self.theme.clone(),
+                },
+            );
+        }
+    }
+
+    /// The logical name of the child a value-up event came from, for
+    /// attribution.
+    fn child_name(&self, source: Option<MailboxId>) -> &'static str {
+        source
+            .and_then(|id| self.children.iter().find(|child| child.id == id))
+            .map_or("unknown", |child| child.name)
+    }
+}
+
+/// Send a focus transition down: `FocusLost` to the child that lost focus,
+/// `FocusGained` to the one that gained it.
+fn apply_focus(ctx: &mut WasmCtx<'_>, (previous, next): FocusTransition) {
+    if let Some(prev) = previous {
+        ctx.send_to(prev, &FocusLost);
+    }
+    if let Some(gained) = next {
+        ctx.send_to(gained, &FocusGained);
+    }
+}
+
+/// Spawn one inline widget, logging and dropping the slot on failure. Keeps
+/// the per-widget spawn sites in [`WidgetPanel::ensure_spawned`] to one line.
+fn spawn<A>(
+    ctx: &mut WasmCtx<'_, Manual>,
+    subname: &'static str,
+    config: &A::Config,
+) -> Option<MailboxId>
+where
+    A: aether_actor::Instanced + WasmActor + aether_actor::ErasedWasmActor,
+    <A as WasmActor>::State: aether_actor::ErasedWasmActor,
+{
+    match ctx.spawn_inline_child::<A>(Subname::Named(subname), config) {
+        Ok(id) => Some(id),
+        Err(error) => {
+            tracing::warn!(
+                target: "aether_kit",
+                subname,
+                ?error,
+                "widget spawn failed; slot skipped",
+            );
+            None
+        }
+    }
+}
+
+/// The reference panel root. Load it as a component (export
+/// `aether.kit.widget.panel`) with a [`PanelConfig`].
+///
+/// # Agent
+/// Load `aether_kit.wasm` with `export: "aether.kit.widget.panel"` and a
+/// `PanelConfig` (top-left, width, theme, and a font to load). It spawns a
+/// demonstration stack of every widget, routes real input through the
+/// focus model, and logs each value-up event. Fork it into a real editor
+/// panel by replacing the stack and translating the value-up handlers into
+/// your own world-knob driver mail.
+#[actor(instanced)]
+impl WasmActor for WidgetPanel {
+    type Config = PanelConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.panel";
+
+    fn init(config: PanelConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(WidgetPanel {
+            theme: config.theme.clone(),
+            config,
+            composite: Composite::new(),
+            focus: Focus::new(),
+            children: Vec::new(),
+            spawned: false,
+            panel_height: 0.0,
+        })
+    }
+
+    /// Subscribe the pointer / keyboard streams (input cap) and the frame
+    /// stage (lifecycle cap) once, and kick off the font load. Widgets never
+    /// subscribe — the root forwards everything.
+    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+        let input = ctx.actor::<InputCapability>();
+        input.subscribe::<MouseButton>();
+        input.subscribe::<MouseButtonRelease>();
+        input.subscribe::<MouseMove>();
+        input.subscribe::<MouseWheel>();
+        input.subscribe::<Key>();
+        input.subscribe::<KeyRelease>();
+        input.subscribe::<TextInput>();
+        input.subscribe::<ImePreedit>();
+        input.subscribe::<Modifiers>();
+        ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
+        if !self.config.font_path.is_empty() {
+            ctx.actor::<TextCapability>().send(&LoadFont {
+                namespace: self.config.font_namespace.clone(),
+                path: self.config.font_path.clone(),
+            });
+        }
+    }
+
+    /// Frame driver: spawn on the first tick, then open a composite frame, lay
+    /// the panel background, and fan `Collect` to every child. A leaf-free
+    /// panel finishes from `on_draw_list` once the slots close.
+    ///
+    /// # Agent
+    /// Tick-driven; not useful to send manually.
+    #[handler::manual]
+    fn on_tick(&mut self, ctx: &mut WasmCtx<'_, Manual>, _tick: Tick) {
+        self.ensure_spawned(ctx);
+        self.composite.begin_frame();
+        let background = quad(
+            self.config.x,
+            self.config.y,
+            self.config.width,
+            self.panel_height,
+            self.theme.surface,
+        );
+        self.composite.extend_chrome([background]);
+        for child in &self.children {
+            ctx.send_to(child.id, &Collect);
+        }
+        if self.composite.is_complete() {
+            self.finish(ctx);
+        }
+    }
+
+    /// A child's draw list: attribute it by source and, when every child has
+    /// replied this frame, emit the whole panel.
+    ///
+    /// # Agent
+    /// A child's reply; not useful to send manually.
+    #[handler::manual]
+    fn on_draw_list(&mut self, ctx: &mut WasmCtx<'_, Manual>, list: WidgetDrawList) {
+        if let Some(source) = ctx.source_mailbox() {
+            self.composite.fill(source, list);
+        }
+        if self.composite.is_complete() {
+            self.finish(ctx);
+        }
+    }
+
+    /// A left press sets focus + drag capture on the hit child and forwards
+    /// the press; any press forwards to the hit child.
+    #[handler]
+    fn on_mouse_button(&mut self, ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        let target = if press.button == mouse_button::LEFT {
+            let hit = self.focus.hit_test(press.x, press.y);
+            if let Some(child) = hit {
+                self.focus.begin_capture(child);
+            }
+            if let Some(transition) = self.focus.focus_hit(press.x, press.y) {
+                apply_focus(ctx, transition);
+            }
+            hit
+        } else {
+            self.focus.pointer_target(press.x, press.y)
+        };
+        if let Some(child) = target {
+            ctx.send_to(child, &press);
+        }
+    }
+
+    /// A release forwards to the captured / hit child and clears capture.
+    #[handler]
+    fn on_mouse_button_release(&mut self, ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
+        if let Some(child) = self.focus.pointer_target(release.x, release.y) {
+            ctx.send_to(child, &release);
+        }
+        if release.button == mouse_button::LEFT {
+            self.focus.clear_capture();
+        }
+    }
+
+    /// A move forwards to the captured (dragged) or hit child.
+    #[handler]
+    fn on_mouse_move(&mut self, ctx: &mut WasmCtx<'_>, moved: MouseMove) {
+        if let Some(child) = self.focus.pointer_target(moved.x, moved.y) {
+            ctx.send_to(child, &moved);
+        }
+    }
+
+    /// Reserved for scroll-aware widgets; no widget consumes the wheel in v1,
+    /// so the panel absorbs it here (subscribed, but dropped) rather than
+    /// forwarding an unhandled kind to a child.
+    // Subscribing the stream needs a handler to sink it; there is no per-panel
+    // wheel state yet, so the handler is deliberately empty.
+    #[allow(clippy::unused_self)]
+    #[handler]
+    fn on_mouse_wheel(&mut self, _ctx: &mut WasmCtx<'_>, _wheel: MouseWheel) {}
+
+    /// Tab cycles focus; every other key forwards to the focused child.
+    #[handler]
+    fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
+        if key.code == KEY_TAB {
+            if let Some(transition) = self.focus.advance_focus() {
+                apply_focus(ctx, transition);
+            }
+            return;
+        }
+        if let Some(child) = self.focus.keyboard_target() {
+            ctx.send_to(child, &key);
+        }
+    }
+
+    /// Reserved: no widget consumes key releases in v1, so the panel absorbs
+    /// them here (subscribed, but dropped) rather than forwarding an unhandled
+    /// kind to a child.
+    // Subscribing the stream needs a handler to sink it; there is no per-panel
+    // key-release state yet, so the handler is deliberately empty.
+    #[allow(clippy::unused_self)]
+    #[handler]
+    fn on_key_release(&mut self, _ctx: &mut WasmCtx<'_>, _release: KeyRelease) {}
+
+    /// Committed text forwards to the focused child.
+    #[handler]
+    fn on_text_input(&mut self, ctx: &mut WasmCtx<'_>, input: TextInput) {
+        if let Some(child) = self.focus.keyboard_target() {
+            ctx.send_to(child, &input);
+        }
+    }
+
+    /// An IME composition forwards to the focused child.
+    #[handler]
+    fn on_ime_preedit(&mut self, ctx: &mut WasmCtx<'_>, preedit: ImePreedit) {
+        if let Some(child) = self.focus.keyboard_target() {
+            ctx.send_to(child, &preedit);
+        }
+    }
+
+    /// Modifier state forwards to the focused child (the text field caches
+    /// it).
+    #[handler]
+    fn on_modifiers(&mut self, ctx: &mut WasmCtx<'_>, modifiers: Modifiers) {
+        if let Some(child) = self.focus.keyboard_target() {
+            ctx.send_to(child, &modifiers);
+        }
+    }
+
+    /// A slider value-up. The map-editor seam: translate to world-knob driver
+    /// mail here. The reference logs the attributed value.
+    ///
+    /// # Agent
+    /// A child's reply; not useful to send manually.
+    #[handler::manual]
+    fn on_slider_changed(&mut self, ctx: &mut WasmCtx<'_, Manual>, changed: SliderChanged) {
+        tracing::info!(
+            target: "aether_kit",
+            widget = self.child_name(ctx.source_mailbox()),
+            value = changed.value,
+            committed = changed.committed,
+            "widget slider changed",
+        );
+    }
+
+    /// A text-field commit. The map-editor seam; the reference logs it.
+    ///
+    /// # Agent
+    /// A child's reply; not useful to send manually.
+    #[handler::manual]
+    fn on_text_committed(&mut self, ctx: &mut WasmCtx<'_, Manual>, committed: TextCommitted) {
+        tracing::info!(
+            target: "aether_kit",
+            widget = self.child_name(ctx.source_mailbox()),
+            text = %committed.text,
+            "widget text committed",
+        );
+    }
+
+    /// A radio selection. The map-editor seam; the reference logs it.
+    ///
+    /// # Agent
+    /// A child's reply; not useful to send manually.
+    #[handler::manual]
+    fn on_radio_selected(&mut self, ctx: &mut WasmCtx<'_, Manual>, selected: RadioSelected) {
+        tracing::info!(
+            target: "aether_kit",
+            widget = self.child_name(ctx.source_mailbox()),
+            index = selected.index,
+            "widget radio selected",
+        );
+    }
+
+    /// A button click. The map-editor seam; the reference logs it.
+    ///
+    /// # Agent
+    /// A child's reply; not useful to send manually.
+    #[handler::manual]
+    fn on_button_clicked(&mut self, ctx: &mut WasmCtx<'_, Manual>, _clicked: ButtonClicked) {
+        tracing::info!(
+            target: "aether_kit",
+            widget = self.child_name(ctx.source_mailbox()),
+            "widget button clicked",
+        );
+    }
+
+    /// The font finished loading: stamp the real `font_id` into the theme and
+    /// re-fan it so every child draws text with it.
+    #[handler]
+    fn on_load_font_result(&mut self, ctx: &mut WasmCtx<'_>, result: LoadFontResult) {
+        match result {
+            LoadFontResult::Ok { font_id, .. } => {
+                self.theme.font_id = font_id;
+                self.fan_theme(ctx);
+            }
+            LoadFontResult::Err { error, .. } => {
+                tracing::warn!(target: "aether_kit", %error, "panel font load failed");
+            }
+        }
+    }
+
+    /// A live restyle: adopt the new theme and re-fan it to every child.
+    #[handler]
+    fn on_set_theme(&mut self, ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.theme = set.theme;
+        self.fan_theme(ctx);
+    }
+}

--- a/crates/aether-kit/src/runtime/widgets/button.rs
+++ b/crates/aether-kit/src/runtime/widgets/button.rs
@@ -1,0 +1,239 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `runtime/widget.rs`).
+#![allow(clippy::needless_pass_by_value)]
+
+//! The momentary push button (issue 2660).
+//!
+//! A left press inside the button arms it (the root holds the pointer
+//! capture); the matching release fires [`ButtonClicked`] only if it lands
+//! back inside — a press-then-release-inside, so a press that drags off and
+//! releases elsewhere cancels. The armed state draws the pressed overlay.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_kinds::mouse_button;
+use aether_kinds::{MouseButton, MouseButtonRelease};
+
+use crate::runtime::widgets::{push_border, quad};
+use crate::theme::{SetTheme, Theme, WidgetState};
+use crate::widgets::{
+    ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, WidgetDrawItem, WidgetDrawList,
+    WidgetFrame,
+};
+
+/// A momentary push button. Holds its label plus the cached theme / frame /
+/// focus and the armed (`pressed`) state.
+pub struct ButtonWidget {
+    label: String,
+    theme: Theme,
+    frame: WidgetFrame,
+    focused: bool,
+    /// Armed by a press inside; a release-inside while armed fires the click.
+    pressed: bool,
+}
+
+impl ButtonWidget {
+    /// Whether a window-space point falls inside the button's frame.
+    fn contains(&self, x: f32, y: f32) -> bool {
+        x >= self.frame.x
+            && x <= self.frame.x + self.frame.width
+            && y >= self.frame.y
+            && y <= self.frame.y + self.frame.height
+    }
+
+    /// Arm the button if the press landed inside. Owned state-machine step —
+    /// unit-tested.
+    fn press_at(&mut self, x: f32, y: f32) {
+        if self.contains(x, y) {
+            self.pressed = true;
+        }
+    }
+
+    /// Resolve a release: returns `true` (a click fired) only if the button
+    /// was armed and the release landed back inside. Disarms either way.
+    fn release_at(&mut self, x: f32, y: f32) -> bool {
+        let clicked = self.pressed && self.contains(x, y);
+        self.pressed = false;
+        clicked
+    }
+}
+
+/// A push-button widget. Spawned inline by a panel root with a
+/// [`ButtonConfig`]; reports [`ButtonClicked`] up on a completed click.
+///
+/// # Agent
+/// Not loaded directly — the panel root spawns it as an inline child. Send it
+/// its `ButtonConfig` again to relabel or restyle it in place.
+#[actor(instanced)]
+impl WasmActor for ButtonWidget {
+    type Config = ButtonConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.button";
+
+    fn init(config: ButtonConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(ButtonWidget {
+            label: config.label,
+            theme: config.theme,
+            frame: WidgetFrame {
+                x: 0.0,
+                y: 0.0,
+                width: 0.0,
+                height: 0.0,
+            },
+            focused: false,
+            pressed: false,
+        })
+    }
+
+    /// Relabel / restyle in place from a re-sent config.
+    #[handler]
+    fn on_config(&mut self, _ctx: &mut WasmCtx<'_>, config: ButtonConfig) {
+        self.label = config.label;
+        self.theme = config.theme;
+    }
+
+    /// Restyle: adopt the fanned theme.
+    #[handler]
+    fn on_set_theme(&mut self, _ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.theme = set.theme;
+    }
+
+    /// Cache the layout rect the root assigned.
+    #[handler]
+    fn on_frame(&mut self, _ctx: &mut WasmCtx<'_>, frame: WidgetFrame) {
+        self.frame = frame;
+    }
+
+    /// Take keyboard focus.
+    #[handler]
+    fn on_focus_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: FocusGained) {
+        self.focused = true;
+    }
+
+    /// Release keyboard focus.
+    #[handler]
+    fn on_focus_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: FocusLost) {
+        self.focused = false;
+    }
+
+    /// A left press inside arms the button.
+    #[handler]
+    fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        if press.button == mouse_button::LEFT {
+            self.press_at(press.x, press.y);
+        }
+    }
+
+    /// A left release fires the click if it lands back inside while armed.
+    #[handler]
+    fn on_mouse_button_release(&mut self, ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
+        if release.button != mouse_button::LEFT {
+            return;
+        }
+        if self.release_at(release.x, release.y)
+            && let Some(parent) = ctx.parent()
+        {
+            parent.send(&ButtonClicked);
+        }
+    }
+
+    /// Reply the button's local draw: a filled rect (pressed overlay when
+    /// armed), the label, and a focus ring.
+    ///
+    /// # Agent
+    /// The panel root's per-frame poll; not useful to send manually.
+    #[handler]
+    fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
+        let width = self.frame.width;
+        let height = self.frame.height;
+        let state = if self.pressed {
+            WidgetState::Pressed
+        } else {
+            WidgetState::Normal
+        };
+        let size = self.theme.label_size_pixels;
+
+        let mut items: Vec<WidgetDrawItem> = Vec::new();
+        items.push(quad(
+            0.0,
+            0.0,
+            width,
+            height,
+            self.theme.fill(self.theme.accent, state),
+        ));
+        if !self.label.is_empty() {
+            items.push(WidgetDrawItem::Text {
+                x: self.theme.pad,
+                y: size.mul_add(0.35, height * 0.5),
+                font_id: self.theme.font_id,
+                text: self.label.clone(),
+                size_pixels: size,
+                color: self.theme.accent_text,
+            });
+        }
+        if self.focused {
+            push_border(&mut items, width, height, 2.0, self.theme.accent);
+        }
+        if let Some(parent) = ctx.parent() {
+            parent.send(&WidgetDrawList {
+                intrinsic: None,
+                items,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn button() -> ButtonWidget {
+        ButtonWidget {
+            label: String::from("go"),
+            theme: Theme::DEFAULT,
+            frame: WidgetFrame {
+                x: 10.0,
+                y: 10.0,
+                width: 40.0,
+                height: 20.0,
+            },
+            focused: false,
+            pressed: false,
+        }
+    }
+
+    #[test]
+    fn press_inside_then_release_inside_clicks() {
+        let mut b = button();
+        b.press_at(20.0, 20.0);
+        assert!(b.pressed);
+        assert!(
+            b.release_at(30.0, 25.0),
+            "press-inside then release-inside is a click"
+        );
+        assert!(!b.pressed, "disarmed after release");
+    }
+
+    #[test]
+    fn press_inside_then_release_outside_cancels() {
+        let mut b = button();
+        b.press_at(20.0, 20.0);
+        assert!(
+            !b.release_at(200.0, 200.0),
+            "a release that drifts off the button does not click",
+        );
+        assert!(!b.pressed, "disarmed even on a cancel");
+    }
+
+    #[test]
+    fn press_outside_never_arms() {
+        let mut b = button();
+        b.press_at(200.0, 200.0);
+        assert!(!b.pressed);
+        assert!(
+            !b.release_at(20.0, 20.0),
+            "a release with no prior inside-press does not click"
+        );
+    }
+}

--- a/crates/aether-kit/src/runtime/widgets/label.rs
+++ b/crates/aether-kit/src/runtime/widgets/label.rs
@@ -1,0 +1,94 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `runtime/widget.rs`).
+#![allow(clippy::needless_pass_by_value)]
+
+//! The static label (issue 2660).
+//!
+//! Non-interactive text — the trivial widget. It takes no input and is not
+//! focus-eligible (the root's focus register skips it); it only draws its
+//! configured text each `Collect`.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+
+use crate::theme::{SetTheme, Theme};
+use crate::widgets::{Collect, LabelConfig, WidgetDrawItem, WidgetDrawList, WidgetFrame};
+
+/// A static text label. Holds the text plus the cached theme / frame.
+pub struct LabelWidget {
+    text: String,
+    theme: Theme,
+    frame: WidgetFrame,
+}
+
+/// A label widget. Spawned inline by a panel root with a [`LabelConfig`];
+/// draws its text and reports nothing up.
+///
+/// # Agent
+/// Not loaded directly — the panel root spawns it as an inline child. Send it
+/// its `LabelConfig` again to change the text or theme in place.
+#[actor(instanced)]
+impl WasmActor for LabelWidget {
+    type Config = LabelConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.label";
+
+    fn init(config: LabelConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(LabelWidget {
+            text: config.text,
+            theme: config.theme,
+            frame: WidgetFrame {
+                x: 0.0,
+                y: 0.0,
+                width: 0.0,
+                height: 0.0,
+            },
+        })
+    }
+
+    /// Change the text / theme in place from a re-sent config.
+    #[handler]
+    fn on_config(&mut self, _ctx: &mut WasmCtx<'_>, config: LabelConfig) {
+        self.text = config.text;
+        self.theme = config.theme;
+    }
+
+    /// Restyle: adopt the fanned theme.
+    #[handler]
+    fn on_set_theme(&mut self, _ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.theme = set.theme;
+    }
+
+    /// Cache the layout rect the root assigned.
+    #[handler]
+    fn on_frame(&mut self, _ctx: &mut WasmCtx<'_>, frame: WidgetFrame) {
+        self.frame = frame;
+    }
+
+    /// Reply the label's local draw: its text at the theme's label size.
+    ///
+    /// # Agent
+    /// The panel root's per-frame poll; not useful to send manually.
+    #[handler]
+    fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
+        let size = self.theme.label_size_pixels;
+        let mut items: Vec<WidgetDrawItem> = Vec::new();
+        if !self.text.is_empty() {
+            items.push(WidgetDrawItem::Text {
+                x: 0.0,
+                y: size.mul_add(0.35, self.frame.height * 0.5),
+                font_id: self.theme.font_id,
+                text: self.text.clone(),
+                size_pixels: size,
+                color: self.theme.text_primary,
+            });
+        }
+        if let Some(parent) = ctx.parent() {
+            parent.send(&WidgetDrawList {
+                intrinsic: None,
+                items,
+            });
+        }
+    }
+}

--- a/crates/aether-kit/src/runtime/widgets/mod.rs
+++ b/crates/aether-kit/src/runtime/widgets/mod.rs
@@ -1,0 +1,86 @@
+//! The concrete widget set (issue 2660): five plain `#[actor(instanced)]`
+//! types a panel root spawns as inline children and drives by mail in four
+//! lanes — config / style / layout-frame data-down, value events-up — over the
+//! ADR-0117 draw-compositing protocol.
+//!
+//! - [`slider::SliderWidget`] — a horizontal value slider, dragged or
+//!   arrow-nudged.
+//! - [`text_field::TextFieldWidget`] — a single-line editable string.
+//! - [`radio::RadioGroupWidget`] — a vertical list of exclusive options.
+//! - [`button::ButtonWidget`] — a momentary push button.
+//! - [`label::LabelWidget`] — static, non-interactive text.
+//!
+//! Each caches its assigned [`WidgetFrame`](crate::widgets::WidgetFrame) rect
+//! and its [`Theme`](crate::theme::Theme), answers every
+//! [`Collect`](crate::widgets::Collect) with a
+//! [`WidgetDrawList`](crate::widgets::WidgetDrawList) drawn in its own local
+//! coordinates (colors resolved through [`Theme::fill`](crate::theme::Theme::fill)),
+//! and reports value changes up to its parent. Widgets never subscribe to
+//! input; the root forwards it — see [`super::focus::Focus`] and
+//! [`super::widget_panel::WidgetPanel`].
+//!
+//! An inline child receives only `init` (no `wire`, and `init` cannot mail),
+//! so a widget does nothing at boot beyond building its state; the root's
+//! first `WidgetFrame` gives it its rect and the first `Collect` its first
+//! draw.
+
+pub mod button;
+pub mod label;
+pub mod radio;
+pub mod slider;
+pub mod text_field;
+
+pub use button::ButtonWidget;
+pub use label::LabelWidget;
+pub use radio::RadioGroupWidget;
+pub use slider::SliderWidget;
+pub use text_field::TextFieldWidget;
+
+use alloc::vec::Vec;
+
+use crate::widgets::WidgetDrawItem;
+
+/// A flat-colored quad in a widget's own local coordinates — the shared
+/// constructor the widgets build their chrome from.
+pub(crate) fn quad(x: f32, y: f32, width: f32, height: f32, color: [f32; 4]) -> WidgetDrawItem {
+    WidgetDrawItem::Quad {
+        x,
+        y,
+        width,
+        height,
+        color,
+    }
+}
+
+/// Push a `thickness`-pixel border ring around the `width` × `height` local
+/// rect — four thin quads (top, bottom, left, right). A focused widget draws
+/// this from `theme.accent` so the focus ring reads without the root holding
+/// any per-widget-type visual knowledge.
+pub(crate) fn push_border(
+    items: &mut Vec<WidgetDrawItem>,
+    width: f32,
+    height: f32,
+    thickness: f32,
+    color: [f32; 4],
+) {
+    items.push(quad(0.0, 0.0, width, thickness, color));
+    items.push(quad(0.0, height - thickness, width, thickness, color));
+    items.push(quad(0.0, 0.0, thickness, height, color));
+    items.push(quad(width - thickness, 0.0, thickness, height, color));
+}
+
+/// A rough per-character advance for caret placement and content sizing, as a
+/// fraction of the font size. The exact-metric path (a `CachedFontMetrics`
+/// measure) needs the font's metrics fanned down to the widget, which the
+/// `Theme` does not carry in v1; this proportional approximation keeps caret
+/// motion local and synchronous. The byte-offset caret *logic* (which the unit
+/// tests pin) is exact regardless — only the pixel placement approximates.
+pub(crate) const APPROX_ADVANCE_RATIO: f32 = 0.5;
+
+/// The approximate pixel width of `char_count` characters at `size_pixels`,
+/// using [`APPROX_ADVANCE_RATIO`].
+pub(crate) fn approx_text_width(char_count: usize, size_pixels: f32) -> f32 {
+    #[allow(clippy::cast_precision_loss)]
+    let count = char_count as f32;
+    count * size_pixels * APPROX_ADVANCE_RATIO
+}

--- a/crates/aether-kit/src/runtime/widgets/radio.rs
+++ b/crates/aether-kit/src/runtime/widgets/radio.rs
@@ -1,0 +1,289 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `runtime/widget.rs`).
+#![allow(clippy::needless_pass_by_value)]
+
+//! The radio group (issue 2660).
+//!
+//! A vertical list of mutually-exclusive options, one row per option at the
+//! theme's row height. A left click selects the row under the cursor; while
+//! focused, Up / Down move the selection (clamped at the ends). The selected
+//! index reports up as [`RadioSelected`].
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_kinds::keycode::{KEY_DOWN, KEY_UP};
+use aether_kinds::mouse_button;
+use aether_kinds::{Key, MouseButton};
+
+use crate::runtime::widgets::{push_border, quad};
+use crate::theme::{SetTheme, Theme, WidgetState};
+use crate::widgets::{
+    Collect, FocusGained, FocusLost, RadioConfig, RadioSelected, WidgetDrawItem, WidgetDrawList,
+    WidgetFrame,
+};
+
+/// A radio group. Holds the option labels, the selected index, and the cached
+/// theme / frame / focus.
+pub struct RadioGroupWidget {
+    options: Vec<String>,
+    selected: usize,
+    theme: Theme,
+    frame: WidgetFrame,
+    focused: bool,
+}
+
+impl RadioGroupWidget {
+    /// The row a local-y falls in, or `None` past the last option. Owned
+    /// hit math — unit-tested.
+    fn row_at_local_y(&self, local_y: f32) -> Option<usize> {
+        let row_height = self.theme.row_height.max(1.0);
+        if local_y < 0.0 {
+            return None;
+        }
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let row = (local_y / row_height) as usize;
+        (row < self.options.len()).then_some(row)
+    }
+
+    /// Emit the current selection up to the panel root.
+    fn emit(&self, ctx: &WasmCtx<'_>) {
+        if let Some(parent) = ctx.parent() {
+            #[allow(clippy::cast_possible_truncation)]
+            let index = self.selected as u32;
+            parent.send(&RadioSelected { index });
+        }
+    }
+}
+
+/// A radio-group widget. Spawned inline by a panel root with a [`RadioConfig`];
+/// reports [`RadioSelected`] up as the selection changes.
+///
+/// # Agent
+/// Not loaded directly — the panel root spawns it as an inline child. Send it
+/// its `RadioConfig` again to replace the options or theme in place.
+#[actor(instanced)]
+impl WasmActor for RadioGroupWidget {
+    type Config = RadioConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.radio";
+
+    fn init(config: RadioConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        let selected = clamp_index(config.initial_index, config.options.len());
+        Ok(RadioGroupWidget {
+            options: config.options,
+            selected,
+            theme: config.theme,
+            frame: WidgetFrame {
+                x: 0.0,
+                y: 0.0,
+                width: 0.0,
+                height: 0.0,
+            },
+            focused: false,
+        })
+    }
+
+    /// Replace the options / theme in place, re-clamping the selection.
+    #[handler]
+    fn on_config(&mut self, _ctx: &mut WasmCtx<'_>, config: RadioConfig) {
+        self.selected = clamp_index(config.initial_index, config.options.len());
+        self.options = config.options;
+        self.theme = config.theme;
+    }
+
+    /// Restyle: adopt the fanned theme.
+    #[handler]
+    fn on_set_theme(&mut self, _ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.theme = set.theme;
+    }
+
+    /// Cache the layout rect the root assigned.
+    #[handler]
+    fn on_frame(&mut self, _ctx: &mut WasmCtx<'_>, frame: WidgetFrame) {
+        self.frame = frame;
+    }
+
+    /// Take keyboard focus.
+    #[handler]
+    fn on_focus_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: FocusGained) {
+        self.focused = true;
+    }
+
+    /// Release keyboard focus.
+    #[handler]
+    fn on_focus_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: FocusLost) {
+        self.focused = false;
+    }
+
+    /// A left click selects the row under the cursor.
+    #[handler]
+    fn on_mouse_button(&mut self, ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        if press.button != mouse_button::LEFT {
+            return;
+        }
+        if let Some(row) = self.row_at_local_y(press.y - self.frame.y)
+            && row != self.selected
+        {
+            self.selected = row;
+            self.emit(ctx);
+        }
+    }
+
+    /// Up / Down move the selection while focused (clamped at the ends).
+    #[handler]
+    fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
+        if self.options.is_empty() {
+            return;
+        }
+        let next = match key.code {
+            KEY_UP => self.selected.saturating_sub(1),
+            KEY_DOWN => (self.selected + 1).min(self.options.len() - 1),
+            _ => return,
+        };
+        if next != self.selected {
+            self.selected = next;
+            self.emit(ctx);
+        }
+    }
+
+    /// Reply the group's local draw: one marker + label per option row, the
+    /// selected row's marker filled, plus a focus ring.
+    ///
+    /// # Agent
+    /// The panel root's per-frame poll; not useful to send manually.
+    #[handler]
+    fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
+        let row_height = self.theme.row_height.max(1.0);
+        let marker = (row_height * 0.5).max(4.0);
+        let pad = self.theme.pad;
+        let size = self.theme.label_size_pixels;
+
+        let mut items: Vec<WidgetDrawItem> = Vec::new();
+        for (i, option) in self.options.iter().enumerate() {
+            #[allow(clippy::cast_precision_loss)]
+            let row_y = i as f32 * row_height;
+            let marker_y = (row_height - marker).mul_add(0.5, row_y);
+            let base = if i == self.selected {
+                self.theme.accent
+            } else {
+                self.theme.surface_raised
+            };
+            items.push(quad(
+                pad,
+                marker_y,
+                marker,
+                marker,
+                self.theme.fill(base, WidgetState::Normal),
+            ));
+            items.push(WidgetDrawItem::Text {
+                x: pad.mul_add(2.0, marker),
+                y: size.mul_add(0.35, row_height.mul_add(0.5, row_y)),
+                font_id: self.theme.font_id,
+                text: option.clone(),
+                size_pixels: size,
+                color: self.theme.text_primary,
+            });
+        }
+        if self.focused {
+            push_border(
+                &mut items,
+                self.frame.width,
+                self.frame.height,
+                2.0,
+                self.theme.accent,
+            );
+        }
+        if let Some(parent) = ctx.parent() {
+            parent.send(&WidgetDrawList {
+                intrinsic: None,
+                items,
+            });
+        }
+    }
+}
+
+/// Clamp a 1-past-the-end initial index down to the last option (or `0` for an
+/// empty group).
+fn clamp_index(index: u32, len: usize) -> usize {
+    if len == 0 {
+        0
+    } else {
+        (index as usize).min(len - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn group(options: &[&str], selected: usize) -> RadioGroupWidget {
+        RadioGroupWidget {
+            options: options.iter().map(|s| String::from(*s)).collect(),
+            selected,
+            theme: Theme::DEFAULT, // row_height = 24
+            frame: WidgetFrame {
+                x: 0.0,
+                y: 10.0,
+                width: 100.0,
+                height: 72.0,
+            },
+            focused: false,
+        }
+    }
+
+    #[test]
+    fn row_hit_maps_local_y_to_index_and_misses_past_the_end() {
+        let g = group(&["a", "b", "c"], 0);
+        assert_eq!(g.row_at_local_y(0.0), Some(0));
+        assert_eq!(g.row_at_local_y(30.0), Some(1)); // 30 / 24 = 1
+        assert_eq!(g.row_at_local_y(60.0), Some(2)); // 60 / 24 = 2
+        assert_eq!(
+            g.row_at_local_y(72.0),
+            None,
+            "past the third row hits nothing"
+        );
+        assert_eq!(g.row_at_local_y(-1.0), None, "above the group hits nothing");
+    }
+
+    #[test]
+    fn clamp_index_pins_an_over_range_initial() {
+        assert_eq!(clamp_index(0, 3), 0);
+        assert_eq!(
+            clamp_index(5, 3),
+            2,
+            "past the end clamps to the last option"
+        );
+        assert_eq!(clamp_index(1, 0), 0, "an empty group clamps to 0");
+    }
+
+    #[test]
+    fn up_down_selection_clamps_at_the_ends() {
+        // Exercise the clamp arithmetic the key handler uses.
+        let g = group(&["a", "b", "c"], 0);
+        assert_eq!(g.selected.saturating_sub(1), 0, "up at the top stays");
+        let g = group(&["a", "b", "c"], 2);
+        assert_eq!(
+            (g.selected + 1).min(g.options.len() - 1),
+            2,
+            "down at the bottom stays"
+        );
+        let g = group(&["a", "b", "c"], 1);
+        assert_eq!((g.selected + 1).min(g.options.len() - 1), 2);
+        assert_eq!(g.selected.saturating_sub(1), 0);
+    }
+
+    #[test]
+    fn empty_group_has_no_rows() {
+        let g = group(&[], 0);
+        assert_eq!(g.row_at_local_y(0.0), None);
+    }
+
+    #[test]
+    fn options_survive_construction() {
+        let g = group(&["x", "y"], 1);
+        assert_eq!(g.options, vec![String::from("x"), String::from("y")]);
+        assert_eq!(g.selected, 1);
+    }
+}

--- a/crates/aether-kit/src/runtime/widgets/slider.rs
+++ b/crates/aether-kit/src/runtime/widgets/slider.rs
@@ -1,0 +1,331 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `runtime/widget.rs`).
+#![allow(clippy::needless_pass_by_value)]
+
+//! The horizontal value slider (issue 2660).
+//!
+//! A left press within the track begins a drag (the root holds the pointer
+//! capture), setting the value from the cursor's x mapped through the cached
+//! frame and streaming an uncommitted [`SliderChanged`]; each move updates it;
+//! the release commits. Arrow keys nudge by `step` while focused and commit at
+//! once. The value maps `min..=max` snapped to `step`; the consumer maps the
+//! reported `f32` onto its own domain.
+
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_kinds::keycode::{KEY_DOWN, KEY_LEFT, KEY_RIGHT, KEY_UP};
+use aether_kinds::mouse_button;
+use aether_kinds::{Key, MouseButton, MouseButtonRelease, MouseMove};
+
+use crate::runtime::widgets::{push_border, quad};
+use crate::theme::{SetTheme, Theme, WidgetState};
+use crate::widgets::{
+    Collect, FocusGained, FocusLost, SliderChanged, SliderConfig, WidgetDrawItem, WidgetDrawList,
+    WidgetFrame,
+};
+
+/// A horizontal value slider. Local draw is a track with a fill from the left
+/// to the current value, plus a focus ring when focused.
+pub struct SliderWidget {
+    min: f32,
+    max: f32,
+    step: f32,
+    value: f32,
+    theme: Theme,
+    frame: WidgetFrame,
+    focused: bool,
+    /// Whether a drag is in flight (a left press landed and no release has
+    /// cleared it). Streams uncommitted values while set.
+    dragging: bool,
+}
+
+impl SliderWidget {
+    /// Clamp `raw` into `min..=max` and snap it to the nearest `step`. A
+    /// non-positive `step` leaves the value continuous (clamp only).
+    fn snapped(&self, raw: f32) -> f32 {
+        let clamped = raw.clamp(self.min, self.max);
+        if self.step > 0.0 {
+            let steps = ((clamped - self.min) / self.step).round();
+            steps.mul_add(self.step, self.min).clamp(self.min, self.max)
+        } else {
+            clamped
+        }
+    }
+
+    /// The value a local-x within the track maps to: the fraction of the
+    /// track width, remapped across `min..=max` and snapped. Owned math — the
+    /// unit tests pin it.
+    fn value_from_local_x(&self, local_x: f32) -> f32 {
+        let width = self.frame.width.max(1.0);
+        let frac = (local_x / width).clamp(0.0, 1.0);
+        self.snapped(frac.mul_add(self.max - self.min, self.min))
+    }
+
+    /// The value a window-space pointer x maps to, via the cached frame's
+    /// left edge.
+    fn value_from_pointer_x(&self, pointer_x: f32) -> f32 {
+        self.value_from_local_x(pointer_x - self.frame.x)
+    }
+
+    /// The nudge one arrow press applies: `step` when set, else a hundredth of
+    /// the range so a continuous slider still moves.
+    fn nudge_amount(&self) -> f32 {
+        if self.step > 0.0 {
+            self.step
+        } else {
+            (self.max - self.min) * 0.01
+        }
+    }
+
+    /// The value as a `0.0..=1.0` fraction of the range, for the fill width.
+    fn fill_fraction(&self) -> f32 {
+        let span = self.max - self.min;
+        if span > 0.0 {
+            ((self.value - self.min) / span).clamp(0.0, 1.0)
+        } else {
+            0.0
+        }
+    }
+
+    /// Emit the current value up to the panel root, `committed` distinguishing
+    /// a drag stream from a settled value.
+    fn emit(&self, ctx: &WasmCtx<'_>, committed: bool) {
+        if let Some(parent) = ctx.parent() {
+            parent.send(&SliderChanged {
+                value: self.value,
+                committed,
+            });
+        }
+    }
+}
+
+/// A slider widget. Spawned inline by a panel root with a [`SliderConfig`];
+/// reports [`SliderChanged`] up as it is dragged or nudged.
+///
+/// # Agent
+/// Not loaded directly — the panel root spawns it as an inline child. Send it
+/// its `SliderConfig` again to reconfigure the range or theme in place.
+#[actor(instanced)]
+impl WasmActor for SliderWidget {
+    type Config = SliderConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.slider";
+
+    fn init(config: SliderConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        let mut slider = SliderWidget {
+            min: config.min,
+            max: config.max,
+            step: config.step,
+            value: config.initial,
+            theme: config.theme,
+            frame: WidgetFrame {
+                x: 0.0,
+                y: 0.0,
+                width: 0.0,
+                height: 0.0,
+            },
+            focused: false,
+            dragging: false,
+        };
+        slider.value = slider.snapped(config.initial);
+        Ok(slider)
+    }
+
+    /// Reconfigure the range / step / theme in place, re-clamping the current
+    /// value into the new range. `initial` is ignored on re-config (it seeds
+    /// the value only at init) so a restyle does not jump the value.
+    #[handler]
+    fn on_config(&mut self, _ctx: &mut WasmCtx<'_>, config: SliderConfig) {
+        self.min = config.min;
+        self.max = config.max;
+        self.step = config.step;
+        self.theme = config.theme;
+        self.value = self.snapped(self.value);
+    }
+
+    /// Restyle: adopt the fanned theme.
+    #[handler]
+    fn on_set_theme(&mut self, _ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.theme = set.theme;
+    }
+
+    /// Cache the layout rect the root assigned.
+    #[handler]
+    fn on_frame(&mut self, _ctx: &mut WasmCtx<'_>, frame: WidgetFrame) {
+        self.frame = frame;
+    }
+
+    /// Take keyboard focus (draw the focus ring).
+    #[handler]
+    fn on_focus_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: FocusGained) {
+        self.focused = true;
+    }
+
+    /// Release keyboard focus.
+    #[handler]
+    fn on_focus_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: FocusLost) {
+        self.focused = false;
+    }
+
+    /// A left press begins a drag and sets the value from the cursor.
+    #[handler]
+    fn on_mouse_button(&mut self, ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        if press.button != mouse_button::LEFT {
+            return;
+        }
+        self.dragging = true;
+        self.value = self.value_from_pointer_x(press.x);
+        self.emit(ctx, false);
+    }
+
+    /// A move while dragging updates the value and streams it uncommitted.
+    #[handler]
+    fn on_mouse_move(&mut self, ctx: &mut WasmCtx<'_>, moved: MouseMove) {
+        if !self.dragging {
+            return;
+        }
+        self.value = self.value_from_pointer_x(moved.x);
+        self.emit(ctx, false);
+    }
+
+    /// A left release ends the drag and commits the value.
+    #[handler]
+    fn on_mouse_button_release(&mut self, ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
+        if release.button != mouse_button::LEFT || !self.dragging {
+            return;
+        }
+        self.value = self.value_from_pointer_x(release.x);
+        self.dragging = false;
+        self.emit(ctx, true);
+    }
+
+    /// Arrow keys nudge by `step` and commit at once (focused only — the root
+    /// forwards keyboard mail to the focused child).
+    #[handler]
+    fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
+        let delta = match key.code {
+            KEY_LEFT | KEY_DOWN => -self.nudge_amount(),
+            KEY_RIGHT | KEY_UP => self.nudge_amount(),
+            _ => return,
+        };
+        self.value = self.snapped(self.value + delta);
+        self.emit(ctx, true);
+    }
+
+    /// Reply the slider's local draw: track, fill, and a focus ring when
+    /// focused.
+    ///
+    /// # Agent
+    /// The panel root's per-frame poll; not useful to send manually.
+    #[handler]
+    fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
+        let width = self.frame.width;
+        let height = self.frame.height;
+        let track_height = (height * 0.35).clamp(4.0, height.max(4.0));
+        let track_y = (height - track_height) * 0.5;
+
+        let mut items: Vec<WidgetDrawItem> = Vec::new();
+        items.push(quad(
+            0.0,
+            track_y,
+            width,
+            track_height,
+            self.theme
+                .fill(self.theme.surface_raised, WidgetState::Normal),
+        ));
+        items.push(quad(
+            0.0,
+            track_y,
+            width * self.fill_fraction(),
+            track_height,
+            self.theme.fill(self.theme.accent, WidgetState::Normal),
+        ));
+        if self.focused {
+            push_border(&mut items, width, height, 2.0, self.theme.accent);
+        }
+        if let Some(parent) = ctx.parent() {
+            parent.send(&WidgetDrawList {
+                intrinsic: None,
+                items,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slider(min: f32, max: f32, step: f32, initial: f32) -> SliderWidget {
+        SliderWidget {
+            min,
+            max,
+            step,
+            value: initial,
+            theme: Theme::DEFAULT,
+            frame: WidgetFrame {
+                x: 100.0,
+                y: 0.0,
+                width: 200.0,
+                height: 24.0,
+            },
+            focused: false,
+            dragging: false,
+        }
+    }
+
+    #[test]
+    fn pointer_maps_across_the_track_and_snaps_to_step() {
+        let s = slider(0.0, 100.0, 10.0, 0.0);
+        // Left edge of the frame → min.
+        assert_eq!(s.value_from_pointer_x(100.0), 0.0);
+        // Right edge → max.
+        assert_eq!(s.value_from_pointer_x(300.0), 100.0);
+        // Middle → 50, already on a step boundary.
+        assert_eq!(s.value_from_pointer_x(200.0), 50.0);
+        // A point at 27% of the track (x=154 → local 54 → 27.0 raw) snaps to 30.
+        assert_eq!(s.value_from_pointer_x(154.0), 30.0);
+    }
+
+    #[test]
+    fn pointer_past_the_edges_clamps_into_range() {
+        let s = slider(-1.0, 1.0, 0.0, 0.0);
+        assert_eq!(
+            s.value_from_pointer_x(50.0),
+            -1.0,
+            "left of the track clamps to min"
+        );
+        assert_eq!(
+            s.value_from_pointer_x(500.0),
+            1.0,
+            "right of the track clamps to max"
+        );
+    }
+
+    #[test]
+    fn continuous_slider_does_not_snap() {
+        let s = slider(0.0, 1.0, 0.0, 0.0);
+        // Quarter of the track → 0.25, no snapping.
+        assert_eq!(s.value_from_pointer_x(150.0), 0.25);
+    }
+
+    #[test]
+    fn nudge_amount_falls_back_to_a_hundredth_of_range() {
+        assert_eq!(slider(0.0, 100.0, 5.0, 0.0).nudge_amount(), 5.0);
+        assert_eq!(slider(0.0, 100.0, 0.0, 0.0).nudge_amount(), 1.0);
+    }
+
+    #[test]
+    fn fill_fraction_tracks_value_within_range() {
+        let mut s = slider(0.0, 100.0, 0.0, 0.0);
+        assert_eq!(s.fill_fraction(), 0.0);
+        s.value = 25.0;
+        assert_eq!(s.fill_fraction(), 0.25);
+        s.value = 200.0;
+        assert_eq!(
+            s.fill_fraction(),
+            1.0,
+            "an out-of-range value clamps the fill"
+        );
+    }
+}

--- a/crates/aether-kit/src/runtime/widgets/text_field.rs
+++ b/crates/aether-kit/src/runtime/widgets/text_field.rs
@@ -1,0 +1,349 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `runtime/widget.rs`).
+#![allow(clippy::needless_pass_by_value)]
+
+//! The single-line text field (issue 2660).
+//!
+//! Committed text (`TextInput`, already layout- and IME-resolved) inserts at
+//! the caret; the editing keys the substrate emits scancodes for — Backspace,
+//! Left, Right, Enter — move the caret or commit; an in-flight IME composition
+//! (`ImePreedit`) renders as a trailing underlined span. The caret is a
+//! byte-offset into the string and every move lands on a `char` boundary, so a
+//! multi-byte character is never split. There is no selection in v1.
+//!
+//! Home / End are not handled: the substrate's `keycode` space has no
+//! `KEY_HOME` / `KEY_END` scancode yet (only Backspace / arrows / Enter /
+//! Tab), so those edits await the keycodes landing.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_kinds::keycode::{KEY_BACKSPACE, KEY_ENTER, KEY_LEFT, KEY_RIGHT};
+use aether_kinds::{ImePreedit, Key, Modifiers, TextInput};
+
+use crate::runtime::widgets::{approx_text_width, push_border, quad};
+use crate::theme::{SetTheme, Theme, WidgetState};
+use crate::widgets::{
+    Collect, FocusGained, FocusLost, TextCommitted, TextFieldConfig, WidgetDrawItem,
+    WidgetDrawList, WidgetFrame,
+};
+
+/// A single-line editable string. Holds the text, a byte-offset caret, the
+/// character cap, the latest modifiers, and the in-flight IME preedit span.
+pub struct TextFieldWidget {
+    text: String,
+    /// Caret position as a byte offset into `text`, always on a `char`
+    /// boundary.
+    cursor: usize,
+    /// Maximum character count (`0` = uncapped).
+    max_chars: u32,
+    theme: Theme,
+    frame: WidgetFrame,
+    focused: bool,
+    modifiers: Modifiers,
+    /// The current IME composition, drawn underlined after the committed text;
+    /// empty when no composition is active.
+    preedit: String,
+}
+
+impl TextFieldWidget {
+    /// Whether inserting `count` more characters would exceed the cap.
+    fn would_overflow(&self, count: usize) -> bool {
+        self.max_chars > 0 && self.text.chars().count() + count > self.max_chars as usize
+    }
+
+    /// Insert `s` at the caret, advancing the caret past it. Rejected whole if
+    /// it would exceed the character cap. Owned editing op — unit-tested.
+    fn insert(&mut self, s: &str) {
+        if s.is_empty() || self.would_overflow(s.chars().count()) {
+            return;
+        }
+        self.text.insert_str(self.cursor, s);
+        self.cursor += s.len();
+    }
+
+    /// Delete the character before the caret (Backspace), stepping the caret
+    /// back one `char`. No-op at the start.
+    fn backspace(&mut self) {
+        let Some(prev) = self.text[..self.cursor].chars().next_back() else {
+            return;
+        };
+        let start = self.cursor - prev.len_utf8();
+        self.text.replace_range(start..self.cursor, "");
+        self.cursor = start;
+    }
+
+    /// Move the caret one `char` left. No-op at the start.
+    fn move_left(&mut self) {
+        if let Some(prev) = self.text[..self.cursor].chars().next_back() {
+            self.cursor -= prev.len_utf8();
+        }
+    }
+
+    /// Move the caret one `char` right. No-op at the end.
+    fn move_right(&mut self) {
+        if let Some(next) = self.text[self.cursor..].chars().next() {
+            self.cursor += next.len_utf8();
+        }
+    }
+
+    /// The character count before the caret — the caret's column, for its
+    /// approximate pixel placement.
+    fn chars_before_cursor(&self) -> usize {
+        self.text[..self.cursor].chars().count()
+    }
+}
+
+/// A text-field widget. Spawned inline by a panel root with a
+/// [`TextFieldConfig`]; reports [`TextCommitted`] up when Enter commits.
+///
+/// # Agent
+/// Not loaded directly — the panel root spawns it as an inline child. Send it
+/// its `TextFieldConfig` again to reset its contents or theme in place.
+#[actor(instanced)]
+impl WasmActor for TextFieldWidget {
+    type Config = TextFieldConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.text_field";
+
+    fn init(config: TextFieldConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        let cursor = config.initial.len();
+        Ok(TextFieldWidget {
+            text: config.initial,
+            cursor,
+            max_chars: config.max_chars,
+            theme: config.theme,
+            frame: WidgetFrame {
+                x: 0.0,
+                y: 0.0,
+                width: 0.0,
+                height: 0.0,
+            },
+            focused: false,
+            modifiers: Modifiers::default(),
+            preedit: String::new(),
+        })
+    }
+
+    /// Reset the contents / cap / theme in place from a re-sent config.
+    #[handler]
+    fn on_config(&mut self, _ctx: &mut WasmCtx<'_>, config: TextFieldConfig) {
+        self.cursor = config.initial.len();
+        self.text = config.initial;
+        self.max_chars = config.max_chars;
+        self.theme = config.theme;
+        self.preedit.clear();
+    }
+
+    /// Restyle: adopt the fanned theme.
+    #[handler]
+    fn on_set_theme(&mut self, _ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.theme = set.theme;
+    }
+
+    /// Cache the layout rect the root assigned.
+    #[handler]
+    fn on_frame(&mut self, _ctx: &mut WasmCtx<'_>, frame: WidgetFrame) {
+        self.frame = frame;
+    }
+
+    /// Take keyboard focus (draw the caret and focus ring).
+    #[handler]
+    fn on_focus_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: FocusGained) {
+        self.focused = true;
+    }
+
+    /// Release keyboard focus.
+    #[handler]
+    fn on_focus_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: FocusLost) {
+        self.focused = false;
+    }
+
+    /// Insert committed text at the caret. `TextInput` is already resolved
+    /// through the layout and IME, so it inserts verbatim.
+    #[handler]
+    fn on_text_input(&mut self, _ctx: &mut WasmCtx<'_>, input: TextInput) {
+        self.insert(&input.text);
+    }
+
+    /// Editing keys: Backspace deletes, Left / Right move the caret, Enter
+    /// commits the current contents up to the panel root.
+    #[handler]
+    fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
+        match key.code {
+            KEY_BACKSPACE => self.backspace(),
+            KEY_LEFT => self.move_left(),
+            KEY_RIGHT => self.move_right(),
+            KEY_ENTER => {
+                if let Some(parent) = ctx.parent() {
+                    parent.send(&TextCommitted {
+                        text: self.text.clone(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Cache the latest modifier state (Ctrl / Shift / …) so future
+    /// chord-aware edits can consult it.
+    #[handler]
+    fn on_modifiers(&mut self, _ctx: &mut WasmCtx<'_>, modifiers: Modifiers) {
+        self.modifiers = modifiers;
+    }
+
+    /// Track the in-flight IME composition. Empty text clears it.
+    #[handler]
+    fn on_ime_preedit(&mut self, _ctx: &mut WasmCtx<'_>, preedit: ImePreedit) {
+        self.preedit = preedit.text;
+    }
+
+    /// Reply the field's local draw: a box, the text plus any preedit, a caret
+    /// when focused, and a focus ring.
+    ///
+    /// # Agent
+    /// The panel root's per-frame poll; not useful to send manually.
+    #[handler]
+    fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
+        let width = self.frame.width;
+        let height = self.frame.height;
+        let pad = self.theme.pad;
+        let size = self.theme.value_size_pixels;
+        let baseline = size.mul_add(0.35, height * 0.5);
+
+        let mut items: Vec<WidgetDrawItem> = Vec::new();
+        items.push(quad(
+            0.0,
+            0.0,
+            width,
+            height,
+            self.theme
+                .fill(self.theme.surface_raised, WidgetState::Normal),
+        ));
+        let mut shown = self.text.clone();
+        shown.push_str(&self.preedit);
+        if !shown.is_empty() {
+            items.push(WidgetDrawItem::Text {
+                x: pad,
+                y: baseline,
+                font_id: self.theme.font_id,
+                text: shown,
+                size_pixels: size,
+                color: self.theme.text_primary,
+            });
+        }
+        if !self.preedit.is_empty() {
+            // Underline the composition span: a thin bar under the preedit,
+            // which trails the committed text.
+            let committed_width = approx_text_width(self.text.chars().count(), size);
+            let preedit_width = approx_text_width(self.preedit.chars().count(), size);
+            items.push(quad(
+                pad + committed_width,
+                baseline + 2.0,
+                preedit_width,
+                1.0,
+                self.theme.accent,
+            ));
+        }
+        if self.focused {
+            let caret_x = pad + approx_text_width(self.chars_before_cursor(), size);
+            let caret_height = pad.mul_add(-2.0, height).max(1.0);
+            items.push(quad(caret_x, pad, 1.0, caret_height, self.theme.accent));
+            push_border(&mut items, width, height, 2.0, self.theme.accent);
+        }
+        if let Some(parent) = ctx.parent() {
+            parent.send(&WidgetDrawList {
+                intrinsic: None,
+                items,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field(text: &str, max_chars: u32) -> TextFieldWidget {
+        TextFieldWidget {
+            cursor: text.len(),
+            text: String::from(text),
+            max_chars,
+            theme: Theme::DEFAULT,
+            frame: WidgetFrame {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 24.0,
+            },
+            focused: true,
+            modifiers: Modifiers::default(),
+            preedit: String::new(),
+        }
+    }
+
+    #[test]
+    fn insert_advances_the_caret_and_respects_the_cap() {
+        let mut f = field("ab", 0);
+        f.insert("c");
+        assert_eq!(f.text, "abc");
+        assert_eq!(f.cursor, 3);
+
+        let mut capped = field("ab", 3);
+        capped.insert("c");
+        assert_eq!(capped.text, "abc", "fills to the cap");
+        capped.insert("d");
+        assert_eq!(
+            capped.text, "abc",
+            "a further insert past the cap is dropped"
+        );
+    }
+
+    #[test]
+    fn insert_in_the_middle_lands_at_the_caret() {
+        let mut f = field("ac", 0);
+        f.cursor = 1;
+        f.insert("b");
+        assert_eq!(f.text, "abc");
+        assert_eq!(f.cursor, 2);
+    }
+
+    #[test]
+    fn backspace_deletes_a_whole_multibyte_char() {
+        // "é" is two bytes; the caret sits after it.
+        let mut f = field("é", 0);
+        assert_eq!(f.cursor, 2);
+        f.backspace();
+        assert_eq!(f.text, "");
+        assert_eq!(f.cursor, 0);
+        // Backspace at the start is a no-op.
+        f.backspace();
+        assert_eq!(f.cursor, 0);
+    }
+
+    #[test]
+    fn caret_moves_on_char_boundaries_across_multibyte_text() {
+        // "aéb": a(1) é(2) b(1). Caret starts at end (byte 4).
+        let mut f = field("aéb", 0);
+        assert_eq!(f.cursor, 4);
+        f.move_left(); // over 'b'
+        assert_eq!(f.cursor, 3);
+        f.move_left(); // over 'é' (two bytes)
+        assert_eq!(f.cursor, 1);
+        f.move_left(); // over 'a'
+        assert_eq!(f.cursor, 0);
+        f.move_left(); // no-op at start
+        assert_eq!(f.cursor, 0);
+        f.move_right(); // over 'a'
+        assert_eq!(f.cursor, 1);
+        f.move_right(); // over 'é'
+        assert_eq!(f.cursor, 3);
+    }
+
+    #[test]
+    fn chars_before_cursor_counts_characters_not_bytes() {
+        let mut f = field("aéb", 0);
+        f.cursor = 3; // after 'a' and 'é'
+        assert_eq!(f.chars_before_cursor(), 2);
+    }
+}

--- a/crates/aether-kit/src/widgets.rs
+++ b/crates/aether-kit/src/widgets.rs
@@ -34,6 +34,8 @@ use alloc::vec::Vec;
 use aether_math::Vec2;
 use serde::{Deserialize, Serialize};
 
+use crate::theme::Theme;
+
 /// `aether.kit.widget.collect` — a per-frame poll a compositing node
 /// sends to each of its children in layout order. The child answers with
 /// its [`WidgetDrawList`]. Fieldless: the poll carries no data, because
@@ -160,6 +162,156 @@ pub struct WidgetConfig {
     pub chrome: Vec<WidgetDrawItem>,
     pub intrinsic: Option<[f32; 2]>,
     pub children: Vec<WidgetChildSpec>,
+}
+
+/// The four data-down lanes of the widget set (config / style / layout
+/// frame) and the one events-up lane (value) that the reference panel root
+/// drives its inline widget children through. The kinds carry **no widget
+/// identity field**: a value-up reply is attributed by the root against the
+/// `MailboxId` it recorded when it spawned each child (`ctx.source_mailbox`),
+/// so a widget's identity stays its inline subname rather than a field the
+/// widget could get wrong. Layout and focus flow down the same way the
+/// compositing `Collect` does — the root owns every child's rect and focus,
+/// and the widget only reacts.
+///
+/// Each per-widget `Config` embeds a [`Theme`] (the theme-first sequencing:
+/// there is no separate widget-style kind — a widget's whole look is its
+/// theme), and is both the `spawn_inline_child` init config and a re-sendable
+/// data-down mail: sending a widget its `Config` kind again reconfigures it in
+/// place.
+/// `aether.kit.widget.slider.config` — a horizontal value slider over
+/// `min..=max`, snapped to `step`, starting at `initial`. The consumer maps
+/// the reported `f32` onto its own domain (a `u8` intensity, a preset index).
+/// A `step` of `0` (or less) leaves the value continuous.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.slider.config")]
+pub struct SliderConfig {
+    pub min: f32,
+    pub max: f32,
+    pub step: f32,
+    pub initial: f32,
+    pub theme: Theme,
+}
+
+/// `aether.kit.widget.text_field.config` — a single-line editable string
+/// starting at `initial`, capped at `max_chars` characters (`0` = no cap).
+/// The field holds a `String` and a byte-offset caret; there is no selection
+/// in v1.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.text_field.config")]
+pub struct TextFieldConfig {
+    pub initial: String,
+    pub max_chars: u32,
+    pub theme: Theme,
+}
+
+/// `aether.kit.widget.radio.config` — a vertical list of mutually-exclusive
+/// `options`, one selected at a time, starting at `initial_index` (clamped
+/// into range at init). Each option draws as one theme row.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.radio.config")]
+pub struct RadioConfig {
+    pub options: Vec<String>,
+    pub initial_index: u32,
+    pub theme: Theme,
+}
+
+/// `aether.kit.widget.button.config` — a momentary push button showing
+/// `label`, firing [`ButtonClicked`] on a press-then-release-inside.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.button.config")]
+pub struct ButtonConfig {
+    pub label: String,
+    pub theme: Theme,
+}
+
+/// `aether.kit.widget.label.config` — static, non-interactive `text`. A label
+/// is not focus-eligible (the root's focus register skips it).
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.label.config")]
+pub struct LabelConfig {
+    pub text: String,
+    pub theme: Theme,
+}
+
+/// `aether.kit.widget.slider.changed` — a slider's value-up event.
+/// `committed` is `false` for the live values a drag streams and `true` for
+/// the final value when the drag releases (or an arrow-key nudge lands), so a
+/// consumer can throttle expensive work to committed values while still
+/// previewing the drag.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.slider.changed")]
+pub struct SliderChanged {
+    pub value: f32,
+    pub committed: bool,
+}
+
+/// `aether.kit.widget.text_field.committed` — a text field's value-up event,
+/// emitted when the field's Enter key commits its current contents.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.text_field.committed")]
+pub struct TextCommitted {
+    pub text: String,
+}
+
+/// `aether.kit.widget.radio.selected` — a radio group's value-up event,
+/// carrying the newly selected option's zero-based `index`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.radio.selected")]
+pub struct RadioSelected {
+    pub index: u32,
+}
+
+/// `aether.kit.widget.button.clicked` — a button's value-up event, fired once
+/// per completed press-then-release-inside. Fieldless: the click carries no
+/// data, and which button clicked is the root's `source_mailbox` attribution.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.button.clicked")]
+pub struct ButtonClicked;
+
+/// `aether.kit.widget.frame` — the layout rect the root assigns a child,
+/// data-down. `(x, y)` is the child's top-left in window pixels and
+/// `(width, height)` its size. The child caches it to lay out its own local
+/// draw and to map a forwarded pointer position into its local space; the
+/// root keeps the same rect in its layout table to offset the child's draws
+/// and to hit-test pointer input.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.frame")]
+pub struct WidgetFrame {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+/// `aether.kit.widget.focus_gained` — the root tells a child it now holds
+/// keyboard focus, so the child draws its focus ring and caret. Fieldless.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.focus_gained")]
+pub struct FocusGained;
+
+/// `aether.kit.widget.focus_lost` — the root tells a child it no longer holds
+/// keyboard focus, so the child stops drawing its focus ring and caret.
+/// Fieldless.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.focus_lost")]
+pub struct FocusLost;
+
+/// `aether.kit.widget.panel.config` — the reference panel root's layout
+/// config: where the vertical widget stack sits (`x` / `y` top-left, `width`),
+/// its base [`Theme`], and the font it loads through `aether.text` to fill the
+/// theme's `font_id`. The panel spawns a fixed demonstration stack (a label, a
+/// slider, a radio group, a text field, an apply button) from this — the
+/// copy-paste starting point a real editor panel forks.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.panel.config")]
+pub struct PanelConfig {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub font_namespace: String,
+    pub font_path: String,
+    pub theme: Theme,
 }
 
 #[cfg(test)]

--- a/crates/aether-substrate-bundle/tests/widget_set.rs
+++ b/crates/aether-substrate-bundle/tests/widget_set.rs
@@ -1,0 +1,220 @@
+//! Widget-set end-to-end scenario (issue 2660).
+//!
+//! Load the reference `WidgetPanel` root, drive it with synthetic pointer and
+//! keyboard input, and assert the value-up events reach the panel end-to-end —
+//! the kit-owned routing (`Focus` hit-test / drag-capture / Tab cycle), the
+//! slider drag-value math, radio selection, and text editing all working
+//! through the real inline-cluster FIFO drain, not just the unit tests over
+//! the helper structs. The panel logs each value-up into its per-actor log
+//! ring (ADR-0081); the scenario tails the ring and reads the attributed
+//! events back.
+//!
+//! Value-up events flow child → panel *inside the cluster*, so they never
+//! cross the observable render / broadcast sink `count_observed` watches — the
+//! log ring is the correct observation surface here. The rendered-output gate
+//! (one `DrawSolidQuads` per cluster) is issue 2659's `widget_compositing`
+//! scenario and is not duplicated.
+//!
+//! Skipped when no wgpu adapter is available or the `aether_kit` wasm has not
+//! been pre-built (the shared `require_runtime` gate). CI sets
+//! `AETHER_REQUIRE_RUNTIME=1` to turn either skip into a hard failure.
+
+// Integration-test skip diagnostic: emit via stderr so `cargo test` surfaces
+// "skipping: ..." alongside `test ... ok` (issue 891).
+#![allow(clippy::print_stderr)]
+// Pixel-rect layout constants read clearest as float literals inline.
+#![allow(clippy::cast_precision_loss)]
+
+use std::fs;
+
+use aether_actor::Addressable;
+use aether_data::Kind;
+use aether_kinds::keycode::{KEY_DOWN, KEY_ENTER, KEY_TAB};
+use aether_kinds::mouse_button::LEFT;
+use aether_kinds::{
+    Key, LoadComponent, LoadResult, LogTailResult, MouseButton, MouseButtonRelease, MouseMove,
+    TextInput, Tick,
+};
+use aether_kit::{PanelConfig, Theme};
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
+
+/// The full trampoline address the loaded panel registers at (ADR-0099 §4).
+fn panel_address() -> String {
+    format!(
+        "aether.component/{}:panel",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    )
+}
+
+/// Load the `WidgetPanel` root under the name `panel` (export
+/// `aether.kit.widget.panel`) with a config that places its stack at
+/// `(10, 10)` 200px wide, no font (`font_path` empty, so no `aether.text`
+/// dependency), and the default theme.
+fn load_panel(bench: &mut TestBench, wasm: &[u8]) {
+    let config = PanelConfig {
+        x: 10.0,
+        y: 10.0,
+        width: 200.0,
+        font_namespace: String::new(),
+        font_path: String::new(),
+        theme: Theme::DEFAULT,
+    };
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: wasm.to_vec(),
+                    name: Some("panel".to_owned()),
+                    config: config.encode_into_bytes(),
+                    export: Some("aether.kit.widget.panel".to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { name, .. } => assert!(
+            name.ends_with(":panel"),
+            "the panel root should register under :panel; got {name}",
+        ),
+        LoadResult::Err { error } => panic!("load WidgetPanel root: {error}"),
+    }
+}
+
+/// Every log message in the panel's ring, oldest first.
+fn panel_log_messages(bench: &mut TestBench) -> Vec<String> {
+    match bench.log_tail(&panel_address(), None) {
+        LogTailResult::Ok { entries, .. } => entries.into_iter().map(|e| e.message).collect(),
+        LogTailResult::Err { error } => panic!("log_tail on the panel failed: {error}"),
+    }
+}
+
+/// A left mouse-button press at `(x, y)`.
+fn press(x: f32, y: f32) -> MouseButton {
+    MouseButton { button: LEFT, x, y }
+}
+
+/// A left mouse-button release at `(x, y)`.
+fn release(x: f32, y: f32) -> MouseButtonRelease {
+    MouseButtonRelease { button: LEFT, x, y }
+}
+
+/// Drive the reference panel through a full input session — a slider drag, a
+/// Tab-then-arrow keyboard move, a radio click, and a text entry — and read
+/// the attributed value-up events back off the panel's log ring.
+///
+/// Layout under the default theme (`row_height` 24, `gap` 6), stack at
+/// `(10, 10)` 200px wide:
+///   label   y 10..34   slider  y 40..64   radio y 70..142
+///   text    y 148..172 button  y 178..202
+#[test]
+fn panel_routes_input_to_widgets_and_reports_values_up() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = TestBench::start_with_size(240, 220).expect("boot");
+    load_panel(&mut bench, &wasm);
+
+    let panel = panel_address();
+    // The first tick spawns the widget stack and assigns each child its frame;
+    // every later step drives one input event, settling its whole in-cluster
+    // chain before the next.
+    // Each input kind is fire-and-forget (no reply), so `send_mail` — which
+    // still blocks until the whole dispatched chain settles — is the op;
+    // `send_and_await` would hang waiting for a reply that never comes.
+    bench
+        .execute(vec![
+            ("spawn", BenchOp::send_mail(&panel, &Tick)),
+            // Slider drag: press mid-track, drag right, release — the release
+            // commits at the dragged value (x=160 → 75% of 0..255 ≈ 191). The
+            // press also focuses the slider.
+            (
+                "drag_press",
+                BenchOp::send_mail(&panel, &press(110.0, 52.0)),
+            ),
+            (
+                "drag_move",
+                BenchOp::send_mail(&panel, &MouseMove { x: 160.0, y: 52.0 }),
+            ),
+            (
+                "drag_release",
+                BenchOp::send_mail(&panel, &release(160.0, 52.0)),
+            ),
+            // Tab moves focus off the slider to the radio group; Down then
+            // routes to the focused radio, moving its selection to index 1.
+            ("tab", BenchOp::send_mail(&panel, &Key { code: KEY_TAB })),
+            (
+                "radio_key",
+                BenchOp::send_mail(&panel, &Key { code: KEY_DOWN }),
+            ),
+            // A click on the third radio row (y 118..142) selects index 2.
+            (
+                "radio_press",
+                BenchOp::send_mail(&panel, &press(30.0, 125.0)),
+            ),
+            (
+                "radio_release",
+                BenchOp::send_mail(&panel, &release(30.0, 125.0)),
+            ),
+            // Focus the text field (y 148..172), type into it, and commit.
+            (
+                "text_focus",
+                BenchOp::send_mail(&panel, &press(50.0, 160.0)),
+            ),
+            (
+                "text_focus_up",
+                BenchOp::send_mail(&panel, &release(50.0, 160.0)),
+            ),
+            (
+                "type",
+                BenchOp::send_mail(
+                    &panel,
+                    &TextInput {
+                        text: "hi".to_owned(),
+                    },
+                ),
+            ),
+            (
+                "commit",
+                BenchOp::send_mail(&panel, &Key { code: KEY_ENTER }),
+            ),
+        ])
+        .expect("input session");
+
+    let log = panel_log_messages(&mut bench);
+    let joined = log.join("\n");
+
+    assert!(
+        log.iter()
+            .any(|m| m.contains("widget slider changed") && m.contains("committed=true")),
+        "the slider drag-release should log a committed change; log was:\n{joined}",
+    );
+    assert!(
+        log.iter().any(|m| m.contains("widget slider changed")
+            && m.contains("widget=slider")
+            && m.contains("committed=false")),
+        "the drag should stream at least one uncommitted change; log was:\n{joined}",
+    );
+    assert!(
+        log.iter()
+            .any(|m| m.contains("widget radio selected") && m.contains("index=1")),
+        "Tab-then-Down should route to the radio and select index 1 — proving the \
+         focus cycle and keyboard routing; log was:\n{joined}",
+    );
+    assert!(
+        log.iter()
+            .any(|m| m.contains("widget radio selected") && m.contains("index=2")),
+        "the radio row click should select index 2; log was:\n{joined}",
+    );
+    assert!(
+        log.iter()
+            .any(|m| m.contains("widget text committed") && m.contains("text=hi")),
+        "the text entry then Enter should commit \"hi\" — proving pointer focus \
+         and text routing; log was:\n{joined}",
+    );
+}

--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -25,6 +25,7 @@
   - [The scheduler](systems/scheduler.md)
   - [Components & lifecycle](systems/components.md)
   - [Rendering & camera](systems/rendering.md)
+  - [Widget set & focus model](systems/widgets.md)
   - [Mesh authoring & the DSL]()
   - [Input streams](systems/input.md)
   - [The frame lifecycle](systems/lifecycle.md)

--- a/docs/guide/systems/widgets.md
+++ b/docs/guide/systems/widgets.md
@@ -1,0 +1,88 @@
+# The widget set & focus model
+
+`aether-kit` ships a set of guest-side widgets — a slider, a text field, a
+radio group, a button, and a label — as ordinary `#[actor(instanced)]` types.
+A panel root spawns them as inline children (ADR-0114) and drives them entirely
+by mail, so composing an editor panel is a matter of laying out widgets and
+translating their value events, never re-deriving hit rects, focus, or per-row
+layout for each new knob.
+
+The widgets build on two foundations documented alongside them: the
+draw-compositing protocol (ADR-0117 — `Collect` down, `WidgetDrawList` up, the
+`Composite` helper, and the one-render-sender-per-cluster emit) and the theme
+(`Theme` tokens plus `Theme::fill`, carried on each widget's config). This page
+covers the layer above those: the four mail lanes every widget speaks and the
+focus-and-input model the root owns.
+
+## Four lanes of mail
+
+A widget reacts to three data-down lanes and reports on one events-up lane. The
+value kinds carry **no widget-identity field** — the root attributes a reply by
+the sender's `MailboxId` (`ctx.source_mailbox()`) against the children it
+recorded at spawn, so a widget's identity is its inline subname and nothing a
+widget sends can misreport it.
+
+- **Config, down.** One `Config` kind per widget — `SliderConfig`,
+  `TextFieldConfig`, `RadioConfig`, `ButtonConfig`, `LabelConfig` — each
+  embedding a `theme: Theme`. The config is both the value
+  `spawn_inline_child::<W>(subname, &config)` boots the widget with and a
+  re-sendable mail: send a widget its config kind again to reconfigure it in
+  place (a slider's range, a field's cap, a button's label).
+- **Style, down.** `SetTheme { theme }` re-fans a live restyle. A widget adopts
+  the new tokens and the next immediate-mode frame draws with them — one frame
+  of latency, no invalidation bookkeeping. There is no cascade and no
+  selectors; a one-off look is an explicit `theme` override on that widget's
+  own config.
+- **Layout, down.** The root assigns each child a `WidgetFrame { x, y, width,
+  height }` in window pixels. The child caches it to lay out its local draw and
+  to map a forwarded pointer position into its own space; the root keeps the
+  same rect to offset the child's draws (through `Composite`) and to hit-test
+  pointer input (through `Focus`).
+- **Value, up.** `SliderChanged { value, committed }`, `TextCommitted { text }`,
+  `RadioSelected { index }`, and `ButtonClicked` flow to the parent through
+  `ctx.parent()`. A slider streams `committed: false` values through a drag and
+  a final `committed: true` on release, so a consumer previews the drag and
+  commits the expensive work once.
+
+## Root-owned focus and input
+
+Widgets never subscribe to input. The panel root subscribes the pointer and
+keyboard streams once (the input cap) and the frame stage once (the lifecycle
+cap), then routes every event through a `Focus` helper it embeds — the
+input-side counterpart to `Composite`. `Focus` holds the child hit rects in
+layout order, the focused child, and the drag-captured child, and answers three
+questions:
+
+- **Where does a pointer event go?** To the drag-captured child if one holds
+  capture — so a drag that leaves a widget's rect still reaches it — otherwise
+  to the topmost child under the cursor.
+- **Where does a keyboard event go?** To the focused child.
+- **What moves focus?** A left press on a focusable child, or Tab (which cycles
+  focusable children in registration order, wrapping). Each move yields the
+  `(previous, next)` pair the root turns into a `FocusLost` down to the old
+  holder and a `FocusGained` down to the new one, and each widget draws its own
+  focus ring and caret from that — the root carries no per-widget-type visual
+  knowledge.
+
+Drag capture is the kit's own policy over the raw button vocabulary: a left
+press that hits a widget sets capture on that child, moves route to it while
+capture holds, and the matching release clears it. That is what lets a slider
+track the cursor past the end of its track and a button cancel when the release
+drifts off it.
+
+## The reference panel
+
+`WidgetPanel` (export `aether.kit.widget.panel`) is the worked example — the
+test vehicle and the template a real editor forks. It embeds `Composite` and
+`Focus`, spawns a vertical stack of every widget on its first frame, loads a
+font through `aether.text` and stamps the session `font_id` into its theme when
+`load_font_result` arrives, drives the collect/emit loop each frame, and routes
+input through `Focus`. Its value-up handlers are the seam: each attributes the
+event by `ctx.source_mailbox()` and is where a map editor translates a widget
+change into world-knob driver mail. Fork it by replacing the stack and filling
+in those handlers.
+
+To add a new widget — a dropdown, a checkbox, a color well — write one more
+`#[actor(instanced)]` type that speaks the same four lanes and answers `Collect`
+with a `WidgetDrawList`, then spawn it into a panel's stack. The focus model and
+the draw protocol carry it with no new machinery.


### PR DESCRIPTION
Closes #2660.

## Summary

The widget set the map editor composes from: `SliderWidget`, `TextFieldWidget`, `RadioGroupWidget`, plus `Button` and `Label`, as plain `#[actor]` inline child actors under `crates/aether-kit/src/runtime/widgets/`. Contracts run in the four mail lanes the scope settled — config, theme, and layout frame data-down; value events up (`SliderChanged`, `TextCommitted`, `RadioSelected`, carrying no identity fields — the panel root correlates by inbound source against the subnames it spawned). The `widget_panel` root owns focus and input routing: it subscribes input once, hit-tests presses against assigned frames, holds drag capture for the slider's press-move-release loop, forwards keyboard and text mail to the focused child, and cycles focus on Tab in spawn order. Widgets draw local-coordinate `WidgetDrawList` batches through the landed compositing protocol (one render sender per tree) and resolve every color through `Theme::fill` — no literal color arrays in widget draw code. Text editing composes the landed kinds: `TextInput` inserts at the byte-offset caret, `ImePreedit` renders in-flight composition, editing keys pair `Key` scancodes with cached `Modifiers`.

## Test plan

Owned-logic unit tests across the widgets (slider value math and step quantization, text-field caret/insert/delete ops, radio selection, focus cycling and drag-capture routing in the panel) — `cargo nextest run -p aether-kit` 122/122 green. One TestBench e2e (`crates/aether-substrate-bundle/tests/widget_set.rs`): a panel with slider + text field + radio children routes injected pointer/text mail to the right widget and reports committed values up to the root. Clippy `-D warnings` clean on both crates; guide page added under systems/widgets.

## Generated by

`/implement` — agent execution of [scoped issue #2660](https://github.com/iamacoffeepot/aether/issues/2660).
