### PR TITLE
fix(substrate-bundle): strip control characters from the text-input gate

### DIFF
--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -530,6 +530,11 @@ pub struct WindowSize {
 /// run of characters. A text-field widget subscribes this and inserts
 /// `text` at its caret with no guest-side scancode keymap. Headless and
 /// hub chassis never publish — they have no window (same as `Key`).
+/// `text` never carries a control character: named keys with a
+/// control-char text representation (Backspace, Enter, Tab, Escape,
+/// Delete) arrive only as `Key` scancode edges, and the chassis strips
+/// any control characters winit's `KeyEvent.text` reports before
+/// publishing.
 ///
 /// Carries a `String`, so it rides the structured wire path
 /// (`Kind::encode_into_bytes` → `encode_wire`), not the `#[repr(C)]`

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -324,9 +324,23 @@ enum TextSource {
 /// source of truth. `Preedit { active }` opens or closes the gate without
 /// publishing (the in-flight text rides `ImePreedit` instead); `Disabled`
 /// closes it. Winit-free so the dedupe is testable without a winit `App`.
+///
+/// `KeyText` also strips control characters before publishing. Winit
+/// reports a named key's (Backspace / Enter / Tab / Escape / Delete) text
+/// representation as a C0 control character, and those keys already
+/// arrive as `Key` scancode edges — publishing the control character too
+/// would double-report the keystroke as printable text (e.g. Backspace
+/// inserting a glyph on the same frame its scancode edge deletes one).
+/// The strip is per-character rather than whole-event: winit documents
+/// that `KeyEvent.text` can carry a dead-key char followed by a resolved
+/// character, so a run is not guaranteed to be a single glyph, and
+/// dropping only the control chars preserves any printable characters
+/// riding alongside them.
 fn text_input_gate(composing: &mut bool, source: TextSource) -> Option<String> {
     match source {
-        TextSource::KeyText(text) => (!*composing).then_some(text),
+        TextSource::KeyText(text) => (!*composing)
+            .then(|| text.chars().filter(|c| !c.is_control()).collect::<String>())
+            .filter(|t| !t.is_empty()),
         TextSource::Preedit { active } => {
             *composing = active;
             None
@@ -1860,6 +1874,44 @@ mod tests {
             text_input_gate(&mut composing, TextSource::KeyText("z".to_owned())).as_deref(),
             Some("z"),
         );
+    }
+
+    // Tripwire: a named key's control-char text representation must never
+    // publish as `TextInput` — Backspace's scancode edge is the sole
+    // delete signal, so a published `"\u{8}"` would re-insert a glyph on
+    // the same frame the edge deletes one.
+    #[test]
+    fn gate_suppresses_pure_backspace_keytext() {
+        let mut composing = false;
+        let out = text_input_gate(&mut composing, TextSource::KeyText("\u{8}".to_owned()));
+        assert_eq!(out, None);
+        assert!(!composing, "a suppressed control char opens no composition");
+    }
+
+    // Tripwire: Enter and Tab carry the same C0-control-char shape as
+    // Backspace and must be suppressed identically.
+    #[test]
+    fn gate_suppresses_pure_enter_and_tab_keytext() {
+        let mut composing = false;
+        assert_eq!(
+            text_input_gate(&mut composing, TextSource::KeyText("\r".to_owned())),
+            None
+        );
+        assert_eq!(
+            text_input_gate(&mut composing, TextSource::KeyText("\t".to_owned())),
+            None
+        );
+    }
+
+    // Tripwire: a run mixing a printable character with a control
+    // character strips only the control char, pinning strip-per-char over
+    // whole-event drop (winit can pair a dead-key char with a resolved
+    // character in one `KeyEvent.text`).
+    #[test]
+    fn gate_strips_control_char_from_mixed_keytext() {
+        let mut composing = false;
+        let out = text_input_gate(&mut composing, TextSource::KeyText("a\u{8}".to_owned()));
+        assert_eq!(out.as_deref(), Some("a"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #2671.

## Summary

Backspace in a text field looked dead because it did two things at once: winit's documented cross-platform contract puts a control character in `KeyEvent.text` for named keys (Backspace is `\u{8}`, Enter `\r`), and the composition gate forwarded it verbatim as `TextInput` — so each press inserted a control character in the same frame the scancode edge deleted one, and the string never shrank. The gate's `KeyText` arm now strips control characters per-character and suppresses the event when nothing printable remains, so the scancode path is the sole editing signal for named keys; a dead-key-resolved run riding alongside a control character keeps its printable content. `Ime::Commit` is untouched — commits are final graphemes and never carry control characters. `TextInput`'s doc now states the no-control-characters guarantee.

## Test plan

Three new tripwires on the gate's owned dedupe logic beside the existing three: pure Backspace and Enter/Tab key-text suppress to `None`, and mixed `"a\u{8}"` strips to `Some("a")` (pinning strip-over-drop). The widget-tier entry + backspace round-trip lands in #2674's scenario suite. Clippy and rustdoc gates clean on both touched crates.

## Generated by

`/implement` — agent execution of [scoped issue #2671](https://github.com/iamacoffeepot/aether/issues/2671).
