### PR TITLE
feat(kit): live material-style authoring over mail

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -15,7 +15,7 @@
 //! driver kinds live in [`camera`]; the mesh viewer's `aether.mesh.load`
 //! kind lives in [`mesh`]. The [`world`] module holds the chunked world
 //! plane stack — the `World` / `Chunk` / `Material` data layer and its
-//! `aether.kit.world.{set_chunk,set_region,set_smoothing_profile,set_view_mode,load}` wire kinds
+//! `aether.kit.world.{set_chunk,set_region,set_smoothing_profile,set_material_style,set_view_mode,load}` wire kinds
 //! — that `WorldView` meshes to the render sink. The [`widgets`] module
 //! holds the widget-compositing vocabulary (ADR-0117) — `Collect` /
 //! `WidgetDrawList` and the `WidgetConfig` tree — that
@@ -56,8 +56,8 @@ pub use widgets::{
 };
 pub use world::{
     CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk, ChunkPos, Material, Region,
-    SetChunk, SetRegion, SetSmoothingProfile, SetViewMode, SmoothingProfile, ViewMode, World,
-    WorldDecodeError, WorldLoad,
+    SetChunk, SetMaterialStyle, SetRegion, SetSmoothingProfile, SetViewMode, SmoothingProfile,
+    ViewMode, World, WorldDecodeError, WorldLoad,
 };
 
 #[cfg(feature = "runtime")]

--- a/crates/aether-kit/src/runtime/mesher/mod.rs
+++ b/crates/aether-kit/src/runtime/mesher/mod.rs
@@ -100,7 +100,8 @@ use contour::{
     minimize_corners, push_quad, repartition,
 };
 use style::{
-    ResolvedCell, hsl_to_linear_rgb, raw_field, resolve_cell, rim_strength, style, wash_lightness,
+    ResolvedCell, StyleTable, hsl_to_linear_rgb, raw_field, resolve_cell, rim_strength,
+    wash_lightness,
 };
 
 /// Cells along one chunk edge, as a plain `i32` for loop bounds.
@@ -164,17 +165,23 @@ const MAX_SHORE_SCAN: i32 = 8;
 /// is unit-testable host-side. Reads neighbor cells through [`World`] (a
 /// bounded apron); a missing neighbor reads as empty. `mode` selects the
 /// painted gouache grammar or the raw grayscale calibration field.
+/// `styles` resolves each material's live style row.
 #[must_use]
-pub fn mesh_chunk(world: &World, at: ChunkPos, mode: ViewMode) -> Vec<DrawTriangle> {
+pub fn mesh_chunk(
+    world: &World,
+    at: ChunkPos,
+    mode: ViewMode,
+    styles: &StyleTable,
+) -> Vec<DrawTriangle> {
     let mut tris = Vec::new();
     match mode {
-        ViewMode::Raw => mesh_raw(world, at, &mut tris),
+        ViewMode::Raw => mesh_raw(world, at, styles, &mut tris),
         ViewMode::Painted => {
-            mesh_underlay(world, at, &mut tris);
-            mesh_overlay(world, at, &mut tris);
+            mesh_underlay(world, at, styles, &mut tris);
+            mesh_overlay(world, at, styles, &mut tris);
         }
     }
-    emit_skirts(world, at, mode, &mut tris);
+    emit_skirts(world, at, mode, styles, &mut tris);
     tris
 }
 
@@ -267,9 +274,15 @@ fn floor_to_i32(v: f32) -> i32 {
 /// edges rim through the partition's marched band, never here. A pure
 /// function of the cell and its four neighbors, so the two cells sharing
 /// an edge agree on the rim there.
-fn cell_rims(world: &World, cell: CellPos, material: Material) -> [f32; 4] {
-    let hue_a = resolve_cell(material, cell.x as f32 + 0.5, cell.z as f32 + 0.5, None).hue;
-    let threshold = style(material).blob_merge_degrees;
+fn cell_rims(world: &World, cell: CellPos, material: Material, styles: &StyleTable) -> [f32; 4] {
+    let hue_a = resolve_cell(
+        styles.get(material),
+        cell.x as f32 + 0.5,
+        cell.z as f32 + 0.5,
+        None,
+    )
+    .hue;
+    let threshold = styles.get(material).blob_merge_degrees;
     let sides = [
         (cell.x - 1, cell.z),
         (cell.x + 1, cell.z),
@@ -282,7 +295,13 @@ fn cell_rims(world: &World, cell: CellPos, material: Material) -> [f32; 4] {
         if neighbor != material {
             continue; // the partition's marched rim owns this edge
         }
-        let hue_b = resolve_cell(neighbor, *nx as f32 + 0.5, *nz as f32 + 0.5, None).hue;
+        let hue_b = resolve_cell(
+            styles.get(neighbor),
+            *nx as f32 + 0.5,
+            *nz as f32 + 0.5,
+            None,
+        )
+        .hue;
         rims[k] = rim_strength(true, true, hue_a, hue_b, threshold);
     }
     rims
@@ -297,6 +316,7 @@ fn partition_inputs(
     at: ChunkPos,
     apron: i32,
     n: usize,
+    styles: &StyleTable,
 ) -> Option<(Vec<u8>, Vec<SmoothParams>)> {
     let mut ids = vec![0u8; n * n];
     let mut params = vec![
@@ -319,7 +339,7 @@ fn partition_inputs(
             any |= material != Material::Void;
             params[idx] = world.smoothing_override(cell).map_or_else(
                 || {
-                    let s = style(material);
+                    let s = styles.get(material);
                     SmoothParams {
                         iterations: s.smoothing_iterations,
                         smoothing_degrees: s.smoothing_degrees,
@@ -358,10 +378,10 @@ fn display_label(material: u8, body: bool) -> u8 {
 /// polygons everywhere else, all at `y = 0` with no lifts. Every decision
 /// is a pure function of world coordinates, so two chunks emit identical
 /// geometry over their shared apron and the overlap is invisible.
-fn mesh_underlay(world: &World, at: ChunkPos, tris: &mut Vec<DrawTriangle>) {
+fn mesh_underlay(world: &World, at: ChunkPos, styles: &StyleTable, tris: &mut Vec<DrawTriangle>) {
     let apron = MAX_APRON_SUBCELLS;
     let n = (SUBCELLS_PER_CHUNK_EDGE + 2 * apron) as usize;
-    let Some((ids, params)) = partition_inputs(world, at, apron, n) else {
+    let Some((ids, params)) = partition_inputs(world, at, apron, n, styles) else {
         return;
     };
 
@@ -381,8 +401,11 @@ fn mesh_underlay(world: &World, at: ChunkPos, tris: &mut Vec<DrawTriangle>) {
             continue;
         }
         let region: Vec<bool> = grid.iter().map(|&g| g == m).collect();
-        let rim_width =
-            (style(Material::from_u8_or_void(m)).rim_inset_octimeters / step_oct).max(1);
+        let rim_width = (styles
+            .get(Material::from_u8_or_void(m))
+            .rim_inset_octimeters
+            / step_oct)
+            .max(1);
         let eroded = erode(&region, gw, gw, rim_width);
         for (idx, &g) in grid.iter().enumerate() {
             if g == m {
@@ -438,15 +461,22 @@ fn mesh_underlay(world: &World, at: ChunkPos, tris: &mut Vec<DrawTriangle>) {
                 z: at.z * EDGE + lz,
             };
             let material = world.underlay(cell);
-            let resolved = resolve_cell(material, cell.x as f32 + 0.5, cell.z as f32 + 0.5, None);
-            let rims = cell_rims(world, cell, material);
+            let resolved = resolve_cell(
+                styles.get(material),
+                cell.x as f32 + 0.5,
+                cell.z as f32 + 0.5,
+                None,
+            );
+            let rims = cell_rims(world, cell, material, styles);
             let lift = CellLift::of(world, cell);
-            emit_underlay_cell(material, &resolved, cell.x, cell.z, rims, &lift, tris);
+            emit_underlay_cell(
+                material, &resolved, cell.x, cell.z, rims, &lift, styles, tris,
+            );
         }
     }
 
     emit_partition_windows(
-        world, at, &display, gw, apron, step_oct, &interior, lo, tris,
+        world, at, &display, gw, apron, step_oct, &interior, lo, styles, tris,
     );
 }
 
@@ -469,6 +499,7 @@ fn emit_partition_windows(
     step_oct: i32,
     interior: &[bool],
     lo: i32,
+    styles: &StyleTable,
     tris: &mut Vec<DrawTriangle>,
 ) {
     let hi = EDGE;
@@ -500,7 +531,7 @@ fn emit_partition_windows(
             origin_oct[0] + end_wi as i32 * step_oct,
             origin_oct[1] + (wj + 1) as i32 * step_oct,
         ];
-        emit_label_quad(world, label, owner, rect, tris);
+        emit_label_quad(world, label, owner, rect, styles, tris);
     };
     let windows = gw - 1;
     for wj in 0..windows {
@@ -568,7 +599,9 @@ fn emit_partition_windows(
                 continue;
             }
             flush(&mut run, wi, wj, tris);
-            emit_mixed_window(world, display, gw, wi, wj, corners, owner, &place, tris);
+            emit_mixed_window(
+                world, display, gw, wi, wj, corners, owner, &place, styles, tris,
+            );
         }
         flush(&mut run, windows, wj, tris);
     }
@@ -583,17 +616,23 @@ fn emit_label_quad(
     label: u8,
     owner: CellPos,
     rect: [i32; 4],
+    styles: &StyleTable,
     tris: &mut Vec<DrawTriangle>,
 ) {
     let material = Material::from_u8_or_void(label.div_ceil(2));
-    let resolved = resolve_cell(material, owner.x as f32 + 0.5, owner.z as f32 + 0.5, None);
+    let resolved = resolve_cell(
+        styles.get(material),
+        owner.x as f32 + 0.5,
+        owner.z as f32 + 0.5,
+        None,
+    );
     let rim = if label % 2 == 1 {
-        style(material).rim_darken
+        styles.get(material).rim_darken
     } else {
         0.0
     };
     let surface = |wx: f32, wz: f32| label_lift(world, owner, wx, wz);
-    emit_quad_shaded(material, &resolved, rect, rim, &surface, tris);
+    emit_quad_shaded(material, &resolved, rect, rim, &surface, styles, tris);
 }
 
 /// Emit every label's case polygon for one mixed boundary window, colored
@@ -611,6 +650,7 @@ fn emit_mixed_window(
     corners: [u8; 4],
     owner: CellPos,
     place: &GridPlacement,
+    styles: &StyleTable,
     tris: &mut Vec<DrawTriangle>,
 ) {
     let step_oct = place.step_oct;
@@ -637,9 +677,9 @@ fn emit_mixed_window(
             true
         };
         let material = Material::from_u8_or_void(label.div_ceil(2));
-        let s = style(material);
-        let resolved = resolve_cell(material, owner.x as f32 + 0.5, owner.z as f32 + 0.5, None);
-        let mut light = wash_lightness(material, resolved.light, wash_x, wash_z, resolved.stroke);
+        let s = styles.get(material);
+        let resolved = resolve_cell(s, owner.x as f32 + 0.5, owner.z as f32 + 0.5, None);
+        let mut light = wash_lightness(s, resolved.light, wash_x, wash_z, resolved.stroke);
         if label % 2 == 1 {
             light *= 1.0 - s.rim_darken;
         }
@@ -666,6 +706,8 @@ fn emit_mixed_window(
 /// Emit one cell's geometry: a single flat quad when no side rims, else a
 /// nine-slice whose edge strips and corners darken by the pooled-rim
 /// factor. All geometry stays inside the cell — the rim only pools inward.
+#[allow(clippy::too_many_arguments)] // one call site; the cell state travels together
+#[allow(clippy::too_many_lines)] // a flat sequence of nine quad emits; splitting hides the slice
 fn emit_underlay_cell(
     material: Material,
     resolved: &ResolvedCell,
@@ -673,11 +715,12 @@ fn emit_underlay_cell(
     cz: i32,
     rims: [f32; 4],
     patch: &CellLift,
+    styles: &StyleTable,
     tris: &mut Vec<DrawTriangle>,
 ) {
     let surface = |wx: f32, wz: f32| (patch.y(wx, wz), patch.shade(wx, wz));
     let surface = &surface;
-    let s = style(material);
+    let s = styles.get(material);
     let inset = s.rim_inset_octimeters;
     let x0 = cx * 256;
     let x3 = (cx + 1) * 256;
@@ -689,13 +732,29 @@ fn emit_underlay_cell(
     let z2 = z3 - inset;
 
     if rims.iter().all(|&r| r == 0.0) {
-        emit_quad_shaded(material, resolved, [x0, z0, x3, z3], 0.0, surface, tris);
+        emit_quad_shaded(
+            material,
+            resolved,
+            [x0, z0, x3, z3],
+            0.0,
+            surface,
+            styles,
+            tris,
+        );
         return;
     }
     let darken = s.rim_darken;
     let (left, right, top, bottom) = (rims[0], rims[1], rims[2], rims[3]);
     // Interior.
-    emit_quad_shaded(material, resolved, [x1, z1, x2, z2], 0.0, surface, tris);
+    emit_quad_shaded(
+        material,
+        resolved,
+        [x1, z1, x2, z2],
+        0.0,
+        surface,
+        styles,
+        tris,
+    );
     // Edge strips.
     emit_quad_shaded(
         material,
@@ -703,6 +762,7 @@ fn emit_underlay_cell(
         [x0, z1, x1, z2],
         darken * left,
         surface,
+        styles,
         tris,
     );
     emit_quad_shaded(
@@ -711,6 +771,7 @@ fn emit_underlay_cell(
         [x2, z1, x3, z2],
         darken * right,
         surface,
+        styles,
         tris,
     );
     emit_quad_shaded(
@@ -719,6 +780,7 @@ fn emit_underlay_cell(
         [x1, z0, x2, z1],
         darken * top,
         surface,
+        styles,
         tris,
     );
     emit_quad_shaded(
@@ -727,6 +789,7 @@ fn emit_underlay_cell(
         [x1, z2, x2, z3],
         darken * bottom,
         surface,
+        styles,
         tris,
     );
     // Corners darken by the stronger of their two adjacent sides.
@@ -736,6 +799,7 @@ fn emit_underlay_cell(
         [x0, z0, x1, z1],
         darken * left.max(top),
         surface,
+        styles,
         tris,
     );
     emit_quad_shaded(
@@ -744,6 +808,7 @@ fn emit_underlay_cell(
         [x2, z0, x3, z1],
         darken * right.max(top),
         surface,
+        styles,
         tris,
     );
     emit_quad_shaded(
@@ -752,6 +817,7 @@ fn emit_underlay_cell(
         [x0, z2, x1, z3],
         darken * left.max(bottom),
         surface,
+        styles,
         tris,
     );
     emit_quad_shaded(
@@ -760,6 +826,7 @@ fn emit_underlay_cell(
         [x2, z2, x3, z3],
         darken * right.max(bottom),
         surface,
+        styles,
         tris,
     );
 }
@@ -769,19 +836,25 @@ fn emit_underlay_cell(
 /// (`(wx, wz)` meters to `(y, slope shade)`), each corner shaded by the
 /// wash field and the slope shade at its own world position and darkened
 /// by `rim_darken`.
+// The resolved style row `s` plus the quad's four corners (`a`..`d`) read
+// clearest under these conventional short names.
+#[allow(clippy::many_single_char_names)]
+#[allow(clippy::too_many_arguments)] // two call sites; the quad state travels together
 fn emit_quad_shaded(
     material: Material,
     resolved: &ResolvedCell,
     rect: [i32; 4],
     rim_darken: f32,
     surface: &impl Fn(f32, f32) -> (f32, f32),
+    styles: &StyleTable,
     tris: &mut Vec<DrawTriangle>,
 ) {
+    let s = styles.get(material);
     let corner = |xo: i32, zo: i32| {
         let wx = xo as f32 / OCTIMETERS_PER_METER;
         let wz = zo as f32 / OCTIMETERS_PER_METER;
         let (y, shade) = surface(wx, wz);
-        let light = wash_lightness(material, resolved.light, wx, wz, resolved.stroke);
+        let light = wash_lightness(s, resolved.light, wx, wz, resolved.stroke);
         let light = (light * (1.0 - rim_darken) * shade).clamp(0.0, 100.0);
         let rgb = hsl_to_linear_rgb(resolved.hue, resolved.sat, light);
         Vertex {
@@ -819,7 +892,7 @@ fn subcell_covered(world: &World, at: ChunkPos, six: i32, siz: i32, material: Ma
 
 /// Emit the overlay pass: for each distinct overlay material present in
 /// the chunk, contour its subcell field.
-fn mesh_overlay(world: &World, at: ChunkPos, tris: &mut Vec<DrawTriangle>) {
+fn mesh_overlay(world: &World, at: ChunkPos, styles: &StyleTable, tris: &mut Vec<DrawTriangle>) {
     let Some(chunk) = world.chunk(at) else {
         return;
     };
@@ -831,7 +904,7 @@ fn mesh_overlay(world: &World, at: ChunkPos, tris: &mut Vec<DrawTriangle>) {
     }
     for (id, seen) in present.iter().enumerate() {
         if *seen {
-            mesh_overlay_material(world, at, Material::from_u8_or_void(id as u8), tris);
+            mesh_overlay_material(world, at, Material::from_u8_or_void(id as u8), styles, tris);
         }
     }
 }
@@ -861,8 +934,9 @@ fn sample_params(
     material: Material,
     apron: i32,
     n: usize,
+    styles: &StyleTable,
 ) -> Vec<SmoothParams> {
-    let s = style(material);
+    let s = styles.get(material);
     let default = SmoothParams {
         iterations: s.smoothing_iterations,
         smoothing_degrees: s.smoothing_degrees,
@@ -897,12 +971,13 @@ fn mesh_overlay_material(
     world: &World,
     at: ChunkPos,
     material: Material,
+    styles: &StyleTable,
     tris: &mut Vec<DrawTriangle>,
 ) {
-    let s = style(material);
+    let s = styles.get(material);
     let apron = MAX_APRON_SUBCELLS;
     let (field, n) = sample_field(world, at, material, apron);
-    let params = sample_params(world, at, material, apron, n);
+    let params = sample_params(world, at, material, apron, n, styles);
     let base_oct = [
         at.x * SUBCELLS_PER_CHUNK_EDGE * OCTIMETERS_PER_SUBCELL,
         at.z * SUBCELLS_PER_CHUNK_EDGE * OCTIMETERS_PER_SUBCELL,
@@ -926,7 +1001,7 @@ fn mesh_overlay_material(
     let eroded = erode(&smoothed, gw, gh, rim_width);
 
     if material == Material::Water {
-        emit_water(world, &eroded, gw, apron, upsample, base_oct, tris);
+        emit_water(world, &eroded, gw, apron, upsample, base_oct, styles, tris);
         return;
     }
 
@@ -957,6 +1032,7 @@ fn surface_vertex(world: &World, lift: f32, color: [f32; 3]) -> impl Fn(f32, f32
 /// so the body hugs the smoothed contour at the smoothing grid's own
 /// resolution and the marched rim band beneath shows as an even pooled
 /// edge instead of subcell-scale teeth.
+#[allow(clippy::too_many_arguments)] // one call site; the water pass state travels together
 fn emit_water(
     world: &World,
     eroded: &[bool],
@@ -964,6 +1040,7 @@ fn emit_water(
     apron: i32,
     upsample: usize,
     base_oct: [i32; 2],
+    styles: &StyleTable,
     tris: &mut Vec<DrawTriangle>,
 ) {
     let u = upsample as i32;
@@ -989,7 +1066,8 @@ fn emit_water(
                 let depth = subcell_shore_depth(&inside, si, sj);
                 let center_x = (x_oct + OCTIMETERS_PER_SUBCELL / 2) as f32 / OCTIMETERS_PER_METER;
                 let center_z = (z_oct + OCTIMETERS_PER_SUBCELL / 2) as f32 / OCTIMETERS_PER_METER;
-                let resolved = resolve_cell(Material::Water, center_x, center_z, Some(depth));
+                let resolved =
+                    resolve_cell(styles.get(Material::Water), center_x, center_z, Some(depth));
                 let color = hsl_to_linear_rgb(resolved.hue, resolved.sat, resolved.light);
                 push_quad(
                     tris,
@@ -1018,7 +1096,7 @@ fn emit_water(
             }
             let center_x = (x_oct + OCTIMETERS_PER_SUBCELL / 2) as f32 / OCTIMETERS_PER_METER;
             let center_z = (z_oct + OCTIMETERS_PER_SUBCELL / 2) as f32 / OCTIMETERS_PER_METER;
-            let resolved = resolve_cell(Material::Water, center_x, center_z, Some(0.0));
+            let resolved = resolve_cell(styles.get(Material::Water), center_x, center_z, Some(0.0));
             let color = hsl_to_linear_rgb(resolved.hue, resolved.sat, resolved.light);
             let vertex = surface_vertex(world, OVERLAY_BODY_LIFT, color);
             for dz in 0..u {
@@ -1055,7 +1133,7 @@ fn subcell_shore_depth(inside: &impl Fn(i32, i32) -> bool, x: i32, z: i32) -> f3
 /// underlay cell on the cell's surface patch, its value the cell's own
 /// hue-noise field (no slope shade — the gray is the calibration
 /// instrument).
-fn mesh_raw(world: &World, at: ChunkPos, tris: &mut Vec<DrawTriangle>) {
+fn mesh_raw(world: &World, at: ChunkPos, styles: &StyleTable, tris: &mut Vec<DrawTriangle>) {
     let base_x = at.x * EDGE;
     let base_z = at.z * EDGE;
     for lz in 0..EDGE {
@@ -1068,7 +1146,11 @@ fn mesh_raw(world: &World, at: ChunkPos, tris: &mut Vec<DrawTriangle>) {
             if material == Material::Void {
                 continue;
             }
-            let v = raw_field(material, cell.x as f32 + 0.5, cell.z as f32 + 0.5);
+            let v = raw_field(
+                styles.get(material),
+                cell.x as f32 + 0.5,
+                cell.z as f32 + 0.5,
+            );
             let x0 = cell.x * 256;
             let z0 = cell.z * 256;
             let lift = CellLift::of(world, cell);
@@ -1094,7 +1176,14 @@ fn mesh_raw(world: &World, at: ChunkPos, tris: &mut Vec<DrawTriangle>) {
 /// keeps them a flat gray so the terrain stays closed without polluting
 /// the calibration field. Where the corner walk merged the two sides'
 /// plates the gap tapers to nothing and the face is skipped.
-fn emit_skirts(world: &World, at: ChunkPos, mode: ViewMode, tris: &mut Vec<DrawTriangle>) {
+#[allow(clippy::too_many_lines)] // one linear pass: enumerate, color, emit — no seams to split at
+fn emit_skirts(
+    world: &World,
+    at: ChunkPos,
+    mode: ViewMode,
+    styles: &StyleTable,
+    tris: &mut Vec<DrawTriangle>,
+) {
     // Per direction: neighbor offset, the shared edge's two lattice
     // corners as indices into the high cell's corner order, and the same
     // lattice points in the neighbor's order (the low side's plates).
@@ -1164,8 +1253,12 @@ fn emit_skirts(world: &World, at: ChunkPos, mode: ViewMode, tris: &mut Vec<DrawT
                     ViewMode::Raw => ([RAW_SKIRT_GRAY; 3], [RAW_SKIRT_GRAY; 3]),
                     ViewMode::Painted => {
                         let material = world.cliff_material(cell);
-                        let resolved =
-                            resolve_cell(material, cell.x as f32 + 0.5, cell.z as f32 + 0.5, None);
+                        let resolved = resolve_cell(
+                            styles.get(material),
+                            cell.x as f32 + 0.5,
+                            cell.z as f32 + 0.5,
+                            None,
+                        );
                         (
                             hsl_to_linear_rgb(
                                 resolved.hue,
@@ -1202,7 +1295,7 @@ fn emit_skirts(world: &World, at: ChunkPos, mode: ViewMode, tris: &mut Vec<DrawT
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::world::{CELLS_PER_CHUNK_AREA, Chunk, Region, SmoothingProfile};
+    use crate::world::{CELLS_PER_CHUNK_AREA, Chunk, Region, SetMaterialStyle, SmoothingProfile};
     use style::ResolvedCell;
 
     fn grass_cell() -> ResolvedCell {
@@ -1242,6 +1335,7 @@ mod tests {
             5,
             [0.0; 4],
             &flat_lift(3, 5),
+            &StyleTable::default(),
             &mut tris,
         );
         assert_eq!(tris.len(), 2, "no rims is one flat quad");
@@ -1260,6 +1354,7 @@ mod tests {
             5,
             [1.0; 4],
             &flat_lift(3, 5),
+            &StyleTable::default(),
             &mut tris,
         );
         assert_eq!(tris.len(), 18, "a fully-rimmed cell is a nine-slice");
@@ -1298,8 +1393,18 @@ mod tests {
         right.underlay = [Material::Grass; CELLS_PER_CHUNK_AREA];
         world.insert_chunk(ChunkPos { x: 1, z: 0 }, right);
 
-        let left_cell_right_rim = cell_rims(&world, CellPos { x: 15, z: 4 }, Material::Grass)[1];
-        let right_cell_left_rim = cell_rims(&world, CellPos { x: 16, z: 4 }, Material::Grass)[0];
+        let left_cell_right_rim = cell_rims(
+            &world,
+            CellPos { x: 15, z: 4 },
+            Material::Grass,
+            &StyleTable::default(),
+        )[1];
+        let right_cell_left_rim = cell_rims(
+            &world,
+            CellPos { x: 16, z: 4 },
+            Material::Grass,
+            &StyleTable::default(),
+        )[0];
         assert_eq!(
             left_cell_right_rim, right_cell_left_rim,
             "both sides must agree on the shared-edge rim",
@@ -1349,7 +1454,12 @@ mod tests {
                 world.insert_chunk(ChunkPos { x: dx, z: dz }, c);
             }
         }
-        let tris = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted);
+        let tris = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
         assert_eq!(overlay_tris(&tris), 8194, "8192 body + one merged rim quad");
     }
 
@@ -1370,7 +1480,12 @@ mod tests {
             }
         }
         world.insert_chunk(ChunkPos { x: 0, z: 0 }, c);
-        let tris = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted);
+        let tris = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
 
         let rim_tris = tris
             .iter()
@@ -1427,7 +1542,12 @@ mod tests {
             world.insert_chunk(ChunkPos { x: cx, z: 0 }, chunk);
         }
         for cx in 0..2 {
-            let tris = mesh_chunk(&world, ChunkPos { x: cx, z: 0 }, ViewMode::Painted);
+            let tris = mesh_chunk(
+                &world,
+                ChunkPos { x: cx, z: 0 },
+                ViewMode::Painted,
+                &StyleTable::default(),
+            );
             for v in tris
                 .iter()
                 .filter(|t| t.verts.iter().all(|v| v.y > 0.0 && v.y < OVERLAY_BODY_LIFT))
@@ -1474,8 +1594,18 @@ mod tests {
             }
             world.insert_chunk(ChunkPos { x: cx, z: 0 }, chunk);
         }
-        let mesh0 = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted);
-        let mesh1 = mesh_chunk(&world, ChunkPos { x: 1, z: 0 }, ViewMode::Painted);
+        let mesh0 = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
+        let mesh1 = mesh_chunk(
+            &world,
+            ChunkPos { x: 1, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
         let max_x = |mesh: &[DrawTriangle]| {
             mesh.iter()
                 .flat_map(|t| t.verts.iter())
@@ -1580,6 +1710,7 @@ mod tests {
             })),
             ChunkPos { x: 0, z: 0 },
             ViewMode::Painted,
+            &StyleTable::default(),
         );
         assert!(
             has_smoothed_crossing(&smoothed),
@@ -1592,6 +1723,7 @@ mod tests {
             })),
             ChunkPos { x: 0, z: 0 },
             ViewMode::Painted,
+            &StyleTable::default(),
         );
         assert!(
             !has_smoothed_crossing(&crisp),
@@ -1606,7 +1738,12 @@ mod tests {
         // ground-plane triangle. A saddle-rule or window-skip bug shows up
         // as a hole here.
         let world = sand_band_world(None);
-        let mesh = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted);
+        let mesh = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
         let ground: Vec<&DrawTriangle> = mesh
             .iter()
             .filter(|t| t.verts.iter().all(|v| v.y == 0.0))
@@ -1631,8 +1768,18 @@ mod tests {
         // classification disagreement between the two chunks shows up as a
         // hole here.
         let world = sand_band_world(None);
-        let mesh0 = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted);
-        let mesh1 = mesh_chunk(&world, ChunkPos { x: 1, z: 0 }, ViewMode::Painted);
+        let mesh0 = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
+        let mesh1 = mesh_chunk(
+            &world,
+            ChunkPos { x: 1, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
         let ground_covers = |mesh: &[DrawTriangle], px: f32, pz: f32| {
             mesh.iter()
                 .filter(|t| t.verts.iter().all(|v| v.y == 0.0))
@@ -1680,7 +1827,12 @@ mod tests {
             }
         }
         world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
-        let mesh = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted);
+        let mesh = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
         assert!(
             has_smoothed_crossing(&mesh),
             "a region-default boundary smooths like any material boundary",
@@ -1715,7 +1867,12 @@ mod tests {
         // a mover will stand on. Any lift path that misses a vertex
         // (nine-slice, strip, window poly) diverges here.
         let world = ramp_world();
-        let mesh = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted);
+        let mesh = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
         assert!(!mesh.is_empty());
         for v in mesh.iter().flat_map(|t| t.verts.iter()) {
             let surface = world.surface_height(v.x, v.z);
@@ -1734,7 +1891,12 @@ mod tests {
         // The no-gap probe on sloped ground: the strip fallback and the
         // per-window bilinear quads must tile exactly like the flat path.
         let world = ramp_world();
-        let mesh = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted);
+        let mesh = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
         for j in 0..32 {
             for i in 0..32 {
                 let px = (i as f32 + 0.37) * 0.5;
@@ -1768,8 +1930,18 @@ mod tests {
                 && t.verts.iter().any(|v| v.y > 0.9)
                 && t.verts.iter().any(|v| v.y < 0.1)
         };
-        let low_mesh = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted);
-        let high_mesh = mesh_chunk(&world, ChunkPos { x: 1, z: 0 }, ViewMode::Painted);
+        let low_mesh = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
+        let high_mesh = mesh_chunk(
+            &world,
+            ChunkPos { x: 1, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
         assert!(
             high_mesh.iter().any(is_border_skirt),
             "the high chunk closes its cliff face",
@@ -1797,7 +1969,7 @@ mod tests {
         world.insert_chunk(ChunkPos { x: 1, z: 0 }, high);
 
         for at in [ChunkPos { x: 0, z: 0 }, ChunkPos { x: 1, z: 0 }] {
-            let mesh = mesh_chunk(&world, at, ViewMode::Painted);
+            let mesh = mesh_chunk(&world, at, ViewMode::Painted, &StyleTable::default());
             for t in &mesh {
                 let gray = t
                     .verts
@@ -1833,7 +2005,7 @@ mod tests {
             }
         }
         world.insert_chunk(at, chunk);
-        let mesh = mesh_chunk(&world, at, ViewMode::Painted);
+        let mesh = mesh_chunk(&world, at, ViewMode::Painted, &StyleTable::default());
         let mut overlay_verts = 0;
         for v in mesh.iter().flat_map(|t| t.verts.iter()) {
             let lift = v.y - world.surface_height(v.x, v.z);
@@ -1857,12 +2029,22 @@ mod tests {
         // for calibration; switching back to painted must repaint in color
         // (some vertex has r != g). A stuck mode would fail one side.
         let world = world_with_underlay(ChunkPos { x: 0, z: 0 }, |_, _| Material::Grass);
-        let raw = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Raw);
+        let raw = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Raw,
+            &StyleTable::default(),
+        );
         assert!(!raw.is_empty(), "raw mode emits geometry");
         for v in raw.iter().flat_map(|t| t.verts.iter()) {
             assert!(v.r == v.g && v.g == v.b, "raw vertex is grayscale");
         }
-        let painted = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted);
+        let painted = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
         assert!(
             painted
                 .iter()
@@ -1876,7 +2058,68 @@ mod tests {
     fn void_chunk_meshes_to_nothing() {
         let mut world = World::new();
         world.insert_chunk(ChunkPos { x: 0, z: 0 }, Chunk::empty());
-        let tris = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted);
+        let tris = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &StyleTable::default(),
+        );
         assert!(tris.is_empty(), "an all-Void chunk emits no geometry");
+    }
+
+    #[test]
+    fn a_live_style_write_repaints_the_mesh() {
+        // Threading StyleTable through the mesher is mechanical (dozens of
+        // call sites); this catches any path that kept reading a stale
+        // baked-in row instead of the table argument — a grass world meshed
+        // against the default table and one with grass's base lightness
+        // moved far must paint different colors.
+        let world = world_with_underlay(ChunkPos { x: 0, z: 0 }, |_, _| Material::Grass);
+        let default_styles = StyleTable::default();
+        let baseline = mesh_chunk(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            ViewMode::Painted,
+            &default_styles,
+        );
+
+        let grass = default_styles.get(Material::Grass);
+        let mut tuned = StyleTable::default();
+        tuned.apply(&SetMaterialStyle {
+            material: Material::Grass.to_u8(),
+            base_hue: grass.base_hue,
+            base_sat: grass.base_sat,
+            base_light: grass.base_light + 30.0,
+            amp_hue: grass.amp_hue,
+            amp_sat: grass.amp_sat,
+            amp_light: grass.amp_light,
+            wavelength: grass.wavelength,
+            octaves: grass.octaves,
+            persistence: grass.persistence,
+            seed_offset: grass.seed_offset,
+            flow_wavelength: grass.flow_wavelength,
+            smoothing_degrees: grass.smoothing_degrees,
+            smoothing_iterations: grass.smoothing_iterations,
+            rim_inset_octimeters: grass.rim_inset_octimeters,
+            rim_darken: grass.rim_darken,
+            wash_grade: grass.wash_grade,
+            water_depth_darken: grass.water_depth_darken,
+            blob_merge_degrees: grass.blob_merge_degrees,
+        });
+        let tuned_mesh = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, ViewMode::Painted, &tuned);
+
+        assert_eq!(
+            baseline.len(),
+            tuned_mesh.len(),
+            "the same world tiles identically regardless of style values"
+        );
+        let base_color = |t: &DrawTriangle| (t.verts[0].r, t.verts[0].g, t.verts[0].b);
+        assert!(
+            baseline
+                .iter()
+                .zip(tuned_mesh.iter())
+                .any(|(a, b)| base_color(a) != base_color(b)),
+            "a live style-table write must change the painted mesh's colors",
+        );
     }
 }

--- a/crates/aether-kit/src/runtime/mesher/style.rs
+++ b/crates/aether-kit/src/runtime/mesher/style.rs
@@ -26,8 +26,11 @@
 //! its base color in HSL, per-channel noise amplitudes, the value-noise
 //! field shape (wavelength / octaves / persistence), a seed offset, the
 //! stroke flow-field wavelength, the corner-smoothing setting its overlay
-//! contours use, and the rim / wash / water tunables. [`style`] indexes
-//! the table by [`Material`].
+//! contours use, and the rim / wash / water tunables. [`StyleTable`] holds
+//! one row per [`Material`] as runtime state — [`StyleTable::get`] reads a
+//! row, [`StyleTable::apply`] overwrites one live from a
+//! `aether.kit.world.set_material_style` mail — so a tuning pass needs no
+//! rebuild.
 //!
 //! A cell's color resolves from its world coordinates alone: base HSL plus
 //! three world-anchored fractal value-noise samples (one per channel,
@@ -38,11 +41,11 @@
 
 use core::f32::consts::FRAC_1_SQRT_2;
 
-use crate::world::Material;
+use crate::world::{MAX_SMOOTHING_ITERATIONS, Material, SetMaterialStyle};
 
 /// One material's complete render style. Indexed by [`Material`] through
-/// [`style`]; the [`Material::Void`] row is a placeholder that is never
-/// painted.
+/// [`StyleTable::get`]; the [`Material::Void`] row is a placeholder that
+/// is never painted.
 pub struct MaterialStyle {
     /// Base hue in degrees `[0, 360)`.
     pub base_hue: f32,
@@ -223,10 +226,62 @@ const STYLES: [MaterialStyle; 6] = [
     },
 ];
 
-/// The style row for `material`.
-#[must_use]
-pub fn style(material: Material) -> &'static MaterialStyle {
-    &STYLES[material as usize]
+/// Runtime-authored material style rows. `Default` seeds every row from
+/// the built-in defaults; a `WorldView` actor holds one instance as
+/// session-scoped
+/// state (never serialized into the world format — the tuning loop's
+/// output is new source defaults, not world data) and applies live writes
+/// through [`StyleTable::apply`].
+pub struct StyleTable([MaterialStyle; 6]);
+
+impl Default for StyleTable {
+    fn default() -> Self {
+        Self(STYLES)
+    }
+}
+
+impl StyleTable {
+    /// The style row for `material`.
+    #[must_use]
+    pub fn get(&self, material: Material) -> &MaterialStyle {
+        &self.0[material as usize]
+    }
+
+    /// Write a full style row from a `aether.kit.world.set_material_style`
+    /// mail, clamping `smoothing_iterations` to [`MAX_SMOOTHING_ITERATIONS`]
+    /// and `smoothing_degrees` to `[45, 90]` — the same rule
+    /// [`crate::world::World::insert_smoothing_profile`] applies to the
+    /// per-cell smoothing table. An undecodable or `Void` material byte is
+    /// a no-op; the caller (the `WorldView` handler) is expected to have
+    /// already rejected it with a warn log.
+    pub fn apply(&mut self, msg: &SetMaterialStyle) {
+        let Ok(material) = Material::try_from(msg.material) else {
+            return;
+        };
+        if material == Material::Void {
+            return;
+        }
+        self.0[material as usize] = MaterialStyle {
+            base_hue: msg.base_hue,
+            base_sat: msg.base_sat,
+            base_light: msg.base_light,
+            amp_hue: msg.amp_hue,
+            amp_sat: msg.amp_sat,
+            amp_light: msg.amp_light,
+            wavelength: msg.wavelength,
+            octaves: msg.octaves,
+            persistence: msg.persistence,
+            seed_offset: msg.seed_offset,
+            flow_wavelength: msg.flow_wavelength,
+            smoothing_degrees: msg.smoothing_degrees.clamp(45, 90),
+            smoothing_iterations: msg.smoothing_iterations.min(MAX_SMOOTHING_ITERATIONS),
+            rim_inset_octimeters: msg.rim_inset_octimeters,
+            rim_darken: msg.rim_darken,
+            wash_grade: msg.wash_grade,
+            water_depth_darken: msg.water_depth_darken,
+            blob_merge_degrees: msg.blob_merge_degrees,
+        };
+    }
 }
 
 /// Base seed for the hue channel. Each channel keys a distinct seed so the
@@ -303,13 +358,12 @@ pub struct ResolvedCell {
     pub stroke: (f32, f32),
 }
 
-/// Resolve a cell's color from its world center `(wx, wz)` in cells. When
-/// `depth` is `Some`, the material is water and the lightness grades down
-/// toward the given shore depth `[0, 1]` with its noise amplitude
-/// enveloped by depth.
+/// Resolve a cell's color from its world center `(wx, wz)` in cells, using
+/// the resolved style row `s`. When `depth` is `Some`, the material is
+/// water and the lightness grades down toward the given shore depth
+/// `[0, 1]` with its noise amplitude enveloped by depth.
 #[must_use]
-pub fn resolve_cell(material: Material, wx: f32, wz: f32, depth: Option<f32>) -> ResolvedCell {
-    let s = style(material);
+pub fn resolve_cell(s: &MaterialStyle, wx: f32, wz: f32, depth: Option<f32>) -> ResolvedCell {
     let seed = s.seed_offset;
     let n_hue = fbm(
         wx,
@@ -366,13 +420,14 @@ fn stroke_byte(s: &MaterialStyle, wx: f32, wz: f32) -> u8 {
     floor_to_i32(n * 256.0).clamp(0, 255) as u8
 }
 
-/// The wash-adjusted lightness at a world vertex `(wx, wz)`: project the
-/// world position onto the cell's stroke direction and grade lightness by
-/// a low-frequency density field so the wash runs continuously along the
-/// stroke rather than restarting per cell.
+/// The wash-adjusted lightness at a world vertex `(wx, wz)`, using the
+/// resolved style row `s`: project the world position onto the cell's
+/// stroke direction and grade lightness by a low-frequency density field so
+/// the wash runs continuously along the stroke rather than restarting per
+/// cell.
 #[must_use]
-pub fn wash_lightness(material: Material, light: f32, wx: f32, wz: f32, stroke: (f32, f32)) -> f32 {
-    let grade = style(material).wash_grade;
+pub fn wash_lightness(s: &MaterialStyle, light: f32, wx: f32, wz: f32, stroke: (f32, f32)) -> f32 {
+    let grade = s.wash_grade;
     if grade == 0.0 {
         return light;
     }
@@ -383,10 +438,10 @@ pub fn wash_lightness(material: Material, light: f32, wx: f32, wz: f32, stroke: 
 }
 
 /// The raw hue-field sample for a cell, mapped to `[0, 1]` — the grayscale
-/// value the raw view mode paints for calibrating the table by eye.
+/// value the raw view mode paints for calibrating the table by eye. Uses
+/// the resolved style row `s`.
 #[must_use]
-pub fn raw_field(material: Material, wx: f32, wz: f32) -> f32 {
-    let s = style(material);
+pub fn raw_field(s: &MaterialStyle, wx: f32, wz: f32) -> f32 {
     let n = fbm(
         wx,
         wz,
@@ -724,7 +779,8 @@ mod tests {
         // linear RGB) folds into one pinned value. Any drift in the noise
         // or conversion re-keys every cell in every world, so a change here
         // must be deliberate.
-        let r = resolve_cell(Material::Grass, 8.5, 8.5, None);
+        let styles = StyleTable::default();
+        let r = resolve_cell(styles.get(Material::Grass), 8.5, 8.5, None);
         let rgb = hsl_to_linear_rgb(r.hue, r.sat, r.light);
         assert_eq!(rgb, [0.086_620_346, 0.271_466, 0.056_088_015]);
     }
@@ -734,8 +790,10 @@ mod tests {
         // The keyed quilt exists to make neighbors visibly distinct; if the
         // field collapsed to a constant, every grass cell would render the
         // same flat color.
-        let a = resolve_cell(Material::Grass, 8.5, 8.5, None);
-        let b = resolve_cell(Material::Grass, 9.5, 8.5, None);
+        let styles = StyleTable::default();
+        let grass = styles.get(Material::Grass);
+        let a = resolve_cell(grass, 8.5, 8.5, None);
+        let b = resolve_cell(grass, 9.5, 8.5, None);
         assert_ne!((a.hue, a.light), (b.hue, b.light));
     }
 
@@ -743,11 +801,12 @@ mod tests {
     fn hue_offset_stays_within_amplitude() {
         // The field must not push hue past its declared amplitude, or a
         // cell reads as a foreign material rather than a variant.
-        let s = style(Material::Grass);
+        let styles = StyleTable::default();
+        let s = styles.get(Material::Grass);
         for i in 0..64 {
             let wx = i as f32 * 0.37 - 5.0;
             let wz = i as f32 * -0.21 + 3.0;
-            let r = resolve_cell(Material::Grass, wx, wz, None);
+            let r = resolve_cell(s, wx, wz, None);
             assert!(
                 (r.hue - s.base_hue).abs() <= s.amp_hue + 1e-4,
                 "hue {} escaped base {} +/- {}",
@@ -791,5 +850,76 @@ mod tests {
         assert_eq!(rim_strength(true, true, 110.0, 112.0, 6.0), 2.0 / 6.0);
         assert_eq!(rim_strength(true, true, 110.0, 130.0, 6.0), 1.0);
         assert_eq!(rim_strength(true, true, 110.0, 110.0, 6.0), 0.0);
+    }
+
+    #[test]
+    fn apply_clamps_the_smoothing_pair() {
+        // Catches a dropped clamp: the mesher's fixed two-cell smoothing
+        // apron assumes `smoothing_iterations` never exceeds
+        // MAX_SMOOTHING_ITERATIONS, and the windowed smoothing rule assumes
+        // `smoothing_degrees` never drops below 45.
+        let mut styles = StyleTable::default();
+        styles.apply(&SetMaterialStyle {
+            material: Material::Grass.to_u8(),
+            base_hue: 110.0,
+            base_sat: 37.5,
+            base_light: 40.0,
+            amp_hue: 8.0,
+            amp_sat: 0.0,
+            amp_light: 6.0,
+            wavelength: 6.0,
+            octaves: 2,
+            persistence: 0.45,
+            seed_offset: 20011,
+            flow_wavelength: 4.0,
+            smoothing_degrees: 10,
+            smoothing_iterations: 99,
+            rim_inset_octimeters: 32,
+            rim_darken: 0.15,
+            wash_grade: 0.10,
+            water_depth_darken: 0.0,
+            blob_merge_degrees: 6.0,
+        });
+        let row = styles.get(Material::Grass);
+        assert_eq!(row.smoothing_iterations, MAX_SMOOTHING_ITERATIONS);
+        assert_eq!(row.smoothing_degrees, 45);
+    }
+
+    #[test]
+    fn apply_rejects_void_and_out_of_range_bytes() {
+        // Void (0) is never painted and a byte past Water (5) doesn't decode
+        // to a Material at all; both must leave every row untouched rather
+        // than panic on an out-of-bounds index or silently write a row no
+        // material reads.
+        let mut styles = StyleTable::default();
+        for byte in [0u8, 6, 255] {
+            styles.apply(&SetMaterialStyle {
+                material: byte,
+                base_hue: 1.0,
+                base_sat: 1.0,
+                base_light: 1.0,
+                amp_hue: 1.0,
+                amp_sat: 1.0,
+                amp_light: 1.0,
+                wavelength: 1.0,
+                octaves: 1,
+                persistence: 1.0,
+                seed_offset: 1,
+                flow_wavelength: 1.0,
+                smoothing_degrees: 45,
+                smoothing_iterations: 0,
+                rim_inset_octimeters: 1,
+                rim_darken: 1.0,
+                wash_grade: 1.0,
+                water_depth_darken: 1.0,
+                blob_merge_degrees: 1.0,
+            });
+        }
+        let grass = styles.get(Material::Grass);
+        assert_eq!(
+            (grass.base_hue, grass.base_sat, grass.base_light),
+            (110.0, 37.5, 40.0),
+            "an undecodable or Void material byte must not mutate the table",
+        );
     }
 }

--- a/crates/aether-kit/src/runtime/mod.rs
+++ b/crates/aether-kit/src/runtime/mod.rs
@@ -49,6 +49,7 @@ pub use camera::CameraComponent;
 pub use locomotion::Locomotion;
 pub use mesh_viewer::MeshViewer;
 pub use mesher::mesh_chunk;
+pub use mesher::style::StyleTable;
 pub use widget::Widget;
 pub use widget_panel::WidgetPanel;
 pub use widgets::{ButtonWidget, LabelWidget, RadioGroupWidget, SliderWidget, TextFieldWidget};

--- a/crates/aether-kit/src/runtime/world_view.rs
+++ b/crates/aether-kit/src/runtime/world_view.rs
@@ -28,6 +28,11 @@
 //! - `aether.kit.world.set_smoothing_profile` — register a contour-
 //!   smoothing profile the per-cell smoothing plane points at; remeshes
 //!   every cached chunk.
+//! - `aether.kit.world.set_material_style` — write a material's complete
+//!   live style row (base HSL, noise shape, smoothing defaults, rim /
+//!   wash / water tunables) and remesh every cached chunk, so a tuning
+//!   pass needs no rebuild. An undecodable or `Void` material byte is
+//!   rejected with a warn log and leaves the table untouched.
 //! - `aether.kit.world.set_view_mode` — switch between the painted gouache
 //!   grammar and the raw grayscale calibration field; remeshes all.
 //! - `aether.kit.world.load` — fetch a serialized world through
@@ -44,8 +49,10 @@ use aether_capabilities::{FsCapability, LifecycleCapability, RenderCapability};
 use aether_kinds::Render;
 
 use super::mesher::mesh_chunk;
+use super::mesher::style::StyleTable;
 use crate::world::{
-    ChunkPos, SetChunk, SetRegion, SetSmoothingProfile, SetViewMode, ViewMode, World, WorldLoad,
+    ChunkPos, Material, SetChunk, SetMaterialStyle, SetRegion, SetSmoothingProfile, SetViewMode,
+    ViewMode, World, WorldLoad,
 };
 
 /// World-view component: holds the world plane stack and a per-chunk
@@ -64,18 +71,19 @@ pub struct WorldView {
     world: World,
     meshes: BTreeMap<ChunkPos, Vec<DrawTriangle>>,
     mode: ViewMode,
+    styles: StyleTable,
 }
 
 impl WorldView {
     /// Rebuild every chunk's cached mesh from the current world — used
-    /// after a whole-world change (region default, world load, view mode)
-    /// that can alter any chunk's mesh.
+    /// after a whole-world change (region default, world load, view mode,
+    /// material style) that can alter any chunk's mesh.
     fn remesh_all(&mut self) {
         self.meshes.clear();
         let positions: Vec<ChunkPos> = self.world.chunks().map(|(pos, _)| pos).collect();
         for pos in positions {
             self.meshes
-                .insert(pos, mesh_chunk(&self.world, pos, self.mode));
+                .insert(pos, mesh_chunk(&self.world, pos, self.mode, &self.styles));
         }
     }
 }
@@ -89,6 +97,7 @@ impl WasmActor for WorldView {
             world: World::new(),
             meshes: BTreeMap::new(),
             mode: ViewMode::default(),
+            styles: StyleTable::default(),
         })
     }
 
@@ -137,8 +146,10 @@ impl WasmActor for WorldView {
                     z: pos.z + dz,
                 };
                 if (dx == 0 && dz == 0) || self.meshes.contains_key(&neighbor) {
-                    self.meshes
-                        .insert(neighbor, mesh_chunk(&self.world, neighbor, self.mode));
+                    self.meshes.insert(
+                        neighbor,
+                        mesh_chunk(&self.world, neighbor, self.mode, &self.styles),
+                    );
                 }
             }
         }
@@ -184,6 +195,37 @@ impl WasmActor for WorldView {
         self.world
             .insert_smoothing_profile(msg.profile_id, msg.profile());
         self.remesh_all();
+    }
+
+    /// Write a material's complete live style row, then remesh every
+    /// cached chunk — a style change alters the resolved color, noise
+    /// field, and smoothing defaults of every cell of that material. An
+    /// undecodable or `Void` material byte is rejected with a warn log and
+    /// leaves the table untouched.
+    ///
+    /// # Agent
+    /// Send `aether.kit.world.set_material_style` with a raw `material`
+    /// byte (`1` Grass … `5` Water) and every `MaterialStyle` field — it is
+    /// a full-row write, not a delta. Tune against `capture_frame`, and
+    /// switch to `aether.kit.world.set_view_mode`'s raw mode to read the
+    /// noise field directly. Tuned values are session-scoped; commit the
+    /// judged row back into `mesher::style`'s const table as the new
+    /// default once satisfied.
+    #[handler]
+    fn on_set_material_style(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetMaterialStyle) {
+        match Material::try_from(msg.material) {
+            Ok(Material::Void) | Err(_) => {
+                tracing::warn!(
+                    target: "aether_kit",
+                    material = msg.material,
+                    "set_material_style: undecodable or Void material byte; table unchanged",
+                );
+            }
+            Ok(_) => {
+                self.styles.apply(&msg);
+                self.remesh_all();
+            }
+        }
     }
 
     /// Trigger an asynchronous world load. The reply arrives as

--- a/crates/aether-kit/src/world.rs
+++ b/crates/aether-kit/src/world.rs
@@ -708,6 +708,64 @@ impl SetSmoothingProfile {
     }
 }
 
+/// `aether.kit.world.set_material_style` — write a material's complete
+/// live style row (base HSL, noise shape, smoothing defaults, rim / wash /
+/// water tunables), then remesh every cached chunk. A full-row write:
+/// every field of the resolved row is replaced, none carried over from the
+/// prior value. `smoothing_iterations` clamps to
+/// [`MAX_SMOOTHING_ITERATIONS`] and `smoothing_degrees` to `[45, 90]`, the
+/// same rule [`World::insert_smoothing_profile`] applies to the per-cell
+/// smoothing table. `material` is a raw [`Material`] byte; an undecodable
+/// byte or `Void` rejects the whole write (see
+/// `runtime::mesher::style::StyleTable::apply`).
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.world.set_material_style")]
+pub struct SetMaterialStyle {
+    pub material: u8,
+    /// Base hue in degrees `[0, 360)`.
+    pub base_hue: f32,
+    /// Base saturation in percent `[0, 100]`.
+    pub base_sat: f32,
+    /// Base lightness in percent `[0, 100]`.
+    pub base_light: f32,
+    /// Peak hue deviation in degrees the noise field adds.
+    pub amp_hue: f32,
+    /// Peak saturation deviation in percent.
+    pub amp_sat: f32,
+    /// Peak lightness deviation in percent.
+    pub amp_light: f32,
+    /// Noise wavelength in cells — the world distance over one lattice
+    /// period at the base octave.
+    pub wavelength: f32,
+    /// Fractal octave count.
+    pub octaves: u32,
+    /// Per-octave amplitude falloff (lacunarity is fixed at 2).
+    pub persistence: f32,
+    /// Seed offset folded into every channel so each material keys its own
+    /// decorrelated field.
+    pub seed_offset: u32,
+    /// Wavelength in cells of the stroke flow field the wash grades along.
+    pub flow_wavelength: f32,
+    /// Corner-smoothing angle in degrees for this material's overlay
+    /// contours (`45` chamfers hardest, `90` only true right-angle
+    /// corners). Clamped to `[45, 90]` on apply.
+    pub smoothing_degrees: u32,
+    /// Corner-smoothing iteration count (`0` = raw blocky contours).
+    /// Clamped to [`MAX_SMOOTHING_ITERATIONS`] on apply.
+    pub smoothing_iterations: u32,
+    /// Rim inset in octimeters — the width of a pooled edge strip.
+    pub rim_inset_octimeters: i32,
+    /// Rim lightness darkening `[0, 1]` where the paint pools.
+    pub rim_darken: f32,
+    /// Wash lightness gradient depth `[0, 1]` along the stroke direction.
+    pub wash_grade: f32,
+    /// Water lightness reduction in percent at full depth.
+    pub water_depth_darken: f32,
+    /// Blob-merge hue-step threshold in degrees: same-material cells whose
+    /// resolved hue differs by more than this pool a rim between them.
+    pub blob_merge_degrees: f32,
+}
+
 /// How the mesher paints a chunk: the finished gouache grammar, or the
 /// raw grayscale noise field for calibrating the material table by eye.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]

--- a/crates/aether-kit/tests/partition_probe.rs
+++ b/crates/aether-kit/tests/partition_probe.rs
@@ -12,7 +12,7 @@
 use aether_capabilities::render::DrawTriangle;
 use aether_kit::{
     CELLS_PER_CHUNK_AREA, Chunk, ChunkPos, Material, Region, ViewMode, World,
-    runtime::mesher::mesh_chunk,
+    runtime::{StyleTable, mesher::mesh_chunk},
 };
 
 fn lake_world() -> World {
@@ -69,8 +69,16 @@ fn lake_world() -> World {
 #[test]
 fn demo_world_ground_has_no_holes() {
     let world = lake_world();
+    let styles = StyleTable::default();
     let meshes: Vec<_> = (0..4)
-        .map(|k| mesh_chunk(&world, ChunkPos { x: k % 2, z: k / 2 }, ViewMode::Painted))
+        .map(|k| {
+            mesh_chunk(
+                &world,
+                ChunkPos { x: k % 2, z: k / 2 },
+                ViewMode::Painted,
+                &styles,
+            )
+        })
         .collect();
     let covers = |t: &DrawTriangle, px: f32, pz: f32| {
         let sign =
@@ -111,8 +119,17 @@ fn demo_world_fits_the_frame_vertex_budget() {
     // the failure mode that motivated window ownership and strip merging.
     // The four-chunk lake scene must sit comfortably inside it.
     let world = lake_world();
+    let styles = StyleTable::default();
     let total: usize = (0..4)
-        .map(|k| mesh_chunk(&world, ChunkPos { x: k % 2, z: k / 2 }, ViewMode::Painted).len())
+        .map(|k| {
+            mesh_chunk(
+                &world,
+                ChunkPos { x: k % 2, z: k / 2 },
+                ViewMode::Painted,
+                &styles,
+            )
+            .len()
+        })
         .sum();
     assert!(total < 45_000, "frame budget headroom: {total} triangles");
 }


### PR DESCRIPTION
Makes the material style table runtime state authored over mail, so a tuning pass against the live engine needs no rebuild — the agent drives a set → capture → judge loop over MCP the way the smoothing field already works. Entirely in `crates/aether-kit`; no save-format change.

- **StyleTable** — `StyleTable([MaterialStyle; 6])` in `runtime/mesher/style.rs`, defaulting to the previous const rows; the free `style()` lookup is gone and the style-layer pure functions (`resolve_cell`, `wash_lightness`, `raw_field`) take the resolved row. `apply` writes a full row, clamping the smoothing pair by the same rule the per-cell profile table uses, and defensively rejects an undecodable or `Void` material byte.
- **Threading** — `mesh_chunk` gains a `&StyleTable` parameter threaded through every internal consumer, including `partition_inputs`' material-default smoothing read — so per-material smoothing defaults are live-tunable too (the per-cell field override path is untouched).
- **Kind + handler** — `aether.kit.world.set_material_style` (`world.rs`) carries the material byte plus every row field explicitly, fire-and-forget like the rest of the world-authoring family; `WorldView` holds the table beside the view mode (a `WorldLoad` swap replaces the world and leaves tuned rows standing) and remeshes all on apply.
- Session-scoped by design: the tuning loop's terminal step is committing the found values back into the const rows as new defaults, so nothing persists in the world format.
- Tests: `apply` clamps the smoothing pair and rejects bad bytes; a live style write repaints the mesh (catches any leftover read of the old const path).

Closes #2668

🤖 Generated with [Claude Code](https://claude.com/claude-code)
