### PR TITLE
fix(kit): align widget label text with its row frame in screen space

### DIFF
--- a/crates/aether-kit/src/runtime/widgets/button.rs
+++ b/crates/aether-kit/src/runtime/widgets/button.rs
@@ -16,7 +16,7 @@ use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_kinds::mouse_button;
 use aether_kinds::{MouseButton, MouseButtonRelease};
 
-use crate::runtime::widgets::{push_border, quad};
+use crate::runtime::widgets::{push_border, quad, text_origin_y};
 use crate::theme::{SetTheme, Theme, WidgetState};
 use crate::widgets::{
     ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, WidgetDrawItem, WidgetDrawList,
@@ -165,7 +165,7 @@ impl WasmActor for ButtonWidget {
         if !self.label.is_empty() {
             items.push(WidgetDrawItem::Text {
                 x: self.theme.pad,
-                y: size.mul_add(0.35, height * 0.5),
+                y: text_origin_y(0.0, height, size),
                 font_id: self.theme.font_id,
                 text: self.label.clone(),
                 size_pixels: size,

--- a/crates/aether-kit/src/runtime/widgets/label.rs
+++ b/crates/aether-kit/src/runtime/widgets/label.rs
@@ -13,6 +13,7 @@ use alloc::vec::Vec;
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 
+use crate::runtime::widgets::text_origin_y;
 use crate::theme::{SetTheme, Theme};
 use crate::widgets::{Collect, LabelConfig, WidgetDrawItem, WidgetDrawList, WidgetFrame};
 
@@ -77,7 +78,7 @@ impl WasmActor for LabelWidget {
         if !self.text.is_empty() {
             items.push(WidgetDrawItem::Text {
                 x: 0.0,
-                y: size.mul_add(0.35, self.frame.height * 0.5),
+                y: text_origin_y(0.0, self.frame.height, size),
                 font_id: self.theme.font_id,
                 text: self.text.clone(),
                 size_pixels: size,

--- a/crates/aether-kit/src/runtime/widgets/mod.rs
+++ b/crates/aether-kit/src/runtime/widgets/mod.rs
@@ -3,12 +3,12 @@
 //! lanes — config / style / layout-frame data-down, value events-up — over the
 //! ADR-0117 draw-compositing protocol.
 //!
-//! - [`slider::SliderWidget`] — a horizontal value slider, dragged or
+//! - [`SliderWidget`] — a horizontal value slider, dragged or
 //!   arrow-nudged.
-//! - [`text_field::TextFieldWidget`] — a single-line editable string.
-//! - [`radio::RadioGroupWidget`] — a vertical list of exclusive options.
-//! - [`button::ButtonWidget`] — a momentary push button.
-//! - [`label::LabelWidget`] — static, non-interactive text.
+//! - [`TextFieldWidget`] — a single-line editable string.
+//! - [`RadioGroupWidget`] — a vertical list of exclusive options.
+//! - [`ButtonWidget`] — a momentary push button.
+//! - [`LabelWidget`] — static, non-interactive text.
 //!
 //! Each caches its assigned [`WidgetFrame`](crate::widgets::WidgetFrame) rect
 //! and its [`Theme`](crate::theme::Theme), answers every
@@ -83,4 +83,15 @@ pub(crate) fn approx_text_width(char_count: usize, size_pixels: f32) -> f32 {
     #[allow(clippy::cast_precision_loss)]
     let count = char_count as f32;
     count * size_pixels * APPROX_ADVANCE_RATIO
+}
+
+/// The `Screen`-space `DrawText` origin y that vertically centers a single
+/// line of `size_pixels` text in a row `row_height` tall whose top is
+/// `row_top` (widget-local). `aether.text` treats a `Screen` draw `origin`
+/// as the line box's top-left and places the baseline one ascent below it,
+/// so centering the em box keeps the glyph ink inside the row without the
+/// font's exact ascent — which the theme does not fan to widgets (see
+/// [`APPROX_ADVANCE_RATIO`]).
+pub(crate) fn text_origin_y(row_top: f32, row_height: f32, size_pixels: f32) -> f32 {
+    (row_height - size_pixels).mul_add(0.5, row_top)
 }

--- a/crates/aether-kit/src/runtime/widgets/radio.rs
+++ b/crates/aether-kit/src/runtime/widgets/radio.rs
@@ -17,7 +17,7 @@ use aether_kinds::keycode::{KEY_DOWN, KEY_UP};
 use aether_kinds::mouse_button;
 use aether_kinds::{Key, MouseButton};
 
-use crate::runtime::widgets::{push_border, quad};
+use crate::runtime::widgets::{push_border, quad, text_origin_y};
 use crate::theme::{SetTheme, Theme, WidgetState};
 use crate::widgets::{
     Collect, FocusGained, FocusLost, RadioConfig, RadioSelected, WidgetDrawItem, WidgetDrawList,
@@ -178,7 +178,7 @@ impl WasmActor for RadioGroupWidget {
             ));
             items.push(WidgetDrawItem::Text {
                 x: pad.mul_add(2.0, marker),
-                y: size.mul_add(0.35, row_height.mul_add(0.5, row_y)),
+                y: text_origin_y(row_y, row_height, size),
                 font_id: self.theme.font_id,
                 text: option.clone(),
                 size_pixels: size,

--- a/crates/aether-kit/src/runtime/widgets/text_field.rs
+++ b/crates/aether-kit/src/runtime/widgets/text_field.rs
@@ -22,7 +22,7 @@ use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_kinds::keycode::{KEY_BACKSPACE, KEY_ENTER, KEY_LEFT, KEY_RIGHT};
 use aether_kinds::{ImePreedit, Key, Modifiers, TextInput};
 
-use crate::runtime::widgets::{approx_text_width, push_border, quad};
+use crate::runtime::widgets::{approx_text_width, push_border, quad, text_origin_y};
 use crate::theme::{SetTheme, Theme, WidgetState};
 use crate::widgets::{
     Collect, FocusGained, FocusLost, TextCommitted, TextFieldConfig, WidgetDrawItem,
@@ -209,7 +209,7 @@ impl WasmActor for TextFieldWidget {
         let height = self.frame.height;
         let pad = self.theme.pad;
         let size = self.theme.value_size_pixels;
-        let baseline = size.mul_add(0.35, height * 0.5);
+        let text_y = text_origin_y(0.0, height, size);
 
         let mut items: Vec<WidgetDrawItem> = Vec::new();
         items.push(quad(
@@ -225,7 +225,7 @@ impl WasmActor for TextFieldWidget {
         if !shown.is_empty() {
             items.push(WidgetDrawItem::Text {
                 x: pad,
-                y: baseline,
+                y: text_y,
                 font_id: self.theme.font_id,
                 text: shown,
                 size_pixels: size,
@@ -239,7 +239,7 @@ impl WasmActor for TextFieldWidget {
             let preedit_width = approx_text_width(self.preedit.chars().count(), size);
             items.push(quad(
                 pad + committed_width,
-                baseline + 2.0,
+                text_y + size,
                 preedit_width,
                 1.0,
                 self.theme.accent,

--- a/crates/aether-substrate-bundle/tests/widget_text_alignment.rs
+++ b/crates/aether-substrate-bundle/tests/widget_text_alignment.rs
@@ -1,0 +1,343 @@
+//! Widget-text vertical-alignment regression scenario (issue 2670).
+//!
+//! The reference `WidgetPanel` routes clicks by row frame, so its glyphs must
+//! sit inside the row frame their widget owns. A shared per-widget text-origin
+//! expression once mis-used the `aether.text` `Screen`-space convention —
+//! treating the line-box top as the baseline — so every glyph sagged about one
+//! ascent below its row, uniformly, while every quad stayed put. Nothing
+//! rendered text under test (`widget_compositing` pixel-asserts quads only;
+//! `widget_set` loads the panel with an empty font path and reads the log
+//! ring), so the sag shipped.
+//!
+//! This scenario loads the panel with a real font (`RobotoMono.ttf`), draws it,
+//! and captures with region-scoped `FrameCheck` centroids — one per text row.
+//! Each check pins the row's own fill color as the background so only glyph ink
+//! lights up, then asserts the in-row glyph centroid sits near the row's
+//! vertical center. The centroid over the *exact* row rect is the clean catch:
+//! an ascent-sized sag drags the in-row centroid down (or clips it against the
+//! row's bottom edge) far past a quarter-row tolerance, while the corrected
+//! origin lands it near center. Asserted rows: the fill-free label (keystone),
+//! the accent-filled button (a filled row), and the three radio option rows.
+//! The slider draws no text; the text field is empty at rest (no glyphs to
+//! score) and is left to `widget_set`.
+//!
+//! Skipped when no wgpu adapter is available or the `aether_kit` wasm has not
+//! been pre-built (the shared `require_runtime` gate). CI sets
+//! `AETHER_REQUIRE_RUNTIME=1` to turn either skip into a hard failure.
+
+// Integration-test skip diagnostic: emit via stderr so `cargo test` surfaces
+// "skipping: ..." alongside `test ... ok` (issue 891).
+#![allow(clippy::print_stderr)]
+// Pixel-rect layout constants read clearest as float literals inline, and the
+// window rects cast small, non-negative float pixel coords to the u32
+// `FrameRect` fields.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+// Row-rect geometry reads clearest as plain `top + n * height` sums; the
+// `mul_add` rewrite obscures the layout math for no accuracy that matters to
+// a pixel region.
+#![allow(clippy::suboptimal_flops)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use aether_actor::Addressable;
+use aether_capabilities::RenderCapability;
+use aether_capabilities::fs::NamespaceRoots;
+use aether_capabilities::text::{LoadFont, LoadFontResult};
+use aether_data::Kind;
+use aether_kinds::{
+    CaptureFrame, CaptureFrameResult, FrameCheck, FrameCheckResult, FrameRect, FrameReduction,
+    LoadComponent, LoadResult, NamedMail, Tick,
+};
+use aether_kit::{PanelConfig, Theme};
+use aether_substrate_bundle::test_bench::{
+    BenchOp, TestBench,
+    test_helpers::{init_save_sandbox, require_runtime},
+};
+
+/// Panel origin and stack width (widget-local `(0, 0)` maps to this window
+/// point). Chosen so the whole stack fits the capture surface with margin.
+const PANEL_X: f32 = 10.0;
+const PANEL_Y: f32 = 10.0;
+const PANEL_WIDTH: f32 = 200.0;
+
+/// Default-theme layout metrics the panel lays its stack out with — mirrored
+/// here so the test computes each row's window rect (`Theme::DEFAULT`).
+const ROW_HEIGHT: f32 = 24.0;
+const GAP: f32 = 6.0;
+/// Radio marker inset: `pad` + `max(row_height * 0.5, 4)`, the local x the
+/// marker quad ends by. Region scoping starts past it so the selected row's
+/// accent marker never pollutes the glyph mask.
+const RADIO_TEXT_INSET: f32 = 24.0;
+
+/// Per-channel tolerance partitioning lit glyph ink from the pinned row
+/// background. Far below every glyph-vs-fill gap here (text ink and each fill
+/// differ by ~140+ on some channel) yet above interior-fill render rounding.
+const LIT_TOLERANCE: u8 = 24;
+
+/// Readback sRGB8 of the three row fills a text row can sit over
+/// (`Theme::DEFAULT`, whose colors are the sRGB hex the comments name). An
+/// interior fill pixel reads back at its source hex, so these pin the
+/// background each row's glyphs light up against.
+const SURFACE_SRGB: [u8; 3] = [0x19, 0x1b, 0x15];
+const ACCENT_SRGB: [u8; 3] = [0xa8, 0xc9, 0x7a];
+
+/// The full trampoline address the loaded panel registers at (ADR-0099 §4).
+fn panel_address() -> String {
+    format!(
+        "aether.component/{}:panel",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    )
+}
+
+/// The bundle's `assets/` dir — where `RobotoMono.ttf` ships, resolved
+/// relative to this crate at build time.
+fn assets_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("assets")
+}
+
+/// Deterministically load `RobotoMono.ttf` into the shared `aether.text`
+/// registry and return its session-scoped `font_id`. Loading it here — rather
+/// than letting the panel's `wire` kick off the load — settles the font before
+/// any draw, so no capture races the async fs-read + parse.
+fn load_font(bench: &mut TestBench) -> u32 {
+    let loaded = bench
+        .execute(vec![(
+            "font",
+            BenchOp::send_and_await(
+                "aether.text",
+                &LoadFont {
+                    namespace: "assets".to_owned(),
+                    path: "fonts/RobotoMono.ttf".to_owned(),
+                },
+            ),
+        )])
+        .expect("load_font sequence");
+    match loaded
+        .reply::<LoadFontResult>("font")
+        .expect("decode LoadFontResult")
+    {
+        LoadFontResult::Ok { font_id, .. } => font_id,
+        LoadFontResult::Err { error, .. } => panic!("load RobotoMono: {error}"),
+    }
+}
+
+/// Load the reference `WidgetPanel` (export `aether.kit.widget.panel`) under
+/// the name `panel`, with its stack at `(PANEL_X, PANEL_Y)` and its theme
+/// pinned to the already-resident `font_id` (empty font path, so the panel
+/// does not kick off its own load) — every widget draws text with that font.
+fn load_panel(bench: &mut TestBench, wasm: &[u8], font_id: u32) {
+    let config = PanelConfig {
+        x: PANEL_X,
+        y: PANEL_Y,
+        width: PANEL_WIDTH,
+        font_namespace: String::new(),
+        font_path: String::new(),
+        theme: Theme {
+            font_id,
+            ..Theme::DEFAULT
+        },
+    };
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: wasm.to_vec(),
+                    name: Some("panel".to_owned()),
+                    config: config.encode_into_bytes(),
+                    export: Some("aether.kit.widget.panel".to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { name, .. } => assert!(
+            name.ends_with(":panel"),
+            "the panel root should register under :panel; got {name}",
+        ),
+        LoadResult::Err { error } => panic!("load WidgetPanel root: {error}"),
+    }
+}
+
+/// One synthesized frame tick addressed straight to the panel's mailbox.
+fn tick_to_panel() -> NamedMail {
+    NamedMail {
+        recipient_name: panel_address(),
+        kind_name: Tick::NAME.to_owned(),
+        payload: Vec::new(),
+        count: 1,
+    }
+}
+
+/// A region-scoped `Centroid` check over the inclusive window rect
+/// `(min_x, min_y)..=(max_x, max_y)`, scored against `background` so only
+/// glyph ink lights up.
+fn centroid_check(rect: FrameRect, background: [u8; 3]) -> FrameCheck {
+    FrameCheck {
+        reduction: FrameReduction::Centroid,
+        tolerance: LIT_TOLERANCE,
+        background: Some(background),
+        region: Some(rect),
+    }
+}
+
+/// A row to assert: its human label, the window y its glyph centroid should
+/// land near (its vertical center), and the region-scoped check that scores
+/// it.
+struct RowCheck {
+    name: &'static str,
+    center_y: f32,
+    check: FrameCheck,
+}
+
+/// The per-row region checks, in the layout order the panel stacks its widgets
+/// (window coords; stack at `(10, 10)`, row 24, gap 6):
+///   `label 10..34   slider 40..64   radio 70..142 (3 rows)`
+///   `text 148..172  button 178..202`.
+/// The slider draws no text and the text field is empty at rest, so neither is
+/// scored; each radio row skips its left marker so the glyph mask is pure text.
+fn row_checks() -> Vec<RowCheck> {
+    let label_top = PANEL_Y;
+    let radio_top = PANEL_Y + 2.0 * (ROW_HEIGHT + GAP);
+    let button_top = PANEL_Y + 4.0 * (ROW_HEIGHT + GAP) + 2.0 * ROW_HEIGHT;
+
+    let rect = |min_x: f32, top: f32| FrameRect {
+        min_x: min_x as u32,
+        min_y: top as u32,
+        max_x: (PANEL_X + PANEL_WIDTH) as u32 - 1,
+        max_y: (top + ROW_HEIGHT) as u32 - 1,
+    };
+    let center = |top: f32| top + ROW_HEIGHT * 0.5;
+
+    let mut rows = vec![
+        RowCheck {
+            name: "label",
+            center_y: center(label_top),
+            check: centroid_check(rect(PANEL_X, label_top), SURFACE_SRGB),
+        },
+        RowCheck {
+            name: "button",
+            center_y: center(button_top),
+            check: centroid_check(rect(PANEL_X, button_top), ACCENT_SRGB),
+        },
+    ];
+    for i in 0..3u32 {
+        let top = radio_top + i as f32 * ROW_HEIGHT;
+        rows.push(RowCheck {
+            name: ["radio[0]", "radio[1]", "radio[2]"][i as usize],
+            center_y: center(top),
+            check: centroid_check(rect(PANEL_X + RADIO_TEXT_INSET, top), SURFACE_SRGB),
+        });
+    }
+    rows
+}
+
+/// Every glyph the corrected panel draws sits inside the row frame its widget
+/// owns: the in-row glyph centroid lands within a quarter row of the row's
+/// vertical center, for the fill-free label, the accent-filled button, and
+/// each radio option row alike. Under the one-ascent sag this fix removes, the
+/// centroid drags a full ascent below center — well past the tolerance — so
+/// this is the tripwire that would have caught the bug.
+#[test]
+fn panel_glyphs_sit_inside_their_row_frames() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+
+    // `assets://` points at the bundle assets dir (where the TTF lives);
+    // `save://` / `config://` sink into a per-process sandbox tempdir.
+    let sandbox = init_save_sandbox("widget-text-alignment");
+    let roots = NamespaceRoots {
+        save: sandbox.to_path_buf(),
+        assets: assets_dir(),
+        config: sandbox.to_path_buf(),
+    };
+    let mut bench = TestBench::builder()
+        .size(240, 220)
+        .namespace_roots(roots)
+        .build()
+        .expect("boot");
+    let font_id = load_font(&mut bench);
+    load_panel(&mut bench, &wasm, font_id);
+
+    let panel = panel_address();
+    // Warm the panel: the first tick spawns + lays out the widget stack and
+    // draws it. That first glyph draw only *primes* the atlas — the text cap
+    // lazily creates its atlas texture and the `create_texture` reply has to
+    // round-trip (the `advance`) before glyphs rasterize into it. The capture
+    // then draws once more, so the glyph quads reach the renderer the same
+    // frame it reads back.
+    bench
+        .execute(vec![
+            ("spawn", BenchOp::send_mail(&panel, &Tick)),
+            ("prime", BenchOp::send_mail(&panel, &Tick)),
+            ("settle", BenchOp::advance(2)),
+        ])
+        .expect("warm-up");
+
+    let rows = row_checks();
+    let checks: Vec<FrameCheck> = rows.iter().map(|r| r.check.clone()).collect();
+    let captured = bench
+        .execute(vec![(
+            "snap",
+            BenchOp::send_and_await(
+                RenderCapability::NAMESPACE,
+                &CaptureFrame {
+                    mails: vec![tick_to_panel()],
+                    after_mails: Vec::new(),
+                    checks,
+                    similarity: None,
+                },
+            ),
+        )])
+        .expect("capture with region checks");
+    let verdict = match captured
+        .reply::<CaptureFrameResult>("snap")
+        .expect("decode CaptureFrameResult")
+    {
+        CaptureFrameResult::Ok { verdict, .. } => verdict.expect("checks requested → verdict"),
+        CaptureFrameResult::Err { error } => panic!("capture failed: {error}"),
+    };
+
+    assert_eq!(
+        verdict.results.len(),
+        rows.len(),
+        "one result per requested check",
+    );
+
+    // A quarter of the row height: the corrected origin centers glyphs well
+    // inside this band, while the removed ascent sag sits a full ascent
+    // (~13px at 14px text) below — far outside it.
+    let tolerance_y = ROW_HEIGHT * 0.25;
+    for (row, result) in rows.iter().zip(&verdict.results) {
+        let FrameCheckResult::Centroid { centroid, .. } = result else {
+            panic!("row {} scored a non-Centroid result: {result:?}", row.name);
+        };
+        let centroid =
+            centroid.unwrap_or_else(|| panic!("row {} drew no glyphs (empty mask)", row.name));
+        let offset = centroid[1] - row.center_y;
+        eprintln!(
+            "row {}: centroid_y={:.1} row_center={:.1} offset={:+.1} (tol ±{tolerance_y:.1})",
+            row.name, centroid[1], row.center_y, offset,
+        );
+        assert!(
+            offset.abs() <= tolerance_y,
+            "row {} glyphs must sit within {tolerance_y:.1}px of the row center {:.1}; \
+             centroid landed at y={:.1} (offset {:+.1}) — the one-ascent sag this fix removes",
+            row.name,
+            row.center_y,
+            centroid[1],
+            offset,
+        );
+    }
+}


### PR DESCRIPTION
Closes #2670.

## Summary

Every glyph the widget panel drew sat roughly one ascent below its row — uniformly, panel title through Apply label — because the widgets computed a correct baseline y and passed it as the `aether.text.draw` origin, which the text cap treats as the line-box top-left (the baseline sits one ascent *below* it). All quads were placed correctly, so clicking visible text landed one row off. The fix is one shared metric-free helper, `text_origin_y(row_top, row_height, size_pixels)` — em-box centering, since `CachedFontMetrics` exposes no ascent and the theme deliberately fans no font metrics to widgets — routed through every text-emitting widget (button, label, radio, text field; the slider draws no text), with the text field's preedit underline repositioned below the glyph run to match. The Qodana note-level doc-link qualifiers in the widgets module were folded in; the duplicated-code note was judged and skipped (two distinct dispatch entry points sharing a helper — merging would obscure).

## Test plan

New TestBench scenario (`widget_text_alignment.rs`): renders the reference panel with the real RobotoMono font (deterministically pre-loaded and atlas-primed, pinned `font_id`), then asserts per-row glyph-centroid-y within ±6px of row center using #2673's region-scoped frame checks — label, button, and all three radio rows. Measured post-fix offsets run +2.9 to +3.7px; the bug's ~13px sag blows the band, so the check separates fix from regression by ~10px. Sibling `widget_set` and `widget_compositing` scenarios pass unchanged; clippy and strict rustdoc clean.

## Generated by

`/implement` — agent execution of [scoped issue #2670](https://github.com/iamacoffeepot/aether/issues/2670).
