### PR TITLE
docs(adr): flip ADR-0117 widget compositing to accepted

### DIFF
--- a/docs/adr/0117-widget-compositing.md
+++ b/docs/adr/0117-widget-compositing.md
@@ -1,6 +1,6 @@
 # ADR-0117: Widget Compositing
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-15
 
 ## Context


### PR DESCRIPTION
Flips ADR-0117 to Accepted: its implementation arc is fully landed — the guest-library compositing realization (#2666), the widget set consuming it (#2669), and the render/interaction scenario suite gating it (#2683).
