### PR TITLE
feat(kit): water as underlay with an authored water level

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -15,7 +15,7 @@
 //! driver kinds live in [`camera`]; the mesh viewer's `aether.mesh.load`
 //! kind lives in [`mesh`]. The [`world`] module holds the chunked world
 //! plane stack — the `World` / `Chunk` / `Material` data layer and its
-//! `aether.kit.world.{set_chunk,set_region,set_smoothing_profile,set_material_style,set_view_mode,load}` wire kinds
+//! `aether.kit.world.{set_chunk,set_region,set_smoothing_profile,set_water_plane,set_material_style,set_view_mode,load}` wire kinds
 //! — that `WorldView` meshes to the render sink. The [`widgets`] module
 //! holds the widget-compositing vocabulary (ADR-0117) — `Collect` /
 //! `WidgetDrawList` and the `WidgetConfig` tree — that
@@ -56,8 +56,8 @@ pub use widgets::{
 };
 pub use world::{
     CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk, ChunkPos, Material, Region,
-    SetChunk, SetMaterialStyle, SetRegion, SetSmoothingProfile, SetViewMode, SmoothingProfile,
-    ViewMode, World, WorldDecodeError, WorldLoad,
+    SetChunk, SetMaterialStyle, SetRegion, SetSmoothingProfile, SetViewMode, SetWaterPlane,
+    SmoothingProfile, ViewMode, WaterPlane, World, WorldDecodeError, WorldLoad,
 };
 
 #[cfg(feature = "runtime")]

--- a/crates/aether-kit/src/runtime/mesher/mod.rs
+++ b/crates/aether-kit/src/runtime/mesher/mod.rs
@@ -56,13 +56,25 @@
 //! versus crisp is authored on the map. The pooled rim is a second marched
 //! layer over an eroded mask: the smoothed shape draws in a darkened rim
 //! color, and the body draws one octimeter above it inset by the rim
-//! width. Water's body swaps the flat marched interior for a graded quad
-//! per subcell fully inside the eroded region — lightness driven down by a
-//! bounded shore-distance scan, hue varied per subcell — while the marched
-//! rim band beneath carries the smoothed shoreline silhouette. Overlay
-//! geometry lifts a hair above the underlay surface so the coplanar
-//! passes never z-fight, and it carries its own vertices so the seam
-//! stays hard.
+//! width. Every overlay material contours identically — water is underlay
+//! ground fabric (below), so an overlay-painted water body draws as a
+//! generic marched surface with no special treatment. Overlay geometry
+//! lifts a hair above the underlay surface so the coplanar passes never
+//! z-fight, and it carries its own vertices so the seam stays hard.
+//!
+//! # Water — a flat underlay plane
+//!
+//! [`Material::Water`] is an underlay partition material, so the waterline
+//! smooths, rims, and tiles through the underlay repartition like every
+//! other boundary. What makes it read as water is the surface level: a
+//! water cell resolves its corners at its authored water-plane level
+//! ([`World::water_level`]) rather than its lakebed [`World::height`], and a
+//! corner plate with any water member pins to that level — so the surface
+//! is exactly flat, a connected shore blends down to the waterline (beach),
+//! and a past-step bank splits and wears the skirt down to the water. An
+//! interior water cell tiles the flat patch with a depth-graded quad per
+//! subcell, depth derived as the plane level minus the bilinear lakebed
+//! [`World::height`] over [`WATER_DEPTH_FULL_OCTIMETERS`].
 //!
 //! # Height pass — plates, slopes, and skirts
 //!
@@ -75,9 +87,11 @@
 //! the skirt pass closes that gap with a vertical face wearing the high
 //! cell's region cliff material, darkened toward its base. Boundary
 //! windows and overlay contours lift each vertex through its own
-//! (floor) cell — continuous wherever no cliff intervenes — and water
-//! rides the same surface for now (an authored per-body water level is
-//! future work). A slope shade from the patch normal bakes into vertex
+//! (floor) cell — continuous wherever no cliff intervenes — and a water
+//! cell reads its flat authored plane level (the water section above)
+//! rather than the lakebed, so a lake on sloped terrain lies flat and a
+//! bank above it wears the skirt down to the water. A slope shade from the
+//! patch normal bakes into vertex
 //! color so slopes read under the flat-color grammar; it multiplies by
 //! exactly one on level ground, so an all-flat world meshes
 //! byte-identically to a world with no height pass at all.
@@ -92,8 +106,7 @@ use aether_capabilities::render::{DrawTriangle, Vertex};
 use aether_math::Vec3;
 
 use crate::world::{
-    CELLS_PER_CHUNK, CellPos, ChunkPos, Material, STEP_MAX_OCTIMETERS, SUBCELLS_PER_CELL_EDGE,
-    ViewMode, World,
+    CELLS_PER_CHUNK, CellPos, ChunkPos, Material, SUBCELLS_PER_CELL_EDGE, ViewMode, World,
 };
 use contour::{
     GridPlacement, SmoothParams, emit_label_window, erode, label_case, march_grid,
@@ -157,9 +170,11 @@ const CONTOUR_UPSAMPLE: usize = 2;
 /// within the eight-neighbor remesh the `R = 1` invalidation covers.
 const MAX_APRON_SUBCELLS: i32 = 8;
 
-/// Bounded outward scan length in subcells for the water shore-distance
-/// derivation.
-const MAX_SHORE_SCAN: i32 = 8;
+/// Water depth in octimeters at which the depth grading reaches full
+/// darkening — one meter of water below the surface. Shallower water grades
+/// proportionally between the shore (depth `0`) and this floor; deeper
+/// water clamps here.
+const WATER_DEPTH_FULL_OCTIMETERS: f32 = 256.0;
 
 /// Mesh one chunk into its triangle list. Pure — no wgpu, no ctx — so it
 /// is unit-testable host-side. Reads neighbor cells through [`World`] (a
@@ -254,7 +269,7 @@ fn label_lift(world: &World, owner: CellPos, wx: f32, wz: f32) -> (f32, f32) {
         x: floor_to_i32(wx),
         z: floor_to_i32(wz),
     };
-    if cell != owner && (world.height(cell) - world.height(owner)).abs() > STEP_MAX_OCTIMETERS {
+    if cell != owner && world.edge_is_cliff(cell, owner) {
         let lift = CellLift::of(world, owner);
         return (lift.y(wx, wz), lift.shade(wx, wz));
     }
@@ -461,6 +476,10 @@ fn mesh_underlay(world: &World, at: ChunkPos, styles: &StyleTable, tris: &mut Ve
                 z: at.z * EDGE + lz,
             };
             let material = world.underlay(cell);
+            if material == Material::Water {
+                emit_water_cell(world, cell, styles, tris);
+                continue;
+            }
             let resolved = resolve_cell(
                 styles.get(material),
                 cell.x as f32 + 0.5,
@@ -620,11 +639,12 @@ fn emit_label_quad(
     tris: &mut Vec<DrawTriangle>,
 ) {
     let material = Material::from_u8_or_void(label.div_ceil(2));
+    let depth = (material == Material::Water).then(|| owner_water_depth(world, owner));
     let resolved = resolve_cell(
         styles.get(material),
         owner.x as f32 + 0.5,
         owner.z as f32 + 0.5,
-        None,
+        depth,
     );
     let rim = if label % 2 == 1 {
         styles.get(material).rim_darken
@@ -678,7 +698,8 @@ fn emit_mixed_window(
         };
         let material = Material::from_u8_or_void(label.div_ceil(2));
         let s = styles.get(material);
-        let resolved = resolve_cell(s, owner.x as f32 + 0.5, owner.z as f32 + 0.5, None);
+        let depth = (material == Material::Water).then(|| owner_water_depth(world, owner));
+        let resolved = resolve_cell(s, owner.x as f32 + 0.5, owner.z as f32 + 0.5, depth);
         let mut light = wash_lightness(s, resolved.light, wash_x, wash_z, resolved.stroke);
         if label % 2 == 1 {
             light *= 1.0 - s.rim_darken;
@@ -874,6 +895,84 @@ fn emit_quad_shaded(
     tris.push(DrawTriangle { verts: [a, c, d] });
 }
 
+/// The bilinear lakebed height in octimeters at world point `(wx, wz)`
+/// (meters), interpolated over the raw per-cell [`World::height`] plane
+/// anchored at cell centers — the ground the water depth grades against.
+fn bilinear_lakebed(world: &World, wx: f32, wz: f32) -> f32 {
+    let fx = wx - 0.5;
+    let fz = wz - 0.5;
+    let x0 = floor_to_i32(fx);
+    let z0 = floor_to_i32(fz);
+    let tx = fx - x0 as f32;
+    let tz = fz - z0 as f32;
+    let h = |cx: i32, cz: i32| world.height(CellPos { x: cx, z: cz }) as f32;
+    let bottom = h(x0, z0) * (1.0 - tx) + h(x0 + 1, z0) * tx;
+    let top = h(x0, z0 + 1) * (1.0 - tx) + h(x0 + 1, z0 + 1) * tx;
+    bottom * (1.0 - tz) + top * tz
+}
+
+/// The water depth `[0, 1]` at world point `(wx, wz)` for a surface at
+/// `level_octimeters`: the surface-to-lakebed drop over
+/// [`WATER_DEPTH_FULL_OCTIMETERS`], clamped. `0` at the waterline, `1` in
+/// water at least [`WATER_DEPTH_FULL_OCTIMETERS`] deep.
+fn water_depth(world: &World, level_octimeters: i32, wx: f32, wz: f32) -> f32 {
+    ((level_octimeters as f32 - bilinear_lakebed(world, wx, wz)) / WATER_DEPTH_FULL_OCTIMETERS)
+        .clamp(0.0, 1.0)
+}
+
+/// The depth to grade a water label owned by `owner`: the depth at the
+/// owner's center when it is a water cell, else `0` (a water polygon owned
+/// by a land cell reads as the shallow rim, not deep water).
+fn owner_water_depth(world: &World, owner: CellPos) -> f32 {
+    world.water_level(owner).map_or(0.0, |level| {
+        water_depth(world, level, owner.x as f32 + 0.5, owner.z as f32 + 0.5)
+    })
+}
+
+/// Emit one interior water cell's body: the flat water patch at the plane
+/// level, tiled as a depth-graded quad per subcell. Each subcell grades
+/// toward the pooled deep-water hue by the lakebed drop below the surface
+/// at its center, so a shelving lakebed reads as shallows deepening inward
+/// while the surface stays exactly flat. No pooled-rim nine-slice — the
+/// shoreline rim is the partition's marched band around the water body.
+fn emit_water_cell(
+    world: &World,
+    cell: CellPos,
+    styles: &StyleTable,
+    tris: &mut Vec<DrawTriangle>,
+) {
+    let level = world.water_level(cell).unwrap_or(0);
+    let s = styles.get(Material::Water);
+    let lift = CellLift::of(world, cell);
+    for sj in 0..SUB {
+        for si in 0..SUB {
+            let x0 = cell.x * 256 + si * OCTIMETERS_PER_SUBCELL;
+            let z0 = cell.z * 256 + sj * OCTIMETERS_PER_SUBCELL;
+            let center_x = (x0 + OCTIMETERS_PER_SUBCELL / 2) as f32 / OCTIMETERS_PER_METER;
+            let center_z = (z0 + OCTIMETERS_PER_SUBCELL / 2) as f32 / OCTIMETERS_PER_METER;
+            let depth = water_depth(world, level, center_x, center_z);
+            let resolved = resolve_cell(s, center_x, center_z, Some(depth));
+            let color = hsl_to_linear_rgb(resolved.hue, resolved.sat, resolved.light);
+            let vertex = |wx: f32, wz: f32| Vertex {
+                x: wx,
+                y: lift.y(wx, wz),
+                z: wz,
+                r: color[0],
+                g: color[1],
+                b: color[2],
+            };
+            push_quad(
+                tris,
+                x0,
+                z0,
+                x0 + OCTIMETERS_PER_SUBCELL,
+                z0 + OCTIMETERS_PER_SUBCELL,
+                &vertex,
+            );
+        }
+    }
+}
+
 /// Is the subcell at chunk-local index `(six, siz)` covered by `material`?
 /// Indices range over the field plus its apron; an out-of-chunk index
 /// resolves to a neighbor cell through [`World`], reading empty for a
@@ -962,11 +1061,11 @@ fn sample_params(
 
 /// Contour one overlay material's subcell field: smooth its corners per
 /// the spatial smoothing field, then march a rim layer and an inset body
-/// layer. Water's body swaps the flat marched interior for per-subcell
-/// depth-graded quads over the eroded region, keeping the smoothed rim
-/// band as its shoreline silhouette. The apron is fixed at the maximum a
-/// profile can demand ([`MAX_APRON_SUBCELLS`]), so field content never
-/// changes a chunk's read reach.
+/// layer. Every overlay material contours the same way — water is ground
+/// fabric in the underlay, so an overlay-painted water body draws as a
+/// generic marched surface with no special treatment. The apron is fixed at
+/// the maximum a profile can demand ([`MAX_APRON_SUBCELLS`]), so field
+/// content never changes a chunk's read reach.
 fn mesh_overlay_material(
     world: &World,
     at: ChunkPos,
@@ -1000,11 +1099,6 @@ fn mesh_overlay_material(
     let rim_width = (s.rim_inset_octimeters / step_oct).max(1);
     let eroded = erode(&smoothed, gw, gh, rim_width);
 
-    if material == Material::Water {
-        emit_water(world, &eroded, gw, apron, upsample, base_oct, styles, tris);
-        return;
-    }
-
     let body_color = hsl_to_linear_rgb(s.base_hue, s.base_sat, s.base_light);
     let body_vertex = surface_vertex(world, OVERLAY_BODY_LIFT, body_color);
     march_grid(&eroded, gw, gh, &place, &body_vertex, tris);
@@ -1023,110 +1117,6 @@ fn surface_vertex(world: &World, lift: f32, color: [f32; 3]) -> impl Fn(f32, f32
         g: color[1],
         b: color[2],
     }
-}
-
-/// Emit water's body: a graded quad per subcell whose sample block sits
-/// fully inside the eroded smoothed grid, lightness falling with derived
-/// shore depth and hue varying per subcell. A shoreline subcell only
-/// partially inside refines to per-sample quads over its covered samples,
-/// so the body hugs the smoothed contour at the smoothing grid's own
-/// resolution and the marched rim band beneath shows as an even pooled
-/// edge instead of subcell-scale teeth.
-#[allow(clippy::too_many_arguments)] // one call site; the water pass state travels together
-fn emit_water(
-    world: &World,
-    eroded: &[bool],
-    gw: usize,
-    apron: i32,
-    upsample: usize,
-    base_oct: [i32; 2],
-    styles: &StyleTable,
-    tris: &mut Vec<DrawTriangle>,
-) {
-    let u = upsample as i32;
-    let sample = |gx: i32, gz: i32| {
-        // The grid is square (n × n upsampled), so gw bounds both.
-        gx >= 0
-            && gz >= 0
-            && (gx as usize) < gw
-            && (gz as usize) < gw
-            && eroded[gz as usize * gw + gx as usize]
-    };
-    let inside = |six: i32, siz: i32| {
-        let gx0 = (six + apron) * u;
-        let gz0 = (siz + apron) * u;
-        (0..u).all(|dz| (0..u).all(|dx| sample(gx0 + dx, gz0 + dz)))
-    };
-    let step_oct = OCTIMETERS_PER_SUBCELL / u;
-    for sj in 0..SUBCELLS_PER_CHUNK_EDGE {
-        for si in 0..SUBCELLS_PER_CHUNK_EDGE {
-            let x_oct = base_oct[0] + si * OCTIMETERS_PER_SUBCELL;
-            let z_oct = base_oct[1] + sj * OCTIMETERS_PER_SUBCELL;
-            if inside(si, sj) {
-                let depth = subcell_shore_depth(&inside, si, sj);
-                let center_x = (x_oct + OCTIMETERS_PER_SUBCELL / 2) as f32 / OCTIMETERS_PER_METER;
-                let center_z = (z_oct + OCTIMETERS_PER_SUBCELL / 2) as f32 / OCTIMETERS_PER_METER;
-                let resolved =
-                    resolve_cell(styles.get(Material::Water), center_x, center_z, Some(depth));
-                let color = hsl_to_linear_rgb(resolved.hue, resolved.sat, resolved.light);
-                push_quad(
-                    tris,
-                    x_oct,
-                    z_oct,
-                    x_oct + OCTIMETERS_PER_SUBCELL,
-                    z_oct + OCTIMETERS_PER_SUBCELL,
-                    &surface_vertex(world, OVERLAY_BODY_LIFT, color),
-                );
-                continue;
-            }
-            // Shoreline refinement: per-sample quads over the covered
-            // samples of a partially-inside subcell, at the shore depth.
-            let gx0 = (si + apron) * u;
-            let gz0 = (sj + apron) * u;
-            let mut any = false;
-            for dz in 0..u {
-                for dx in 0..u {
-                    if sample(gx0 + dx, gz0 + dz) {
-                        any = true;
-                    }
-                }
-            }
-            if !any {
-                continue;
-            }
-            let center_x = (x_oct + OCTIMETERS_PER_SUBCELL / 2) as f32 / OCTIMETERS_PER_METER;
-            let center_z = (z_oct + OCTIMETERS_PER_SUBCELL / 2) as f32 / OCTIMETERS_PER_METER;
-            let resolved = resolve_cell(styles.get(Material::Water), center_x, center_z, Some(0.0));
-            let color = hsl_to_linear_rgb(resolved.hue, resolved.sat, resolved.light);
-            let vertex = surface_vertex(world, OVERLAY_BODY_LIFT, color);
-            for dz in 0..u {
-                for dx in 0..u {
-                    if sample(gx0 + dx, gz0 + dz) {
-                        let sx = x_oct + dx * step_oct;
-                        let sz = z_oct + dz * step_oct;
-                        push_quad(tris, sx, sz, sx + step_oct, sz + step_oct, &vertex);
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Derived shore depth `[0, 1]` for a water subcell: a bounded four-way
-/// outward scan (in subcells) for the nearest subcell not fully inside
-/// the water body. `0` at the shore edge, rising monotonically inward to
-/// `1` past the scan reach.
-fn subcell_shore_depth(inside: &impl Fn(i32, i32) -> bool, x: i32, z: i32) -> f32 {
-    let mut nearest = MAX_SHORE_SCAN;
-    for (dx, dz) in [(-1, 0), (1, 0), (0, -1), (0, 1)] {
-        for step in 1..=MAX_SHORE_SCAN {
-            if !inside(x + dx * step, z + dz * step) {
-                nearest = nearest.min(step);
-                break;
-            }
-        }
-    }
-    ((nearest - 1) as f32 / (MAX_SHORE_SCAN - 1) as f32).clamp(0.0, 1.0)
 }
 
 /// Emit the raw calibration view: one grayscale quad per non-Void
@@ -1220,14 +1210,16 @@ fn emit_skirts(
                 x: at.x * EDGE + lx,
                 z: at.z * EDGE + lz,
             };
-            let cell_height = world.height(cell);
+            let cell_level = world.surface_level(cell);
             let mut cached: Option<[f32; 4]> = None;
             for edge in &DIRECTIONS {
                 let neighbor = CellPos {
                     x: cell.x + edge.offset.0,
                     z: cell.z + edge.offset.1,
                 };
-                if cell_height <= world.height(neighbor) || !world.edge_is_cliff(cell, neighbor) {
+                if cell_level <= world.surface_level(neighbor)
+                    || !world.edge_is_cliff(cell, neighbor)
+                {
                     continue;
                 }
                 let top = *cached.get_or_insert_with(|| world.cell_corner_heights(cell));
@@ -1295,7 +1287,10 @@ fn emit_skirts(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::world::{CELLS_PER_CHUNK_AREA, Chunk, Region, SetMaterialStyle, SmoothingProfile};
+    use crate::world::{
+        CELLS_PER_CHUNK_AREA, Chunk, Region, STEP_MAX_OCTIMETERS, SetMaterialStyle,
+        SmoothingProfile,
+    };
     use style::ResolvedCell;
 
     fn grass_cell() -> ResolvedCell {
@@ -1314,12 +1309,6 @@ mod tests {
             z0: cz as f32,
             corners: [0.0; 4],
         }
-    }
-
-    fn overlay_tris(tris: &[DrawTriangle]) -> usize {
-        tris.iter()
-            .filter(|t| t.verts.iter().all(|v| v.y > 0.0))
-            .count()
     }
 
     #[test]
@@ -1412,45 +1401,52 @@ mod tests {
     }
 
     #[test]
-    fn water_depth_is_monotone_inward_and_absent_outside() {
-        // Shore depth must be zero at the shoreline and rise monotonically
-        // toward the interior; a subcell one step from open water is
-        // shallower than one buried deep. Depth outside the water body is
-        // never sampled (the caller skips subcells not fully inside).
-        let n = 24i32;
-        let mut field = vec![false; (n * n) as usize];
-        for z in 0..n {
-            for x in 0..n {
-                if (x - 12) * (x - 12) + (z - 12) * (z - 12) <= 81 {
-                    field[(z * n + x) as usize] = true;
-                }
+    fn water_depth_grades_with_the_lakebed_and_clamps() {
+        // Depth is the surface-to-lakebed drop over
+        // WATER_DEPTH_FULL_OCTIMETERS: zero at the waterline, rising as the
+        // lakebed falls away, clamped to full a meter down. A lakebed
+        // shelving eastward reads monotonically deeper — the level-minus-
+        // lakebed grading that replaced the shore-distance scan.
+        let mut chunk = Chunk::empty();
+        for lz in 0..EDGE {
+            for lx in 0..EDGE {
+                // Lakebed drops 20 octimeters per cell to the east.
+                chunk.height[(lz * EDGE + lx) as usize] = -20 * lx;
             }
         }
-        let inside =
-            |x: i32, z: i32| x >= 0 && z >= 0 && x < n && z < n && field[(z * n + x) as usize];
-        let center = subcell_shore_depth(&inside, 12, 12);
-        let shore = subcell_shore_depth(&inside, 21, 12);
-        assert!(center > shore, "deeper inside: {center} > {shore}");
-        assert_eq!(shore, 0.0, "a subcell touching open water is at depth 0");
-        assert_eq!(center, 1.0, "the middle of a wide lake is fully deep");
+        let mut world = World::new();
+        world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
+        // Surface at the datum; depth rises with the eastward lakebed drop.
+        let shallow = water_depth(&world, 0, 2.5, 5.5);
+        let deep = water_depth(&world, 0, 8.5, 5.5);
+        assert!(deep > shallow, "deeper east: {deep} > {shallow}");
+        assert_eq!(
+            water_depth(&world, 0, 0.5, 5.5),
+            0.0,
+            "at the waterline depth is zero",
+        );
+        // Cell 14's lakebed is -280 octimeters, past a meter — clamps to 1.
+        assert_eq!(
+            water_depth(&world, 0, 14.5, 5.5),
+            1.0,
+            "past full depth clamps"
+        );
     }
 
     #[test]
     fn full_water_chunk_budget_is_pinned() {
-        // Tripwire: the water budget is body + rim, all derivable. Body: a
-        // graded quad per subcell fully inside the eroded grid — with water
-        // on every side, all 64*64 subcells qualify = 8192 tris. Rim: the
-        // smoothed grid is all-true, so its march greedy-merges to one quad
-        // (2 tris); water never marches the eroded grid (the body quads
-        // replace that layer). Total 8194. A change to the water
-        // resolution, rim width, or grading fan-out moves this and must be
-        // deliberate.
+        // Tripwire: water is underlay fabric, so a fully-water chunk is all
+        // interior body — each of its 256 cells tiles the flat water patch
+        // with one depth-graded quad per subcell (16 subcells x 2 tris), and
+        // nothing else draws (no partition windows inside a uniform body, no
+        // overlay, no skirts on flat water). 256 * 32 = 8192. A change to the
+        // per-subcell water resolution or the interior body path moves this
+        // and must be deliberate.
         let mut world = World::new();
         for dz in -1..=1 {
             for dx in -1..=1 {
                 let mut c = Chunk::empty();
-                c.overlay = [Material::Water; CELLS_PER_CHUNK_AREA];
-                c.overlay_mask = [0xFFFF; CELLS_PER_CHUNK_AREA];
+                c.underlay = [Material::Water; CELLS_PER_CHUNK_AREA];
                 world.insert_chunk(ChunkPos { x: dx, z: dz }, c);
             }
         }
@@ -1460,23 +1456,22 @@ mod tests {
             ViewMode::Painted,
             &StyleTable::default(),
         );
-        assert_eq!(overlay_tris(&tris), 8194, "8192 body + one merged rim quad");
+        assert_eq!(tris.len(), 8192, "256 cells x 16 subcells x 2 tris");
     }
 
     #[test]
     fn water_shoreline_is_smoothed_and_rimmed() {
-        // The waterline flows through the same corner minimization and rim
-        // march as land contours: a lone water square must emit strictly
-        // more than its raw per-subcell quads (the marched rim band is
-        // present) and its smoothed silhouette must cut the square's
-        // corners (some rim geometry sits off the subcell lattice).
+        // Water is underlay fabric: a water square painted into a grass
+        // field smooths and rims its waterline through the same partition as
+        // any material boundary (a crossing lands off the cell lattice), and
+        // the body renders as blue water.
         let mut world = World::new();
         let mut c = Chunk::empty();
+        c.underlay = [Material::Grass; CELLS_PER_CHUNK_AREA];
         // A 4x4-cell water square in the chunk interior.
         for lz in 6..10 {
             for lx in 6..10 {
-                c.overlay[(lz * EDGE + lx) as usize] = Material::Water;
-                c.overlay_mask[(lz * EDGE + lx) as usize] = 0xFFFF;
+                c.underlay[(lz * EDGE + lx) as usize] = Material::Water;
             }
         }
         world.insert_chunk(ChunkPos { x: 0, z: 0 }, c);
@@ -1486,25 +1481,16 @@ mod tests {
             ViewMode::Painted,
             &StyleTable::default(),
         );
-
-        let rim_tris = tris
-            .iter()
-            .filter(|t| t.verts.iter().all(|v| v.y > 0.0 && v.y < OVERLAY_BODY_LIFT))
-            .count();
-        assert!(rim_tris > 0, "water marches a shoreline rim layer");
-        // The smoothed rim contour cuts corners between subcell lattice
-        // points: some rim vertex sits on the half-subcell grid (odd
-        // multiple of 1/8 m), which raw per-subcell quads never produce.
-        let off_lattice = tris
-            .iter()
-            .filter(|t| t.verts.iter().all(|v| v.y > 0.0 && v.y < OVERLAY_BODY_LIFT))
-            .flat_map(|t| t.verts.iter())
-            .any(|v| {
-                let scaled = v.x * 8.0;
-                let eighths = scaled.round();
-                (scaled - eighths).abs() < 1e-4 && (eighths as i64) % 2 != 0
-            });
-        assert!(off_lattice, "the shoreline silhouette is corner-minimized");
+        assert!(
+            has_smoothed_crossing(&tris),
+            "the waterline is corner-minimized like any material boundary",
+        );
+        assert!(
+            tris.iter()
+                .flat_map(|t| t.verts.iter())
+                .any(|v| v.b > v.r && v.b > v.g),
+            "the water body renders as blue water",
+        );
     }
 
     #[test]

--- a/crates/aether-kit/src/runtime/mesher/mod.rs
+++ b/crates/aether-kit/src/runtime/mesher/mod.rs
@@ -74,7 +74,7 @@
 //! and a past-step bank splits and wears the skirt down to the water. An
 //! interior water cell tiles the flat patch with a depth-graded quad per
 //! subcell, depth derived as the plane level minus the bilinear lakebed
-//! [`World::height`] over [`WATER_DEPTH_FULL_OCTIMETERS`].
+//! [`World::height`] over `WATER_DEPTH_FULL_OCTIMETERS`.
 //!
 //! # Height pass — plates, slopes, and skirts
 //!

--- a/crates/aether-kit/src/runtime/world_view.rs
+++ b/crates/aether-kit/src/runtime/world_view.rs
@@ -28,6 +28,9 @@
 //! - `aether.kit.world.set_smoothing_profile` — register a contour-
 //!   smoothing profile the per-cell smoothing plane points at; remeshes
 //!   every cached chunk.
+//! - `aether.kit.world.set_water_plane` — register a water plane so water
+//!   cells pointing at it resolve their flat surface level; remeshes every
+//!   cached chunk (retuning a level restyles every referencing water body).
 //! - `aether.kit.world.set_material_style` — write a material's complete
 //!   live style row (base HSL, noise shape, smoothing defaults, rim /
 //!   wash / water tunables) and remesh every cached chunk, so a tuning
@@ -52,7 +55,7 @@ use super::mesher::mesh_chunk;
 use super::mesher::style::StyleTable;
 use crate::world::{
     ChunkPos, Material, SetChunk, SetMaterialStyle, SetRegion, SetSmoothingProfile, SetViewMode,
-    ViewMode, World, WorldLoad,
+    SetWaterPlane, ViewMode, World, WorldLoad,
 };
 
 /// World-view component: holds the world plane stack and a per-chunk
@@ -194,6 +197,22 @@ impl WasmActor for WorldView {
     fn on_set_smoothing_profile(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetSmoothingProfile) {
         self.world
             .insert_smoothing_profile(msg.profile_id, msg.profile());
+        self.remesh_all();
+    }
+
+    /// Register a water plane in the world's table, then remesh every cached
+    /// chunk — the level sets the flat surface of every water cell pointing
+    /// at this plane, so retuning it repaints all of them.
+    ///
+    /// # Agent
+    /// Send `aether.kit.world.set_water_plane` with a 1-based `plane_id` and
+    /// a `level_octimeters`. Point water cells at it through the
+    /// `water_plane` plane of `aether.kit.world.set_chunk` (id = plane,
+    /// `0` = the datum-0 level). One write retunes a whole lake live; use
+    /// `capture_frame` to verify.
+    #[handler]
+    fn on_set_water_plane(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetWaterPlane) {
+        self.world.insert_water_plane(msg.plane_id, msg.plane());
         self.remesh_all();
     }
 

--- a/crates/aether-kit/src/world.rs
+++ b/crates/aether-kit/src/world.rs
@@ -42,8 +42,8 @@
 //!   cascade resolves ([`World::underlay`]): the cell's own underlay if
 //!   non-[`Material::Void`], else the cell's region's `default_material`,
 //!   else `Void`.
-//! - [`Chunk::overlay`] — an optional crisp placed surface (path, water,
-//!   floor). `Void` means no overlay. Never cascade-resolved
+//! - [`Chunk::overlay`] — an optional crisp placed surface (path, floor).
+//!   `Void` means no overlay. Never cascade-resolved
 //!   ([`World::overlay`] is a raw plane read).
 //! - [`Chunk::overlay_mask`] — a subcell coverage bitmask per cell. Each
 //!   cell holds a [`SUBCELLS_PER_CELL_EDGE`]² bit grid (bit `z*SUB + x`,
@@ -54,6 +54,19 @@
 //!   painter's order applies across layers. Reserved here — the wire
 //!   layout is final, but mask meshing is a follow-up; nothing in this
 //!   module interprets the bits.
+//!
+//! # Water planes
+//!
+//! [`Material::Water`] is underlay ground fabric, not an overlay: a cell
+//! painted Water in the underlay reads as water, tiling and smoothing
+//! through the same partition as every other material. What makes its
+//! surface flat is a **water-plane table** — [`WaterPlane`] rows holding a
+//! [`WaterPlane::level_octimeters`], referenced by 1-based id from the
+//! per-cell [`Chunk::water_plane`] plane (`0` = the datum-0 level). A water
+//! cell resolves its surface at its plane's level ([`World::water_level`])
+//! rather than its own lakebed [`Chunk::height`], so the surface lies flat
+//! regardless of the ground beneath — disconnected areas sharing a plane
+//! share a level (one sea row every coastal cell references).
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;
@@ -239,8 +252,21 @@ pub struct SmoothingProfile {
     pub degrees: u32,
 }
 
-/// One `16 × 16` block of the world, as a struct-of-arrays: five
-/// property planes, each row-major (`z * 16 + x`).
+/// An authored water surface level. Water cells reference a plane by
+/// 1-based id from the per-cell water plane (`0` = the datum-0 level); the
+/// table is positional like the region table, so a plane's id is its index
+/// in [`World`]'s table plus one. Disconnected water bodies can share a
+/// plane (one sea row every coastal cell points at); the level is authored,
+/// not derived from the ground.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WaterPlane {
+    /// The surface height in octimeters the referencing water cells lie at,
+    /// regardless of their lakebed [`Chunk::height`].
+    pub level_octimeters: i32,
+}
+
+/// One `16 × 16` block of the world, as a struct-of-arrays: property
+/// planes, each row-major (`z * 16 + x`).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Chunk {
     /// Ground fabric — cascade-resolved by [`World::underlay`].
@@ -256,6 +282,11 @@ pub struct Chunk {
     pub height: [i32; CELLS_PER_CHUNK_AREA],
     /// Region id per cell (`0` = no region).
     pub region: [u16; CELLS_PER_CHUNK_AREA],
+    /// Water-plane id per cell (`0` = none — the datum-0 level). Meaningful
+    /// only where the cascade-resolved underlay is [`Material::Water`];
+    /// selects the row of [`World`]'s water-plane table whose level the
+    /// cell's water surface lies at.
+    pub water_plane: [u16; CELLS_PER_CHUNK_AREA],
     /// Smoothing-profile id per cell (`0` = no override — the material's
     /// own smoothing applies).
     pub smoothing: [u8; CELLS_PER_CHUNK_AREA],
@@ -271,6 +302,7 @@ impl Chunk {
             overlay_mask: [0; CELLS_PER_CHUNK_AREA],
             height: [0; CELLS_PER_CHUNK_AREA],
             region: [0; CELLS_PER_CHUNK_AREA],
+            water_plane: [0; CELLS_PER_CHUNK_AREA],
             smoothing: [0; CELLS_PER_CHUNK_AREA],
         }
     }
@@ -289,6 +321,7 @@ pub struct World {
     chunks: BTreeMap<ChunkPos, Chunk>,
     regions: Vec<Region>,
     smoothing_profiles: Vec<SmoothingProfile>,
+    water_planes: Vec<WaterPlane>,
 }
 
 impl World {
@@ -360,7 +393,9 @@ impl World {
             .map_or(0, |chunk| chunk.overlay_mask[cell.chunk_index()])
     }
 
-    /// Elevation at `cell` in octimeters. Unset cells read `0`.
+    /// Elevation at `cell` in octimeters — the raw lakebed read. Unset
+    /// cells read `0`. Under a water cell this is the ground beneath the
+    /// surface, not the water level ([`World::water_level`] resolves that).
     #[must_use]
     pub fn height(&self, cell: CellPos) -> i32 {
         self.chunks
@@ -368,22 +403,67 @@ impl World {
             .map_or(0, |chunk| chunk.height[cell.chunk_index()])
     }
 
-    /// Do two edge-adjacent cells meet at a cliff — a height step strictly
-    /// past [`STEP_MAX_OCTIMETERS`]? The rule is pairwise over the two
-    /// heights, so any caller holding two adjacent cells derives the same
-    /// answer.
+    /// The authored water surface level in octimeters at `cell`, or `None`
+    /// if the cell is not water. `Some` exactly when the cascade-resolved
+    /// underlay is [`Material::Water`]: the level is the cell's water
+    /// plane's [`WaterPlane::level_octimeters`], with the datum `0` for
+    /// plane id `0` or an unregistered id — the level is authored, never
+    /// derived from the lakebed [`World::height`].
+    #[must_use]
+    pub fn water_level(&self, cell: CellPos) -> Option<i32> {
+        if self.underlay(cell) != Material::Water {
+            return None;
+        }
+        let Some(chunk) = self.chunks.get(&cell.chunk()) else {
+            return Some(0);
+        };
+        let plane_id = chunk.water_plane[cell.chunk_index()];
+        if plane_id == 0 {
+            return Some(0);
+        }
+        Some(
+            self.water_planes
+                .get(plane_id as usize - 1)
+                .map_or(0, |plane| plane.level_octimeters),
+        )
+    }
+
+    /// The effective surface level in octimeters at `cell`: the water
+    /// level for a water cell, else the lakebed [`World::height`]. The
+    /// surface-resolution machinery — [`World::edge_is_cliff`], the corner
+    /// plate walk, the mesher's lift and skirt passes — reads this so a
+    /// water cell resolves at its flat authored level instead of the ground
+    /// beneath it.
+    pub(crate) fn surface_level(&self, cell: CellPos) -> i32 {
+        self.water_level(cell).unwrap_or_else(|| self.height(cell))
+    }
+
+    /// Do two edge-adjacent cells meet at a cliff — an effective-level step
+    /// strictly past [`STEP_MAX_OCTIMETERS`]? The rule is pairwise over the
+    /// two [`World::surface_level`]s, so any caller holding two adjacent
+    /// cells derives the same answer, and a bank standing past the step
+    /// ceiling above a water surface cliffs against it.
     #[must_use]
     pub fn edge_is_cliff(&self, a: CellPos, b: CellPos) -> bool {
-        (self.height(a) - self.height(b)).abs() > STEP_MAX_OCTIMETERS
+        (self.surface_level(a) - self.surface_level(b)).abs() > STEP_MAX_OCTIMETERS
     }
 
     /// The plate-resolved elevation of lattice corner `(kx, kz)` as seen
     /// from `cell` (one of the corner's four incident cells), in meters.
     /// The four incident cells partition into groups connected by
     /// non-cliff shared edges — a walk around the corner — and the plate
-    /// containing `cell` averages its members' heights. Connected cells
-    /// share a plate (the surface blends); a cliff splits the plates (the
-    /// surface breaks, and the gap is the skirt's job).
+    /// containing `cell` averages its members' effective surface levels
+    /// ([`World::surface_level`]). Connected cells share a plate (the
+    /// surface blends); a cliff splits the plates (the surface breaks, and
+    /// the gap is the skirt's job).
+    ///
+    /// A plate with any water member pins to the mean of its **water**
+    /// members' levels alone, not the mixed mean — so an interior water
+    /// corner is exactly flat at the authored level, and a connected shore
+    /// corner (land within the step ceiling of the level) meets the water
+    /// plane exactly, blending the land down to the waterline like a beach
+    /// with no slit and no extra geometry. Past the step ceiling the plates
+    /// split as usual and the skirt closes the face.
     fn corner_plate(&self, kx: i32, kz: i32, cell: CellPos) -> f32 {
         // Incident cells in cyclic order, so consecutive entries (mod 4)
         // share an edge and the diagonal pairs do not.
@@ -396,7 +476,8 @@ impl World {
             CellPos { x: kx, z: kz },
             CellPos { x: kx - 1, z: kz },
         ];
-        let heights = cells.map(|c| self.height(c));
+        let levels = cells.map(|c| self.surface_level(c));
+        let is_water = cells.map(|c| self.water_level(c).is_some());
         let start = cells.iter().position(|&c| c == cell);
         debug_assert!(start.is_some(), "cell must be incident to the corner");
         let start = start.unwrap_or(2);
@@ -410,7 +491,7 @@ impl World {
             for k in 0..4 {
                 let a = k;
                 let b = (k + 1) % 4;
-                let connected = (heights[a] - heights[b]).abs() <= STEP_MAX_OCTIMETERS;
+                let connected = (levels[a] - levels[b]).abs() <= STEP_MAX_OCTIMETERS;
                 if connected && member[a] != member[b] {
                     member[a] = true;
                     member[b] = true;
@@ -418,11 +499,14 @@ impl World {
                 }
             }
         }
+        // A water member pins the plate to the water level: average only the
+        // water members when any is present, else the whole connected plate.
+        let any_water = (0..4).any(|k| member[k] && is_water[k]);
         let mut sum = 0i32;
         let mut count = 0i32;
         for k in 0..4 {
-            if member[k] {
-                sum += heights[k];
+            if member[k] && (!any_water || is_water[k]) {
+                sum += levels[k];
                 count += 1;
             }
         }
@@ -460,11 +544,14 @@ impl World {
         bottom + (top - bottom) * fz
     }
 
-    /// The ground elevation in meters at `(wx, wz)`, resolved through the
+    /// The surface elevation in meters at `(wx, wz)`, resolved through the
     /// owning cell (floor). This is the stood-on height for movers,
     /// ray-picks, and the camera — the same bilinear patch the mesher
-    /// draws, so what is drawn is what is stood on. A point exactly on a
-    /// cliff edge reads the higher-coordinate side (the floor convention).
+    /// draws, so what is drawn is what is stood on. Over a water cell the
+    /// patch reads the water surface (the corner plates pin to the water
+    /// level), so a mover on water stands at the surface — the swimming
+    /// datum, ahead of any blocking rules. A point exactly on a cliff edge
+    /// reads the higher-coordinate side (the floor convention).
     #[must_use]
     pub fn surface_height(&self, wx: f32, wz: f32) -> f32 {
         let cell = CellPos {
@@ -549,6 +636,27 @@ impl World {
         self.smoothing_profiles[index] = clamped;
     }
 
+    /// Register a water plane under a 1-based `id`. The table is positional
+    /// like the region table, so this grows it (padding intervening slots
+    /// with the datum-0 level) and writes `plane` at index `id - 1`.
+    /// `id == 0` is ignored (`0` is the "no plane" sentinel — the datum-0
+    /// level).
+    pub fn insert_water_plane(&mut self, id: u32, plane: WaterPlane) {
+        if id == 0 {
+            return;
+        }
+        let index = id as usize - 1;
+        if index >= self.water_planes.len() {
+            self.water_planes.resize(
+                index + 1,
+                WaterPlane {
+                    level_octimeters: 0,
+                },
+            );
+        }
+        self.water_planes[index] = plane;
+    }
+
     /// The smoothing override at `cell`, if the cell's smoothing plane
     /// points at a registered profile. `None` — plane `0`, missing chunk,
     /// or an unregistered id — means the material default applies.
@@ -571,8 +679,8 @@ impl World {
 
 /// `aether.kit.world.set_chunk` — write one chunk's planes. The three
 /// ground planes ride as raw `Bytes` (256 material/shape bytes each);
-/// `height` / `region` ride as length-256 vectors. Shorter vectors pad
-/// with `Void` / `0`; longer ones truncate.
+/// `height` / `region` / `water_plane` ride as length-256 vectors. Shorter
+/// vectors pad with `Void` / `0`; longer ones truncate.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.kit.world.set_chunk")]
 pub struct SetChunk {
@@ -590,6 +698,9 @@ pub struct SetChunk {
     pub height: Vec<i32>,
     /// Region-id plane — 256 values. `0` = no region.
     pub region: Vec<u32>,
+    /// Water-plane-id plane — 256 values, narrowing to `u16` like `region`.
+    /// `0` = the datum-0 level; meaningful only under a water cell.
+    pub water_plane: Vec<u32>,
     /// Smoothing-profile-id plane — 256 raw bytes. `0` = no override.
     pub smoothing: Vec<u8>,
 }
@@ -629,6 +740,9 @@ impl SetChunk {
             *dst = *value;
         }
         for (dst, value) in chunk.region.iter_mut().zip(&self.region) {
+            *dst = *value as u16;
+        }
+        for (dst, value) in chunk.water_plane.iter_mut().zip(&self.water_plane) {
             *dst = *value as u16;
         }
         for (dst, byte) in chunk.smoothing.iter_mut().zip(&self.smoothing) {
@@ -704,6 +818,28 @@ impl SetSmoothingProfile {
         SmoothingProfile {
             iterations: self.iterations,
             degrees: self.degrees,
+        }
+    }
+}
+
+/// `aether.kit.world.set_water_plane` — register a water plane in the table
+/// under a 1-based `plane_id`, giving water cells a flat authored surface
+/// level to resolve at. The per-cell water plane (`aether.kit.world.set_chunk`'s
+/// `water_plane`) points at the row; retuning a lake's level is this one
+/// table write, live like `set_region`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.world.set_water_plane")]
+pub struct SetWaterPlane {
+    pub plane_id: u32,
+    pub level_octimeters: i32,
+}
+
+impl SetWaterPlane {
+    /// The [`WaterPlane`] this registers.
+    #[must_use]
+    pub fn plane(&self) -> WaterPlane {
+        WaterPlane {
+            level_octimeters: self.level_octimeters,
         }
     }
 }
@@ -827,22 +963,26 @@ pub enum WorldDecodeError {
     BadName,
 }
 
-/// The current write version. Version 3 adds a cliff-material byte to
-/// each region record; version 2 adds the smoothing-profile table (after
-/// the region table) and the per-chunk smoothing plane (after the region
-/// plane). Older buffers still decode: a pre-3 region reads Stone cliffs,
-/// a version-1 buffer reads an empty profile table and an all-zero
-/// smoothing plane.
-const WORLD_FORMAT_VERSION: u8 = 3;
+/// The current write version. Version 4 adds the water-plane table (after
+/// the smoothing-profile table) and the per-chunk water-plane plane (after
+/// the height plane); version 3 adds a cliff-material byte to each region
+/// record; version 2 adds the smoothing-profile table (after the region
+/// table) and the per-chunk smoothing plane (after the region plane).
+/// Older buffers still decode: a pre-4 buffer reads an empty water-plane
+/// table and an all-zero water plane, a pre-3 region reads Stone cliffs, a
+/// version-1 buffer reads an empty profile table and an all-zero smoothing
+/// plane.
+const WORLD_FORMAT_VERSION: u8 = 4;
 
 /// The oldest version [`World::from_bytes`] still decodes.
 const WORLD_FORMAT_VERSION_MIN: u8 = 1;
 
 impl World {
     /// Serialize to the compact `aether.kit.world.load` binary format: a
-    /// version byte, the region table, the smoothing-profile table, then
-    /// per-chunk plane records — all little-endian. Region and profile ids
-    /// are positional (index + 1), so the table order is the id order.
+    /// version byte, the region table, the smoothing-profile table, the
+    /// water-plane table, then per-chunk plane records — all little-endian.
+    /// Region, profile, and water-plane ids are positional (index + 1), so
+    /// the table order is the id order.
     #[must_use]
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut out = Vec::new();
@@ -860,6 +1000,10 @@ impl World {
             out.push(profile.iterations as u8);
             out.extend_from_slice(&(profile.degrees as u16).to_le_bytes());
         }
+        out.extend_from_slice(&(self.water_planes.len() as u32).to_le_bytes());
+        for plane in &self.water_planes {
+            out.extend_from_slice(&plane.level_octimeters.to_le_bytes());
+        }
         out.extend_from_slice(&(self.chunks.len() as u32).to_le_bytes());
         for (pos, chunk) in &self.chunks {
             out.extend_from_slice(&pos.x.to_le_bytes());
@@ -876,6 +1020,9 @@ impl World {
             for h in &chunk.height {
                 out.extend_from_slice(&h.to_le_bytes());
             }
+            for w in &chunk.water_plane {
+                out.extend_from_slice(&w.to_le_bytes());
+            }
             for r in &chunk.region {
                 out.extend_from_slice(&r.to_le_bytes());
             }
@@ -884,11 +1031,12 @@ impl World {
         out
     }
 
-    /// Decode the [`World::to_bytes`] format, current or older (a pre-3
-    /// region reads Stone cliffs; a version-1 buffer carries no smoothing
-    /// table or plane — both read empty / zero). A truncated buffer or
-    /// unknown version returns `Err` rather than panicking; the caller
-    /// keeps its prior world on any error.
+    /// Decode the [`World::to_bytes`] format, current or older (a pre-4
+    /// buffer carries no water-plane table or plane — both read empty /
+    /// zero; a pre-3 region reads Stone cliffs; a version-1 buffer carries
+    /// no smoothing table or plane). A truncated buffer or unknown version
+    /// returns `Err` rather than panicking; the caller keeps its prior
+    /// world on any error.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, WorldDecodeError> {
         let mut reader = Reader::new(bytes);
         let version = reader.u8()?;
@@ -927,6 +1075,16 @@ impl World {
                 });
             }
         }
+        let mut water_planes = Vec::new();
+        if version >= 4 {
+            let plane_count = reader.u32()? as usize;
+            water_planes.reserve(plane_count);
+            for _ in 0..plane_count {
+                water_planes.push(WaterPlane {
+                    level_octimeters: reader.i32()?,
+                });
+            }
+        }
         let chunk_count = reader.u32()? as usize;
         let mut chunks = BTreeMap::new();
         for _ in 0..chunk_count {
@@ -945,6 +1103,11 @@ impl World {
             for slot in &mut chunk.height {
                 *slot = reader.i32()?;
             }
+            if version >= 4 {
+                for slot in &mut chunk.water_plane {
+                    *slot = reader.u16()?;
+                }
+            }
             for slot in &mut chunk.region {
                 *slot = reader.u16()?;
             }
@@ -959,6 +1122,7 @@ impl World {
             chunks,
             regions,
             smoothing_profiles,
+            water_planes,
         })
     }
 }
@@ -1127,6 +1291,7 @@ mod tests {
             overlay_mask: vec![0u8; OVERLAY_MASK_WIRE_BYTES],
             height: vec![0i32; CELLS_PER_CHUNK_AREA],
             region,
+            water_plane: vec![0u32; CELLS_PER_CHUNK_AREA],
             smoothing: vec![0u8; CELLS_PER_CHUNK_AREA],
         };
         assert_eq!(set.chunk_pos(), ChunkPos { x: 2, z: -1 });
@@ -1154,6 +1319,7 @@ mod tests {
             overlay_mask,
             height: Vec::new(),
             region: Vec::new(),
+            water_plane: Vec::new(),
             smoothing: Vec::new(),
         };
         let chunk = set.into_chunk();
@@ -1172,6 +1338,7 @@ mod tests {
             overlay_mask: Vec::new(),
             height: vec![5i32; 1],
             region: Vec::new(),
+            water_plane: Vec::new(),
             smoothing: vec![3u8; 1], // short → rest no-override
         };
         let chunk = set.into_chunk();
@@ -1210,12 +1377,25 @@ mod tests {
                 degrees: 60,
             },
         );
+        world.insert_water_plane(
+            1,
+            WaterPlane {
+                level_octimeters: -17,
+            },
+        );
+        world.insert_water_plane(
+            2,
+            WaterPlane {
+                level_octimeters: 320,
+            },
+        );
         let mut a = Chunk::empty();
         a.underlay[0] = Material::Stone;
         a.overlay[5] = Material::Water;
         a.overlay_mask[5] = 0x0F0F;
         a.height[10] = -42;
         a.region[20] = 2;
+        a.water_plane[40] = 2;
         a.smoothing[30] = 1;
         world.insert_chunk(ChunkPos { x: 1, z: -3 }, a);
         let mut b = Chunk::empty();
@@ -1228,6 +1408,7 @@ mod tests {
         // Structural equality across the whole world.
         assert_eq!(decoded.regions, world.regions);
         assert_eq!(decoded.smoothing_profiles, world.smoothing_profiles);
+        assert_eq!(decoded.water_planes, world.water_planes);
         assert_eq!(
             decoded.chunk(ChunkPos { x: 1, z: -3 }),
             world.chunk(ChunkPos { x: 1, z: -3 })
@@ -1451,5 +1632,161 @@ mod tests {
         chunk3.region[0] = 3;
         world.insert_chunk(ChunkPos { x: 1, z: 0 }, chunk3);
         assert_eq!(world.underlay(cell(16, 0)), Material::Stone);
+    }
+
+    #[test]
+    fn pre_v4_buffer_decodes_empty_water_table_and_zero_plane() {
+        // Tripwire: a version-3 buffer carries no water-plane table and no
+        // per-chunk water plane; both must read empty / zero, and a water
+        // cell in it resolves at the datum-0 level. Hand-built: no regions
+        // or profiles, one chunk with a water cell and the exact v3 plane
+        // bytes (no water plane between height and region).
+        let mut buf = vec![3u8];
+        buf.extend_from_slice(&0u32.to_le_bytes()); // no regions
+        buf.extend_from_slice(&0u32.to_le_bytes()); // no profiles
+        buf.extend_from_slice(&1u32.to_le_bytes()); // one chunk
+        buf.extend_from_slice(&0i32.to_le_bytes()); // chunk x
+        buf.extend_from_slice(&0i32.to_le_bytes()); // chunk z
+        let mut underlay = [0u8; CELLS_PER_CHUNK_AREA];
+        underlay[0] = Material::Water.to_u8();
+        buf.extend_from_slice(&underlay);
+        buf.extend_from_slice(&[0u8; CELLS_PER_CHUNK_AREA]); // overlay
+        buf.extend_from_slice(&[0u8; 2 * CELLS_PER_CHUNK_AREA]); // masks
+        buf.extend_from_slice(&[0u8; 4 * CELLS_PER_CHUNK_AREA]); // heights
+        buf.extend_from_slice(&[0u8; 2 * CELLS_PER_CHUNK_AREA]); // regions
+        buf.extend_from_slice(&[0u8; CELLS_PER_CHUNK_AREA]); // smoothing
+
+        let world = World::from_bytes(&buf).expect("a v3 buffer still decodes");
+        assert!(world.water_planes.is_empty());
+        let chunk = world.chunk(ChunkPos { x: 0, z: 0 }).expect("chunk");
+        assert_eq!(chunk.water_plane, [0u16; CELLS_PER_CHUNK_AREA]);
+        assert_eq!(world.water_level(cell(0, 0)), Some(0), "datum-0 level");
+    }
+
+    /// A one-chunk world whose underlay / water-plane / height planes come
+    /// from `fill(lx, lz) -> (material, plane id, lakebed height)`, with the
+    /// given `(id, level)` water planes registered.
+    fn plane_world(
+        planes: &[(u32, i32)],
+        fill: impl Fn(i32, i32) -> (Material, u16, i32),
+    ) -> World {
+        let mut chunk = Chunk::empty();
+        for lz in 0..CELLS_PER_CHUNK {
+            for lx in 0..CELLS_PER_CHUNK {
+                let (material, plane, height) = fill(lx, lz);
+                let i = (lz * CELLS_PER_CHUNK + lx) as usize;
+                chunk.underlay[i] = material;
+                chunk.water_plane[i] = plane;
+                chunk.height[i] = height;
+            }
+        }
+        let mut world = World::new();
+        for &(id, level) in planes {
+            world.insert_water_plane(
+                id,
+                WaterPlane {
+                    level_octimeters: level,
+                },
+            );
+        }
+        world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
+        world
+    }
+
+    #[test]
+    fn water_level_resolves_plane_then_datum_and_none_off_water() {
+        // A water cell reads its plane's level; plane 0 and an unregistered
+        // id both read the datum 0; a non-water cell reads None.
+        let world = plane_world(&[(1, 100)], |lx, _| match lx {
+            0 => (Material::Water, 1, 0),  // registered plane 1
+            1 => (Material::Water, 0, 0),  // plane 0 → datum
+            2 => (Material::Water, 9, 0),  // unregistered id → datum
+            3 => (Material::Grass, 0, 50), // not water
+            _ => (Material::Void, 0, 0),
+        });
+        assert_eq!(world.water_level(cell(0, 0)), Some(100));
+        assert_eq!(world.water_level(cell(1, 0)), Some(0));
+        assert_eq!(world.water_level(cell(2, 0)), Some(0));
+        assert_eq!(world.water_level(cell(3, 0)), None);
+        // The lakebed read is unchanged — height stays the raw ground.
+        assert_eq!(world.height(cell(3, 0)), 50);
+    }
+
+    #[test]
+    fn interior_water_surface_is_flat_at_the_plane_level() {
+        // A block of water on one plane renders exactly flat at the authored
+        // level regardless of the lakebed heights beneath — every corner of
+        // an interior water cell pins to the level.
+        let world = plane_world(&[(1, 128)], |lx, lz| {
+            // A bumpy lakebed under the water so a non-pinned plate would tilt.
+            (Material::Water, 1, 11 * lx - 7 * lz)
+        });
+        let level_m = 128.0 / 256.0;
+        for corner in world.cell_corner_heights(cell(5, 5)) {
+            assert!(
+                (corner - level_m).abs() < 1e-6,
+                "water corner {corner} not flat at {level_m}",
+            );
+        }
+        // And it is the stood-on surface, while height stays the raw lakebed.
+        assert!((world.surface_height(5.5, 5.5) - level_m).abs() < 1e-6);
+        assert_eq!(world.height(cell(5, 5)), 11 * 5 - 7 * 5);
+    }
+
+    #[test]
+    fn connected_shore_land_blends_to_the_water_level() {
+        // Land within the step ceiling of the water level shares the corner
+        // plate, and the plate pins to the water members — so the land's
+        // shared corner meets the water plane exactly (the beach blend), not
+        // the mixed mean.
+        let world = plane_world(&[(1, 100)], |_, lz| {
+            if lz == 0 {
+                (Material::Water, 1, 0) // level 100, lakebed 0
+            } else {
+                (Material::Grass, 0, 140) // within 64 of 100 → connected
+            }
+        });
+        let level_m = 100.0 / 256.0;
+        // Corner (1, 1) is shared by the two water cells (0,0),(1,0) and the
+        // two land cells (0,1),(1,1); the plate has water members, so every
+        // incident cell reads the water level there.
+        assert!((world.cell_corner_heights(cell(0, 0))[3] - level_m).abs() < 1e-6);
+        assert!(
+            (world.cell_corner_heights(cell(1, 1))[0] - level_m).abs() < 1e-6,
+            "connected shore land does not blend to the waterline",
+        );
+    }
+
+    #[test]
+    fn past_step_bank_splits_from_the_water_plane() {
+        // Land standing past the step ceiling above the water cliffs against
+        // it: the corner plates split, the water side stays at its level and
+        // the bank reads its own height — the gap the skirt closes.
+        let world = plane_world(&[(1, 100)], |_, lz| {
+            if lz == 0 {
+                (Material::Water, 1, 0) // level 100
+            } else {
+                (Material::Grass, 0, 200) // |200 - 100| = 100 > 64 → cliff
+            }
+        });
+        assert!(world.edge_is_cliff(cell(0, 0), cell(0, 1)));
+        // At corner (1, 1) the water side reads 100 and the bank reads 200.
+        assert!((world.cell_corner_heights(cell(0, 0))[3] - 100.0 / 256.0).abs() < 1e-6);
+        assert!((world.cell_corner_heights(cell(1, 1))[0] - 200.0 / 256.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn a_water_plane_row_rewrite_retunes_the_level() {
+        // Retuning a lake is one table write: the same water cell resolves at
+        // the new level after re-registering its plane id.
+        let mut world = plane_world(&[(1, 100)], |_, _| (Material::Water, 1, 0));
+        assert_eq!(world.water_level(cell(3, 3)), Some(100));
+        world.insert_water_plane(
+            1,
+            WaterPlane {
+                level_octimeters: 240,
+            },
+        );
+        assert_eq!(world.water_level(cell(3, 3)), Some(240));
     }
 }

--- a/crates/aether-kit/src/world.rs
+++ b/crates/aether-kit/src/world.rs
@@ -440,7 +440,8 @@ impl World {
 
     /// Do two edge-adjacent cells meet at a cliff — an effective-level step
     /// strictly past [`STEP_MAX_OCTIMETERS`]? The rule is pairwise over the
-    /// two [`World::surface_level`]s, so any caller holding two adjacent
+    /// two cells' effective surface levels (`surface_level`), so any
+    /// caller holding two adjacent
     /// cells derives the same answer, and a bank standing past the step
     /// ceiling above a water surface cliffs against it.
     #[must_use]

--- a/crates/aether-kit/tests/partition_probe.rs
+++ b/crates/aether-kit/tests/partition_probe.rs
@@ -11,7 +11,7 @@
 
 use aether_capabilities::render::DrawTriangle;
 use aether_kit::{
-    CELLS_PER_CHUNK_AREA, Chunk, ChunkPos, Material, Region, ViewMode, World,
+    CELLS_PER_CHUNK_AREA, Chunk, ChunkPos, Material, Region, ViewMode, WaterPlane, World,
     runtime::{StyleTable, mesher::mesh_chunk},
 };
 
@@ -23,6 +23,13 @@ fn lake_world() -> World {
             name: "meadow".into(),
             default_material: Material::Grass,
             cliff_material: Material::Stone,
+        },
+    );
+    // The lake surface plane every lake cell references.
+    world.insert_water_plane(
+        1,
+        WaterPlane {
+            level_octimeters: 0,
         },
     );
     let in_lake = |x: f32, z: f32| {
@@ -44,19 +51,12 @@ fn lake_world() -> World {
                     if near_lake(wx + 0.5, wz + 0.5, 2.2) {
                         chunk.underlay[i] = Material::Sand;
                     }
-                    let mut mask = 0u16;
-                    for sz in 0..4 {
-                        for sx in 0..4 {
-                            let scx = wx + (sx as f32 + 0.5) / 4.0;
-                            let scz = wz + (sz as f32 + 0.5) / 4.0;
-                            if in_lake(scx, scz) {
-                                mask |= 1 << (sz * 4 + sx);
-                            }
-                        }
-                    }
-                    if mask != 0 {
-                        chunk.overlay[i] = Material::Water;
-                        chunk.overlay_mask[i] = mask;
+                    // Water is underlay fabric now: paint the lake cells Water
+                    // and point them at the water plane; the partition smooths
+                    // the waterline at subcell expression from the cell paint.
+                    if in_lake(wx + 0.5, wz + 0.5) {
+                        chunk.underlay[i] = Material::Water;
+                        chunk.water_plane[i] = 1;
                     }
                 }
             }


### PR DESCRIPTION
Closes #2679.

## Summary

Water renders today as a placed overlay surface draped over the terrain — it reads as paint on top of the scene, and with heights landed a lake on sloped ground tilts with the terrain. This PR makes water ground fabric: a cell painted Water in the underlay tiles, smooths, and rims its waterline through the same one-surface repartition as every other material boundary, and references a world-level water-plane table (`WaterPlane { level_octimeters }`, 1-based ids, registered by the new `aether.kit.world.set_water_plane` kind) holding its flat surface level. Retuning a level is one table write, live over MCP, remeshing all cached chunks.

The surface-resolution machinery reads an effective level — the referenced plane's level for water cells, `height` otherwise — through `edge_is_cliff`, the corner-plate walk, `label_lift`, and the skirt pass. A corner plate containing any water member pins to its water members' level, so the water plane is exactly flat and the shore is watertight: connected land blends down to the waterline (a beach), a past-step bank splits and wears the existing skirt down to the water. Interior water cells tile per-subcell depth-graded quads (plane level minus bilinear lakebed height over `WATER_DEPTH_FULL_OCTIMETERS`); the overlay pass's water special case (`emit_water`, the shore-distance scan) is deleted. Drawn-equals-stood-on extends to water: `World::surface_height` over a water cell reads the water surface, while `World::height` stays the raw lakebed read.

The rung's one wire change: `aether.kit.world.set_chunk` gains a `water_plane` plane (u32 wire, u16 in memory like `region`), the new `set_water_plane` kind registers table rows, and the save format bumps to v4 — pre-4 buffers decode as an empty table plus zero plane.

## Test plan

- Save v4 roundtrip plus a pinned pre-v4 buffer decoding to an empty table and zero plane.
- Water surface exactly flat at the plane level from both sides of a shore corner; connected shore land blends to the level at shared corners; a past-step bank splits; a table-row rewrite changes the resolved level.
- `surface_height` over a water cell reads the plane level (the drawn-equals-stood-on extension).
- Reworked water tests against the underlay pass: depth follows level-minus-lakebed on an authored basin; the full-water-chunk budget repinned as a tripwire; an underlay water square emits the rim-band label and a smoothed crossing.
- `partition_probe::lake_world` paints the lake into underlay plus a plane row instead of overlay plus mask.

## Generated by

`/implement` — agent execution of [scoped issue #2679](https://github.com/iamacoffeepot/aether/issues/2679).
