### PR TITLE
fix(actor): composite reload drops typed-config inline children's state

### DIFF
--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -449,6 +449,7 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
             full_subname,
             is_counter,
             self.mailbox,
+            bytes,
             owned,
         )
     }
@@ -603,7 +604,14 @@ fn resolve_subname(subname: Subname<'_>) -> Result<(bool, String), SpawnError> {
 ///
 /// ADR-0114 §5: `type_tag` / `full_subname` / `is_counter` are recorded in
 /// the slot so a `replace_component` swap can reconstruct the child by
-/// type and re-fold its metadata.
+/// type and re-fold its metadata. `config_bytes` (issue 2690) is the
+/// child's encoded `Config` — the same bytes `config` was decoded from —
+/// retained in the slot so a subsequent dehydrate/reconstruct cycle can
+/// re-init the child from its real config instead of empty bytes.
+// The parameters are the slot's reconstruct record (ADR-0114 §5) plus the
+// decoded config — a fixed set with no meaningful grouping short of a
+// one-use struct.
+#[allow(clippy::too_many_arguments)]
 fn install_inline_child<A>(
     registry: &Registry,
     alias: MailboxId,
@@ -611,6 +619,7 @@ fn install_inline_child<A>(
     full_subname: String,
     is_counter: bool,
     parent: u64,
+    config_bytes: Vec<u8>,
     config: A::Config,
 ) -> Result<MailboxId, SpawnError>
 where
@@ -627,6 +636,7 @@ where
         full_subname,
         is_counter,
         parent,
+        config_bytes,
         Box::new(child),
     );
     Ok(alias)
@@ -1015,6 +1025,7 @@ mod tests {
     use crate::wasm::{ActorInitError, ErasedWasmActor, WasmActor, WasmDropCtx, WasmInitCtx};
     use aether_data::MailboxId;
     use alloc::string::String;
+    use alloc::vec::Vec;
     use core::mem::{align_of, size_of};
 
     /// Test inline child whose `init` always fails — drives the
@@ -1086,6 +1097,7 @@ mod tests {
             String::from("child"),
             false,
             0,
+            Vec::new(),
             (),
         );
         assert!(
@@ -1266,6 +1278,7 @@ mod tests {
             String::from("widget"),
             false,
             root,
+            Vec::new(),
             (),
         )
         .expect("a succeeding init installs the inline child");

--- a/crates/aether-actor/src/wasm/inline/bundle.rs
+++ b/crates/aether-actor/src/wasm/inline/bundle.rs
@@ -34,6 +34,8 @@
 //!   version:      u32 LE
 //!   state_len:    u32 LE
 //!   state_bytes:  state_len bytes
+//!   config_len:   u32 LE
+//!   config_bytes: config_len bytes
 //! ```
 
 use alloc::string::String;
@@ -69,6 +71,10 @@ pub struct ChildEntry {
     pub version: u32,
     /// The child's `on_dehydrate` bundle bytes.
     pub state_bytes: Vec<u8>,
+    /// The child's encoded `Config` bytes (from the slot's retained
+    /// `config_bytes`), so reconstruct can re-init the child from its real
+    /// config instead of empty bytes (issue 2690).
+    pub config_bytes: Vec<u8>,
 }
 
 /// The parent half of a decomposed bundle — exactly the `(version,
@@ -119,6 +125,8 @@ pub fn compose(
         out.extend_from_slice(&child.version.to_le_bytes());
         out.extend_from_slice(&len_u32(child.state_bytes.len()).to_le_bytes());
         out.extend_from_slice(&child.state_bytes);
+        out.extend_from_slice(&len_u32(child.config_bytes.len()).to_le_bytes());
+        out.extend_from_slice(&child.config_bytes);
     }
     (COMPOSITE_VERSION, out)
 }
@@ -173,6 +181,8 @@ fn parse_framed(bytes: &[u8]) -> Option<Decomposed> {
         let version = cursor.read_u32()?;
         let state_len = cursor.read_u32()? as usize;
         let state_bytes = cursor.take(state_len)?.to_vec();
+        let config_len = cursor.read_u32()? as usize;
+        let config_bytes = cursor.take(config_len)?.to_vec();
         children.push(ChildEntry {
             alias_id,
             type_tag,
@@ -180,6 +190,7 @@ fn parse_framed(bytes: &[u8]) -> Option<Decomposed> {
             full_subname: subname,
             version,
             state_bytes,
+            config_bytes,
         });
     }
     Some(Decomposed {
@@ -241,6 +252,7 @@ mod tests {
     use alloc::string::String;
     use alloc::vec;
     use alloc::vec::Vec;
+    use core::slice;
 
     fn child(alias: u64, tag: u64, name: &str, state: &[u8]) -> ChildEntry {
         ChildEntry {
@@ -250,6 +262,7 @@ mod tests {
             full_subname: String::from(name),
             version: 0,
             state_bytes: state.to_vec(),
+            config_bytes: Vec::new(),
         }
     }
 
@@ -317,6 +330,37 @@ mod tests {
         assert_eq!(
             decomposed.children, children,
             "every child entry survives the composite round-trip",
+        );
+    }
+
+    /// Step 2 tripwire: a child's non-empty `config_bytes` survive the
+    /// compose → decompose round-trip alongside its `state_bytes` — the
+    /// write/read symmetry the appended `config_len` + bytes span
+    /// introduces (issue 2690). Guards the framed-layout format, not a
+    /// derive or another crate's machinery.
+    #[test]
+    fn child_config_bytes_round_trip_through_compose() {
+        let entry = ChildEntry {
+            config_bytes: vec![0x10, 0x20, 0x30, 0x40, 0x50],
+            ..child(0x5555, 0x6666, "configured", &[0xAA, 0xBB])
+        };
+
+        let (version, bytes) = compose(1, &[], slice::from_ref(&entry));
+        let decomposed = decompose(version, &bytes);
+
+        assert_eq!(
+            decomposed.children.len(),
+            1,
+            "exactly the one entry round-trips",
+        );
+        assert_eq!(
+            decomposed.children[0].config_bytes, entry.config_bytes,
+            "the child's config bytes survive the composite round-trip \
+             alongside its state bytes",
+        );
+        assert_eq!(
+            decomposed.children[0].state_bytes, entry.state_bytes,
+            "state bytes are unaffected by the appended config span",
         );
     }
 

--- a/crates/aether-actor/src/wasm/inline/compose.rs
+++ b/crates/aether-actor/src/wasm/inline/compose.rs
@@ -80,6 +80,7 @@ pub fn dehydrate(
             full_subname: meta.full_subname,
             version,
             state_bytes,
+            config_bytes: meta.config_bytes,
         });
     }
 
@@ -119,6 +120,10 @@ pub struct InlineChildToReconstruct<'a> {
     pub state_version: u32,
     /// The child's saved `on_dehydrate` bundle bytes.
     pub state_bytes: &'a [u8],
+    /// The child's encoded `Config` bytes, retained from the spawning
+    /// slot (issue 2690) — decoded to re-`init` the child from its real
+    /// config instead of empty bytes.
+    pub config_bytes: &'a [u8],
 }
 
 /// Decompose a migration bundle, run the parent's `on_rehydrate` with its
@@ -155,6 +160,7 @@ pub fn reconstruct_inline_children(
             full_subname: &entry.full_subname,
             state_version: entry.version,
             state_bytes: &entry.state_bytes,
+            config_bytes: &entry.config_bytes,
         };
         if !reconstruct_child(registry, &to_reconstruct) {
             // An unknown type tag (a replace that dropped a child type) or
@@ -176,12 +182,21 @@ pub fn reconstruct_inline_children(
 /// §5). Called by the `export!`-generated reconstruct callback once it has
 /// matched the child's type tag to one of the module's exported types.
 ///
-/// Returns `false` (and does not register) when `A::Config` cannot decode
-/// from empty bytes (a typed-config inline child — its config isn't
-/// persisted across replace) or `A::init` returns `Err`; the caller logs
-/// and skips. The substrate alias route under `alias` survived the swap
-/// (ADR-0022; the parent slot is stable), so re-keying the guest registry
-/// by `alias` restores addressing with no host round-trip.
+/// Decodes `A::Config` from `to_reconstruct.config_bytes` — the child's
+/// real encoded config, retained in the slot since spawn (issue 2690) — so
+/// a typed-config child re-`init`s with the config it was actually spawned
+/// with, not empty bytes. A `()`-config child still round-trips (empty
+/// bytes decode `Some(())`). Returns `false` (and does not register) when
+/// the config bytes fail to decode (a genuinely undecodable blob) or
+/// `A::init` returns `Err`; the caller logs and skips. The substrate alias
+/// route under `alias` survived the swap (ADR-0022; the parent slot is
+/// stable), so re-keying the guest registry by `alias` restores addressing
+/// with no host round-trip.
+///
+/// This is the "decode real config → init → insert" core #2692's
+/// `spawn_one_child` (tag-dispatched inline child spawn) is expected to
+/// share as a sibling function, adding only the `on_rehydrate` restore
+/// step below (per #2690's design notes, §Sequencing with #2692).
 #[must_use]
 pub fn reconstruct_one_child<A>(
     registry: &Registry,
@@ -194,11 +209,7 @@ where
     // identity's `ErasedWasmActor` impl satisfies this.
     <A as WasmActor>::State: ErasedWasmActor,
 {
-    // The child's config isn't part of the migration bundle; re-`init`
-    // from empty config bytes, the same shape the legacy zero-config
-    // `init` shim uses. A typed-config child decodes `None` here and is
-    // skipped.
-    let Some(config) = <A::Config as Kind>::decode_from_bytes(&[]) else {
+    let Some(config) = <A::Config as Kind>::decode_from_bytes(to_reconstruct.config_bytes) else {
         return false;
     };
     let mut init_ctx = WasmInitCtx::__new(to_reconstruct.alias.0);
@@ -234,6 +245,7 @@ where
         String::from(to_reconstruct.full_subname),
         to_reconstruct.is_counter,
         registry.self_id(),
+        to_reconstruct.config_bytes.to_vec(),
         Box::new(child),
     );
     true
@@ -241,13 +253,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{Registry, dehydrate, reconstruct_inline_children};
-    use crate::Manual;
+    use super::{
+        InlineChildToReconstruct, Registry, dehydrate, reconstruct_inline_children,
+        reconstruct_one_child,
+    };
     use crate::mail::{Mail, PriorState};
-    use crate::wasm::ctx::WasmDropCtx;
+    use crate::wasm::ctx::{NO_INBOUND_SOURCE, WasmDropCtx, WasmInitCtx};
     use crate::wasm::inline::bundle;
-    use crate::wasm::{ErasedWasmActor, WasmCtx};
-    use aether_data::MailboxId;
+    use crate::wasm::{ActorInitError, ErasedWasmActor, WasmActor, WasmCtx};
+    use crate::{Addressable, Lifecycle, Manual};
+    use aether_data::{Kind, KindId, MailboxId};
     use alloc::boxed::Box;
     use alloc::string::String;
     use alloc::vec;
@@ -291,6 +306,7 @@ mod tests {
             String::from("a"),
             false,
             0,
+            vec![0x11, 0x22],
             Box::new(SavingChild { tag: 0x1111_2222 }),
         );
         registry.insert_child(
@@ -299,6 +315,7 @@ mod tests {
             String::from("b"),
             true,
             0,
+            Vec::new(),
             Box::new(SavingChild { tag: 0x3333_4444 }),
         );
 
@@ -325,6 +342,11 @@ mod tests {
             .expect("child a present");
         assert_eq!(a.type_tag, 0xAAAA);
         assert_eq!(a.state_bytes, 0x1111_2222u32.to_le_bytes().to_vec());
+        assert_eq!(
+            a.config_bytes,
+            vec![0x11, 0x22],
+            "child a's config bytes ride the compose alongside its state",
+        );
         let b = decomposed
             .children
             .iter()
@@ -332,6 +354,10 @@ mod tests {
             .expect("child b present");
         assert!(b.is_counter, "child b's counter flag is carried");
         assert_eq!(b.state_bytes, 0x3333_4444u32.to_le_bytes().to_vec());
+        assert!(
+            b.config_bytes.is_empty(),
+            "child b was spawned with no retained config bytes",
+        );
     }
 
     /// Step 4 coverage: each child entry is offered to the reconstruct
@@ -356,6 +382,7 @@ mod tests {
                 full_subname: String::from("a"),
                 version: 1,
                 state_bytes: vec![1, 2, 3],
+                config_bytes: Vec::new(),
             },
             ChildEntry {
                 alias_id: 0xC2,
@@ -364,6 +391,7 @@ mod tests {
                 full_subname: String::from("b"),
                 version: 2,
                 state_bytes: vec![4, 5],
+                config_bytes: Vec::new(),
             },
         ];
         let (version, bytes) = compose(5, &[7, 7], &children);
@@ -395,5 +423,152 @@ mod tests {
         );
         assert_eq!(offered[0].1, vec![1, 2, 3], "child a state is carried");
         assert_eq!(offered[1].1, vec![4, 5], "child b state is carried");
+    }
+
+    /// A typed (non-`()`) `Config` for step 5's reconstruct coverage: wraps
+    /// a `u32`. Hand-rolls `Kind` rather than deriving it (a host-only test
+    /// fixture needs no `Schema`/serde machinery) — `decode_from_bytes`
+    /// only succeeds on exactly 4 bytes, so it decodes `None` from empty
+    /// bytes just like a real typed config would, the branch
+    /// `reconstruct_one_child` must still honor.
+    #[derive(Clone, Copy)]
+    struct TypedConfig(u32);
+
+    impl Kind for TypedConfig {
+        const NAME: &'static str = "test.inline.typed_config";
+        const ID: KindId = KindId(0x7A11_0000_0000_0001);
+
+        fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+            let arr: [u8; 4] = bytes.try_into().ok()?;
+            Some(Self(u32::from_le_bytes(arr)))
+        }
+
+        fn encode_into_bytes(&self) -> Vec<u8> {
+            self.0.to_le_bytes().to_vec()
+        }
+    }
+
+    /// A typed-config inline child for step 5's reconstruct coverage.
+    /// `init` copies the decoded config into `observed`; `erased_dispatch`
+    /// returns it as the dispatch code so the test can read back the value
+    /// the child was actually `init`ed with — the erasure has no
+    /// downcasting, so the dispatch return code is the observation channel
+    /// (the same technique `RecordingChild` in `inline::mod`'s tests uses).
+    struct TypedConfigChild {
+        observed: u32,
+    }
+
+    impl Addressable for TypedConfigChild {
+        const NAMESPACE: &'static str = "test.inline.typed_config_child";
+        type Resolver = crate::Many;
+    }
+
+    impl Lifecycle<Self> for TypedConfigChild {
+        type Config = TypedConfig;
+        type InitError = ActorInitError;
+        type InitCtx<'a> = WasmInitCtx<'a>;
+        type Ctx<'a> = WasmCtx<'a>;
+
+        fn init(config: TypedConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+            Ok(Self { observed: config.0 })
+        }
+    }
+
+    impl WasmActor for TypedConfigChild {
+        type State = Self;
+        type Persist = ();
+    }
+
+    impl crate::WasmDispatch<Self> for TypedConfigChild {
+        fn dispatch(state: &mut Self, _ctx: &mut WasmCtx<'_, Manual>, _mail: Mail<'_>) -> u32 {
+            state.observed
+        }
+    }
+
+    impl ErasedWasmActor for TypedConfigChild {
+        fn erased_namespace(&self) -> &'static str {
+            Self::NAMESPACE
+        }
+        fn erased_dispatch(&mut self, _ctx: &mut WasmCtx<'_, Manual>, _mail: Mail<'_>) -> u32 {
+            self.observed
+        }
+        fn erased_wire(&mut self, _ctx: &mut WasmCtx<'_, Manual>) {}
+        fn erased_unwire(&mut self, _ctx: &mut WasmCtx<'_, Manual>) {}
+        fn erased_on_dehydrate(&mut self, _ctx: &mut WasmDropCtx<'_>) {}
+        fn erased_on_rehydrate(&mut self, _ctx: &mut WasmCtx<'_, Manual>, _prior: PriorState<'_>) {}
+    }
+
+    /// Step 5 coverage (the branch this issue fixes): `reconstruct_one_child`
+    /// over a `ChildEntry` carrying a typed-config child's real encoded
+    /// config bytes re-`init`s it with that config — not the empty-bytes
+    /// re-init that dropped every typed-config child before this fix. The
+    /// reconstructed child is registered (returns `true`) and its
+    /// `erased_dispatch` echoes back the decoded value, proving `init` saw
+    /// the real config rather than a default.
+    #[test]
+    fn reconstruct_one_child_reinits_typed_config_from_real_bytes() {
+        let registry = Registry::new();
+        let alias = MailboxId(0x9001);
+        let config = TypedConfig(0xDEAD_BEEF);
+        let config_bytes = config.encode_into_bytes();
+        let to_reconstruct = InlineChildToReconstruct {
+            alias,
+            type_tag: 0x1234,
+            is_counter: false,
+            full_subname: "typed",
+            state_version: 0,
+            state_bytes: &[],
+            config_bytes: &config_bytes,
+        };
+
+        let reconstructed = reconstruct_one_child::<TypedConfigChild>(&registry, &to_reconstruct);
+        assert!(
+            reconstructed,
+            "a typed-config child with real config bytes must reconstruct",
+        );
+
+        let mut child = registry
+            .take(alias)
+            .expect("the reconstructed child is registered under its alias");
+        let code = child.erased_dispatch(
+            &mut WasmCtx::__new(alias.0, &registry, NO_INBOUND_SOURCE),
+            // SAFETY: a zero-length mail frame — ptr 0 with len 0 spans no
+            // memory, and the probe child's dispatch reads no payload.
+            unsafe { Mail::__from_ptr(0, 1, 0, 1, crate::NO_REPLY_HANDLE, alias.0) },
+        );
+        assert_eq!(
+            code, 0xDEAD_BEEF,
+            "the child's init decoded the real config value, not a default",
+        );
+    }
+
+    /// Step 5 coverage: an empty-bytes entry for a typed-config child still
+    /// skips — the honest degradation for a genuinely undecodable blob
+    /// (`TypedConfig::decode_from_bytes` requires exactly 4 bytes). Distinct
+    /// from the `()`-config case, where empty bytes are the *correct*
+    /// encoding and always decode `Some(())`.
+    #[test]
+    fn reconstruct_one_child_skips_typed_config_with_undecodable_bytes() {
+        let registry = Registry::new();
+        let alias = MailboxId(0x9002);
+        let to_reconstruct = InlineChildToReconstruct {
+            alias,
+            type_tag: 0x1234,
+            is_counter: false,
+            full_subname: "typed",
+            state_version: 0,
+            state_bytes: &[],
+            config_bytes: &[],
+        };
+
+        let reconstructed = reconstruct_one_child::<TypedConfigChild>(&registry, &to_reconstruct);
+        assert!(
+            !reconstructed,
+            "empty bytes don't decode as a typed (non-unit) Config, so reconstruct skips",
+        );
+        assert!(
+            registry.take(alias).is_none(),
+            "a skipped child is never registered",
+        );
     }
 }

--- a/crates/aether-actor/src/wasm/inline/mod.rs
+++ b/crates/aether-actor/src/wasm/inline/mod.rs
@@ -88,6 +88,11 @@ struct InlineSlot {
     /// guest cannot reproduce a relative's id by folding; it looks the
     /// recorded id up instead).
     parent: u64,
+    /// The child's encoded `Config` bytes (`A::Config::encode_into_bytes`
+    /// at spawn time). Retained so a `replace_component` swap can decode
+    /// the real config on reconstruct (`reconstruct_one_child`) instead of
+    /// re-`init`ing a typed-config child from empty bytes (issue 2690).
+    config_bytes: Vec<u8>,
     actor: Option<Box<dyn ErasedWasmActor>>,
 }
 
@@ -105,6 +110,10 @@ pub(crate) struct InlineChildMeta {
     pub(crate) full_subname: String,
     /// Whether the original spawn used a counter discriminator.
     pub(crate) is_counter: bool,
+    /// The child's encoded `Config` bytes, carried into the dehydrate
+    /// bundle's `ChildEntry` so reconstruct can re-init from the real
+    /// config instead of empty bytes (issue 2690).
+    pub(crate) config_bytes: Vec<u8>,
 }
 
 /// One intra-cluster send buffered on the per-component queue
@@ -237,6 +246,9 @@ impl Registry {
     /// alongside the actor box. Replaces the actor + metadata if `id` is
     /// already present (a re-spawn / rehydrate re-register of the same
     /// alias). O(log n).
+    // The parameters are the slot's reconstruct record (ADR-0114 §5); see
+    // `install_inline_child` for the same shape on the spawn side.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn insert_child(
         &self,
         id: MailboxId,
@@ -244,6 +256,7 @@ impl Registry {
         full_subname: String,
         is_counter: bool,
         parent: u64,
+        config_bytes: Vec<u8>,
         actor: Box<dyn ErasedWasmActor>,
     ) {
         // SAFETY: single-threaded guest + serialized delivery — no other
@@ -257,6 +270,7 @@ impl Registry {
                 full_subname,
                 is_counter,
                 parent,
+                config_bytes,
                 actor: Some(actor),
             },
         );
@@ -330,6 +344,7 @@ impl Registry {
                 type_tag: slot.type_tag,
                 full_subname: slot.full_subname.clone(),
                 is_counter: slot.is_counter,
+                config_bytes: slot.config_bytes.clone(),
             })
             .collect()
     }
@@ -766,6 +781,7 @@ mod tests {
             String::from("widget"),
             false,
             0,
+            Vec::new(),
             Box::new(RecordingChild::new().0),
         );
         let taken = registry
@@ -796,6 +812,7 @@ mod tests {
             String::from("widget"),
             false,
             0,
+            Vec::new(),
             Box::new(RecordingChild::new().0),
         );
 
@@ -836,6 +853,7 @@ mod tests {
             String::from("widget"),
             false,
             0,
+            Vec::new(),
             Box::new(recording),
         );
 
@@ -888,6 +906,7 @@ mod tests {
             String::from("widget"),
             false,
             0,
+            Vec::new(),
             Box::new(SelfDespawningChild {
                 id: MailboxId(child),
                 drops: Rc::clone(&drops),
@@ -927,6 +946,7 @@ mod tests {
             String::from("recording"),
             false,
             parent,
+            Vec::new(),
             Box::new(recording),
         );
         dispatches
@@ -952,6 +972,7 @@ mod tests {
             String::from("bar"),
             false,
             root,
+            Vec::new(),
             Box::new(RecordingChild::new().0),
         );
         registry.insert_child(
@@ -960,6 +981,7 @@ mod tests {
             String::from("baz"),
             false,
             root,
+            Vec::new(),
             Box::new(RecordingChild::new().0),
         );
         registry.insert_child(
@@ -968,6 +990,7 @@ mod tests {
             String::from("button"),
             false,
             bar.0,
+            Vec::new(),
             Box::new(RecordingChild::new().0),
         );
 
@@ -1192,6 +1215,7 @@ mod tests {
             String::from("recording"),
             false,
             parent,
+            Vec::new(),
             Box::new(recording),
         );
         (dispatches, source)

--- a/crates/aether-substrate-bundle/tests/fleetbench_inline_child.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_inline_child.rs
@@ -18,7 +18,8 @@ mod fleetbench;
 mod tests {
     use aether_data::Kind;
     use aether_test_fixtures_kinds::{
-        INLINE_WHO_CHILD, INLINE_WHO_PARENT, InlineEcho, InlineProbe,
+        Bump, CONFIGURED_CHILD_INITIAL, CountQuery, CountReport, INLINE_WHO_CHILD,
+        INLINE_WHO_PARENT, InlineEcho, InlineProbe,
     };
 
     use crate::fleetbench::{FleetBench, dist_manifest_present};
@@ -101,5 +102,96 @@ mod tests {
             Some(engine),
             "the InlineProbe is routed to the forked engine",
         );
+    }
+
+    /// Issue 2690 reload gate: a typed-config inline child's state
+    /// survives a `replace_component` swap. Loads `InlineConfiguredParent`
+    /// (spawns `InlineConfiguredChild` with a non-default
+    /// `InlineConfiguredChildConfig`), bumps the child's counter off its
+    /// config-derived starting value, replaces the component in place with
+    /// the identical stem/export (the common same-SDK-build swap), and
+    /// asserts the moved value — not the config default, not a reset to
+    /// `0` — survives. Before the fix, `reconstruct_one_child` re-inited
+    /// every child from empty config bytes: a typed (non-`()`) `Config`
+    /// decoded `None` there, so the child was dropped outright (not
+    /// merely reset) and the post-replace query would have gone
+    /// unanswered by the child at all.
+    #[test]
+    fn fleetbench_inline_configured_child_state_survives_replace() {
+        const BUMPS: u32 = 3;
+        if !dist_manifest_present() {
+            return;
+        }
+        let mut bench = FleetBench::start();
+        let engine = bench.spawn_headless();
+        let parent = bench.load_full_export(
+            engine,
+            "aether_test_fixtures_bundle",
+            "test.inline.configured_parent",
+        );
+        let child_addr = format!("{}/aether.embedded:widget", parent.addr);
+
+        // Baseline: the child's durable counter starts from the spawn
+        // config's `initial`, not `0` — proving the spawn-time config path
+        // (not yet the reconstruct path this issue fixes) decoded the real
+        // bytes.
+        let baseline = count(&mut bench, engine, &child_addr);
+        assert_eq!(
+            baseline, CONFIGURED_CHILD_INITIAL,
+            "the child's counter starts from the spawn config's initial value",
+        );
+
+        // Move the state off both the config default (0) and the spawn
+        // config's initial value.
+        for _ in 0..BUMPS {
+            bench.send(engine, &child_addr, &Bump);
+        }
+        let moved = count(&mut bench, engine, &child_addr);
+        let expected_moved = CONFIGURED_CHILD_INITIAL + BUMPS;
+        assert_eq!(
+            moved, expected_moved,
+            "the child's counter moved off both the config default and its initial value",
+        );
+
+        // Same-stem in-place replace (ADR-0022): the common in-place
+        // rebuild where both sides are the same SDK build (per issue
+        // 2690's design notes on the composite bundle's transience).
+        bench.replace_export(
+            engine,
+            parent.mailbox_id,
+            "aether_test_fixtures_bundle",
+            "test.inline.configured_parent",
+        );
+
+        // The moved state — not the config default, not the spawn
+        // config's initial value, not silently dropped — survives the
+        // swap: the fix this issue makes.
+        let after_replace = count(&mut bench, engine, &child_addr);
+        assert_eq!(
+            after_replace, expected_moved,
+            "the typed-config child's moved state survives replace_component",
+        );
+    }
+
+    /// Send a `CountQuery` to `recipient` and decode the single
+    /// `CountReport` reply's `count`. Shared by the reload gate's
+    /// baseline / post-bump / post-replace reads.
+    fn count(bench: &mut FleetBench, engine: aether_data::EngineId, recipient: &str) -> u32 {
+        let replies = bench.send(engine, recipient, &CountQuery);
+        let reply = match replies.as_slice() {
+            [one] => one,
+            other => panic!(
+                "CountQuery should get exactly one reply, got {}",
+                other.len()
+            ),
+        };
+        assert_eq!(
+            reply.kind,
+            CountReport::ID,
+            "the reply should be a CountReport"
+        );
+        CountReport::decode_from_bytes(&reply.payload)
+            .expect("the CountReport reply decodes")
+            .count
     }
 }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/inline_child.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/inline_child.rs
@@ -41,6 +41,23 @@
 //!
 //! Consumers load this actor from the `inline_child` bundle with
 //! `export: Some("test.inline.despawn_parent")`.
+//!
+//! # `InlineConfiguredParent` / `InlineConfiguredChild`
+//!
+//! Issue 2690 fixture: the coverage hole every other inline-child fixture
+//! here leaves open. `InlineStatefulChild` above carries durable state
+//! but spawns with a `()` config, which decodes `Some(())` from empty
+//! bytes on reconstruct — the branch that never exercises a typed
+//! (non-`()`) config's decode-from-real-bytes path. The entry
+//! `InlineConfiguredParent` spawns a co-located `InlineConfiguredChild`
+//! in `wire` with a **non-default** `InlineConfiguredChildConfig`
+//! (`initial: CONFIGURED_CHILD_INITIAL`), and the child's durable
+//! `InlineCounterState` starts from that config value rather than `0` —
+//! so a reload that silently re-inited from a default/empty config would
+//! be distinguishable from one that decoded the real bytes.
+//!
+//! Consumers load this actor from the `inline_child` bundle with
+//! `export: Some("test.inline.configured_parent")`.
 
 // `#[handler::manual]` methods take `&mut self` to match the dispatch ABI
 // even though stateless replies never read it. `rehydrate` takes its
@@ -53,8 +70,8 @@ use aether_actor::{
 };
 use aether_data::MailboxId;
 use aether_test_fixtures_kinds::{
-    Bump, CountQuery, CountReport, DespawnChild, INLINE_WHO_CHILD, INLINE_WHO_PARENT, InlineEcho,
-    InlineProbe,
+    Bump, CONFIGURED_CHILD_INITIAL, CountQuery, CountReport, DespawnChild, INLINE_WHO_CHILD,
+    INLINE_WHO_PARENT, InlineConfiguredChildConfig, InlineEcho, InlineProbe,
 };
 
 /// Durable state the `InlineStatefulChild` carries across `replace_component`.
@@ -278,5 +295,97 @@ impl WasmActor for InlineDespawnChild {
     #[handler::manual]
     fn on_despawn(&mut self, ctx: &mut WasmCtx<'_, Manual>, _trigger: DespawnChild) {
         let _ = ctx.despawn_inline_child(ctx.mailbox_id());
+    }
+}
+
+/// Entry export for issue 2690's config-carrying inline-child reload
+/// fixture. Spawns a co-located `InlineConfiguredChild` in `wire` with a
+/// non-default typed config.
+///
+/// Load from the `inline_child` bundle with
+/// `export: Some("test.inline.configured_parent")`.
+pub struct InlineConfiguredParent;
+
+#[actor]
+impl WasmActor for InlineConfiguredParent {
+    const NAMESPACE: &'static str = "test.inline.configured_parent";
+
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(InlineConfiguredParent)
+    }
+
+    /// ADR-0114: co-locate an `InlineConfiguredChild` under the `Named`
+    /// subname `widget`, spawned with a non-default config so the child's
+    /// durable counter starts from `CONFIGURED_CHILD_INITIAL`, not `0`.
+    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+        let _ = ctx.spawn_inline_child::<InlineConfiguredChild>(
+            Subname::Named("widget"),
+            &InlineConfiguredChildConfig {
+                initial: CONFIGURED_CHILD_INITIAL,
+            },
+        );
+    }
+
+    /// The parent ignores mail addressed to its own id — only the child
+    /// carries state. A `#[fallback]` keeps the parent a valid receiver.
+    #[fallback]
+    fn on_other(&mut self, _ctx: &mut WasmCtx<'_>, _mail: Mail<'_>) {}
+}
+
+/// Config-carrying inline child for issue 2690's reload fixture. `init`
+/// seeds the durable counter from the config's `initial` rather than a
+/// hardcoded `0`, so a test can move the state off *that* config-derived
+/// value and assert the moved value — not the config default — survives
+/// a `replace_component` swap. `Instanced` satisfies the
+/// `spawn_inline_child` bound; it is in the `export!` list so the
+/// rehydrate reconstruct can re-`init` it by type, decoding its real
+/// config bytes (the branch issue 2690 fixes).
+pub struct InlineConfiguredChild {
+    count: u32,
+}
+
+#[actor(instanced)]
+impl WasmActor for InlineConfiguredChild {
+    type Config = InlineConfiguredChildConfig;
+    const NAMESPACE: &'static str = "test.inline.configured_child";
+
+    /// ADR-0113: the durable shape, shared with `InlineStatefulChild` —
+    /// both carry a plain counter, packed / restored through the
+    /// composite migration bundle (ADR-0114 §5).
+    type State = InlineCounterState;
+
+    fn init(
+        config: InlineConfiguredChildConfig,
+        _ctx: &mut WasmInitCtx<'_>,
+    ) -> Result<Self, ActorInitError> {
+        Ok(InlineConfiguredChild {
+            count: config.initial,
+        })
+    }
+
+    /// Save-side accessor: snapshot the live counter for the composite.
+    fn dehydrate(&self) -> InlineCounterState {
+        InlineCounterState { count: self.count }
+    }
+
+    /// Restore-side accessor: adopt the recovered snapshot after the swap.
+    fn rehydrate(&mut self, state: InlineCounterState) {
+        self.count = state.count;
+    }
+
+    /// Increment the child's in-memory counter (mail demuxed to the
+    /// child's alias).
+    #[handler]
+    fn on_bump(&mut self, _ctx: &mut WasmCtx<'_>, _bump: Bump) {
+        self.count += 1;
+    }
+
+    /// Reply with the live counter so a test can read the child's state
+    /// across a swap.
+    #[handler::manual]
+    fn on_count_query(&mut self, ctx: &mut WasmCtx<'_, Manual>, _query: CountQuery) {
+        if ctx.reply_target().is_some() {
+            ctx.reply(&CountReport { count: self.count });
+        }
     }
 }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
@@ -30,7 +30,8 @@ pub use http_handler::{
     WebSocketHandler,
 };
 pub use inline_child::{
-    InlineDespawnParent, InlineParent, InlineStatefulChild, InlineStatefulParent,
+    InlineConfiguredChild, InlineConfiguredParent, InlineDespawnParent, InlineParent,
+    InlineStatefulChild, InlineStatefulParent,
 };
 pub use mat4_source::MatSource;
 pub use matrix_sweep::{MatrixChild, MatrixParent};
@@ -64,6 +65,8 @@ aether_actor::export!(
     InlineStatefulParent,
     InlineStatefulChild,
     InlineDespawnParent,
+    InlineConfiguredParent,
+    InlineConfiguredChild,
     Counter,
     Sidecar,
 );

--- a/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
@@ -286,6 +286,37 @@ pub const INLINE_WHO_CHILD: u32 = 2;
 #[kind(name = "aether.test_fixtures.despawn_child")]
 pub struct DespawnChild;
 
+/// Issue 2690 typed config for the config-carrying inline-child reload
+/// fixture: the durable counter's starting value. Distinct from the
+/// `()`-config `InlineStatefulChild` — this is the config-bytes case the
+/// composite reload bundle dropped before the fix (`reconstruct_one_child`
+/// re-inited every child from empty config bytes, so a typed (non-`()`)
+/// `Config` decoded `None` and the child was skipped, not just reset).
+#[derive(
+    aether_data::Kind,
+    aether_data::Schema,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[kind(name = "aether.test_fixtures.inline_configured_child_config")]
+pub struct InlineConfiguredChildConfig {
+    pub initial: u32,
+}
+
+/// The non-default `initial` value the `inline_child` bundle's
+/// `InlineConfiguredParent` spawns its child with — distinct from
+/// `InlineConfiguredChildConfig::default()`'s `0`, so a reload that
+/// silently re-inited from a default/empty config is distinguishable
+/// from one that decoded the real config bytes. Shared here (not just
+/// hardcoded in the fixture) so the `FleetBench` reload scenario asserts
+/// against the same constant rather than a magic number.
+pub const CONFIGURED_CHILD_INITIAL: u32 = 100;
+
 /// Issue 1958: trigger sent to a `source_observer` fixture to request that
 /// it forward a `SourceQuery` to the named target mailbox. The fixture then
 /// sends `SourceQuery` to `MailboxId(to)`, making itself the component


### PR DESCRIPTION
Closes #2690.

## Summary

The composite reload walk dropped a typed-config inline child entirely across a `replace_component` swap: `reconstruct_one_child` re-inits every child by decoding `A::Config` from empty bytes, so a child whose `Config` needs bytes decodes `None` and is skipped — neither reconstructed nor restored. Every widget in the landed widget set carries a typed `Config`, so panel state reset on any swap.

This threads the child's encoded config bytes from spawn through the slot and the composite bundle into reconstruct:

- `InlineSlot` / `InlineChildMeta` retain `config_bytes`; `insert_child` stores them (all 9 call sites updated).
- `ChildEntry` carries them in the composite bundle — an appended `config_len: u32 LE` + bytes span per child after `state_bytes` (additive layout, no `COMPOSITE_VERSION` bump; an old frame degrades through the existing `raw_passthrough` fallback).
- `reconstruct_one_child` decodes `A::Config` from the retained bytes (was `&[]`) and re-inserts with them, so config also survives a subsequent reload.
- `spawn_inline_child` passes its already-computed encode into `install_inline_child` instead of discarding it.

## Test plan

- Bundle unit tripwire: compose→decompose round-trip over a child carrying non-empty config bytes.
- `compose.rs` units: a stub child with a typed (non-`()`) config re-inits from a config-carrying `ChildEntry` (the branch that returned `false` before); an empty-bytes entry for a typed-config child still skips; `compose_dehydrate_packs_parent_and_children` asserts `config_bytes` rides the compose.
- FleetBench reload gate (`fleetbench_inline_child.rs`): a typed-config fixture child (`InlineConfiguredParent`/`InlineConfiguredChild`) spawns with a non-default config, moves its durable state, survives `replace_component` with the moved state intact. Verified as a real tripwire: with the decode source reverted to `&[]` the scenario fails exactly as the issue describes (child dropped, not reset).

## Generated by

`/implement` — agent execution of [scoped issue #2690](https://github.com/iamacoffeepot/aether/issues/2690).
