### PR TITLE
feat(behavior): behavior script SDK crates with the behavior authoring macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-behavior"
+version = "0.3.0-alpha"
+dependencies = [
+ "aether-data",
+ "serde",
+]
+
+[[package]]
+name = "aether-behavior-derive"
+version = "0.3.0-alpha"
+dependencies = [
+ "aether-behavior",
+ "aether-data",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "trybuild",
+]
+
+[[package]]
 name = "aether-capabilities"
 version = "0.3.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ members = [
     "crates/aether-math",
     "crates/aether-actor",
     "crates/aether-actor-derive",
+    "crates/aether-behavior",
+    "crates/aether-behavior-derive",
     "crates/aether-capabilities-derive",
     "crates/aether-data-derive",
     "crates/aether-derive",

--- a/crates/aether-behavior-derive/Cargo.toml
+++ b/crates/aether-behavior-derive/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "aether-behavior-derive"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# Proc-macro home for `#[behavior]` (ADR-0137). Kept separate from
+# `aether-behavior` because a proc-macro crate must opt into
+# `proc-macro = true` and can export nothing else — and, load-bearing
+# here, so the SDK trunk a future host consumes carries no proc-macro
+# machinery. A behavior script lists both crates: `aether-behavior` for
+# the runtime surface the generated code targets, this crate for the
+# `#[behavior]` attribute.
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
+
+[dev-dependencies]
+aether-behavior = { path = "../aether-behavior" }
+aether-data = { path = "../aether-data", features = ["derive"] }
+serde = { workspace = true, features = ["derive", "alloc"] }
+trybuild = "1"
+
+[lints]
+workspace = true

--- a/crates/aether-behavior-derive/src/lib.rs
+++ b/crates/aether-behavior-derive/src/lib.rs
@@ -1,0 +1,490 @@
+//! Proc-macro home for `#[behavior]` (ADR-0137). Ports the `#[actor]`
+//! template one tier over: third-parameter kind inference (extended to read
+//! the `&mut K` vs `&K` intercept-vs-observe intent), an inert-marker scan
+//! for `#[on]` / `#[on_attach]` / `#[on_frame]` / `#[on_detach]`, a kind-id
+//! if-chain dispatch table, an ids-only exports-manifest custom section, and
+//! the four guest exports (`alloc` / `filter` / `state_save` / `state_load`)
+//! emitted only on `wasm`.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{Attribute, FnArg, ImplItem, ItemImpl, Type, parse_macro_input};
+
+/// The lifecycle sentinel a marker attribute routes to.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Lifecycle {
+    Attach,
+    Frame,
+    Detach,
+}
+
+impl Lifecycle {
+    fn from_attr(attr: &Attribute) -> Option<Self> {
+        let ident = attr.path().segments.last()?.ident.to_string();
+        match ident.as_str() {
+            "on_attach" => Some(Self::Attach),
+            "on_frame" => Some(Self::Frame),
+            "on_detach" => Some(Self::Detach),
+            _ => None,
+        }
+    }
+
+    /// The `Behavior` trait method this hook overrides.
+    fn trait_method(self) -> syn::Ident {
+        match self {
+            Self::Attach => format_ident!("on_attach"),
+            Self::Frame => format_ident!("on_frame"),
+            Self::Detach => format_ident!("on_detach"),
+        }
+    }
+}
+
+/// A `#[on(K)]` handler and the intercept-vs-observe intent read off its
+/// third parameter (`&mut K` intercepts, `&K` observes).
+struct Handler {
+    method: syn::Ident,
+    kind_ty: Type,
+    intercepts: bool,
+}
+
+/// A lifecycle hook the author marked (`#[on_attach]` etc.) on a method of
+/// any name — the macro wraps it into the corresponding `Behavior` override.
+struct LifecycleHook {
+    hook: Lifecycle,
+    method: syn::Ident,
+}
+
+/// Outer attribute on an `impl Behavior for X` block (ADR-0137). Reads the
+/// `#[on]` handlers and lifecycle markers inside, then emits the inherent
+/// dispatch table + exports manifest, the `impl Behavior` overrides, and the
+/// four guest exports.
+#[proc_macro_attribute]
+pub fn behavior(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "#[behavior] takes no arguments",
+        )
+        .to_compile_error()
+        .into();
+    }
+    let item = parse_macro_input!(item as ItemImpl);
+    match expand_behavior(item) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// Inert marker for a `#[behavior]` mail handler. Real logic runs inside
+/// `#[behavior]`, which strips this before it expands standalone; the shim
+/// only exists so `#[on]` parses syntactically and rust-analyzer accepts it.
+#[proc_macro_attribute]
+pub fn on(_attr: TokenStream, _item: TokenStream) -> TokenStream {
+    marker_error("on")
+}
+
+/// Inert marker for the attach lifecycle hook (see [`macro@on`]).
+#[proc_macro_attribute]
+pub fn on_attach(_attr: TokenStream, _item: TokenStream) -> TokenStream {
+    marker_error("on_attach")
+}
+
+/// Inert marker for the per-frame lifecycle hook (see [`macro@on`]).
+#[proc_macro_attribute]
+pub fn on_frame(_attr: TokenStream, _item: TokenStream) -> TokenStream {
+    marker_error("on_frame")
+}
+
+/// Inert marker for the detach lifecycle hook (see [`macro@on`]).
+#[proc_macro_attribute]
+pub fn on_detach(_attr: TokenStream, _item: TokenStream) -> TokenStream {
+    marker_error("on_detach")
+}
+
+fn marker_error(name: &str) -> TokenStream {
+    syn::Error::new(
+        proc_macro2::Span::call_site(),
+        format!("#[{name}] may only appear inside a `#[behavior]` impl block"),
+    )
+    .to_compile_error()
+    .into()
+}
+
+fn attr_is_on(attr: &Attribute) -> bool {
+    attr.path().segments.last().is_some_and(|s| s.ident == "on")
+}
+
+#[allow(clippy::too_many_lines)]
+fn expand_behavior(item: ItemImpl) -> syn::Result<TokenStream2> {
+    let self_ty = &item.self_ty;
+    let trait_ok = item
+        .trait_
+        .as_ref()
+        .and_then(|(_, path, _)| path.segments.last())
+        .is_some_and(|s| s.ident == "Behavior");
+    if !trait_ok {
+        return Err(syn::Error::new_spanned(
+            self_ty,
+            "#[behavior] expects `impl Behavior for X`",
+        ));
+    }
+
+    let mut handlers: Vec<Handler> = Vec::new();
+    let mut lifecycle_hooks: Vec<LifecycleHook> = Vec::new();
+    // Author-provided items that stay verbatim: `#[on]` handler methods,
+    // marked lifecycle methods, helpers (all inherent), plus any trait
+    // overrides named on_attach/on_frame/on_detach/state_save/state_load.
+    let mut inherent_items: Vec<ImplItem> = Vec::new();
+    let mut trait_overrides: Vec<ImplItem> = Vec::new();
+    let mut has_state_save = false;
+    let mut has_state_load = false;
+
+    for impl_item in item.items {
+        let ImplItem::Fn(mut method) = impl_item else {
+            return Err(syn::Error::new_spanned(
+                impl_item,
+                "#[behavior] impl blocks hold only fns",
+            ));
+        };
+        let name = method.sig.ident.to_string();
+        let on_idx = method.attrs.iter().position(attr_is_on);
+        let lifecycle_idx = method
+            .attrs
+            .iter()
+            .position(|a| Lifecycle::from_attr(a).is_some());
+
+        if let Some(idx) = on_idx {
+            let (kind_ty, intercepts) = extract_handler_kind(&method.sig)?;
+            method.attrs.remove(idx);
+            handlers.push(Handler {
+                method: method.sig.ident.clone(),
+                kind_ty,
+                intercepts,
+            });
+            inherent_items.push(ImplItem::Fn(method));
+        } else if let Some(idx) = lifecycle_idx {
+            let hook = Lifecycle::from_attr(&method.attrs[idx]).expect("checked present");
+            method.attrs.remove(idx);
+            lifecycle_hooks.push(LifecycleHook {
+                hook,
+                method: method.sig.ident.clone(),
+            });
+            inherent_items.push(ImplItem::Fn(method));
+        } else if matches!(name.as_str(), "on_attach" | "on_frame" | "on_detach") {
+            // A directly-named lifecycle override stays in `impl Behavior`.
+            trait_overrides.push(ImplItem::Fn(method));
+        } else if name == "state_save" {
+            has_state_save = true;
+            trait_overrides.push(ImplItem::Fn(method));
+        } else if name == "state_load" {
+            has_state_load = true;
+            trait_overrides.push(ImplItem::Fn(method));
+        } else {
+            inherent_items.push(ImplItem::Fn(method));
+        }
+    }
+
+    reject_conflicts(&handlers, &lifecycle_hooks)?;
+
+    let dispatch = build_dispatch_body(&handlers);
+    let manifest = build_exports_manifest(&handlers);
+    let lifecycle_overrides = lifecycle_hooks.iter().map(|h| {
+        let method = &h.method;
+        let trait_method = h.hook.trait_method();
+        quote! {
+            fn #trait_method(&mut self, __aether_ctx: &mut ::aether_behavior::BehaviorCtx) {
+                self.#method(__aether_ctx);
+            }
+        }
+    });
+    let state_default = build_state_defaults(has_state_save, has_state_load);
+    let exports = build_guest_exports(self_ty);
+
+    Ok(quote! {
+        impl #self_ty {
+            #( #inherent_items )*
+
+            #[doc(hidden)]
+            fn __aether_behavior_dispatch(
+                &mut self,
+                __aether_ctx: &mut ::aether_behavior::BehaviorCtx,
+                __aether_kind: ::aether_behavior::__macro_internals::KindId,
+                __aether_bytes: &[u8],
+            ) {
+                #dispatch
+            }
+
+            #manifest
+        }
+
+        impl ::aether_behavior::Behavior for #self_ty {
+            #( #trait_overrides )*
+            #( #lifecycle_overrides )*
+            #state_default
+        }
+
+        #exports
+    })
+}
+
+/// Third-parameter kind inference. The handler signature is
+/// `(&mut self, ctx: &mut BehaviorCtx, m: &K)` (observe) or `… m: &mut K`
+/// (intercept); the referenced type is the kind, the mutability is the
+/// intent.
+fn extract_handler_kind(sig: &syn::Signature) -> syn::Result<(Type, bool)> {
+    if sig.inputs.len() != 3 {
+        return Err(syn::Error::new_spanned(
+            sig,
+            "#[on] handler must have signature `(&mut self, ctx: &mut BehaviorCtx, m: &K)` \
+             or `(&mut self, ctx: &mut BehaviorCtx, m: &mut K)`",
+        ));
+    }
+    if !matches!(sig.inputs[0], FnArg::Receiver(_)) {
+        return Err(syn::Error::new_spanned(
+            &sig.inputs[0],
+            "#[on] handler's first parameter must be `&mut self`",
+        ));
+    }
+    let FnArg::Typed(pat) = &sig.inputs[2] else {
+        return Err(syn::Error::new_spanned(
+            &sig.inputs[2],
+            "#[on] handler's third parameter must be a typed `m: &K` or `m: &mut K`",
+        ));
+    };
+    let Type::Reference(reference) = &*pat.ty else {
+        return Err(syn::Error::new_spanned(
+            &pat.ty,
+            "#[on] handler's kind parameter must be a reference — `&K` observes, `&mut K` intercepts",
+        ));
+    };
+    let intercepts = reference.mutability.is_some();
+    Ok(((*reference.elem).clone(), intercepts))
+}
+
+/// The kind-id if-chain. Sentinel arms route lifecycle to the `Behavior`
+/// trait methods; kind arms decode `K`, call the handler, and set the
+/// verdict — `&mut K` re-encodes and forwards the mutation, `&K` leaves the
+/// default forward-original.
+fn build_dispatch_body(handlers: &[Handler]) -> TokenStream2 {
+    let handler_arms = handlers.iter().map(|h| {
+        let method = &h.method;
+        let k = &h.kind_ty;
+        let call = if h.intercepts {
+            quote! {
+                let mut __aether_decoded = __aether_decoded;
+                self.#method(__aether_ctx, &mut __aether_decoded);
+                __aether_ctx.__forward_mutated(
+                    ::aether_behavior::__macro_internals::Kind::encode_into_bytes(&__aether_decoded),
+                );
+            }
+        } else {
+            quote! {
+                self.#method(__aether_ctx, &__aether_decoded);
+            }
+        };
+        quote! {
+            if __aether_kind == <#k as ::aether_behavior::__macro_internals::Kind>::ID {
+                if let ::core::option::Option::Some(__aether_decoded) =
+                    <#k as ::aether_behavior::__macro_internals::Kind>::decode_from_bytes(__aether_bytes)
+                {
+                    #call
+                }
+                return;
+            }
+        }
+    });
+
+    quote! {
+        if __aether_kind == ::aether_behavior::sentinel::ATTACH {
+            <Self as ::aether_behavior::Behavior>::on_attach(self, __aether_ctx);
+            return;
+        }
+        if __aether_kind == ::aether_behavior::sentinel::FRAME {
+            <Self as ::aether_behavior::Behavior>::on_frame(self, __aether_ctx);
+            return;
+        }
+        if __aether_kind == ::aether_behavior::sentinel::DETACH {
+            <Self as ::aether_behavior::Behavior>::on_detach(self, __aether_ctx);
+            return;
+        }
+        #( #handler_arms )*
+        let _ = (__aether_ctx, __aether_bytes);
+    }
+}
+
+/// The ids-only exports manifest: a version byte then each handled kind id
+/// as a little-endian `u64`. Emitted as inherent consts the guest exports
+/// pin into the `aether.behavior.exports` custom section.
+fn build_exports_manifest(handlers: &[Handler]) -> TokenStream2 {
+    let word_count = handlers.len();
+    let copy_blocks = handlers.iter().map(|h| {
+        let k = &h.kind_ty;
+        quote! {
+            {
+                let __aether_id =
+                    <#k as ::aether_behavior::__macro_internals::Kind>::ID.0.to_le_bytes();
+                let mut __aether_i = 0;
+                while __aether_i < 8 {
+                    out[pos] = __aether_id[__aether_i];
+                    pos += 1;
+                    __aether_i += 1;
+                }
+            }
+        }
+    });
+
+    quote! {
+        #[doc(hidden)]
+        pub const __AETHER_BEHAVIOR_EXPORTS_LEN: usize = 1 + #word_count * 8;
+
+        #[doc(hidden)]
+        pub const __AETHER_BEHAVIOR_EXPORTS: [u8; Self::__AETHER_BEHAVIOR_EXPORTS_LEN] = {
+            let mut out = [0u8; Self::__AETHER_BEHAVIOR_EXPORTS_LEN];
+            out[0] = ::aether_behavior::__macro_internals::EXPORTS_MANIFEST_VERSION;
+            let mut pos = 1;
+            #( #copy_blocks )*
+            let _ = pos;
+            out
+        };
+    }
+}
+
+/// The default `state_save` / `state_load` bodies (serde over `Self`),
+/// emitted only when the author did not override them. The `Serialize` /
+/// `DeserializeOwned` bound lands at the emitted call site, so a behavior
+/// leaning on the default must derive them.
+fn build_state_defaults(has_state_save: bool, has_state_load: bool) -> TokenStream2 {
+    let save = if has_state_save {
+        quote! {}
+    } else {
+        quote! {
+            fn state_save(&self) -> ::aether_behavior::__macro_internals::Vec<u8> {
+                ::aether_behavior::__macro_internals::state_save_serde(self)
+            }
+        }
+    };
+    let load = if has_state_load {
+        quote! {}
+    } else {
+        quote! {
+            fn state_load(&mut self, __aether_bytes: &[u8]) {
+                ::aether_behavior::__macro_internals::state_load_serde(self, __aether_bytes);
+            }
+        }
+    };
+    quote! { #save #load }
+}
+
+/// The four guest exports (`alloc` / `filter` / `state_save` / `state_load`),
+/// emitted behind `#[cfg(target_family = "wasm")]` so they are inert on
+/// native (the `aether-actor` `export!` pattern). The instance is held in a
+/// module-level `Slot`, lazily constructed via `Default` on first access.
+fn build_guest_exports(self_ty: &Type) -> TokenStream2 {
+    quote! {
+        #[cfg(target_family = "wasm")]
+        const _: () = {
+            static __AETHER_BEHAVIOR_SLOT:
+                ::aether_behavior::__macro_internals::Slot<#self_ty> =
+                ::aether_behavior::__macro_internals::Slot::new();
+
+            #[used]
+            #[unsafe(link_section = "aether.behavior.exports")]
+            static __AETHER_BEHAVIOR_EXPORTS_SECTION:
+                [u8; <#self_ty>::__AETHER_BEHAVIOR_EXPORTS_LEN] =
+                <#self_ty>::__AETHER_BEHAVIOR_EXPORTS;
+
+            /// # Safety
+            /// Called by the host per the `cabi_realloc` layout contract.
+            #[unsafe(export_name = "alloc")]
+            pub unsafe extern "C" fn alloc(
+                old_ptr: u32,
+                old_size: u32,
+                align: u32,
+                new_size: u32,
+            ) -> u32 {
+                // SAFETY: the host upholds the realloc layout contract.
+                unsafe {
+                    ::aether_behavior::__macro_internals::realloc_bytes(
+                        old_ptr as usize as *mut u8,
+                        old_size as usize,
+                        align as usize,
+                        new_size as usize,
+                    ) as usize as u32
+                }
+            }
+
+            /// # Safety
+            /// The host wrote `len` bytes at `ptr` before this call.
+            #[unsafe(export_name = "filter")]
+            pub unsafe extern "C" fn filter(kind: u64, ptr: u32, len: u32) -> u64 {
+                let __aether_kind = ::aether_behavior::__macro_internals::KindId(kind);
+                // SAFETY: host wrote `len` bytes at `ptr`; slice bounded here.
+                let __aether_bytes =
+                    unsafe { ::aether_behavior::__macro_internals::read_guest_slice(ptr, len) };
+                let __aether_instance = __AETHER_BEHAVIOR_SLOT.get_or_default();
+                let __aether_encoded = ::aether_behavior::__macro_internals::run_filter(
+                    __aether_kind,
+                    __aether_bytes,
+                    |__aether_ctx| {
+                        __aether_instance
+                            .__aether_behavior_dispatch(__aether_ctx, __aether_kind, __aether_bytes);
+                    },
+                );
+                ::aether_behavior::__macro_internals::leak_packed(__aether_encoded)
+            }
+
+            #[unsafe(export_name = "state_save")]
+            pub extern "C" fn state_save() -> u64 {
+                let __aether_instance = __AETHER_BEHAVIOR_SLOT.get_or_default();
+                let __aether_bytes =
+                    ::aether_behavior::Behavior::state_save(__aether_instance);
+                ::aether_behavior::__macro_internals::leak_packed(__aether_bytes)
+            }
+
+            /// # Safety
+            /// The host wrote `len` bytes at `ptr` before this call.
+            #[unsafe(export_name = "state_load")]
+            pub unsafe extern "C" fn state_load(ptr: u32, len: u32) -> u32 {
+                // SAFETY: host wrote `len` bytes at `ptr`; slice bounded here.
+                let __aether_bytes =
+                    unsafe { ::aether_behavior::__macro_internals::read_guest_slice(ptr, len) };
+                let __aether_instance = __AETHER_BEHAVIOR_SLOT.get_or_default();
+                ::aether_behavior::Behavior::state_load(__aether_instance, __aether_bytes);
+                0
+            }
+        };
+    }
+}
+
+fn reject_conflicts(handlers: &[Handler], lifecycle: &[LifecycleHook]) -> syn::Result<()> {
+    // Two handlers on the same kind would emit two dead if-chain arms (the
+    // first shadows the second); token-equality dedup, since the macro has
+    // no type resolution.
+    for (i, a) in handlers.iter().enumerate() {
+        for b in &handlers[i + 1..] {
+            if tokens_eq(&a.kind_ty, &b.kind_ty) {
+                return Err(syn::Error::new(
+                    b.method.span(),
+                    "two #[on] handlers cover the same kind",
+                ));
+            }
+        }
+    }
+    // At most one hook per lifecycle sentinel.
+    for (i, a) in lifecycle.iter().enumerate() {
+        for b in &lifecycle[i + 1..] {
+            if a.hook == b.hook {
+                return Err(syn::Error::new(
+                    b.method.span(),
+                    "duplicate lifecycle hook — mark at most one method per sentinel",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn tokens_eq(a: &Type, b: &Type) -> bool {
+    quote!(#a).to_string() == quote!(#b).to_string()
+}

--- a/crates/aether-behavior-derive/tests/behavior.rs
+++ b/crates/aether-behavior-derive/tests/behavior.rs
@@ -1,0 +1,151 @@
+// Native execution of the `#[behavior]` macro's generated code — the
+// dispatch table's kind routing, the `&mut K` re-encode/forward, the
+// consume-wins verdict interplay, the exports manifest bytes, and the
+// serde `state_save`/`state_load` defaults. The trybuild pass fixture only
+// proves this code compiles; these tests run it. The ctx drain mechanics
+// themselves are `aether-behavior`'s own tests — what is under test here
+// is the glue the macro emits around them.
+
+use aether_behavior::envelope::Verdict;
+use aether_behavior::manifest::decode_exports_manifest;
+use aether_behavior::{Behavior, BehaviorCtx};
+use aether_behavior_derive::behavior;
+use aether_data::{Kind, KindId};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.behavior_native.gauge")]
+struct Gauge {
+    value: u32,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.behavior_native.blur")]
+struct Blur {
+    hard: bool,
+}
+
+#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
+struct Limiter {
+    cap: u32,
+    hits: u32,
+}
+
+#[behavior]
+impl Behavior for Limiter {
+    #[on]
+    fn limit(&mut self, _ctx: &mut BehaviorCtx, gauge: &mut Gauge) {
+        if gauge.value > self.cap {
+            gauge.value = self.cap;
+        }
+        self.hits += 1;
+    }
+
+    #[on]
+    fn blur(&mut self, ctx: &mut BehaviorCtx, blur: &Blur) {
+        if blur.hard {
+            ctx.consume();
+        }
+        self.hits += 1;
+    }
+
+    #[on_attach]
+    fn setup(&mut self, _ctx: &mut BehaviorCtx) {
+        self.cap = 100;
+    }
+}
+
+fn dispatch<K: Kind>(limiter: &mut Limiter, kind: &K) -> Verdict {
+    let bytes = kind.encode_into_bytes();
+    let mut ctx = BehaviorCtx::__new_inbound(K::ID, &bytes);
+    limiter.__aether_behavior_dispatch(&mut ctx, K::ID, &bytes);
+    ctx.__into_output().verdict
+}
+
+/// A `&mut K` handler's mutation is the verdict: the forwarded bytes are
+/// the re-encoded, mutated kind — not the inbound original.
+#[test]
+fn intercept_forwards_the_mutated_re_encode() {
+    let mut limiter = Limiter { cap: 100, hits: 0 };
+    let verdict = dispatch(&mut limiter, &Gauge { value: 250 });
+    let Verdict::Forward(bytes) = verdict else {
+        panic!("an intercept handler forwards");
+    };
+    assert_eq!(
+        Gauge::decode_from_bytes(&bytes),
+        Some(Gauge { value: 100 }),
+        "the forwarded bytes carry the clamped value, not the inbound 250",
+    );
+    assert_eq!(limiter.hits, 1, "the intercept handler ran exactly once");
+}
+
+/// A `&K` observe handler forwards the original bytes untouched.
+#[test]
+fn observe_forwards_the_original_bytes() {
+    let mut limiter = Limiter { cap: 100, hits: 0 };
+    let inbound = Blur { hard: false };
+    let verdict = dispatch(&mut limiter, &inbound);
+    let Verdict::Forward(bytes) = verdict else {
+        panic!("an observe handler forwards");
+    };
+    assert_eq!(
+        bytes,
+        inbound.encode_into_bytes(),
+        "observe forwards the inbound encoding verbatim",
+    );
+    assert_eq!(limiter.hits, 1);
+}
+
+/// `ctx.consume()` drops the mail — and wins over any later re-encode.
+#[test]
+fn consume_drops_the_in_flight_mail() {
+    let mut limiter = Limiter { cap: 100, hits: 0 };
+    let verdict = dispatch(&mut limiter, &Blur { hard: true });
+    assert!(
+        matches!(verdict, Verdict::Consume),
+        "a consumed mail must not forward",
+    );
+}
+
+/// A kind with no `#[on]` handler passes through as a forward of the
+/// original bytes and runs nothing — the dispatch chain's fall-through.
+#[test]
+fn undeclared_kind_falls_through_untouched() {
+    #[derive(Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
+    #[kind(name = "test.behavior_native.unhandled")]
+    struct Unhandled {
+        payload: u32,
+    }
+
+    let mut limiter = Limiter { cap: 100, hits: 0 };
+    let inbound = Unhandled { payload: 7 };
+    let verdict = dispatch(&mut limiter, &inbound);
+    let Verdict::Forward(bytes) = verdict else {
+        panic!("an unhandled kind forwards");
+    };
+    assert_eq!(bytes, inbound.encode_into_bytes());
+    assert_eq!(limiter.hits, 0, "no handler ran");
+}
+
+/// The emitted exports manifest lists exactly the `#[on]` kind ids — the
+/// id set the host's skip-set is built from. Lifecycle hooks ride
+/// sentinels and must not appear.
+#[test]
+fn exports_manifest_lists_exactly_the_handled_kind_ids() {
+    let mut listed: Vec<KindId> =
+        decode_exports_manifest(&Limiter::__AETHER_BEHAVIOR_EXPORTS).collect();
+    let mut expected = vec![Gauge::ID, Blur::ID];
+    listed.sort();
+    expected.sort();
+    assert_eq!(listed, expected);
+}
+
+/// The macro-emitted serde `state_save`/`state_load` defaults round-trip
+/// the author's struct through the wire codec.
+#[test]
+fn state_defaults_round_trip_the_author_struct() {
+    let saved = Limiter { cap: 42, hits: 9 }.state_save();
+    let mut restored = Limiter::default();
+    restored.state_load(&saved);
+    assert_eq!(restored, Limiter { cap: 42, hits: 9 });
+}

--- a/crates/aether-behavior-derive/tests/trybuild.rs
+++ b/crates/aether-behavior-derive/tests/trybuild.rs
@@ -1,0 +1,12 @@
+//! Compile-time checks for `#[behavior]`: a pass case exercising a `&mut K`
+//! intercept, a `&K` observe, an `#[on_attach]`, and a derived-serde state
+//! struct, and a fail case where a malformed handler signature yields the
+//! pointed error. A proc-macro pass/fail suite catches codegen breakage the
+//! macro owns.
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/pass_behavior.rs");
+    t.compile_fail("tests/ui/fail_bad_handler_signature.rs");
+}

--- a/crates/aether-behavior-derive/tests/ui/fail_bad_handler_signature.rs
+++ b/crates/aether-behavior-derive/tests/ui/fail_bad_handler_signature.rs
@@ -1,0 +1,27 @@
+// A `#[on]` handler whose kind parameter is by-value rather than a
+// reference. The macro must point at the parameter and explain the
+// `&K` / `&mut K` intent encoding rather than emitting an opaque error.
+#![allow(unused)]
+
+use aether_behavior::{Behavior, BehaviorCtx};
+use aether_behavior_derive::{behavior, on};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.behavior.slider")]
+struct Slider {
+    value: u32,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct Clamp;
+
+#[behavior]
+impl Behavior for Clamp {
+    #[on]
+    fn clamp(&mut self, _ctx: &mut BehaviorCtx, slider: Slider) {
+        let _ = slider;
+    }
+}
+
+fn main() {}

--- a/crates/aether-behavior-derive/tests/ui/fail_bad_handler_signature.stderr
+++ b/crates/aether-behavior-derive/tests/ui/fail_bad_handler_signature.stderr
@@ -1,0 +1,5 @@
+error: #[on] handler's kind parameter must be a reference — `&K` observes, `&mut K` intercepts
+  --> tests/ui/fail_bad_handler_signature.rs:22:57
+   |
+22 |     fn clamp(&mut self, _ctx: &mut BehaviorCtx, slider: Slider) {
+   |                                                         ^^^^^^

--- a/crates/aether-behavior-derive/tests/ui/pass_behavior.rs
+++ b/crates/aether-behavior-derive/tests/ui/pass_behavior.rs
@@ -1,0 +1,59 @@
+// A behavior with a `&mut K` intercept, a `&K` observe, an `#[on_attach]`,
+// and a derived-serde state struct. The generated dispatch table, exports
+// manifest, and `Behavior` impl must typecheck.
+
+use aether_behavior::{Behavior, BehaviorCtx};
+use aether_behavior_derive::{behavior, on, on_attach};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.behavior.slider")]
+struct Slider {
+    value: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.behavior.focus")]
+struct Focus {
+    focused: bool,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct Clamp {
+    seen: u32,
+}
+
+#[behavior]
+impl Behavior for Clamp {
+    #[on]
+    fn clamp(&mut self, _ctx: &mut BehaviorCtx, slider: &mut Slider) {
+        if slider.value > 200 {
+            slider.value = 200;
+        }
+        self.seen += 1;
+    }
+
+    #[on]
+    fn watch(&mut self, ctx: &mut BehaviorCtx, focus: &Focus) {
+        if focus.focused {
+            ctx.widget().set(&Slider { value: 0 });
+        }
+    }
+
+    #[on_attach]
+    fn setup(&mut self, _ctx: &mut BehaviorCtx) {
+        self.seen = 0;
+    }
+}
+
+fn main() {
+    // Touch the generated manifest const so it is not stripped, confirming
+    // it typechecks against the exports section length.
+    assert_eq!(
+        Clamp::__AETHER_BEHAVIOR_EXPORTS_LEN,
+        Clamp::__AETHER_BEHAVIOR_EXPORTS.len()
+    );
+
+    let clamp = Clamp::default();
+    let _ = clamp.state_save();
+}

--- a/crates/aether-behavior/Cargo.toml
+++ b/crates/aether-behavior/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "aether-behavior"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# Script-side SDK for behavior scripts (ADR-0137). One crate with two
+# faces: the always-compiled trunk holds the host<->script envelope, the
+# packed-pointer ABI, the exports-manifest decoder, and the reserved
+# lifecycle sentinels — a later issue's host consumes exactly this trunk
+# with `default-features = false`. The `runtime` feature (on by default,
+# so a bare wasm32 build produces the full guest surface) adds the
+# authoring SDK: `BehaviorCtx`, the widget/child/panel handles, the
+# decode-once mirror, the effect accumulator, and the `Behavior`
+# lifecycle trait. The crate depends on `aether-data` and `serde` only —
+# never `aether-actor`, never `wasmi` — which is what keeps a behavior
+# cdylib from classifying as a component (structural discovery keys on an
+# `aether-actor` dependency) and keeps the tier boundary legible.
+[features]
+default = ["runtime"]
+runtime = []
+
+[dependencies]
+aether-data = { path = "../aether-data", default-features = false, features = ["derive"] }
+serde = { workspace = true, default-features = false, features = ["alloc", "derive"] }
+
+[lints]
+workspace = true

--- a/crates/aether-behavior/src/abi.rs
+++ b/crates/aether-behavior/src/abi.rs
@@ -1,0 +1,39 @@
+//! The packed-pointer convention shared by the guest filter shims and
+//! the future host (ADR-0137, mirroring the `_p32` pointer-typed exports
+//! of `aether-actor`'s `export!`).
+//!
+//! A guest export that returns a `(ptr, len)` region — `filter`'s outbound
+//! envelope, `state_save`'s serialized blob — packs both halves into one
+//! `u64`: the guest-memory pointer in the high 32 bits, the byte length in
+//! the low 32 bits. wasm32 pointers and lengths are 32-bit, so both fit
+//! without loss and the host unpacks the pair with a single shift + mask.
+
+/// Pack a guest-memory `(ptr, len)` pair into a single `u64` return value:
+/// `(ptr as u64) << 32 | len as u64`.
+#[must_use]
+pub const fn pack_ptr_len(ptr: u32, len: u32) -> u64 {
+    ((ptr as u64) << 32) | (len as u64)
+}
+
+/// Recover the `(ptr, len)` pair a [`pack_ptr_len`] `u64` carries — the
+/// high 32 bits are the pointer, the low 32 bits the length.
+#[must_use]
+pub const fn unpack_ptr_len(packed: u64) -> (u32, u32) {
+    ((packed >> 32) as u32, (packed & 0xFFFF_FFFF) as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{pack_ptr_len, unpack_ptr_len};
+
+    // Tripwire: the exact bit layout the host decodes against. The pinned
+    // value is computed by the shift/mask, so it drifts the moment the
+    // packing convention changes — which would silently misroute every
+    // guest return across the FFI boundary.
+    #[test]
+    fn pack_ptr_len_bit_layout_is_pinned() {
+        let packed = pack_ptr_len(0x1234_5678, 0x9ABC_DEF0);
+        assert_eq!(packed, 0x1234_5678_9ABC_DEF0);
+        assert_eq!(unpack_ptr_len(packed), (0x1234_5678, 0x9ABC_DEF0));
+    }
+}

--- a/crates/aether-behavior/src/envelope.rs
+++ b/crates/aether-behavior/src/envelope.rs
@@ -1,0 +1,101 @@
+//! The host<->script filter envelope (ADR-0137).
+//!
+//! A script's `filter` call returns one [`FilterOutput`]: a [`Verdict`] on
+//! the in-flight mail plus an ordered list of [`Effect`]s the host drains
+//! into real cluster sends. The verdict comes first and the effects apply
+//! in recorded order, so stacked behaviors see each other's forwards and
+//! never each other's in-flight effects.
+//!
+//! The output is a plain serde struct encoded with the `no_std`
+//! `aether_data::wire` codec behind a leading [`ENVELOPE_VERSION`] byte.
+//! Leaning on the shared wire helper keeps the encoding canonical and the
+//! round-trip symmetric — which is why it earns no round-trip test (a
+//! symmetric serde round-trip only fails if the codec is broken, and the
+//! codec is tested where it lives).
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_data::wire;
+use serde::{Deserialize, Serialize};
+
+/// Leading byte on every encoded [`FilterOutput`]. Bumped when the wire
+/// shape changes so a host decoding an older/newer script's output fails
+/// loudly rather than misreading it.
+pub const ENVELOPE_VERSION: u8 = 1;
+
+/// The verdict a script returns on the in-flight mail. Mutation *is* the
+/// verdict in author code (`&mut K` intercepts, `&K` observes); this is
+/// the wire form the host drains.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Verdict {
+    /// The mail forwards. The bytes are the inbound kind's payload —
+    /// re-encoded when a `&mut K` handler mutated it, the original bytes
+    /// otherwise.
+    Forward(Vec<u8>),
+    /// The mail is dropped (`ctx.consume()`); it does not forward.
+    Consume,
+}
+
+/// Where a drained [`Effect`] is delivered. Subname resolution
+/// (subname -> cluster address) is the host's job at drain time; a script
+/// only ever names a target relative to its own position.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EffectTarget {
+    /// The wrapped widget the host interposes on (`ctx.widget()`).
+    Widget,
+    /// A named child in the host's subtree (`ctx.child(path)`).
+    Child(String),
+    /// The parent lane (`ctx.panel()`).
+    Panel,
+}
+
+/// One method-projected effect the host drains after the verdict applies:
+/// a kind (`kind_id`) plus its encoded `bytes`, delivered to `target`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Effect {
+    /// Where the effect is delivered.
+    pub target: EffectTarget,
+    /// The effect kind's id (raw `u64`, as `KindId` carries no serde impl).
+    pub kind_id: u64,
+    /// The effect kind's encoded payload.
+    pub bytes: Vec<u8>,
+}
+
+/// A script's whole filter output: a [`Verdict`] on the in-flight mail
+/// and the ordered [`Effect`]s the host drains after it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FilterOutput {
+    /// The verdict on the in-flight mail (applied first).
+    pub verdict: Verdict,
+    /// The effects, in the order the script recorded them.
+    pub effects: Vec<Effect>,
+}
+
+/// Encode a [`FilterOutput`] to the wire: an [`ENVELOPE_VERSION`] byte then
+/// the `aether_data::wire` body.
+///
+/// # Panics
+/// Only if the encoded body exceeds the wire codec's `u32` length ceiling —
+/// unreachable for a well-formed filter output at any realistic effect count.
+#[must_use]
+pub fn encode(output: &FilterOutput) -> Vec<u8> {
+    let body =
+        wire::to_vec(output).expect("wire encode of FilterOutput fails only past the u32 ceiling");
+    let mut out = Vec::with_capacity(1 + body.len());
+    out.push(ENVELOPE_VERSION);
+    out.extend_from_slice(&body);
+    out
+}
+
+/// Decode a [`FilterOutput`] the host drains from a script's `filter`
+/// return. Returns `None` on an empty buffer, an unrecognized version
+/// byte, or a malformed body.
+#[must_use]
+pub fn decode(bytes: &[u8]) -> Option<FilterOutput> {
+    let (&version, body) = bytes.split_first()?;
+    if version != ENVELOPE_VERSION {
+        return None;
+    }
+    wire::from_bytes(body).ok()
+}

--- a/crates/aether-behavior/src/lib.rs
+++ b/crates/aether-behavior/src/lib.rs
@@ -1,0 +1,63 @@
+//! aether-behavior: the script-side SDK for behavior scripts (ADR-0137).
+//!
+//! A behavior script is small wasm injected at a position in a running
+//! actor cluster that transforms the mail already flowing there. This
+//! crate is the surface a script compiles against, mirroring the
+//! `aether-actor` / `aether-actor-derive` pairing one tier over. It
+//! depends on `aether-data` and `serde` only — never `aether-actor`,
+//! never `wasmi` — the crate-boundary invariant the whole tier split
+//! rests on (a `cdylib` with an `aether-actor` dependency *is* a
+//! component to structural discovery, so behavior wasm must not name it).
+//!
+//! ## Two faces, one crate
+//!
+//! - **Trunk** (always compiled, visible under `default-features = false`):
+//!   the host<->script [`envelope`] (`FilterOutput` / `Verdict` / `Effect`),
+//!   the packed-pointer [`abi`], the exports-[`manifest`] decoder, and the
+//!   reserved lifecycle [`sentinel`]s. A later issue's script host consumes
+//!   exactly this trunk to drain a script's output without pulling the guest
+//!   surface.
+//! - **Runtime** (the `runtime` feature, on by default): the authoring SDK —
+//!   [`BehaviorCtx`], the widget/child/panel handles, the decode-once mirror,
+//!   the effect accumulator, and the [`Behavior`] lifecycle trait. It compiles
+//!   FFI-free on native so host-side `cargo test` exercises the ctx / mirror /
+//!   drain logic, and the `#[behavior]` macro's guest exports (`alloc` /
+//!   `filter` / `state_save` / `state_load`) are emitted only on `wasm`.
+//!
+//! Authoring lives in the sibling `aether-behavior-derive` crate; a script
+//! lists both.
+
+#![no_std]
+
+extern crate alloc;
+
+pub mod abi;
+pub mod envelope;
+pub mod manifest;
+pub mod sentinel;
+
+#[cfg(feature = "runtime")]
+pub mod runtime;
+
+#[cfg(feature = "runtime")]
+pub use runtime::{Behavior, BehaviorCtx, ChildHandle, PanelHandle, WidgetHandle};
+
+/// Items the `#[behavior]` macro's generated code names by absolute path,
+/// re-exported so a script depends on `aether-behavior` alone (never a
+/// direct `aether-data` path) for the surface the codegen touches.
+#[doc(hidden)]
+pub mod __macro_internals {
+    pub use aether_data::{Kind, KindId};
+    pub use alloc::boxed::Box;
+    pub use alloc::vec::Vec;
+
+    pub use crate::abi::pack_ptr_len;
+    pub use crate::manifest::EXPORTS_MANIFEST_VERSION;
+
+    #[cfg(feature = "runtime")]
+    pub use crate::runtime::{
+        Behavior, BehaviorCtx, Slot, run_filter, state_load_serde, state_save_serde,
+    };
+    #[cfg(all(feature = "runtime", target_family = "wasm"))]
+    pub use crate::runtime::{leak_packed, read_guest_slice, realloc_bytes};
+}

--- a/crates/aether-behavior/src/manifest.rs
+++ b/crates/aether-behavior/src/manifest.rs
@@ -1,0 +1,66 @@
+//! The exports-manifest custom section (ADR-0137).
+//!
+//! A behavior script carries no `aether.kinds` section — it declares no
+//! kinds, only handles kinds already flowing past it. What it does carry is
+//! the id set its `#[on(K)]` handlers cover, so the host can skip the
+//! interpreter entirely for undeclared kinds (a map lookup, not a wasm
+//! call). The `#[behavior]` macro pins those ids into the
+//! [`EXPORTS_SECTION`] custom section: a leading [`EXPORTS_MANIFEST_VERSION`]
+//! byte then each handled kind id as a little-endian `u64`.
+
+use aether_data::KindId;
+
+/// Name of the wasm custom section the `#[behavior]` macro pins the handled
+/// kind ids into.
+pub const EXPORTS_SECTION: &str = "aether.behavior.exports";
+
+/// Leading byte on the [`EXPORTS_SECTION`] bytes. Bumped when the framing
+/// changes so a host reading an older/newer script's manifest fails loudly.
+pub const EXPORTS_MANIFEST_VERSION: u8 = 1;
+
+/// Recover the handled kind ids from an [`EXPORTS_SECTION`] byte buffer: a
+/// version byte then little-endian `u64` words. A buffer that is empty, on
+/// an unrecognized version, or whose body is not a whole number of `u64`
+/// words yields no ids (the trailing partial word, if any, is dropped).
+pub fn decode_exports_manifest(bytes: &[u8]) -> impl Iterator<Item = KindId> + '_ {
+    let body = match bytes.split_first() {
+        Some((&version, rest)) if version == EXPORTS_MANIFEST_VERSION => rest,
+        _ => &[][..],
+    };
+    body.chunks_exact(8).map(|word| {
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(word);
+        KindId(u64::from_le_bytes(buf))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use aether_data::KindId;
+    use alloc::vec::Vec;
+
+    use super::{EXPORTS_MANIFEST_VERSION, decode_exports_manifest};
+
+    // Tripwire: the exact framing the host reads a script's handled-kind
+    // set out of — version byte then LE `u64` words. A hand-built buffer is
+    // decoded back to its id list, so any drift in the byte layout (word
+    // order, width, version handling) trips here rather than silently
+    // reshaping every script's manifest.
+    #[test]
+    fn decode_exports_manifest_recovers_hand_built_ids() {
+        let ids = [KindId(0x0102_0304_0506_0708), KindId(0xDEAD_BEEF_CAFE_F00D)];
+        let mut buf = Vec::new();
+        buf.push(EXPORTS_MANIFEST_VERSION);
+        for id in ids {
+            buf.extend_from_slice(&id.0.to_le_bytes());
+        }
+
+        let decoded: Vec<KindId> = decode_exports_manifest(&buf).collect();
+        assert_eq!(decoded, ids);
+
+        // A wrong version byte yields no ids.
+        let mut wrong = buf.clone();
+        wrong[0] = EXPORTS_MANIFEST_VERSION.wrapping_add(1);
+        assert_eq!(decode_exports_manifest(&wrong).count(), 0);
+    }
+}

--- a/crates/aether-behavior/src/runtime/mod.rs
+++ b/crates/aether-behavior/src/runtime/mod.rs
@@ -1,0 +1,464 @@
+//! The guest authoring surface (ADR-0137), behind the `runtime` feature.
+//!
+//! This is what a behavior script's handlers touch: [`BehaviorCtx`] and its
+//! [`WidgetHandle`] / [`ChildHandle`] / [`PanelHandle`] trinity, the
+//! decode-once [`last`](WidgetHandle::last) mirror, the effect accumulator,
+//! and the [`Behavior`] lifecycle trait. The module compiles FFI-free on
+//! native so host-side tests drive the ctx / mirror / drain logic directly;
+//! the guest FFI helpers (`leak_packed`, `read_guest_slice`) are the only
+//! `wasm`-gated surface, and the `#[behavior]` macro's four exports are the
+//! only callers.
+
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::any::Any;
+use core::cell::UnsafeCell;
+
+use aether_data::wire;
+use aether_data::{Kind, KindId};
+use serde::de::DeserializeOwned;
+
+use crate::envelope::{Effect, EffectTarget, FilterOutput, Verdict, encode};
+use crate::sentinel;
+
+/// One entry in a handle's mirror: the raw kind bytes plus a lazily-filled
+/// decode cache. Storing bytes and decoding on read is the only shape that
+/// works generically over an open `K` — a per-kind typed slot is
+/// impossible without naming every custom-widget kind ahead of time.
+struct MirrorSlot {
+    bytes: Vec<u8>,
+    cache: Option<Box<dyn Any>>,
+}
+
+impl MirrorSlot {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self { bytes, cache: None }
+    }
+
+    /// Replace the stored bytes and drop any cached decode — the next
+    /// `last::<K>()` re-decodes from the new bytes.
+    fn set(&mut self, bytes: Vec<u8>) {
+        self.bytes = bytes;
+        self.cache = None;
+    }
+}
+
+/// A per-handle last-value-per-kind mirror. Writes pay serialize-once-per-
+/// *change* (bytes already in flight); reads pay decode-once-per-*change*.
+#[derive(Default)]
+struct Mirror {
+    slots: BTreeMap<KindId, MirrorSlot>,
+}
+
+impl Mirror {
+    /// Record a kind's latest bytes, invalidating the decode cache.
+    fn update(&mut self, id: KindId, bytes: Vec<u8>) {
+        match self.slots.get_mut(&id) {
+            Some(slot) => slot.set(bytes),
+            None => {
+                self.slots.insert(id, MirrorSlot::new(bytes));
+            }
+        }
+    }
+
+    /// The last value seen for `K`, decoded once and cached. Returns `None`
+    /// if no `K` has flowed through this handle, or if the stored bytes no
+    /// longer decode as `K`.
+    fn last<K: Kind + 'static>(&mut self) -> Option<&K> {
+        let slot = self.slots.get_mut(&K::ID)?;
+        if slot.cache.is_none() {
+            let decoded = K::decode_from_bytes(&slot.bytes)?;
+            slot.cache = Some(Box::new(decoded));
+        }
+        slot.cache.as_deref()?.downcast_ref::<K>()
+    }
+}
+
+/// The in-flight mail verdict as the ctx accumulates it, projected to the
+/// wire [`Verdict`] at drain. Kept internal so author code never names a
+/// verdict type — mutation *is* the verdict.
+enum VerdictState {
+    /// The default: forward the inbound bytes unchanged (a `&K` observer,
+    /// or a lifecycle call with no inbound mail).
+    ForwardOriginal,
+    /// A `&mut K` handler mutated the kind; forward the re-encoded bytes.
+    ForwardMutated(Vec<u8>),
+    /// `ctx.consume()` dropped the mail.
+    Consume,
+}
+
+/// The pure filter-call context handed to every handler. Accumulates
+/// effects and the verdict, and carries the decode-once mirror each handle
+/// reads. The host builds one per `filter` call and drains it after.
+pub struct BehaviorCtx {
+    inbound: Vec<u8>,
+    verdict: VerdictState,
+    effects: Vec<Effect>,
+    widget_mirror: Mirror,
+    panel_mirror: Mirror,
+    child_mirrors: BTreeMap<String, Mirror>,
+}
+
+impl BehaviorCtx {
+    /// Build a ctx for an inbound `filter` call, seeding the widget mirror
+    /// from the inbound kind (the kind flowing through the interposition
+    /// updates the mirror before handler dispatch, ADR-0137). A sentinel
+    /// kind carries no payload, so it seeds nothing.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __new_inbound(kind_id: KindId, bytes: &[u8]) -> Self {
+        let mut ctx = Self {
+            inbound: bytes.to_vec(),
+            verdict: VerdictState::ForwardOriginal,
+            effects: Vec::new(),
+            widget_mirror: Mirror::default(),
+            panel_mirror: Mirror::default(),
+            child_mirrors: BTreeMap::new(),
+        };
+        if !sentinel::is_sentinel(kind_id) {
+            ctx.widget_mirror.update(kind_id, bytes.to_vec());
+        }
+        ctx
+    }
+
+    /// The wrapped widget the host interposes on.
+    #[must_use]
+    pub fn widget(&mut self) -> WidgetHandle<'_> {
+        WidgetHandle { ctx: self }
+    }
+
+    /// The parent lane.
+    #[must_use]
+    pub fn panel(&mut self) -> PanelHandle<'_> {
+        PanelHandle { ctx: self }
+    }
+
+    /// A named child in the host's subtree, addressed path-relative.
+    #[must_use]
+    pub fn child(&mut self, path: &str) -> ChildHandle<'_> {
+        ChildHandle {
+            ctx: self,
+            path: String::from(path),
+        }
+    }
+
+    /// Drop the in-flight mail. Effects still apply — consume plus an
+    /// emitted effect substitutes for a forward.
+    pub fn consume(&mut self) {
+        self.verdict = VerdictState::Consume;
+    }
+
+    /// Record a `&mut K` handler's re-encoded bytes as the forward payload.
+    /// A prior `consume()` wins — the drop is not undone by the unconditional
+    /// re-encode the dispatch table emits after every intercept handler.
+    #[doc(hidden)]
+    pub fn __forward_mutated(&mut self, bytes: Vec<u8>) {
+        if !matches!(self.verdict, VerdictState::Consume) {
+            self.verdict = VerdictState::ForwardMutated(bytes);
+        }
+    }
+
+    /// Consume the ctx into the wire [`FilterOutput`] the host drains.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __into_output(self) -> FilterOutput {
+        let verdict = match self.verdict {
+            VerdictState::ForwardOriginal => Verdict::Forward(self.inbound),
+            VerdictState::ForwardMutated(bytes) => Verdict::Forward(bytes),
+            VerdictState::Consume => Verdict::Consume,
+        };
+        FilterOutput {
+            verdict,
+            effects: self.effects,
+        }
+    }
+}
+
+/// Handle to the wrapped widget: intercept-time writes (`set`), the mirror
+/// read (`last`), and a replay request (`report`).
+pub struct WidgetHandle<'c> {
+    ctx: &'c mut BehaviorCtx,
+}
+
+impl WidgetHandle<'_> {
+    /// Write a kind to the widget. The effect is drained into a real send
+    /// after the filter returns; the write also integrates into the mirror
+    /// so a later `last::<K>()` reflects the script's own write (echo
+    /// suppression, truthful mirror).
+    pub fn set<K: Kind + 'static>(&mut self, value: &K) {
+        let bytes = value.encode_into_bytes();
+        self.ctx.widget_mirror.update(K::ID, bytes.clone());
+        self.ctx.effects.push(Effect {
+            target: EffectTarget::Widget,
+            kind_id: K::ID.0,
+            bytes,
+        });
+    }
+
+    /// The last value the widget emitted for `K`, decoded once.
+    pub fn last<K: Kind + 'static>(&mut self) -> Option<&K> {
+        self.ctx.widget_mirror.last::<K>()
+    }
+
+    /// Ask the widget to re-emit its observable kinds up-lane. The reply is
+    /// that traffic filling the mirror, not a return value.
+    pub fn report(&mut self) {
+        self.ctx.effects.push(Effect {
+            target: EffectTarget::Widget,
+            kind_id: sentinel::REPORT.0,
+            bytes: Vec::new(),
+        });
+    }
+}
+
+/// Handle to a named child: a send (`send`), the mirror read (`last`), and a
+/// replay request (`report`).
+pub struct ChildHandle<'c> {
+    ctx: &'c mut BehaviorCtx,
+    path: String,
+}
+
+impl ChildHandle<'_> {
+    /// Send a kind to the child. Drained into a real cluster send after the
+    /// filter returns; the write integrates into the child's mirror.
+    pub fn send<K: Kind + 'static>(&mut self, value: &K) {
+        let bytes = value.encode_into_bytes();
+        self.ctx
+            .child_mirrors
+            .entry(self.path.clone())
+            .or_default()
+            .update(K::ID, bytes.clone());
+        self.ctx.effects.push(Effect {
+            target: EffectTarget::Child(self.path.clone()),
+            kind_id: K::ID.0,
+            bytes,
+        });
+    }
+
+    /// The last value the child emitted for `K`, decoded once.
+    pub fn last<K: Kind + 'static>(&mut self) -> Option<&K> {
+        self.ctx.child_mirrors.get_mut(&self.path)?.last::<K>()
+    }
+
+    /// Ask the child to re-emit its observable kinds up-lane.
+    pub fn report(&mut self) {
+        self.ctx.effects.push(Effect {
+            target: EffectTarget::Child(self.path.clone()),
+            kind_id: sentinel::REPORT.0,
+            bytes: Vec::new(),
+        });
+    }
+}
+
+/// Handle to the parent lane: emit up (`emit`) and the mirror read (`last`).
+pub struct PanelHandle<'c> {
+    ctx: &'c mut BehaviorCtx,
+}
+
+impl PanelHandle<'_> {
+    /// Emit a kind up the parent lane. Drained into a real send after the
+    /// filter returns; the write integrates into the panel mirror.
+    pub fn emit<K: Kind + 'static>(&mut self, value: &K) {
+        let bytes = value.encode_into_bytes();
+        self.ctx.panel_mirror.update(K::ID, bytes.clone());
+        self.ctx.effects.push(Effect {
+            target: EffectTarget::Panel,
+            kind_id: K::ID.0,
+            bytes,
+        });
+    }
+
+    /// The last value seen on the parent lane for `K`, decoded once.
+    pub fn last<K: Kind + 'static>(&mut self) -> Option<&K> {
+        self.ctx.panel_mirror.last::<K>()
+    }
+}
+
+/// The lifecycle contract a `#[behavior]` script fulfills (ADR-0137). The
+/// three lifecycle hooks default to no-ops and are dispatched from `filter`
+/// on the reserved [`sentinel`]s; `state_save` / `state_load` are the
+/// migration blob accessors the `state_save` / `state_load` guest exports
+/// call, and the `#[behavior]` macro emits their default serde bodies (over
+/// `state_save_serde` / `state_load_serde`) unless the author overrides them.
+pub trait Behavior: Sized {
+    /// Runs post-restore with mirrors primed and ctx available.
+    fn on_attach(&mut self, ctx: &mut BehaviorCtx) {
+        let _ = ctx;
+    }
+
+    /// Per-frame work, dispatched on the SDK-owned frame sentinel (no kit
+    /// coupling).
+    fn on_frame(&mut self, ctx: &mut BehaviorCtx) {
+        let _ = ctx;
+    }
+
+    /// Best-effort teardown as the script leaves its position.
+    fn on_detach(&mut self, ctx: &mut BehaviorCtx) {
+        let _ = ctx;
+    }
+
+    /// Serialize the migration state blob.
+    fn state_save(&self) -> Vec<u8>;
+
+    /// Restore from a migration state blob.
+    fn state_load(&mut self, bytes: &[u8]);
+}
+
+/// Default `state_save` body the `#[behavior]` macro emits — serialize the
+/// author's struct through the `no_std` wire codec. The `Serialize` bound
+/// lands at the macro's emitted call site, so a behavior using the default
+/// must derive `Serialize` (author-derived, as `#[actor]` components derive
+/// on their kind types).
+#[must_use]
+pub fn state_save_serde<T: serde::Serialize>(value: &T) -> Vec<u8> {
+    wire::to_vec(value).unwrap_or_default()
+}
+
+/// Default `state_load` body the `#[behavior]` macro emits — overwrite the
+/// author's struct from a prior wire blob, leaving it untouched on an
+/// undecodable blob (fail-open).
+pub fn state_load_serde<T: DeserializeOwned>(slot: &mut T, bytes: &[u8]) {
+    if let Ok(value) = wire::from_bytes(bytes) {
+        *slot = value;
+    }
+}
+
+/// Build a `FilterOutput`'s encoded bytes for one filter call: seed the ctx
+/// from the inbound `(kind_id, bytes)`, run the macro-generated `dispatch`,
+/// drain, and encode. The guest `filter` shim wraps the result with
+/// `leak_packed`; host tests drive [`BehaviorCtx`] directly.
+#[must_use]
+pub fn run_filter(
+    kind_id: KindId,
+    inbound: &[u8],
+    dispatch: impl FnOnce(&mut BehaviorCtx),
+) -> Vec<u8> {
+    let mut ctx = BehaviorCtx::__new_inbound(kind_id, inbound);
+    dispatch(&mut ctx);
+    encode(&ctx.__into_output())
+}
+
+/// Single-instance backing store for the macro-emitted `static` script
+/// slot. A wasm guest is single-threaded (ADR-0010 §5) and the host
+/// serializes `filter` / `state_*` calls, so an `UnsafeCell` with a blanket
+/// `Sync` impl is sound — the same argument that licenses `aether-actor`'s
+/// component slot. The behavior struct is instantiated lazily via `Default`
+/// on first access, since the four-export ABI carries no constructor.
+pub struct Slot<T> {
+    cell: UnsafeCell<Option<T>>,
+}
+
+impl<T> Slot<T> {
+    /// Build an empty slot. `const` so it can live in a `static`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            cell: UnsafeCell::new(None),
+        }
+    }
+}
+
+impl<T: Default> Slot<T> {
+    /// Borrow the instance, constructing it via `Default` on first access.
+    // Returning `&mut T` from `&self` is the load-bearing interior-mutability
+    // pattern here; the `UnsafeCell` makes it sound under the host's
+    // serialized-dispatch guarantee, the same exception `aether-actor`'s
+    // slot carries.
+    #[allow(clippy::mut_from_ref)]
+    pub fn get_or_default(&self) -> &mut T {
+        // SAFETY: single-threaded guest + host-serialized entry points mean
+        // no other live reference to the cell exists at this call.
+        let opt = unsafe { &mut *self.cell.get() };
+        opt.get_or_insert_with(T::default)
+    }
+}
+
+impl<T> Default for Slot<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// SAFETY: single-threaded wasm guest + host-serialized FFI entry points mean
+// the `UnsafeCell` is only ever touched from one thread at a time — no
+// concurrent access is possible inside one wasm linear memory.
+unsafe impl<T> Sync for Slot<T> {}
+
+/// `cabi_realloc`-shaped guest allocator backing the `alloc` export: the
+/// host obtains a region from it, writes the inbound payload, then calls
+/// `filter` / `state_load`. Not target-gated (plain `alloc`-crate code, so
+/// it is host-testable); the `alloc` FFI shim that calls it is `wasm`-only.
+///
+/// # Safety
+/// `old_ptr` / `old_size` / `align` must describe a live allocation from a
+/// prior call (or `(0, 0)` for a fresh allocation), and `align` must be a
+/// nonzero power of two.
+pub unsafe fn realloc_bytes(
+    old_ptr: *mut u8,
+    old_size: usize,
+    align: usize,
+    new_size: usize,
+) -> *mut u8 {
+    use alloc::alloc::{Layout, alloc, dealloc, realloc};
+    use core::ptr::null_mut;
+
+    if new_size == 0 {
+        if !old_ptr.is_null() {
+            // SAFETY: caller's layout contract holds; `old_ptr` is a live
+            // allocation described by `(old_size, align)`.
+            unsafe {
+                dealloc(old_ptr, Layout::from_size_align_unchecked(old_size, align));
+            }
+        }
+        return null_mut();
+    }
+    if old_ptr.is_null() {
+        // SAFETY: caller's layout contract holds; a fresh allocation.
+        return unsafe { alloc(Layout::from_size_align_unchecked(new_size, align)) };
+    }
+    // SAFETY: caller's layout contract holds; `old_ptr` is a live allocation
+    // described by `(old_size, align)`, resized to `new_size`.
+    unsafe {
+        realloc(
+            old_ptr,
+            Layout::from_size_align_unchecked(old_size, align),
+            new_size,
+        )
+    }
+}
+
+/// Leak an owned byte buffer into guest memory and pack its `(ptr, len)` for
+/// return across the FFI. The host reads the region and never frees it
+/// (wasm has no `memory.shrink`), so the leak is the contract, not a bug.
+#[cfg(target_family = "wasm")]
+#[must_use]
+pub fn leak_packed(bytes: Vec<u8>) -> u64 {
+    let boxed = bytes.into_boxed_slice();
+    let len = boxed.len() as u32;
+    let ptr = boxed.as_ptr() as u32;
+    core::mem::forget(boxed);
+    crate::abi::pack_ptr_len(ptr, len)
+}
+
+/// Borrow a host-written `(ptr, len)` region as a byte slice. A zero length
+/// short-circuits to an empty slice so a null pointer is never dereferenced.
+///
+/// # Safety
+/// The host wrote `len` bytes at `ptr` (via the `alloc` export); the slice
+/// is bounded by the current call, which finishes before the host reuses the
+/// region.
+#[cfg(target_family = "wasm")]
+#[must_use]
+pub unsafe fn read_guest_slice<'a>(ptr: u32, len: u32) -> &'a [u8] {
+    if len == 0 {
+        &[]
+    } else {
+        // SAFETY: caller upholds the region contract above.
+        unsafe { core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/aether-behavior/src/runtime/tests.rs
+++ b/crates/aether-behavior/src/runtime/tests.rs
@@ -1,0 +1,94 @@
+use alloc::string::String;
+
+use aether_data::Kind;
+use serde::{Deserialize, Serialize};
+
+use super::BehaviorCtx;
+use crate::envelope::{EffectTarget, Verdict};
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "test.behavior.slider")]
+struct Slider {
+    value: u32,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "test.behavior.label")]
+struct Label {
+    text: String,
+}
+
+// Exercises the effect accumulator + verdict drain: the three handle verbs
+// each push one targeted effect, `consume` sets the verdict, and the drained
+// `FilterOutput` reports them verdict-first, effects in recorded order, with
+// the right targets / kind ids / bytes. All owned SDK logic.
+#[test]
+fn drain_reports_verdict_then_ordered_effects() {
+    let inbound = Slider { value: 5 }.encode_into_bytes();
+    let mut ctx = BehaviorCtx::__new_inbound(Slider::ID, &inbound);
+
+    ctx.widget().set(&Slider { value: 8 });
+    ctx.child("row/label").send(&Label {
+        text: String::from("hi"),
+    });
+    ctx.panel().emit(&Slider { value: 1 });
+    ctx.consume();
+
+    let output = ctx.__into_output();
+
+    assert!(matches!(output.verdict, Verdict::Consume));
+    assert_eq!(output.effects.len(), 3);
+
+    assert_eq!(output.effects[0].target, EffectTarget::Widget);
+    assert_eq!(output.effects[0].kind_id, Slider::ID.0);
+    assert_eq!(
+        output.effects[0].bytes,
+        Slider { value: 8 }.encode_into_bytes()
+    );
+
+    assert_eq!(
+        output.effects[1].target,
+        EffectTarget::Child(String::from("row/label"))
+    );
+    assert_eq!(output.effects[1].kind_id, Label::ID.0);
+
+    assert_eq!(output.effects[2].target, EffectTarget::Panel);
+    assert_eq!(output.effects[2].kind_id, Slider::ID.0);
+}
+
+// A `&mut K`-style intercept forwards the re-encoded bytes; the default
+// verdict forwards the inbound bytes unchanged.
+#[test]
+fn forward_carries_original_then_mutated_bytes() {
+    let inbound = Slider { value: 5 }.encode_into_bytes();
+
+    let original = BehaviorCtx::__new_inbound(Slider::ID, &inbound);
+    assert_eq!(
+        original.__into_output().verdict,
+        Verdict::Forward(inbound.clone())
+    );
+
+    let mut mutated = BehaviorCtx::__new_inbound(Slider::ID, &inbound);
+    let reencoded = Slider { value: 9 }.encode_into_bytes();
+    mutated.__forward_mutated(reencoded.clone());
+    assert_eq!(mutated.__into_output().verdict, Verdict::Forward(reencoded));
+}
+
+// The mirror decodes once and reflects the latest bytes: the inbound kind
+// seeds the widget mirror, and an intervening own-write invalidates the
+// stale decode so the next read re-decodes to the new value.
+#[test]
+fn mirror_decodes_inbound_and_invalidates_on_update() {
+    let inbound = Slider { value: 5 }.encode_into_bytes();
+    let mut ctx = BehaviorCtx::__new_inbound(Slider::ID, &inbound);
+
+    assert_eq!(ctx.widget().last::<Slider>(), Some(&Slider { value: 5 }));
+
+    // Own write updates the mirror; the cached decode must be dropped.
+    ctx.widget().set(&Slider { value: 9 });
+    assert_eq!(ctx.widget().last::<Slider>(), Some(&Slider { value: 9 }));
+}

--- a/crates/aether-behavior/src/sentinel.rs
+++ b/crates/aether-behavior/src/sentinel.rs
@@ -1,0 +1,37 @@
+//! Reserved lifecycle sentinel kind ids (ADR-0137).
+//!
+//! The guest ABI is fixed at four exports; lifecycle hooks ride *inside*
+//! `filter` rather than adding exports. The host invokes a hook by calling
+//! `filter(sentinel, 0, 0)`, and the `#[behavior]` dispatch table routes
+//! the sentinel to the script's `on_attach` / `on_detach` / `on_frame`.
+//!
+//! Real kind ids carry `Tag::Kind` in their high four bits (they are
+//! `with_tag`-prefixed FNV hashes), so this tiny low-valued block cannot
+//! collide with any authored kind. Keeping `#[on_frame]` on an SDK-owned
+//! sentinel — rather than the kit `Collect` kind its natural spelling
+//! implies — is what frees the SDK of any `aether-kit` dependency.
+
+use aether_data::KindId;
+
+/// Dispatched post-restore, with mirrors primed and ctx available.
+pub const ATTACH: KindId = KindId(1);
+
+/// Dispatched best-effort as the script leaves its position.
+pub const DETACH: KindId = KindId(2);
+
+/// Dispatched once per frame for per-frame work.
+pub const FRAME: KindId = KindId(3);
+
+/// Marker kind on a `report()` replay-request effect. Not a lifecycle
+/// hook — it rides an [`crate::envelope::Effect`] whose empty body asks the
+/// target to re-emit its observable kinds up-lane (the reply is that
+/// traffic filling the mirror, not a return value).
+pub const REPORT: KindId = KindId(4);
+
+/// Whether `id` is one of the reserved sentinels — used to keep a sentinel
+/// dispatch from seeding the inbound-kind mirror (a sentinel carries no
+/// payload).
+#[must_use]
+pub fn is_sentinel(id: KindId) -> bool {
+    id == ATTACH || id == DETACH || id == FRAME || id == REPORT
+}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -49,6 +49,7 @@ exclude:
       # inspection fires on every one. The detachment is the trybuild
       # contract, not a defect; exclude the fixture trees.
       - crates/aether-actor-derive/tests/ui
+      - crates/aether-behavior-derive/tests/ui
       - crates/aether-data-derive/tests/ui
       - crates/aether-derive/tests/ui
 


### PR DESCRIPTION
Closes #2686.

## Summary

The script-side half of the ADR-0137 behavior-script stack: two new workspace crates mirroring the `aether-actor` / `aether-actor-derive` pairing one tier over. Neither declares an `aether-actor` dependency, so behavior wasm never misclassifies as a component (`cargo xtask dist` still reports 4 components).

- **`aether-behavior`** (`no_std` + `alloc`, deps `aether-data` + `serde` only, `default = ["runtime"]`). Trunk (always compiled, host-consumable with `default-features = false`): the host↔script envelope (`FilterOutput` / `Verdict` / `Effect` / `EffectTarget` over `aether_data::wire` behind an `ENVELOPE_VERSION` byte), `pack_ptr_len`/`unpack_ptr_len`, the `aether.behavior.exports` manifest decoder, and the reserved lifecycle sentinel `KindId`s. Runtime (feature-gated, compiles on native so host tests exercise it): `BehaviorCtx` with the widget/child/panel handles, the byte-store mirror with decode-once cache, the effect accumulator, `consume()`/drain, and the `Behavior` lifecycle trait.
- **`aether-behavior-derive`**: the `#[behavior]` macro — `&mut K` (intercept, re-encode + forward) vs `&K` (observe, forward original) third-parameter intent inference, `#[on]`/`#[on_attach]`/`#[on_frame]`/`#[on_detach]` inert markers, kind-id if-chain dispatch with lifecycle keyed on sentinels, ids-only exports-manifest custom section, default serde `state_save`/`state_load` bodies, and the four wasm-only guest exports (`alloc`/`filter`/`state_save`/`state_load`).

Implementation-level reconciliations (no design deviation): `state_save`/`state_load` are required trait methods with the macro emitting the serde default bodies unless overridden (a serde-defaulted trait method is uncallable for non-`Serialize` types, so trait-level defaults could not satisfy both plan bullets); a `REPORT` sentinel joins ATTACH/DETACH/FRAME so `report()` has an encodable replay-request marker; `#[behavior]` requires `Default` on the script struct (the four-export ABI carries no constructor), enforced on the wasm path only.

## Test plan

- ABI bit-layout tripwire (`pack_ptr_len` pins the exact packing) and manifest framing tripwire (`decode_exports_manifest` over a hand-built id list).
- Host-side ctx tests: drain produces the right verdict + ordered effects with correct targets/ids/bytes; forward-original vs forward-mutated; mirror decode-once + invalidation on update.
- trybuild pass + compile-fail pair over the macro.
- Cross-build sanity: `aether-behavior` builds for `wasm32-unknown-unknown` (default features) and native `--no-default-features` (the host-consume shape). A real `#[behavior]` script verified (scratch crate) to emit the four exports + the `aether.behavior.exports` section and no `aether.kinds` section.
- No envelope serde round-trip test (symmetric-derive junk, per the scoped plan).

## Generated by

`/implement` — agent execution of [scoped issue #2686](https://github.com/iamacoffeepot/aether/issues/2686).
