### PR TITLE
feat(kit): declarative panel composition via widget child-spec trees

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -52,7 +52,7 @@ pub use theme::{SetTheme, Theme, WidgetState};
 pub use widgets::{
     ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, LabelConfig, PanelConfig,
     RadioConfig, RadioSelected, SliderChanged, SliderConfig, TextCommitted, TextFieldConfig,
-    WidgetChildSpec, WidgetConfig, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+    WidgetChildSpec, WidgetConfig, WidgetDrawItem, WidgetDrawList, WidgetFrame, WidgetKind,
 };
 pub use world::{
     CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk, ChunkPos, Material, Region,

--- a/crates/aether-kit/src/runtime/widget_panel.rs
+++ b/crates/aether-kit/src/runtime/widget_panel.rs
@@ -1,6 +1,9 @@
 // `#[handler]` methods take their decoded mail by value per the ADR-0033
 // dispatch ABI (see `runtime/widget.rs`).
 #![allow(clippy::needless_pass_by_value)]
+// A radio group's row count is its (small) option count; the `usize as f32`
+// for its stacked pixel height cannot lose precision at any real option count.
+#![allow(clippy::cast_precision_loss)]
 
 //! The reference panel root (issue 2660): the test vehicle, the copy-paste
 //! template a consumer forks, and the map-editor seam.
@@ -9,11 +12,14 @@
 //! [`Composite`] (the ADR-0117 draw protocol's bookkeeping) and [`Focus`] (the
 //! root-owned focus-and-input model) — and ties them together:
 //!
-//! - **Spawn.** On its first frame it spawns a fixed vertical stack of inline
-//!   widgets (a label, a slider, a radio group, a text field, an apply
-//!   button), assigns each a [`WidgetFrame`] rect, and records that rect into
+//! - **Spawn.** On its first frame it spawns its declared vertical stack of
+//!   inline widgets (each [`WidgetChildSpec`] naming a [`WidgetKind`] and
+//!   carrying that widget's pre-encoded config), assigns each a
+//!   [`WidgetFrame`] rect derived from stack order, and records that rect into
 //!   both [`Composite`] (to offset the child's draws) and [`Focus`] (to
-//!   hit-test and Tab-cycle it).
+//!   hit-test and Tab-cycle it). An empty child list falls back to the
+//!   built-in reference stack (a label, a slider, a radio group, a text
+//!   field, an apply button).
 //! - **Font.** In `wire` it loads a font through `aether.text` and, when the
 //!   `load_font_result` arrives, stamps the session-scoped `font_id` into its
 //!   [`Theme`] and re-fans it — the inline responsibility the theme module
@@ -40,7 +46,7 @@ use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::text::{LoadFont, LoadFontResult};
 use aether_capabilities::{InputCapability, LifecycleCapability, TextCapability};
-use aether_data::MailboxId;
+use aether_data::{Kind, MailboxId};
 use aether_kinds::keycode::KEY_TAB;
 use aether_kinds::mouse_button;
 use aether_kinds::{
@@ -59,14 +65,15 @@ use crate::theme::{SetTheme, Theme};
 use crate::widgets::{
     ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, LabelConfig, PanelConfig,
     RadioConfig, RadioSelected, SliderChanged, SliderConfig, TextCommitted, TextFieldConfig,
-    WidgetDrawList, WidgetFrame,
+    WidgetChildSpec, WidgetDrawList, WidgetFrame, WidgetKind,
 };
 
 /// One spawned child's alias plus the logical name the panel attributes its
-/// value-up events under (for the map-editor translation / logging).
+/// value-up events under (for the map-editor translation / logging) — the
+/// child's spec subname.
 struct ChildRef {
     id: MailboxId,
-    name: &'static str,
+    name: String,
 }
 
 /// The reference panel root. Loaded as a component with a [`PanelConfig`]; its
@@ -85,10 +92,14 @@ pub struct WidgetPanel {
 }
 
 impl WidgetPanel {
-    /// Spawn the widget stack once (from the first frame — an inline child
-    /// gets no `wire` and `init` cannot spawn, so the root spawns from its
-    /// first send-capable handler). Each widget gets its rect in both the
-    /// composite layout table and the focus table, and its `WidgetFrame`.
+    /// Spawn the declared widget stack once (from the first frame — an inline
+    /// child gets no `wire` and `init` cannot spawn, so the root spawns from
+    /// its first send-capable handler). Each spec spawns its kind's actor from
+    /// its decoded config; the row height and focusability derive from that
+    /// config, and the vertical position derives from stack order (`origin` on
+    /// the spec is ignored — the panel owns layout). Each widget gets its rect
+    /// in both the composite layout table and the focus table, and its
+    /// `WidgetFrame`. An empty child list falls back to [`reference_stack`].
     fn ensure_spawned(&mut self, ctx: &mut WasmCtx<'_, Manual>) {
         if self.spawned {
             return;
@@ -108,60 +119,62 @@ impl WidgetPanel {
             height,
         };
 
-        let label = LabelConfig {
-            text: String::from("Controls"),
-            theme: self.theme.clone(),
+        let specs = if self.config.children.is_empty() {
+            reference_stack(&self.theme)
+        } else {
+            self.config.children.clone()
         };
-        if let Some(id) = spawn::<LabelWidget>(ctx, "label", &label) {
-            self.place(ctx, id, row_rect(y, row), false, "label");
-        }
-        y += row + gap;
 
-        let slider = SliderConfig {
-            min: 0.0,
-            max: 255.0,
-            step: 1.0,
-            initial: 40.0,
-            theme: self.theme.clone(),
-        };
-        if let Some(id) = spawn::<SliderWidget>(ctx, "slider", &slider) {
-            self.place(ctx, id, row_rect(y, row), true, "slider");
+        let mut first = true;
+        for spec in &specs {
+            // Decode the concrete config, spawn the kind's actor, and derive
+            // the row height + focusability from that config. `None` from any
+            // arm (an undecodable config, a spawn failure, or a rejected
+            // container) skips the slot entirely so the stack stays honest.
+            let placed = match spec.kind {
+                WidgetKind::Label => decode_child::<LabelConfig>(spec)
+                    .and_then(|config| spawn::<LabelWidget>(ctx, &spec.subname, &config))
+                    .map(|id| (id, row, false)),
+                WidgetKind::Slider => decode_child::<SliderConfig>(spec)
+                    .and_then(|config| spawn::<SliderWidget>(ctx, &spec.subname, &config))
+                    .map(|id| (id, row, true)),
+                WidgetKind::Radio => decode_child::<RadioConfig>(spec).and_then(|config| {
+                    let height = row * config.options.len() as f32;
+                    spawn::<RadioGroupWidget>(ctx, &spec.subname, &config)
+                        .map(|id| (id, height, true))
+                }),
+                WidgetKind::TextField => decode_child::<TextFieldConfig>(spec)
+                    .and_then(|config| spawn::<TextFieldWidget>(ctx, &spec.subname, &config))
+                    .map(|id| (id, row, true)),
+                WidgetKind::Button => decode_child::<ButtonConfig>(spec)
+                    .and_then(|config| spawn::<ButtonWidget>(ctx, &spec.subname, &config))
+                    .map(|id| (id, row, true)),
+                WidgetKind::Composite => {
+                    tracing::warn!(
+                        target: "aether_kit",
+                        subname = %spec.subname,
+                        "a Composite child in a panel is not supported (nested \
+                         containers are out of scope in v1); slot skipped",
+                    );
+                    None
+                }
+            };
+            let Some((id, height, focusable)) = placed else {
+                continue;
+            };
+            if !first {
+                y += gap;
+            }
+            first = false;
+            self.place(
+                ctx,
+                id,
+                row_rect(y, height),
+                focusable,
+                spec.subname.clone(),
+            );
+            y += height;
         }
-        y += row + gap;
-
-        let radio = RadioConfig {
-            options: alloc::vec![
-                String::from("Low"),
-                String::from("Medium"),
-                String::from("High"),
-            ],
-            initial_index: 0,
-            theme: self.theme.clone(),
-        };
-        let radio_height = row * 3.0;
-        if let Some(id) = spawn::<RadioGroupWidget>(ctx, "radio", &radio) {
-            self.place(ctx, id, row_rect(y, radio_height), true, "radio");
-        }
-        y += radio_height + gap;
-
-        let text_field = TextFieldConfig {
-            initial: String::new(),
-            max_chars: 32,
-            theme: self.theme.clone(),
-        };
-        if let Some(id) = spawn::<TextFieldWidget>(ctx, "text_field", &text_field) {
-            self.place(ctx, id, row_rect(y, row), true, "text_field");
-        }
-        y += row + gap;
-
-        let button = ButtonConfig {
-            label: String::from("Apply"),
-            theme: self.theme.clone(),
-        };
-        if let Some(id) = spawn::<ButtonWidget>(ctx, "button", &button) {
-            self.place(ctx, id, row_rect(y, row), true, "button");
-        }
-        y += row;
 
         self.panel_height = y - self.config.y;
     }
@@ -175,7 +188,7 @@ impl WidgetPanel {
         id: MailboxId,
         frame: WidgetFrame,
         focusable: bool,
-        name: &'static str,
+        name: String,
     ) {
         self.composite
             .register_slot(id, Vec2::new(frame.x, frame.y));
@@ -206,11 +219,97 @@ impl WidgetPanel {
 
     /// The logical name of the child a value-up event came from, for
     /// attribution.
-    fn child_name(&self, source: Option<MailboxId>) -> &'static str {
+    fn child_name(&self, source: Option<MailboxId>) -> &str {
         source
             .and_then(|id| self.children.iter().find(|child| child.id == id))
-            .map_or("unknown", |child| child.name)
+            .map_or("unknown", |child| child.name.as_str())
     }
+}
+
+/// Decode one child spec's opaque config bytes as the concrete config type
+/// `C` its [`WidgetKind`] selects, warning and yielding `None` on a decode
+/// failure so the caller skips the slot (mirroring `widget.rs`).
+fn decode_child<C: Kind>(spec: &WidgetChildSpec) -> Option<C> {
+    let config = C::decode_from_bytes(&spec.config);
+    if config.is_none() {
+        tracing::warn!(
+            target: "aether_kit",
+            subname = %spec.subname,
+            "widget child config failed to decode; slot skipped",
+        );
+    }
+    config
+}
+
+/// The built-in reference stack the panel falls back to when its config
+/// declares no `children`: a label, a slider over `0..=255`, a three-option
+/// radio group, a text field, and an apply button — the former hardcode,
+/// expressed as the child-spec data the panel could equally have been handed.
+/// Each spec's `origin` is unused (the panel derives layout from stack order);
+/// the concrete configs carry the panel's live `theme`.
+fn reference_stack(theme: &Theme) -> Vec<WidgetChildSpec> {
+    let spec = |subname: &str, kind: WidgetKind, config: Vec<u8>| WidgetChildSpec {
+        subname: String::from(subname),
+        kind,
+        origin: [0.0, 0.0],
+        config,
+    };
+    alloc::vec![
+        spec(
+            "label",
+            WidgetKind::Label,
+            LabelConfig {
+                text: String::from("Controls"),
+                theme: theme.clone(),
+            }
+            .encode_into_bytes(),
+        ),
+        spec(
+            "slider",
+            WidgetKind::Slider,
+            SliderConfig {
+                min: 0.0,
+                max: 255.0,
+                step: 1.0,
+                initial: 40.0,
+                theme: theme.clone(),
+            }
+            .encode_into_bytes(),
+        ),
+        spec(
+            "radio",
+            WidgetKind::Radio,
+            RadioConfig {
+                options: alloc::vec![
+                    String::from("Low"),
+                    String::from("Medium"),
+                    String::from("High"),
+                ],
+                initial_index: 0,
+                theme: theme.clone(),
+            }
+            .encode_into_bytes(),
+        ),
+        spec(
+            "text_field",
+            WidgetKind::TextField,
+            TextFieldConfig {
+                initial: String::new(),
+                max_chars: 32,
+                theme: theme.clone(),
+            }
+            .encode_into_bytes(),
+        ),
+        spec(
+            "button",
+            WidgetKind::Button,
+            ButtonConfig {
+                label: String::from("Apply"),
+                theme: theme.clone(),
+            }
+            .encode_into_bytes(),
+        ),
+    ]
 }
 
 /// Send a focus transition down: `FocusLost` to the child that lost focus,
@@ -226,11 +325,7 @@ fn apply_focus(ctx: &mut WasmCtx<'_>, (previous, next): FocusTransition) {
 
 /// Spawn one inline widget, logging and dropping the slot on failure. Keeps
 /// the per-widget spawn sites in [`WidgetPanel::ensure_spawned`] to one line.
-fn spawn<A>(
-    ctx: &mut WasmCtx<'_, Manual>,
-    subname: &'static str,
-    config: &A::Config,
-) -> Option<MailboxId>
+fn spawn<A>(ctx: &mut WasmCtx<'_, Manual>, subname: &str, config: &A::Config) -> Option<MailboxId>
 where
     A: aether_actor::Instanced + WasmActor + aether_actor::ErasedWasmActor,
     <A as WasmActor>::State: aether_actor::ErasedWasmActor,
@@ -254,11 +349,12 @@ where
 ///
 /// # Agent
 /// Load `aether_kit.wasm` with `export: "aether.kit.widget.panel"` and a
-/// `PanelConfig` (top-left, width, theme, and a font to load). It spawns a
-/// demonstration stack of every widget, routes real input through the
-/// focus model, and logs each value-up event. Fork it into a real editor
-/// panel by replacing the stack and translating the value-up handlers into
-/// your own world-knob driver mail.
+/// `PanelConfig` (top-left, width, theme, a font to load, and the `children`
+/// it stacks). With an empty `children` list it spawns a demonstration stack
+/// of every widget; otherwise it stacks exactly the declared specs. It routes
+/// real input through the focus model and logs each value-up event. Fork it
+/// into a real editor panel by handing it your own `children` and translating
+/// the value-up handlers into your own world-knob driver mail.
 #[actor(instanced)]
 impl WasmActor for WidgetPanel {
     type Config = PanelConfig;

--- a/crates/aether-kit/src/widgets.rs
+++ b/crates/aether-kit/src/widgets.rs
@@ -132,17 +132,51 @@ pub struct WidgetDrawList {
     pub items: Vec<WidgetDrawItem>,
 }
 
+/// The kind of actor a [`WidgetChildSpec`] spawns, and the concrete config
+/// type its opaque [`WidgetChildSpec::config`] bytes decode as. It is the
+/// one tag that lets a single spec type serve both the homogeneous
+/// compositing [`WidgetConfig`] tree (every child a `Composite`) and the
+/// heterogeneous reference panel (a leaf per widget type). The spawnable set
+/// is closed and kit-owned — every variant maps to a compile-time
+/// `spawn_inline_child::<A>` call — so the dispatch match is exhaustive and
+/// an unknown widget is a compile error, not a runtime failure.
+#[derive(
+    aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default,
+)]
+pub enum WidgetKind {
+    /// A nested compositing subtree — the child's `config` decodes as a
+    /// [`WidgetConfig`] and spawns another compositing node. The default, so
+    /// a spec written for the compositing tree needs no tag.
+    #[default]
+    Composite,
+    /// A static label — `config` decodes as [`LabelConfig`]. Not focusable.
+    Label,
+    /// A value slider — `config` decodes as [`SliderConfig`].
+    Slider,
+    /// A radio group — `config` decodes as [`RadioConfig`]; its row count is
+    /// its option count.
+    Radio,
+    /// A single-line text field — `config` decodes as [`TextFieldConfig`].
+    TextField,
+    /// A push button — `config` decodes as [`ButtonConfig`].
+    Button,
+}
+
 /// One child's placement in a compositing node's layout table. `subname`
 /// is the inline-child address segment the parent spawns and collects it
-/// under; `origin` is the local-pixel offset the parent applies to the
-/// child's every draw. `config` is the child's own [`WidgetConfig`],
-/// pre-encoded to bytes — carrying it opaquely (rather than a nested
-/// [`WidgetConfig`] by value) is what lets a tree nest without forming a
+/// under; `kind` selects which actor the parent spawns and how `config`
+/// decodes; `origin` is the local-pixel offset the parent applies to the
+/// child's every draw. `config` is the child's own concrete config (a
+/// [`WidgetConfig`] for a `Composite`, a [`SliderConfig`] for a `Slider`,
+/// …), pre-encoded to bytes — carrying it opaquely (rather than a nested
+/// config by value) is what lets a tree nest without forming a
 /// self-referential schema, which a recursive `const SCHEMA` cannot
-/// express.
+/// express. A layout-owning parent (the reference panel) derives each
+/// child's `origin` from its stack order and ignores this field.
 #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct WidgetChildSpec {
     pub subname: String,
+    pub kind: WidgetKind,
     pub origin: [f32; 2],
     pub config: Vec<u8>,
 }
@@ -299,10 +333,15 @@ pub struct FocusLost;
 
 /// `aether.kit.widget.panel.config` — the reference panel root's layout
 /// config: where the vertical widget stack sits (`x` / `y` top-left, `width`),
-/// its base [`Theme`], and the font it loads through `aether.text` to fill the
-/// theme's `font_id`. The panel spawns a fixed demonstration stack (a label, a
-/// slider, a radio group, a text field, an apply button) from this — the
-/// copy-paste starting point a real editor panel forks.
+/// its base [`Theme`], the font it loads through `aether.text` to fill the
+/// theme's `font_id`, and the ordered `children` it stacks. The panel derives
+/// each child's row height and focusability from its decoded config and lays
+/// them out in the declared order, so the child list — not Rust source — is
+/// what a panel contains. An empty `children` list falls back to the built-in
+/// reference stack (a label, a slider, a radio group, a text field, an apply
+/// button), the copy-paste starting point a real editor panel forks. A
+/// [`WidgetKind::Composite`] child (a nested container) is out of scope in v1
+/// and is rejected with a warn.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.kit.widget.panel.config")]
 pub struct PanelConfig {
@@ -312,6 +351,7 @@ pub struct PanelConfig {
     pub font_namespace: String,
     pub font_path: String,
     pub theme: Theme,
+    pub children: Vec<WidgetChildSpec>,
 }
 
 #[cfg(test)]

--- a/crates/aether-substrate-bundle/tests/widget_compositing.rs
+++ b/crates/aether-substrate-bundle/tests/widget_compositing.rs
@@ -33,7 +33,7 @@ use std::fs;
 
 use aether_data::Kind;
 use aether_kinds::{LoadComponent, LoadResult, NamedMail};
-use aether_kit::{WidgetChildSpec, WidgetConfig, WidgetDrawItem};
+use aether_kit::{WidgetChildSpec, WidgetConfig, WidgetDrawItem, WidgetKind};
 use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
 use aether_substrate_bundle::visual::{Image, background_top_left, decode_png};
 
@@ -156,11 +156,13 @@ fn flat_panel_is_one_sender_with_chrome_under_children() {
         children: vec![
             WidgetChildSpec {
                 subname: "a".to_owned(),
+                kind: WidgetKind::Composite,
                 origin: [12.0, 12.0],
                 config: leaf_config(12.0, 12.0, RED),
             },
             WidgetChildSpec {
                 subname: "b".to_owned(),
+                kind: WidgetKind::Composite,
                 origin: [36.0, 20.0],
                 config: leaf_config(12.0, 12.0, GREEN),
             },
@@ -240,6 +242,7 @@ fn nested_tree_draws_in_depth_first_order() {
         intrinsic: None,
         children: vec![WidgetChildSpec {
             subname: "b1".to_owned(),
+            kind: WidgetKind::Composite,
             origin: [2.0, 2.0],
             config: b1,
         }],
@@ -256,11 +259,13 @@ fn nested_tree_draws_in_depth_first_order() {
         children: vec![
             WidgetChildSpec {
                 subname: "a".to_owned(),
+                kind: WidgetKind::Composite,
                 origin: [12.0, 14.0],
                 config: leaf_config(8.0, 8.0, RED),
             },
             WidgetChildSpec {
                 subname: "b".to_owned(),
+                kind: WidgetKind::Composite,
                 origin: [30.0, 12.0],
                 config: interior_b,
             },

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -185,6 +185,7 @@ fn load_panel(bench: &mut TestBench, wasm: &[u8], font_id: u32) {
             font_id,
             ..Theme::DEFAULT
         },
+        children: Vec::new(),
     };
     let loaded = bench
         .execute(vec![(

--- a/crates/aether-substrate-bundle/tests/widget_set.rs
+++ b/crates/aether-substrate-bundle/tests/widget_set.rs
@@ -29,13 +29,13 @@ use std::fs;
 
 use aether_actor::Addressable;
 use aether_data::Kind;
-use aether_kinds::keycode::{KEY_DOWN, KEY_ENTER, KEY_TAB};
+use aether_kinds::keycode::{KEY_DOWN, KEY_ENTER, KEY_TAB, KEY_UP};
 use aether_kinds::mouse_button::LEFT;
 use aether_kinds::{
     Key, LoadComponent, LoadResult, LogTailResult, MouseButton, MouseButtonRelease, MouseMove,
     TextInput, Tick,
 };
-use aether_kit::{PanelConfig, Theme};
+use aether_kit::{PanelConfig, SliderConfig, Theme, WidgetChildSpec, WidgetKind};
 use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
 
 /// The full trampoline address the loaded panel registers at (ADR-0099 §4).
@@ -58,6 +58,7 @@ fn load_panel(bench: &mut TestBench, wasm: &[u8]) {
         font_namespace: String::new(),
         font_path: String::new(),
         theme: Theme::DEFAULT,
+        children: Vec::new(),
     };
     let loaded = bench
         .execute(vec![(
@@ -216,5 +217,138 @@ fn panel_routes_input_to_widgets_and_reports_values_up() {
             .any(|m| m.contains("widget text committed") && m.contains("text=hi")),
         "the text entry then Enter should commit \"hi\" — proving pointer focus \
          and text routing; log was:\n{joined}",
+    );
+}
+
+/// A slider child spec for the declarative-children scenario: full `0..=255`
+/// range, unit step, seeded at `initial`, default theme.
+fn slider_spec(subname: &str, initial: f32) -> WidgetChildSpec {
+    WidgetChildSpec {
+        subname: subname.to_owned(),
+        kind: WidgetKind::Slider,
+        origin: [0.0, 0.0],
+        config: SliderConfig {
+            min: 0.0,
+            max: 255.0,
+            step: 1.0,
+            initial,
+            theme: Theme::DEFAULT,
+        }
+        .encode_into_bytes(),
+    }
+}
+
+/// Load the reference `WidgetPanel` root with an explicit `children` list (so
+/// it stacks exactly those specs rather than its built-in reference stack) at
+/// `(10, 10)` 200px wide, no font, default theme.
+fn load_panel_with(bench: &mut TestBench, wasm: &[u8], children: Vec<WidgetChildSpec>) {
+    let config = PanelConfig {
+        x: 10.0,
+        y: 10.0,
+        width: 200.0,
+        font_namespace: String::new(),
+        font_path: String::new(),
+        theme: Theme::DEFAULT,
+        children,
+    };
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: wasm.to_vec(),
+                    name: Some("panel".to_owned()),
+                    config: config.encode_into_bytes(),
+                    export: Some("aether.kit.widget.panel".to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { name, .. } => assert!(
+            name.ends_with(":panel"),
+            "the panel root should register under :panel; got {name}",
+        ),
+        LoadResult::Err { error } => panic!("load WidgetPanel root: {error}"),
+    }
+}
+
+/// The widget name a `widget slider changed` log line attributes its value to
+/// (the `widget=NAME` field the panel logs) — `None` for a non-slider line.
+fn slider_changed_widget(message: &str) -> Option<String> {
+    message.split("widget=").nth(1).map(|rest| {
+        rest.split_whitespace()
+            .next()
+            .unwrap_or_default()
+            .to_owned()
+    })
+}
+
+/// A panel handed an explicit `children` list stacks exactly those widgets in
+/// the declared order, and that order drives the focus (Tab) cycle — the
+/// declarative-composition path the built-in reference stack can never
+/// exercise (it only ever sees one fixed order). Two sliders named `first`
+/// then `second`: from a fresh panel, Tab lands focus on `first` (focus
+/// registration index 0), an arrow nudge commits and logs it, and a second
+/// Tab-then-nudge logs `second`. The committed value-up events, read off the
+/// log ring in arrival order, must spell out the declared order — a
+/// spec→spawn dispatch fault or an order-derivation defect would reverse or
+/// drop one.
+#[test]
+fn panel_stacks_declared_children_in_order() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = TestBench::start_with_size(240, 220).expect("boot");
+    load_panel_with(
+        &mut bench,
+        &wasm,
+        vec![slider_spec("first", 40.0), slider_spec("second", 40.0)],
+    );
+
+    let panel = panel_address();
+    bench
+        .execute(vec![
+            // First tick spawns + lays out the declared stack.
+            ("spawn", BenchOp::send_mail(&panel, &Tick)),
+            // Tab from no focus lands on the first focusable child (index 0);
+            // an arrow nudge on the focused slider commits + logs it.
+            (
+                "tab_first",
+                BenchOp::send_mail(&panel, &Key { code: KEY_TAB }),
+            ),
+            (
+                "nudge_first",
+                BenchOp::send_mail(&panel, &Key { code: KEY_UP }),
+            ),
+            // Tab again advances to the second child; nudge + log it.
+            (
+                "tab_second",
+                BenchOp::send_mail(&panel, &Key { code: KEY_TAB }),
+            ),
+            (
+                "nudge_second",
+                BenchOp::send_mail(&panel, &Key { code: KEY_UP }),
+            ),
+        ])
+        .expect("declared-children session");
+
+    let log = panel_log_messages(&mut bench);
+    let joined = log.join("\n");
+    let order: Vec<String> = log
+        .iter()
+        .filter(|m| m.contains("widget slider changed") && m.contains("committed=true"))
+        .filter_map(|m| slider_changed_widget(m))
+        .collect();
+    assert_eq!(
+        order,
+        vec!["first".to_owned(), "second".to_owned()],
+        "the declared child order must drive both the vertical stack and the Tab \
+         focus cycle; committed slider events arrived as {order:?}; log was:\n{joined}",
     );
 }

--- a/crates/aether-substrate-bundle/tests/widget_text_alignment.rs
+++ b/crates/aether-substrate-bundle/tests/widget_text_alignment.rs
@@ -141,6 +141,7 @@ fn load_panel(bench: &mut TestBench, wasm: &[u8], font_id: u32) {
             font_id,
             ..Theme::DEFAULT
         },
+        children: Vec::new(),
     };
     let loaded = bench
         .execute(vec![(

--- a/docs/guide/systems/widgets.md
+++ b/docs/guide/systems/widgets.md
@@ -74,13 +74,18 @@ drifts off it.
 
 `WidgetPanel` (export `aether.kit.widget.panel`) is the worked example — the
 test vehicle and the template a real editor forks. It embeds `Composite` and
-`Focus`, spawns a vertical stack of every widget on its first frame, loads a
-font through `aether.text` and stamps the session `font_id` into its theme when
-`load_font_result` arrives, drives the collect/emit loop each frame, and routes
-input through `Focus`. Its value-up handlers are the seam: each attributes the
-event by `ctx.source_mailbox()` and is where a map editor translates a widget
-change into world-knob driver mail. Fork it by replacing the stack and filling
-in those handlers.
+`Focus`, spawns the vertical stack its `PanelConfig` declares on its first
+frame (each `WidgetChildSpec` names a `WidgetKind` and carries that widget's
+pre-encoded config; an empty child list falls back to the built-in reference
+stack of every widget), loads a font through `aether.text` and stamps the
+session `font_id` into its theme when `load_font_result` arrives, drives the
+collect/emit loop each frame, and routes input through `Focus`. Row height and
+focusability derive from each child's decoded config and the vertical order
+follows the declared order, so what a panel contains is config data. Its
+value-up handlers are the seam: each attributes the event by
+`ctx.source_mailbox()` and is where a map editor translates a widget change
+into world-knob driver mail. Fork it by handing it your own `children` and
+filling in those handlers.
 
 To add a new widget — a dropdown, a checkbox, a color well — write one more
 `#[actor(instanced)]` type that speaks the same four lanes and answers `Collect`


### PR DESCRIPTION
Closes #2681.

## Summary

The reference `WidgetPanel` hardcoded its five-widget stack in `ensure_spawned` and `PanelConfig` carried no notion of a child list — "what widgets a panel contains" was Rust source, not config data. This is the prerequisite for the behavior script host (#2682): a script that wraps a slider is only expressible when composition is config an interposer can read.

- New closed `WidgetKind` enum (`{Composite, Label, Slider, Radio, TextField, Button}`, default `Composite`); `WidgetChildSpec` gains `kind`; `PanelConfig` gains `children: Vec<WidgetChildSpec>`.
- `WidgetPanel::ensure_spawned` is now spec-driven: each spec's `kind` selects the concrete actor and decodes its config, row height (radio = `options.len()`) and focusability (all but `Label`) derive from `(kind, config)`, and vertical position + focus order derive from declared spec order.
- Empty `children` falls back to a `reference_stack(&theme)` builder holding the former hardcode — the default path reproduces the previous five-widget layout byte-for-byte, so the pixel-parity scenarios stay green unchanged except for the one new field.
- A `Composite` spec in a panel is warn-rejected in v1 (containers are a named future issue); `ChildRef.name` becomes `String`.

## Test plan

- Existing `widget_set` / `widget_text_alignment` TestBench scenarios are the byte-for-byte layout-parity tripwire (green, with only `children: Vec::new()` added to their literals; `widget_render_interaction.rs` also constructs a `PanelConfig` and got the same mechanical field add).
- `widget_compositing.rs` literals gain `kind: WidgetKind::Composite`.
- New spec-driven scenario `panel_stacks_declared_children_in_order`: an explicit non-default children list, asserting declared order drives spawn order and focus order — the defect class the default-stack tests can't see.

## Generated by

`/implement` — agent execution of [scoped issue #2681](https://github.com/iamacoffeepot/aether/issues/2681).
