### PR TITLE
feat(capabilities): raise the vertex buffer cap to 64 MiB and make it a boot knob

### DIFF
--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -148,7 +148,7 @@ pub use render::HeadlessRenderCapability;
 #[cfg(feature = "render")]
 pub use render::RenderCapability;
 #[cfg(feature = "render-runtime")]
-pub use render::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles};
+pub use render::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles, RenderTuningConfig};
 pub use tcp::{TcpCapability, TcpListenerActor};
 pub use test_bench::UnsupportedTestBenchCapability;
 #[cfg(feature = "text")]

--- a/crates/aether-capabilities/src/render/mod.rs
+++ b/crates/aether-capabilities/src/render/mod.rs
@@ -67,7 +67,10 @@ use aether_kinds::CaptureFrame;
 // see only the identity ZST + Actor / HandlesKind impls, not these heavy
 // GPU-bound types.
 #[cfg(feature = "render-runtime")]
-pub use runtime::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles};
+pub use runtime::{
+    CaptureBackend, RenderConfig, RenderGpu, RenderHandles, RenderTuningConfig,
+    RenderTuningConfigLayer, RenderTuningOverlay,
+};
 
 // `#[actor]` sits on each capability struct (the struct-hosted ADR-0123
 // form): it reads the cap's sibling runtime module off disk and emits the

--- a/crates/aether-capabilities/src/render/runtime/config.rs
+++ b/crates/aether-capabilities/src/render/runtime/config.rs
@@ -5,10 +5,32 @@ use aether_substrate::render::VERTEX_BUFFER_BYTES;
 
 use super::capture::CaptureBackend;
 
+/// Boot knobs for `RenderCapability` (ADR-0090). The
+/// `#[derive(aether_substrate::Config)]` emits the env-shaped
+/// `RenderTuningConfigLayer`, the clap-shaped `RenderTuningOverlay`,
+/// the `FromArgvThenEnv` impl, and the inherent `from_env` /
+/// `from_argv_then_env` shims — mirrors `AudioConfig`. The chassis
+/// main resolves it and threads the value into the hand-built
+/// [`RenderConfig`], which also carries non-knob wiring (capture
+/// backend, test observability) and so can't ride the derive itself.
+#[derive(Clone, Debug, aether_substrate::Config)]
+#[config(env_prefix = "AETHER_RENDER", cli_prefix = "render")]
+pub struct RenderTuningConfig {
+    /// `AETHER_RENDER_VERTEX_BUFFER_BYTES=<bytes>` per-frame vertex
+    /// buffer cap: the size the GPU vertex buffer is created with and
+    /// the byte count the render accumulator truncates to (with a
+    /// warn) when a frame's triangles exceed it. Default
+    /// [`VERTEX_BUFFER_BYTES`] (64 MiB, ~932k triangles at 72 bytes
+    /// each).
+    #[config(default = 67_108_864)]
+    pub vertex_buffer_bytes: usize,
+}
+
 /// Configuration for `RenderCapability`. `vertex_buffer_bytes` is
 /// the maximum bytes the render accumulator will hold before
-/// truncating with a warn — desktop and test-bench both pass
-/// [`VERTEX_BUFFER_BYTES`].
+/// truncating with a warn, and the size the GPU vertex buffer is
+/// created with — default [`VERTEX_BUFFER_BYTES`]; the chassis main
+/// overrides it from the resolved [`RenderTuningConfig`] knob.
 ///
 /// `observed_kinds`, when set, has every successfully-dispatched
 /// inbound mail's kind name pushed to it from the cap's `#[handler]`

--- a/crates/aether-capabilities/src/render/runtime/mod.rs
+++ b/crates/aether-capabilities/src/render/runtime/mod.rs
@@ -37,10 +37,14 @@ mod pipeline;
 mod quad;
 mod texture;
 
-// The cap-root re-exports source these four names through `runtime`: `pub use
-// runtime::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles};`.
+// The cap-root re-exports source these names through `runtime`: `pub use
+// runtime::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles, …};`.
+// The `RenderTuning*` trio is the derive-Config surface (ADR-0090) the
+// chassis resolves the render boot knobs through.
 pub use self::capture::CaptureBackend;
-pub use self::config::RenderConfig;
+pub use self::config::{
+    RenderConfig, RenderTuningConfig, RenderTuningConfigLayer, RenderTuningOverlay,
+};
 pub use self::pipeline::{RenderGpu, RenderHandles};
 
 // The moved `#[runtime] impl NativeActor for RenderCapability` body names the
@@ -136,6 +140,7 @@ impl NativeActor for RenderCapability {
             quad_last_submitted: Arc::new(Mutex::new(Vec::new())),
             textures: Arc::new(Mutex::new(TextureRegistry::new())),
             gpu: Arc::new(OnceLock::new()),
+            vertex_buffer_bytes: config.vertex_buffer_bytes,
         };
         let mailer = ctx.mailer();
         let registry = Arc::clone(mailer.registry());

--- a/crates/aether-capabilities/src/render/runtime/pipeline.rs
+++ b/crates/aether-capabilities/src/render/runtime/pipeline.rs
@@ -75,6 +75,11 @@ pub struct RenderHandles {
     /// called before install — in practice every code path that
     /// calls them runs after the install site.
     pub gpu: Arc<OnceLock<RenderGpu>>,
+    /// Resolved per-frame vertex buffer cap (`RenderConfig::
+    /// vertex_buffer_bytes`), carried here so the driver sizes the GPU
+    /// vertex buffer ([`RenderGpu::new`]) to the same value the cap's
+    /// accumulator truncates at.
+    pub vertex_buffer_bytes: usize,
 }
 
 /// Commit a frame's live accumulator into its cache, the shared
@@ -517,7 +522,10 @@ impl RenderGpu {
     /// `polygon_mode` is `Fill` for the normal case; desktop's
     /// `AETHER_WIREFRAME=line` chassis env passes `Line` so the main
     /// pipeline draws as wireframe instead of building a separate
-    /// overlay pipeline.
+    /// overlay pipeline. `vertex_buffer_bytes` sizes the per-frame GPU
+    /// vertex buffer — drivers pass
+    /// [`RenderHandles::vertex_buffer_bytes`] so the buffer matches the
+    /// cap accumulator's resolved truncation cap.
     #[must_use]
     pub fn new(
         device: Arc<wgpu::Device>,
@@ -526,8 +534,15 @@ impl RenderGpu {
         width: u32,
         height: u32,
         polygon_mode: wgpu::PolygonMode,
+        vertex_buffer_bytes: usize,
     ) -> Self {
-        let pipeline = build_main_pipeline(&device, &queue, color_format, polygon_mode);
+        let pipeline = build_main_pipeline(
+            &device,
+            &queue,
+            color_format,
+            polygon_mode,
+            vertex_buffer_bytes,
+        );
         let quad_pipeline = build_quad_pipeline(&device, color_format);
         let targets = Targets::new(&device, color_format, width, height);
         Self {

--- a/crates/aether-kit/tests/partition_probe.rs
+++ b/crates/aether-kit/tests/partition_probe.rs
@@ -114,10 +114,10 @@ fn demo_world_ground_has_no_holes() {
 
 #[test]
 fn demo_world_fits_the_frame_vertex_budget() {
-    // The desktop render capability accepts 4 MiB of vertices per frame
-    // (~58k triangles at 24-byte vertices) and warn-drops the excess —
-    // the failure mode that motivated window ownership and strip merging.
-    // The four-chunk lake scene must sit comfortably inside it.
+    // The desktop render capability accepts 64 MiB of vertices per frame
+    // by default (~932k triangles at 24-byte vertices) and warn-drops the
+    // excess — the failure mode that motivated window ownership and strip
+    // merging. The four-chunk lake scene must sit comfortably inside it.
     let world = lake_world();
     let styles = StyleTable::default();
     let total: usize = (0..4)

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -25,6 +25,7 @@ use aether_capabilities::gemini::{GeminiBoot, GeminiConfigLayer};
 use aether_capabilities::http::HttpConfigLayer;
 use aether_capabilities::http::HttpServerConfigLayer;
 use aether_capabilities::lifecycle::LifecycleGraphData;
+use aether_capabilities::render::RenderTuningConfigLayer;
 use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
 use aether_capabilities::{
     AnthropicCapability, AnthropicConfig, ComponentHostCapability, ComponentHostConfig,
@@ -390,7 +391,8 @@ impl ChassisBootConfig {
 
 /// Assemble the chassis-wide [`KnownKeys`] set (ADR-0090 §4): every
 /// migrated `*Layer::META` (http / gemini / anthropic / audio / fs /
-/// actor-ring / scheduler-tuning / chassis-boot / window / tick) plus
+/// render / actor-ring / scheduler-tuning / chassis-boot / window /
+/// tick) plus
 /// the hand-registered chassis knobs ([`CHASSIS_KNOBS`] — the RPC port
 /// and the orphaned frame-size knob) and the runtime log-filter /
 /// panic-hook knobs (`aether_substrate::runtime::RUNTIME_KNOBS`). e1's
@@ -423,6 +425,7 @@ fn chassis_registry() -> (&'static [&'static Meta], Vec<KnobRecord>) {
         &AnthropicConfigLayer::META,
         &AudioConfigLayer::META,
         &NamespaceRootsLayer::META,
+        &RenderTuningConfigLayer::META,
         &ActorRingConfigLayer::META,
         &SchedulerTuningConfigLayer::META,
         &SettlementConfigLayer::META,

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -24,8 +24,8 @@ use aether_capabilities::rpc::RpcServerCapability;
 use aether_capabilities::{
     AnthropicConfig, AudioCapability, CaptureBackend, ComponentHostConfig, ContentGenConfig,
     GeminiConfig, HttpServerConfig, InputConfig, RenderCapability, RenderConfig,
-    UnsupportedTestBenchCapability, audio::AudioConfig as AudioConf, fs::NamespaceRoots,
-    http::HttpConfig as HttpConf,
+    RenderTuningConfig, UnsupportedTestBenchCapability, audio::AudioConfig as AudioConf,
+    fs::NamespaceRoots, http::HttpConfig as HttpConf,
 };
 use aether_kinds::BinaryManifest;
 use aether_kinds::WindowMode;
@@ -214,6 +214,10 @@ pub struct DesktopEnv {
     /// `AETHER_LOCAL_STICKY_MAX` / …). Default is
     /// [`SchedulerTuning::default`] (the built-in scheduler literals).
     pub scheduler_tuning: SchedulerTuning,
+    /// Issue 2706: render boot knobs resolved from the
+    /// `RenderTuningConfig` knob (`AETHER_RENDER_VERTEX_BUFFER_BYTES`).
+    /// Threaded into the render cap's `RenderConfig` in `build_inner`.
+    pub render_tuning: RenderTuningConfig,
     /// Force-complete deadline (ms) for a pending lifecycle advance's
     /// `Settled` (issue 1048). Resolved from
     /// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS` via `ChassisBootConfig`;
@@ -335,6 +339,10 @@ impl DesktopEnv {
         // `AETHER_*_COST_*` (ADR-0090 §4 hard-error on an unparseable
         // known value, surfaced as `DesktopBootError::Config`).
         let scheduler_tuning = SchedulerTuningConfig::try_from_env()?.to_scheduler_tuning();
+        // Issue 2706: resolve the render boot knobs
+        // (`AETHER_RENDER_VERTEX_BUFFER_BYTES`; ADR-0090 §4 hard-error
+        // on an unparseable known value).
+        let render_tuning = RenderTuningConfig::try_from_env()?;
 
         Ok(Self {
             event_loop,
@@ -354,6 +362,7 @@ impl DesktopEnv {
             workers,
             ring_caps,
             scheduler_tuning,
+            render_tuning,
             lifecycle_advance_timeout_millis,
             autoload,
         })
@@ -388,6 +397,7 @@ impl DesktopChassis {
             workers,
             ring_caps,
             scheduler_tuning,
+            render_tuning,
             lifecycle_advance_timeout_millis,
             autoload,
         } = env;
@@ -406,6 +416,10 @@ impl DesktopChassis {
         // so `RedrawRequested` picks it up on the next frame.
         let proxy_for_render = event_loop.create_proxy();
         let render_config = RenderConfig {
+            // Issue 2706: the resolved vertex-buffer cap sizes both the
+            // cap accumulator's truncation and (via `RenderHandles`)
+            // the GPU vertex buffer the driver creates.
+            vertex_buffer_bytes: render_tuning.vertex_buffer_bytes,
             capture_backend: Some(CaptureBackend {
                 queue: capture_queue.clone(),
                 wake: Arc::new(move || {

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -237,6 +237,7 @@ impl Gpu {
             config.width,
             config.height,
             polygon_mode,
+            render_handles.vertex_buffer_bytes,
         ));
 
         // Wireframe overlay pipeline: same vertex/uniform layout, but

--- a/crates/aether-substrate-bundle/src/test_bench/render.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/render.rs
@@ -81,6 +81,7 @@ impl Gpu {
             width,
             height,
             wgpu::PolygonMode::Fill,
+            render_handles.vertex_buffer_bytes,
         ));
 
         Self {

--- a/crates/aether-substrate/src/render/mod.rs
+++ b/crates/aether-substrate/src/render/mod.rs
@@ -38,11 +38,15 @@ pub use targets::Targets;
 /// shader reads `position` from offset 0 and `color` from offset 12.
 pub const VERTEX_STRIDE: u64 = 24;
 
-/// Maximum size of the per-frame vertex buffer. Render sinks truncate
-/// to this cap before forwarding bytes; if a future caller bypasses
-/// the sink-side clamp, `record_main_pass` drops the frame with a
-/// warn rather than overflow the GPU buffer.
-pub const VERTEX_BUFFER_BYTES: usize = 4 * 1024 * 1024;
+/// Default maximum size of the per-frame vertex buffer: 64 MiB
+/// (~2.8M vertices at [`VERTEX_STRIDE`]). The render capability's
+/// `vertex_buffer_bytes` boot knob (`AETHER_RENDER_VERTEX_BUFFER_BYTES`,
+/// ADR-0090) overrides it per chassis; [`build_main_pipeline`] sizes
+/// the GPU buffer from the resolved value. Render sinks truncate to
+/// the resolved cap before forwarding bytes; if a future caller
+/// bypasses the sink-side clamp, `record_main_pass` drops the frame
+/// with a warn rather than overflow the GPU buffer.
+pub const VERTEX_BUFFER_BYTES: usize = 64 * 1024 * 1024;
 
 /// Camera uniform buffer size: a single 4×4 column-major `f32` view-
 /// projection matrix. The vertex shader applies `camera.view_proj *

--- a/crates/aether-substrate/src/render/pipeline.rs
+++ b/crates/aether-substrate/src/render/pipeline.rs
@@ -10,8 +10,8 @@
 
 use super::targets::Targets;
 use super::{
-    CAMERA_UNIFORM_BYTES, DEPTH_FORMAT, IDENTITY_VIEW_PROJ, MAIN_SHADER_WGSL, VERTEX_BUFFER_BYTES,
-    VERTEX_STRIDE, vertex_buffer_layout,
+    CAMERA_UNIFORM_BYTES, DEPTH_FORMAT, IDENTITY_VIEW_PROJ, MAIN_SHADER_WGSL, VERTEX_STRIDE,
+    vertex_buffer_layout,
 };
 use std::slice;
 
@@ -20,8 +20,9 @@ use std::slice;
 /// so callers can decide whether to log + continue or escalate.
 #[derive(Debug)]
 pub enum RenderError {
-    /// Frame's vertex bytes exceed [`VERTEX_BUFFER_BYTES`]. The
-    /// pass is skipped — no draw, no encoder writes. Render sinks
+    /// Frame's vertex bytes exceed the size the vertex buffer was
+    /// created with ([`build_main_pipeline`]'s `vertex_buffer_bytes`).
+    /// The pass is skipped — no draw, no encoder writes. Render sinks
     /// already truncate before forwarding, so this is a belt-and-
     /// suspenders check; if a future caller bypasses the sink-side
     /// clamp this surfaces here instead of overflowing the GPU buffer.
@@ -55,12 +56,17 @@ pub struct Pipeline {
 /// the [`Targets`] colour target the pass attaches to. `polygon_mode`
 /// controls fill vs line at construction — desktop sets `Line` when
 /// `AETHER_WIREFRAME=line`; everything else passes `Fill`.
+/// `vertex_buffer_bytes` sizes the fixed per-frame vertex buffer —
+/// the render capability's resolved config value
+/// ([`super::VERTEX_BUFFER_BYTES`] unless the boot knob overrides it);
+/// `record_main_pass` clamps against the created size.
 #[must_use]
 pub fn build_main_pipeline(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
     color_format: wgpu::TextureFormat,
     polygon_mode: wgpu::PolygonMode,
+    vertex_buffer_bytes: usize,
 ) -> Pipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("aether main shader"),
@@ -148,7 +154,7 @@ pub fn build_main_pipeline(
 
     let vertex_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("aether vertex buffer"),
-        size: VERTEX_BUFFER_BYTES as u64,
+        size: vertex_buffer_bytes as u64,
         usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });
@@ -173,10 +179,10 @@ pub fn build_main_pipeline(
 /// here when `AETHER_WIREFRAME=overlay`; test-bench passes `&[]`.
 ///
 /// Returns `Err(RenderError::VertexBufferOverflow)` if the frame's
-/// bytes exceed [`VERTEX_BUFFER_BYTES`] — the pass is skipped, no
-/// encoder writes happen, the caller decides whether to log and
-/// continue (skipping submit) or short-circuit. Empty `vertices` is
-/// fine: the clear still runs, no draw is issued.
+/// bytes exceed the size the vertex buffer was created with — the
+/// pass is skipped, no encoder writes happen, the caller decides
+/// whether to log and continue (skipping submit) or short-circuit.
+/// Empty `vertices` is fine: the clear still runs, no draw is issued.
 pub fn record_main_pass(
     queue: &wgpu::Queue,
     encoder: &mut wgpu::CommandEncoder,
@@ -187,24 +193,31 @@ pub fn record_main_pass(
     extra_pipelines: &[&wgpu::RenderPipeline],
 ) -> Result<(), RenderError> {
     let vertex_bytes = vertices.len();
-    if vertex_bytes > VERTEX_BUFFER_BYTES {
+    // Clamp against the buffer's created size, so the check tracks
+    // whatever `vertex_buffer_bytes` the boot knob resolved to.
+    let buffer_bytes = pipeline.vertex_buffer.size();
+    if vertex_bytes as u64 > buffer_bytes {
         tracing::warn!(
             target: "aether_substrate::render",
             vertex_bytes,
-            cap = VERTEX_BUFFER_BYTES,
+            cap = buffer_bytes,
             "dropping frame: vertex bytes exceed fixed buffer",
         );
+        // The buffer was created from a `usize`, so its size
+        // round-trips losslessly.
+        #[allow(clippy::cast_possible_truncation)]
         return Err(RenderError::VertexBufferOverflow {
             vertex_bytes,
-            cap: VERTEX_BUFFER_BYTES,
+            cap: buffer_bytes as usize,
         });
     }
     if !vertices.is_empty() {
         queue.write_buffer(&pipeline.vertex_buffer, 0, vertices);
     }
     queue.write_buffer(&pipeline.camera_buffer, 0, bytemuck::cast_slice(view_proj));
-    // `wgpu::RenderPass::draw` takes a `u32` vertex count; vertex
-    // buffer is bounded by `MAX_VERTEX_BYTES` (well below `u32::MAX`).
+    // `wgpu::RenderPass::draw` takes a `u32` vertex count; overflowing
+    // it would take a >100 GB vertex buffer, far beyond any
+    // configurable cap in practice.
     #[allow(clippy::cast_possible_truncation)]
     let vertex_count = (vertex_bytes as u64 / VERTEX_STRIDE) as u32;
 


### PR DESCRIPTION
Closes #2706.

## Summary

The per-frame vertex buffer cap was a compile-time 4 MiB constant (~58k triangles at 72 bytes each); overflow truncates, silently dropping late geometry — skirts and whole chunks in the world demos. Point-authored worlds need ~8–12 MiB per frame and finer-grid experiments 30–50 MiB, while the buffer itself is GPU-trivial: the user approved 64 MiB with a knob.

- `VERTEX_BUFFER_BYTES` default raised 4 → 64 MiB; doc states the default and names the knob.
- `vertex_buffer_bytes` becomes a real boot knob on the ADR-0090 derive-`Config` path (`RenderTuningConfig`, env `AETHER_RENDER_VERTEX_BUFFER_BYTES`), registered in the chassis config registry, resolved by the desktop chassis and threaded so the wgpu buffer allocation, the accumulator truncation clamp, and the record-time clamp all read the one resolved value (the record-time clamp now tracks the created buffer size rather than the const).
- Truncate-and-warn overflow semantics unchanged.

## Test plan

No new tests: the derive's resolution is covered by its own machinery, and the clamp logic is unchanged — a default-equals-const assert would be a constant mirror. Verified live end-to-end: `--config` shows default `67108864`, and the env override shows `134217728 env`. Scoped clippy (including `render-runtime` features), nextest (657 passed), and strict rustdoc all clean; the one bare-`cargo doc` intra-doc warning in `window/mod.rs` is pre-existing on `main`.

## Generated by

`/implement` — agent execution of [scoped issue #2706](https://github.com/iamacoffeepot/aether/issues/2706).
