### PR TITLE
feat(behavior): behavior host actor embedding wasmi, attachable to any wasm actor's children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,8 +66,13 @@ dependencies = [
 name = "aether-behavior"
 version = "0.3.0-alpha"
 dependencies = [
+ "aether-actor",
+ "aether-capabilities",
  "aether-data",
  "serde",
+ "tracing",
+ "wasmi",
+ "wat",
 ]
 
 [[package]]
@@ -192,6 +197,7 @@ name = "aether-kit"
 version = "0.3.0-alpha"
 dependencies = [
  "aether-actor",
+ "aether-behavior",
  "aether-capabilities",
  "aether-data",
  "aether-kinds",
@@ -4014,6 +4020,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spirv"
 version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4773,6 +4785,52 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2300d0f78cba12f14e29e8dd157ea64050c0a688179aefdb2050105805594a0c"
+dependencies = [
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a8c42a2a76148d43097b1d7cc2a5bf33d5c23bd4dd69015fc887e311767884"
+
+[[package]]
+name = "wasmi_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9013136083d988725953390bf668b64b7a218fabf26f8b913bbc59546b97ee27"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1fa003f79156f406d62ef0e1464dc03e11ace37170e9fa7524299a75ad8f68"
+dependencies = [
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -238,6 +238,28 @@ impl Mail<'_> {
         let bytes = unsafe { slice::from_raw_parts(self.ptr as *const u8, self.byte_len as usize) };
         K::decode_from_bytes(bytes)
     }
+
+    /// The raw inbound payload — the `byte_len` bytes the substrate wrote at
+    /// `ptr` for this delivery. The type-erased counterpart of
+    /// [`Self::decode_kind`], for a mail-forwarding interposer (the ADR-0137
+    /// behavior host, issue 2687) that reroutes an arbitrary inbound kind it
+    /// holds no Rust type for, pairing with
+    /// [`RelativeMailbox::send_bytes`](crate::RelativeMailbox::send_bytes). A
+    /// zero length short-circuits to an empty slice so a null pointer is never
+    /// dereferenced.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        if self.byte_len == 0 {
+            &[]
+        } else {
+            // SAFETY: `self.ptr` / `self.byte_len` originate from the
+            // substrate's receive ABI, which guarantees `self.byte_len` bytes
+            // valid at `self.ptr` for this `Mail`'s lifetime — the same
+            // invariant `decode_kind` relies on. The `len == 0` branch avoids
+            // forming a slice over a possibly-null pointer.
+            unsafe { slice::from_raw_parts(self.ptr as *const u8, self.byte_len as usize) }
+        }
+    }
 }
 
 /// Opaque view of a prior state bundle handed to `on_rehydrate` by

--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -135,6 +135,18 @@ impl RelativeMailbox<'_> {
         );
     }
 
+    /// Forward pre-encoded `bytes` of kind `kind` to this relative — the
+    /// type-erased counterpart of [`Self::send`], for a mail-forwarding
+    /// interposer (the ADR-0137 behavior host, issue 2687) that reroutes an
+    /// arbitrary inbound kind it holds no Rust type for. Routes the same way
+    /// [`Self::send`] does — in place through the cluster membrane, inheriting
+    /// the handler's causal chain — so the interposer stays transparent to
+    /// settlement. `count` is fixed at 1: a forward carries one inbound mail.
+    pub fn send_bytes(&self, kind: aether_data::KindId, bytes: &[u8]) {
+        self.inline
+            .route_or_enqueue(self.id.0, kind.0, bytes, 1, ChainMode::Inherit, self.sender);
+    }
+
     /// Fire-and-forget send to this relative (ADR-0080 §7 detach signal).
     /// In-cluster the recipient dispatches in place regardless; the detach
     /// flag rides through only on the cross-cluster fallback path, which a
@@ -332,6 +344,20 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
     #[must_use]
     pub fn reply_target(&self) -> Option<ReplyHandle> {
         self.sender
+    }
+
+    /// The inbound source — the folded [`MailboxId`] of whoever sent the
+    /// mail currently being dispatched, or `None` for a sourceless dispatch
+    /// (session / remote-engine / broadcast mail, or a lifecycle hook with
+    /// no inbound). Reads the same `source` field as
+    /// [`OutboundReply::source_mailbox`], but on the generic ctx so a
+    /// `#[fallback]` (which runs on the downgraded [`Single`] view, issue
+    /// 2687) can resolve a cluster-membrane interposer's lane direction —
+    /// compare the source against a stored child id: equal ⇒ up-lane, else
+    /// ⇒ down-lane.
+    #[must_use]
+    pub fn source_mailbox(&self) -> Option<MailboxId> {
+        (self.source != MailboxId::NONE.0).then_some(MailboxId(self.source))
     }
 
     /// The component's own mailbox id — the value the substrate uses to
@@ -845,14 +871,11 @@ impl OutboundReply for WasmCtx<'_, Manual> {
     }
 
     fn source_mailbox(&self) -> Option<MailboxId> {
-        // Issue 2001: the inbound source rides the ctx's `source` field on
-        // every dispatch — the in-place drain threads it (a drained item has
-        // no reply handle, since the local fast path is fire-and-forget), and
-        // the top-level `receive_p32` membrane threads the host-resolved source
-        // the same ABI slot delivers (issue 1987 completed the top-level half).
-        // So this is a single field read on both paths; `MailboxId::NONE` (0)
-        // means no peer-component origin (session / engine / broadcast mail).
-        (self.source != MailboxId::NONE.0).then_some(MailboxId(self.source))
+        // Issue 2687: delegate to the inherent generic accessor (the single
+        // source of truth), which the `Single` `#[fallback]` ctx also reads.
+        // The fully-qualified path resolves the inherent method, not this
+        // trait method, so there is no recursion.
+        WasmCtx::source_mailbox(self)
     }
 
     fn reply<K: Kind>(&mut self, payload: &K) {
@@ -1108,7 +1131,6 @@ mod tests {
     use crate::Addressable;
     use crate::mail::{Mail, PriorState};
     use crate::model::Subname;
-    use crate::model::ctx::OutboundReply;
     use crate::wasm::inline::RouteDecision;
     use crate::wasm::inline::compose::spawn_one_child;
     use crate::wasm::{ActorInitError, ErasedWasmActor, WasmActor, WasmDropCtx, WasmInitCtx};

--- a/crates/aether-actor/src/wasm/inline/mod.rs
+++ b/crates/aether-actor/src/wasm/inline/mod.rs
@@ -673,7 +673,6 @@ mod tests {
     use super::{ChainMode, Registry, RouteDecision, drain_cluster_queue, membrane_dispatch};
     use crate::WasmCtx;
     use crate::mail::{Mail, PriorState};
-    use crate::model::ctx::OutboundReply;
     use crate::wasm::ErasedWasmActor;
     use aether_data::MailboxId;
     use alloc::boxed::Box;

--- a/crates/aether-behavior/Cargo.toml
+++ b/crates/aether-behavior/Cargo.toml
@@ -7,22 +7,53 @@ license.workspace = true
 # Script-side SDK for behavior scripts (ADR-0137). One crate with two
 # faces: the always-compiled trunk holds the host<->script envelope, the
 # packed-pointer ABI, the exports-manifest decoder, and the reserved
-# lifecycle sentinels — a later issue's host consumes exactly this trunk
-# with `default-features = false`. The `runtime` feature (on by default,
-# so a bare wasm32 build produces the full guest surface) adds the
-# authoring SDK: `BehaviorCtx`, the widget/child/panel handles, the
-# decode-once mirror, the effect accumulator, and the `Behavior`
-# lifecycle trait. The crate depends on `aether-data` and `serde` only —
-# never `aether-actor`, never `wasmi` — which is what keeps a behavior
-# cdylib from classifying as a component (structural discovery keys on an
-# `aether-actor` dependency) and keeps the tier boundary legible.
+# lifecycle sentinels. The `runtime` feature (on by default, so a bare
+# wasm32 build produces the full guest surface) adds the authoring SDK:
+# `BehaviorCtx`, the widget/child/panel handles, the decode-once mirror,
+# the effect accumulator, and the `Behavior` lifecycle trait. The default
+# face depends on `aether-data` and `serde` only — never `aether-actor`,
+# never `wasmi` — which is what keeps a behavior cdylib from classifying
+# as a component (structural discovery keys on an `aether-actor`
+# dependency) and keeps the tier boundary legible.
+#
+# The non-default `host` feature is the third face (ADR-0137, issue
+# 2687): the `BehaviorHost` actor that embeds a `wasmi` interpreter and
+# interposes at a tree slot. It turns on the optional `aether-actor` /
+# `wasmi` / `aether-capabilities` deps, none of which the default face
+# names, so a script build never links them. Host-enabled wasm is
+# compiled in a separate cargo invocation from script wasm (issue 2688),
+# so `host` never feature-unifies into a script's build graph.
 [features]
 default = ["runtime"]
 runtime = []
+# ADR-0137 / issue 2687: the in-cluster behavior script host. Pulls the
+# actor SDK (the host is a wasm `#[actor]`), the `wasmi` interpreter it
+# embeds (no_std, built-in fuel metering), the capability crate for the
+# `aether.fs` surface the host fetches scripts through, and `tracing` for
+# the fail-open trap logs.
+host = ["dep:aether-actor", "dep:wasmi", "dep:aether-capabilities", "dep:tracing"]
 
 [dependencies]
 aether-data = { path = "../aether-data", default-features = false, features = ["derive"] }
 serde = { workspace = true, default-features = false, features = ["alloc", "derive"] }
+
+# `host`-only optional deps. `dep:`-gated so the default face's dependency
+# tree names none of them (the crate-boundary tripwire: `cargo tree -p
+# aether-behavior` shows neither `wasmi` nor `aether-actor`; `-F host`
+# shows both).
+aether-actor = { path = "../aether-actor", optional = true }
+# The capability crate carries the `aether.fs.{read,read_result}` kinds +
+# `FsCapability` the host fetches an `FsRef` script through. Marker layer
+# only (`default-features = false`) — no substrate runtime.
+aether-capabilities = { path = "../aether-capabilities", default-features = false, optional = true }
+wasmi = { version = "1.1", default-features = false, optional = true }
+tracing = { workspace = true, default-features = false, optional = true }
+
+[dev-dependencies]
+# Hand-built minimal wasm for the host-side unit tests (trap / passthrough
+# / manifest fixtures). Behavior-script fixtures compiled from Rust are
+# #2688's; these are tiny WAT modules parsed inline, no build wiring.
+wat = "1"
 
 [lints]
 workspace = true

--- a/crates/aether-behavior/src/host/actor.rs
+++ b/crates/aether-behavior/src/host/actor.rs
@@ -1,0 +1,575 @@
+//! The `BehaviorHost` actor (ADR-0137, issue 2687).
+//!
+//! One non-generic wasm `#[actor]` that interposes at a tree slot: it spawns
+//! its wrapped child (by type tag, #2692) as its own inline child, and offers
+//! the down-lane and up-lane mail flowing through the slot to a fuel-metered
+//! `wasmi` filter call. Its own control vocabulary
+//! (`aether.behavior.{load_script,set_script}` + the `aether.fs.read_result`
+//! reply) are `#[handler]`s — consumed, never forwarded; all other mail is
+//! lane traffic the `#[fallback]` routes by direction, offers to the script
+//! when declared, and drains verdict-then-effects with echo suppression.
+//!
+//! The host is transparent to the causal chain (it forwards in place through
+//! the cluster membrane, inheriting the chain) and the script is invisible to
+//! settlement. A trap fails open — the in-flight mail forwards untransformed —
+//! and persistence defers the wrapped child's reconstruction to the composite
+//! reload walk (#2694), re-instantiating only the host's own script.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_actor::{
+    ActorInitError, ActorTypeTag, Mail, MailboxId, Manual, OutboundReply, PriorState, ReplyHandle,
+    SpawnError, Subname, WasmActor, WasmCtx, WasmDropCtx, WasmInitCtx, actor,
+};
+use aether_capabilities::FsCapability;
+use aether_capabilities::fs::{FsMailboxExt, ReadResult};
+use aether_data::KindId;
+use wasmi::Engine;
+
+use crate::envelope::EffectTarget;
+use crate::host::config::{HostConfig, LoadScript, LoadScriptResult, ScriptSource, SetScript};
+use crate::host::drain::{DrainEvent, DrainSink, EchoGuard, echo_kinds, run_drain};
+use crate::host::persist::{HOST_PERSIST_VERSION, HostPersist};
+use crate::host::slot::{FilterOutcome, ScriptSlot, build_engine};
+use crate::sentinel;
+
+/// The behavior host: a fixed interposer over one wrapped child.
+pub struct BehaviorHost {
+    config: HostConfig,
+    /// One `wasmi::Engine` per host, built at `init` with fuel metering on.
+    engine: Engine,
+    /// The running script, or `None` when the host runs wrapper-transparent
+    /// (no script yet, or a disabled/failed one replaced by nothing).
+    slot: Option<ScriptSlot>,
+    /// The wrapped child's alias id, recorded from the spawn `Ok` (or the
+    /// persisted bundle on reload). `None` ⇒ the host runs wrapper-less.
+    wrapped_child: Option<MailboxId>,
+    /// One-shot suppression of the up-lane echoes of the script's own writes.
+    echo: EchoGuard,
+    /// The current script source (may diverge from `config.script` after a
+    /// swap); persisted so a reload records where the script came from.
+    script_source: ScriptSource,
+    /// The parked reply target of an in-flight `load_script`, discharged when
+    /// its `aether.fs.read` settles.
+    pending_reply: Option<ReplyHandle>,
+    /// The `FsRef` source of an in-flight `load_script`, recorded onto
+    /// `script_source` when the load succeeds.
+    pending_source: Option<ScriptSource>,
+}
+
+/// The reference behavior host. Load it wrapped over a widget slot through the
+/// kit's declarative `WidgetKind::BehaviorHost` attachment (issue 2681 / 2692);
+/// the full live scripted-behavior e2e is #2688.
+#[actor(instanced)]
+impl WasmActor for BehaviorHost {
+    type Config = HostConfig;
+    const NAMESPACE: &'static str = "aether.behavior.host";
+
+    fn init(config: HostConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        let engine = build_engine();
+        // An inline / none script loads now (no mail surface needed); an
+        // `FsRef` defers to `wire`, where the fs fetch can be sent. A failed
+        // inline load boots wrapper-transparent (fail-open).
+        let slot = match &config.script {
+            ScriptSource::Inline(bytes) => try_instantiate(&engine, bytes, None, &config),
+            ScriptSource::FsRef { .. } | ScriptSource::None => None,
+        };
+        let script_source = config.script.clone();
+        Ok(BehaviorHost {
+            config,
+            engine,
+            slot,
+            wrapped_child: None,
+            echo: EchoGuard::default(),
+            script_source,
+            pending_reply: None,
+            pending_source: None,
+        })
+    }
+
+    /// Genuine first attach only (reload runs `init` + `on_rehydrate`, not
+    /// `wire`): spawn the wrapped child by tag, kick an `FsRef` boot fetch,
+    /// prime the widget with a re-emit request, and offer the ATTACH sentinel.
+    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+        match ctx.spawn_inline_child_by_tag(
+            ActorTypeTag(self.config.child.type_tag),
+            Subname::Named(&self.config.child.subname),
+            &self.config.child.config,
+        ) {
+            Ok(id) => self.wrapped_child = Some(id),
+            Err(SpawnError::UnknownActorTag(tag)) => {
+                tracing::warn!(
+                    target: "aether_behavior",
+                    type_tag = tag.0,
+                    subname = %self.config.child.subname,
+                    "wrapped child tag unknown to the module; running wrapper-less (fail-open)",
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "aether_behavior",
+                    subname = %self.config.child.subname,
+                    ?error,
+                    "wrapped child spawn failed; running wrapper-less (fail-open)",
+                );
+            }
+        }
+
+        if let ScriptSource::FsRef { namespace, path } = &self.script_source {
+            ctx.actor::<FsCapability>().read(namespace, path);
+        }
+
+        // Ask the wrapped widget to re-emit its observable kinds up-lane so the
+        // script's mirror is primed (the reply arrives as ordinary up-lane
+        // traffic through the fallback).
+        if let Some(child) = ctx.child(&self.config.child.subname) {
+            child.send_bytes(sentinel::REPORT, &[]);
+        }
+        self.offer_sentinel(&*ctx, sentinel::ATTACH);
+    }
+
+    /// Best-effort teardown: offer the DETACH sentinel as the host leaves.
+    fn unwire(&mut self, ctx: &mut WasmCtx<'_>) {
+        self.offer_sentinel(&*ctx, sentinel::DETACH);
+    }
+
+    /// Save the host bundle (script source + resident bytes + `state_save`
+    /// blob + wrapped-child id) into the host's own parent state. The wrapped
+    /// child persists itself through the composite walk (#2694).
+    fn on_dehydrate(&mut self, ctx: &mut WasmDropCtx<'_>) {
+        let script_bytes = self
+            .slot
+            .as_ref()
+            .map(|s| s.bytes().to_vec())
+            .unwrap_or_default();
+        let script_state = self
+            .slot
+            .as_mut()
+            .map_or_else(Vec::new, ScriptSlot::save_state);
+        let bundle = HostPersist {
+            script_source: self.script_source.clone(),
+            script_bytes,
+            script_state,
+            wrapped_child_id: self.wrapped_child.map_or(0, |id| id.0),
+        };
+        ctx.save_state(u32::from(HOST_PERSIST_VERSION), &bundle.encode());
+    }
+
+    /// Restore from the host bundle — re-instantiate the script from its
+    /// resident bytes (no fs re-fetch), offer the saved state to the fresh
+    /// script, and restore the wrapped-child id for the direction check. The
+    /// wrapped child is **not** re-spawned: the composite walk reconstructs it
+    /// from its own real config + runtime state (#2694), and the reload
+    /// `insert_child` carries no residency guard, so a host-side re-spawn would
+    /// double-spawn. The rehydrate body (the private `apply_rehydrate`) takes
+    /// no spawn surface, so the defer-to-the-walk invariant is enforced by the
+    /// signature, not just discipline.
+    fn on_rehydrate(&mut self, _ctx: &mut WasmCtx<'_>, prior: PriorState<'_>) {
+        self.apply_rehydrate(prior.bytes());
+    }
+
+    /// Load a script from an `aether.fs` namespace. Parks the requester's
+    /// reply target across the async read; `on_read_result` discharges it.
+    #[allow(clippy::needless_pass_by_value)]
+    #[handler::manual]
+    fn on_load_script(&mut self, ctx: &mut WasmCtx<'_, Manual>, msg: LoadScript) {
+        self.pending_reply = ctx.reply_target();
+        self.pending_source = Some(ScriptSource::FsRef {
+            namespace: msg.namespace.clone(),
+            path: msg.path.clone(),
+        });
+        ctx.actor::<FsCapability>().read(&msg.namespace, &msg.path);
+    }
+
+    /// The fs read reply for a `load_script` (or the boot `FsRef` fetch). Swaps
+    /// the script on `Ok`, keeps the prior on `Err`, and discharges the parked
+    /// `load_script_result` reply if one is pending.
+    #[handler::manual]
+    fn on_read_result(&mut self, ctx: &mut WasmCtx<'_, Manual>, reply: ReadResult) {
+        let result = match reply {
+            ReadResult::Ok { bytes, .. } => self.swap_script(&bytes),
+            ReadResult::Err { error, .. } => Err(alloc::format!("read failed: {error:?}")),
+        };
+        match &result {
+            Ok(_) => {
+                if let Some(source) = self.pending_source.take() {
+                    self.script_source = source;
+                }
+            }
+            Err(detail) => {
+                self.pending_source = None;
+                tracing::warn!(
+                    target: "aether_behavior",
+                    error = %detail,
+                    "load_script failed; keeping the prior running script",
+                );
+            }
+        }
+        if let Some(handle) = self.pending_reply.take() {
+            ctx.reply_to(handle, &load_result(result));
+        }
+    }
+
+    /// Swap the script for inline bytes — the synchronous counterpart of
+    /// `load_script`. The return value *is* the `load_script_result` reply.
+    #[handler::single]
+    fn on_set_script(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetScript) -> LoadScriptResult {
+        let result = self.swap_script(&msg.bytes);
+        if result.is_ok() {
+            self.script_source = ScriptSource::Inline(msg.bytes);
+        } else if let Err(detail) = &result {
+            tracing::warn!(
+                target: "aether_behavior",
+                error = %detail,
+                "set_script failed; keeping the prior running script",
+            );
+        }
+        load_result(result)
+    }
+
+    /// Lane traffic: everything that is not the host's own control vocabulary.
+    /// Resolve the direction against the wrapped-child id, skip the interpreter
+    /// for undeclared / suppressed kinds, and otherwise offer to the script and
+    /// drain the verdict then effects.
+    // The `#[fallback]` dispatch ABI hands `mail` by value; the read-only body
+    // does not consume it, but the signature is macro-fixed.
+    #[allow(clippy::needless_pass_by_value)]
+    #[fallback]
+    fn on_lane(&mut self, ctx: &mut WasmCtx<'_>, mail: Mail<'_>) {
+        let kind = mail.kind();
+        let is_up = self.lane_is_up(ctx.source_mailbox());
+        let bytes = mail.bytes();
+
+        // A configured down-lane frame trigger offers FRAME to the script
+        // before the trigger itself forwards onward.
+        if !is_up && self.config.frame_trigger_kind() == Some(kind) {
+            self.offer_sentinel(&*ctx, sentinel::FRAME);
+        }
+
+        // An up-lane echo of the script's own write forwards raw — never
+        // re-offered to the same script's filter.
+        if is_up && self.echo.take(kind) {
+            self.forward_raw(&*ctx, is_up, kind, bytes);
+            return;
+        }
+
+        let declared = self
+            .slot
+            .as_ref()
+            .is_some_and(|slot| !slot.is_disabled() && slot.handles(kind));
+        if !declared {
+            self.forward_raw(&*ctx, is_up, kind, bytes);
+            return;
+        }
+
+        if !self.run_filter_and_drain(&*ctx, is_up, Some(kind), kind, bytes) {
+            // Fail-open passthrough (trap / malformed output).
+            self.forward_raw(&*ctx, is_up, kind, bytes);
+        }
+    }
+}
+
+impl BehaviorHost {
+    /// Whether an inbound source is the wrapped child (up-lane); any other
+    /// source — the parent, or a sourceless dispatch — is down-lane.
+    fn lane_is_up(&self, source: Option<MailboxId>) -> bool {
+        matches!((source, self.wrapped_child), (Some(s), Some(w)) if s == w)
+    }
+
+    /// Compile + instantiate `bytes`, carrying the prior script's `state_save`
+    /// blob into the new script's `state_load`. Returns the resident byte count
+    /// on success; keeps the prior running slot on `Err`.
+    fn swap_script(&mut self, bytes: &[u8]) -> Result<u64, String> {
+        let prior_state = self.slot.as_mut().map(ScriptSlot::save_state);
+        let slot = ScriptSlot::instantiate(
+            &self.engine,
+            bytes,
+            prior_state.as_deref(),
+            self.config.fuel_per_call,
+            self.config.disable_after_traps,
+        )?;
+        let resident = slot.bytes().len() as u64;
+        self.slot = Some(slot);
+        Ok(resident)
+    }
+
+    /// The reload body, factored ctx-free so it structurally *cannot* spawn a
+    /// child (spawn needs a ctx) — the defer-to-the-walk invariant is enforced
+    /// by the signature, not just discipline. Decodes the bundle, restores the
+    /// script from resident bytes + the saved state, and restores the
+    /// wrapped-child id. An undecodable blob boots fresh with a warning.
+    fn apply_rehydrate(&mut self, prior_bytes: &[u8]) {
+        let Some(bundle) = HostPersist::decode(prior_bytes) else {
+            tracing::warn!(
+                target: "aether_behavior",
+                "host state blob did not decode; booting the script fresh (fail-open)",
+            );
+            return;
+        };
+        self.script_source = bundle.script_source;
+        self.wrapped_child =
+            (bundle.wrapped_child_id != 0).then_some(MailboxId(bundle.wrapped_child_id));
+        if !bundle.script_bytes.is_empty() {
+            match ScriptSlot::instantiate(
+                &self.engine,
+                &bundle.script_bytes,
+                Some(&bundle.script_state),
+                self.config.fuel_per_call,
+                self.config.disable_after_traps,
+            ) {
+                Ok(slot) => self.slot = Some(slot),
+                Err(detail) => tracing::warn!(
+                    target: "aether_behavior",
+                    error = %detail,
+                    "resident script failed to re-instantiate on reload; booting fresh",
+                ),
+            }
+        }
+    }
+
+    /// Offer a lifecycle sentinel to the script and drain its effects. A
+    /// sentinel carries no in-flight mail, so its verdict is ignored (only
+    /// effects drain). A no-op when there is no running script.
+    fn offer_sentinel(&mut self, ctx: &WasmCtx<'_>, sentinel: KindId) {
+        self.run_filter_and_drain(ctx, false, None, sentinel, &[]);
+    }
+
+    /// Offer `(offer_kind, bytes)` to the script and, on a well-formed output,
+    /// drain it: apply the verdict (forwarding on the `is_up` lane when
+    /// `forward_kind` is `Some`) then the effects in order, arming echo
+    /// suppression for the writes it emitted. Returns `true` when the script
+    /// produced an output (handled), `false` on passthrough / no script so the
+    /// caller forwards raw.
+    fn run_filter_and_drain(
+        &mut self,
+        ctx: &WasmCtx<'_>,
+        is_up: bool,
+        forward_kind: Option<KindId>,
+        offer_kind: KindId,
+        bytes: &[u8],
+    ) -> bool {
+        let Some(slot) = self.slot.as_mut() else {
+            return false;
+        };
+        let output = match slot.filter(offer_kind, bytes) {
+            FilterOutcome::Output(output) => output,
+            FilterOutcome::Passthrough => return false,
+        };
+        let echoes = echo_kinds(&output);
+        let subname = self.config.child.subname.clone();
+        let mut sink = LaneSink {
+            ctx,
+            wrapped_subname: &subname,
+            is_up,
+        };
+        run_drain(output, forward_kind, &mut sink);
+        self.echo.arm(echoes);
+        true
+    }
+
+    /// Forward the in-flight mail raw (no interpreter call) along its lane —
+    /// up to the parent, or down to the wrapped child.
+    fn forward_raw(&self, ctx: &WasmCtx<'_>, is_up: bool, kind: KindId, bytes: &[u8]) {
+        let relative = if is_up {
+            ctx.parent()
+        } else {
+            ctx.child(&self.config.child.subname)
+        };
+        if let Some(target) = relative {
+            target.send_bytes(kind, bytes);
+        } else {
+            tracing::warn!(
+                target: "aether_behavior",
+                kind = kind.0,
+                up = is_up,
+                "lane forward dropped: no resident relative on that lane",
+            );
+        }
+    }
+}
+
+/// Project a swap result into the wire `load_script_result` reply.
+fn load_result(result: Result<u64, String>) -> LoadScriptResult {
+    match result {
+        Ok(resident_bytes) => LoadScriptResult::Ok { resident_bytes },
+        Err(error) => LoadScriptResult::Err { error },
+    }
+}
+
+/// Instantiate `bytes` best-effort — `None` (with a warn) on failure, so a
+/// failed inline boot load runs wrapper-transparent rather than aborting.
+fn try_instantiate(
+    engine: &Engine,
+    bytes: &[u8],
+    prior_state: Option<&[u8]>,
+    config: &HostConfig,
+) -> Option<ScriptSlot> {
+    match ScriptSlot::instantiate(
+        engine,
+        bytes,
+        prior_state,
+        config.fuel_per_call,
+        config.disable_after_traps,
+    ) {
+        Ok(slot) => Some(slot),
+        Err(detail) => {
+            tracing::warn!(
+                target: "aether_behavior",
+                error = %detail,
+                "inline boot script failed to instantiate; running wrapper-transparent",
+            );
+            None
+        }
+    }
+}
+
+/// The ctx-backed drain sink: routes each drain event to a relative cluster
+/// handle. The in-flight forward follows the mail's lane; an effect follows its
+/// `EffectTarget` (Widget/Child down, Panel up).
+struct LaneSink<'c, 'a> {
+    ctx: &'c WasmCtx<'a>,
+    wrapped_subname: &'c str,
+    is_up: bool,
+}
+
+impl DrainSink for LaneSink<'_, '_> {
+    fn record(&mut self, event: DrainEvent) {
+        let (relative, kind_id, bytes) = match event {
+            DrainEvent::Forward { kind_id, bytes } => {
+                let relative = if self.is_up {
+                    self.ctx.parent()
+                } else {
+                    self.ctx.child(self.wrapped_subname)
+                };
+                (relative, kind_id, bytes)
+            }
+            DrainEvent::Effect {
+                target,
+                kind_id,
+                bytes,
+            } => {
+                let relative = match target {
+                    EffectTarget::Widget => self.ctx.child(self.wrapped_subname),
+                    EffectTarget::Child(path) => self.ctx.child(&path),
+                    EffectTarget::Panel => self.ctx.parent(),
+                };
+                (relative, kind_id, bytes)
+            }
+        };
+        if let Some(target) = relative {
+            target.send_bytes(KindId(kind_id), &bytes);
+        } else {
+            tracing::warn!(
+                target: "aether_behavior",
+                kind = kind_id,
+                "drain send dropped: no resident relative for that target",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::config::ChildSpec;
+    use crate::host::test_support::{fixed_output_wasm, forward_output};
+    use aether_actor::Lifecycle;
+    use alloc::string::ToString;
+    use alloc::vec::Vec;
+
+    fn config(script: ScriptSource) -> HostConfig {
+        HostConfig {
+            child: ChildSpec {
+                type_tag: 0xAAAA,
+                subname: "widget".to_string(),
+                config: Vec::new(),
+            },
+            script,
+            fuel_per_call: HostConfig::DEFAULT_FUEL_PER_CALL,
+            disable_after_traps: HostConfig::DEFAULT_DISABLE_AFTER_TRAPS,
+            frame_trigger: 0,
+        }
+    }
+
+    fn host(script: ScriptSource) -> BehaviorHost {
+        let mut init_ctx = WasmInitCtx::__new(0x10);
+        BehaviorHost::init(config(script), &mut init_ctx).expect("test setup: host inits")
+    }
+
+    // Tripwire: the fallback's lane direction — an inbound source equal to the
+    // wrapped child is up-lane; the parent, or a sourceless dispatch, is
+    // down-lane. A wrong direction would forward mail the opposite way.
+    #[test]
+    fn lane_direction_resolves_against_wrapped_child() {
+        let mut host = host(ScriptSource::None);
+        host.wrapped_child = Some(MailboxId(0xC0FFEE));
+        assert!(host.lane_is_up(Some(MailboxId(0xC0FFEE))));
+        assert!(!host.lane_is_up(Some(MailboxId(0xBEEF))));
+        assert!(!host.lane_is_up(None));
+        // With no wrapped child every source reads down-lane.
+        host.wrapped_child = None;
+        assert!(!host.lane_is_up(Some(MailboxId(0xC0FFEE))));
+    }
+
+    // Tripwire: a failed swap (bad bytes) keeps the prior running script and
+    // reports `Err` — the control path must never silence the widget by
+    // dropping a working script on a bad load.
+    #[test]
+    fn failed_swap_keeps_prior_script_and_reports_error() {
+        let kind = KindId(0x1234);
+        let good = fixed_output_wasm(kind, &forward_output(b"ok"));
+        let mut host = host(ScriptSource::Inline(good));
+        assert!(
+            host.slot.is_some(),
+            "the inline boot script should be resident"
+        );
+
+        let before = host.slot.as_ref().map(|s| s.bytes().to_vec());
+        let result = host.swap_script(b"not wasm");
+        assert!(result.is_err());
+        let after = host.slot.as_ref().map(|s| s.bytes().to_vec());
+        assert_eq!(before, after, "the prior script must survive a failed swap");
+    }
+
+    // Tripwire: `on_rehydrate`'s body restores the wrapped-child id + the
+    // script from resident bytes through a ctx-free path — so it structurally
+    // cannot re-spawn the wrapped child (spawn needs a ctx), the defer-to-the-
+    // walk invariant (#2694). A re-spawn would double-spawn against the
+    // unguarded reload insert.
+    #[test]
+    fn rehydrate_restores_without_spawning() {
+        let kind = KindId(0x5678);
+        let script = fixed_output_wasm(kind, &forward_output(b"resident"));
+        let bundle = HostPersist {
+            script_source: ScriptSource::Inline(script.clone()),
+            script_bytes: script,
+            script_state: Vec::new(),
+            wrapped_child_id: 0x1234_5678,
+        };
+
+        // A host that booted with no script and no wrapped child.
+        let mut host = host(ScriptSource::None);
+        assert!(host.slot.is_none());
+        assert!(host.wrapped_child.is_none());
+
+        host.apply_rehydrate(&bundle.encode());
+
+        assert_eq!(host.wrapped_child, Some(MailboxId(0x1234_5678)));
+        assert!(
+            host.slot.is_some(),
+            "the resident script re-instantiates on reload"
+        );
+        assert!(matches!(host.script_source, ScriptSource::Inline(_)));
+    }
+
+    // Tripwire: an undecodable state blob boots the script fresh (fail-open)
+    // rather than misreading it — the host keeps whatever `init` set.
+    #[test]
+    fn rehydrate_with_garbage_boots_fresh() {
+        let mut host = host(ScriptSource::None);
+        host.apply_rehydrate(b"garbage blob");
+        assert!(host.slot.is_none());
+        assert!(host.wrapped_child.is_none());
+    }
+}

--- a/crates/aether-behavior/src/host/config.rs
+++ b/crates/aether-behavior/src/host/config.rs
@@ -1,0 +1,132 @@
+//! The behavior host's boot config and control-mail vocabulary (ADR-0137,
+//! issue 2687).
+//!
+//! [`HostConfig`] rides the by-value `WasmActor::Config` path — the host is
+//! a wasm actor, so its config crosses the spawn boundary as encoded bytes
+//! and is handed to `init` by value (as `PanelConfig` is to the reference
+//! widget panel), never the ADR-0090 Resolver derive (unreachable without
+//! `aether-substrate`, which this crate's boundary forbids). Since #2694 the
+//! composite reload reconstructs a typed-config inline child from its *real*
+//! retained config bytes, so `HostConfig` carries no decode-from-empty
+//! requirement: the real config arrives once, on the first spawn from the
+//! #2681 child spec, and is retained in the slot for every later reload.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_data::{Kind, KindId, Schema};
+use serde::{Deserialize, Serialize};
+
+/// The wrapped child the host interposes on: the child actor's type tag
+/// (the `hash(NAMESPACE)` `u64` — `ActorTypeTag::of::<W>().0` on the kit
+/// side, the SDK-sanctioned hash), its subname, and its pre-encoded config
+/// bytes. Stored as a raw `u64` because [`ChildSpec`] is a `Schema`-derived
+/// config that wire-encodes and persists cleanly; the host wraps it as
+/// `ActorTypeTag(type_tag)` at the spawn call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Schema)]
+pub struct ChildSpec {
+    /// `hash(NAMESPACE)` of the wrapped actor type.
+    pub type_tag: u64,
+    /// The wrapped child's subname within the cluster.
+    pub subname: String,
+    /// The wrapped child's `Config` encoded to its wire shape (empty for a
+    /// `Config = ()` child).
+    pub config: Vec<u8>,
+}
+
+/// Where the host's script bytes come from at boot / on a swap.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Schema)]
+pub enum ScriptSource {
+    /// Boot wrapper-transparent — no script until a `load_script` /
+    /// `set_script` swaps one in.
+    None,
+    /// The script bytes inline (the kit's `set_script` path, or a config
+    /// that ships the wasm directly).
+    Inline(Vec<u8>),
+    /// Fetch the script from a substrate I/O namespace at boot
+    /// (`aether.fs.read`).
+    FsRef {
+        /// The `aether.fs` namespace prefix (`"save"`, `"assets"`, `"config"`).
+        namespace: String,
+        /// The path within the namespace.
+        path: String,
+    },
+}
+
+/// The behavior host's boot config (ADR-0137). Handed to `init` by value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Kind, Schema)]
+#[kind(name = "aether.behavior.host_config")]
+pub struct HostConfig {
+    /// The wrapped child the host spawns and interposes on.
+    pub child: ChildSpec,
+    /// The initial script source.
+    pub script: ScriptSource,
+    /// Fuel budget per filter call — reset before every call, so a script
+    /// that overruns it traps and fails open rather than wedging the host.
+    pub fuel_per_call: u64,
+    /// After this many consecutive traps the script is disabled (pure
+    /// passthrough) until the next `load_script` / `set_script`.
+    pub disable_after_traps: u32,
+    /// The kind id whose arrival down-lane the host maps onto the reserved
+    /// FRAME sentinel (the script's per-frame hook). `0` disables the frame
+    /// mapping. Configurable rather than hard-wired to a kit kind so the SDK
+    /// keeps no `aether-kit` dependency — the kit arm sets this to its own
+    /// `Collect` id.
+    pub frame_trigger: u64,
+}
+
+impl HostConfig {
+    /// Default fuel budget per filter call (~1M — generous for a small
+    /// intercept, bounded enough that a runaway loop traps promptly).
+    pub const DEFAULT_FUEL_PER_CALL: u64 = 1_000_000;
+
+    /// Default consecutive-trap threshold before the script is disabled.
+    pub const DEFAULT_DISABLE_AFTER_TRAPS: u32 = 3;
+
+    /// The configured frame-trigger kind, or `None` when the mapping is off.
+    #[must_use]
+    pub fn frame_trigger_kind(&self) -> Option<KindId> {
+        (self.frame_trigger != 0).then_some(KindId(self.frame_trigger))
+    }
+}
+
+/// `aether.behavior.load_script` — swap the running script for one fetched
+/// from an `aether.fs` namespace. Replies `LoadScriptResult` once the read
+/// settles (parked reply, ADR-0041 correlation by echoed namespace/path).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Kind, Schema)]
+#[kind(name = "aether.behavior.load_script")]
+pub struct LoadScript {
+    /// The `aether.fs` namespace prefix.
+    pub namespace: String,
+    /// The path within the namespace.
+    pub path: String,
+}
+
+/// `aether.behavior.set_script` — swap the running script for inline bytes.
+/// The synchronous counterpart of `LoadScript`; the reply *is* the handler's
+/// return value (`#[handler::single]`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Kind, Schema)]
+#[kind(name = "aether.behavior.set_script")]
+pub struct SetScript {
+    /// The replacement script's wasm bytes.
+    pub bytes: Vec<u8>,
+}
+
+/// Reply to `LoadScript` / `SetScript` — mirrors `aether.fs.read_result`'s
+/// Ok/Err shape. `Ok` reports the resident script's byte count; `Err`
+/// carries the failure text, and the prior running script is kept.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Kind, Schema)]
+#[kind(name = "aether.behavior.load_script_result")]
+pub enum LoadScriptResult {
+    /// The swap succeeded; `resident_bytes` is the new script's size.
+    Ok {
+        /// Byte length of the now-resident script.
+        resident_bytes: u64,
+    },
+    /// The swap failed (bad bytes, validation error, read error); the prior
+    /// script keeps running.
+    Err {
+        /// Human-readable failure detail.
+        error: String,
+    },
+}

--- a/crates/aether-behavior/src/host/drain.rs
+++ b/crates/aether-behavior/src/host/drain.rs
@@ -1,0 +1,257 @@
+//! Effect drain: verdict-then-effects, in recorded order, with echo
+//! suppression (ADR-0137, issue 2687).
+//!
+//! After a filter call the host applies the verdict to the in-flight mail
+//! first, then drains the effects in the order the script recorded them — so
+//! stacked hosts see each other's forwards and never each other's in-flight
+//! effects. The drain is expressed against a [`DrainSink`] so the ordering is
+//! exercisable with a recording sink in a host-side test while the real host
+//! routes each event to a relative cluster handle.
+//!
+//! **Echo suppression.** An effect the script sends down to its widget/child
+//! provokes an up-lane echo (the widget re-emitting the value it just took).
+//! The host records those kinds in an [`EchoGuard`] at drain time and, when
+//! the matching up-lane mail arrives, forwards it raw instead of re-offering
+//! it to the same script — so a script's own write does not loop back through
+//! its filter.
+
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+
+use aether_data::KindId;
+
+use crate::envelope::{EffectTarget, FilterOutput, Verdict};
+
+/// One ordered step of a drain, surfaced to a [`DrainSink`]. Owned so a
+/// recording sink can assert both the sequence and the payloads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DrainEvent {
+    /// The in-flight mail forwards along its lane, carrying `kind_id` and the
+    /// verdict bytes (re-encoded when a `&mut K` handler mutated it).
+    Forward {
+        /// The forwarded kind's id (the inbound kind — a mutation does not
+        /// change the kind).
+        kind_id: u64,
+        /// The forward payload.
+        bytes: Vec<u8>,
+    },
+    /// One drained effect, delivered to `target`.
+    Effect {
+        /// Where the effect is delivered.
+        target: EffectTarget,
+        /// The effect kind's id.
+        kind_id: u64,
+        /// The effect kind's encoded payload.
+        bytes: Vec<u8>,
+    },
+}
+
+/// The sink a drain writes its ordered events into. The real host implements
+/// it over the relative cluster handles; a test implements it over a `Vec`.
+pub trait DrainSink {
+    /// Record one drain event. Called verdict-first, then effects in order.
+    fn record(&mut self, event: DrainEvent);
+}
+
+/// Drain `output`, applying the verdict first, then the effects in recorded
+/// order. `forward_kind` is `Some(kind)` for a real in-flight mail (a
+/// `Forward` verdict forwards the possibly-mutated bytes as that kind; a
+/// `Consume` forwards nothing but still drains effects) and `None` for a
+/// lifecycle-sentinel offer, which carries no in-flight mail — its verdict is
+/// ignored and only its effects drain.
+pub fn run_drain(output: FilterOutput, forward_kind: Option<KindId>, sink: &mut impl DrainSink) {
+    if let (Some(kind), Verdict::Forward(bytes)) = (forward_kind, output.verdict) {
+        sink.record(DrainEvent::Forward {
+            kind_id: kind.0,
+            bytes,
+        });
+    }
+    for effect in output.effects {
+        sink.record(DrainEvent::Effect {
+            target: effect.target,
+            kind_id: effect.kind_id,
+            bytes: effect.bytes,
+        });
+    }
+}
+
+/// The kinds a drain sends toward the wrapped widget or a named child — the
+/// echoes to suppress when they return up-lane. A `Panel` effect goes up, so
+/// it provokes no down-then-up echo and is not suppressed.
+#[must_use]
+pub fn echo_kinds(output: &FilterOutput) -> Vec<KindId> {
+    output
+        .effects
+        .iter()
+        .filter(|e| matches!(e.target, EffectTarget::Widget | EffectTarget::Child(_)))
+        .map(|e| KindId(e.kind_id))
+        .collect()
+}
+
+/// A one-shot multiset of up-lane echoes to suppress. Arming a kind after a
+/// down-lane effect means the next up-lane mail of that kind (the widget's
+/// re-emit) is forwarded raw rather than re-offered to the script; the entry
+/// is consumed as it fires so a later genuine value of the same kind is
+/// offered normally.
+#[derive(Default)]
+pub struct EchoGuard {
+    pending: BTreeMap<KindId, u32>,
+}
+
+impl EchoGuard {
+    /// Arm one expected up-lane echo per kind in `kinds`.
+    pub fn arm(&mut self, kinds: impl IntoIterator<Item = KindId>) {
+        for kind in kinds {
+            *self.pending.entry(kind).or_insert(0) += 1;
+        }
+    }
+
+    /// If an echo of `kind` is pending, consume one and return `true` (the
+    /// caller forwards raw, skipping the filter). Otherwise `false`.
+    pub fn take(&mut self, kind: KindId) -> bool {
+        match self.pending.get_mut(&kind) {
+            Some(count) => {
+                *count -= 1;
+                if *count == 0 {
+                    self.pending.remove(&kind);
+                }
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Whether any echoes are currently armed (test observability).
+    #[cfg(test)]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::Effect;
+    use alloc::vec;
+
+    #[derive(Default)]
+    struct RecordingSink {
+        events: Vec<DrainEvent>,
+    }
+    impl DrainSink for RecordingSink {
+        fn record(&mut self, event: DrainEvent) {
+            self.events.push(event);
+        }
+    }
+
+    fn effect(target: EffectTarget, kind_id: u64) -> Effect {
+        Effect {
+            target,
+            kind_id,
+            bytes: vec![kind_id as u8],
+        }
+    }
+
+    // Tripwire: the in-flight forward is recorded before any effect — the
+    // fixed verdict-then-effects order stacked hosts rely on. An out-of-order
+    // drain (effects before forward) would let a stacked host observe an
+    // in-flight effect.
+    #[test]
+    fn forward_precedes_effects_in_order() {
+        let output = FilterOutput {
+            verdict: Verdict::Forward(vec![9]),
+            effects: vec![
+                effect(EffectTarget::Widget, 1),
+                effect(EffectTarget::Panel, 2),
+            ],
+        };
+        let mut sink = RecordingSink::default();
+        run_drain(output, Some(KindId(0x55)), &mut sink);
+        assert_eq!(
+            sink.events,
+            vec![
+                DrainEvent::Forward {
+                    kind_id: 0x55,
+                    bytes: vec![9]
+                },
+                DrainEvent::Effect {
+                    target: EffectTarget::Widget,
+                    kind_id: 1,
+                    bytes: vec![1]
+                },
+                DrainEvent::Effect {
+                    target: EffectTarget::Panel,
+                    kind_id: 2,
+                    bytes: vec![2]
+                },
+            ]
+        );
+    }
+
+    // Tripwire: a consumed verdict emits no forward but still drains its
+    // effects — consume-plus-emit substitutes for a forward.
+    #[test]
+    fn consume_drains_effects_without_forward() {
+        let output = FilterOutput {
+            verdict: Verdict::Consume,
+            effects: vec![effect(EffectTarget::Child("slider".into()), 7)],
+        };
+        let mut sink = RecordingSink::default();
+        run_drain(output, Some(KindId(0x55)), &mut sink);
+        assert_eq!(
+            sink.events,
+            vec![DrainEvent::Effect {
+                target: EffectTarget::Child("slider".into()),
+                kind_id: 7,
+                bytes: vec![7],
+            }]
+        );
+    }
+
+    // Tripwire: a sentinel offer (`forward_kind = None`) drains its effects
+    // but never forwards its verdict — a lifecycle hook carries no in-flight
+    // mail, so a stray `Forward(empty)` must not leak out as real mail.
+    #[test]
+    fn sentinel_offer_drains_effects_without_forward() {
+        let output = FilterOutput {
+            verdict: Verdict::Forward(Vec::new()),
+            effects: vec![effect(EffectTarget::Widget, 5)],
+        };
+        let mut sink = RecordingSink::default();
+        run_drain(output, None, &mut sink);
+        assert_eq!(
+            sink.events,
+            vec![DrainEvent::Effect {
+                target: EffectTarget::Widget,
+                kind_id: 5,
+                bytes: vec![5]
+            }]
+        );
+    }
+
+    // Tripwire: a script whose effect targets its own widget/child arms that
+    // kind for suppression, and the one-shot guard skips exactly one up-lane
+    // echo of it — so the script's own write is not re-offered to its filter,
+    // while a later genuine value of the same kind still is. A Panel effect is
+    // not suppressed (it goes up, no echo).
+    #[test]
+    fn echo_of_own_write_is_suppressed_once() {
+        let output = FilterOutput {
+            verdict: Verdict::Forward(vec![0]),
+            effects: vec![
+                effect(EffectTarget::Widget, 42),
+                effect(EffectTarget::Panel, 99),
+            ],
+        };
+        let mut guard = EchoGuard::default();
+        guard.arm(echo_kinds(&output));
+
+        // The panel effect provoked no armed echo.
+        assert!(!guard.take(KindId(99)));
+        // The first up-lane 42 (the echo) is suppressed; the second is not.
+        assert!(guard.take(KindId(42)));
+        assert!(!guard.take(KindId(42)));
+        assert!(guard.is_empty());
+    }
+}

--- a/crates/aether-behavior/src/host/mod.rs
+++ b/crates/aether-behavior/src/host/mod.rs
@@ -1,0 +1,30 @@
+//! The in-cluster behavior script host (ADR-0137, issue 2687) — the crate's
+//! third face, behind the non-default `host` feature.
+//!
+//! Where the default face is the script SDK and the trunk is the host↔script
+//! envelope, this module is the *host* side: [`BehaviorHost`], a non-generic
+//! wasm `#[actor]` that embeds a `wasmi` interpreter and interposes at a tree
+//! slot. It spawns its wrapped child by type tag (#2692), offers the mail
+//! flowing through the slot to a fuel-metered filter call, fails open on a
+//! trap (passthrough + disable-after-threshold), drains effects
+//! verdict-then-effects with echo suppression, handles the
+//! `aether.behavior.{load_script,set_script}` control kinds (fs-fetch through
+//! `aether.fs`), and persists one bundle that re-instantiates only its own
+//! script on reload (the wrapped child reconstructs through the composite
+//! walk, #2694).
+//!
+//! The `host` feature turns on the optional `aether-actor` / `wasmi` /
+//! `aether-capabilities` deps — none named by the default face — so a behavior
+//! script never links them and never misclassifies as a component.
+
+mod actor;
+pub mod config;
+mod drain;
+mod persist;
+mod slot;
+
+#[cfg(test)]
+mod test_support;
+
+pub use actor::BehaviorHost;
+pub use config::{ChildSpec, HostConfig, LoadScript, LoadScriptResult, ScriptSource, SetScript};

--- a/crates/aether-behavior/src/host/persist.rs
+++ b/crates/aether-behavior/src/host/persist.rs
@@ -1,0 +1,97 @@
+//! The host's persistence bundle (ADR-0137, issue 2687).
+//!
+//! One entry written by `on_dehydrate` and read by `on_rehydrate`, serialized
+//! into the host's own parent state bytes: the script source, the resident
+//! running script copy, the script's opaque `state_save` blob, and the
+//! wrapped child's alias id. On reload the composite walk reconstructs the
+//! **wrapped child itself** from its own real config + runtime state (#2694),
+//! so the host does *not* re-spawn it — it re-instantiates only its own script
+//! from `script_bytes` (no fs re-fetch), offers `script_state` to the fresh
+//! script's `state_load`, and restores `wrapped_child_id` so the fallback's
+//! lane-direction check works on the first post-reload mail. An undecodable
+//! blob boots the script fresh with a warning (fail-open).
+
+use alloc::vec::Vec;
+
+use aether_data::wire;
+use serde::{Deserialize, Serialize};
+
+use crate::host::config::ScriptSource;
+
+/// Leading byte on an encoded [`HostPersist`]. Bumped when the bundle shape
+/// changes so a host decoding an older/newer blob boots fresh rather than
+/// misreading it.
+pub const HOST_PERSIST_VERSION: u8 = 1;
+
+/// The host's durable state across a `replace_component` swap.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostPersist {
+    /// The script source, so a reload records where the script came from
+    /// (a subsequent `load_script` correlates against it).
+    pub script_source: ScriptSource,
+    /// The resident running script's bytes — what a reload re-instantiates,
+    /// no fs re-fetch.
+    pub script_bytes: Vec<u8>,
+    /// The script's opaque `state_save` blob, offered to the fresh script's
+    /// `state_load`.
+    pub script_state: Vec<u8>,
+    /// The wrapped child's alias id (`0` when the host runs wrapper-less),
+    /// restored so the fallback's direction check works immediately.
+    pub wrapped_child_id: u64,
+}
+
+impl HostPersist {
+    /// Encode to the host's parent state bytes: a [`HOST_PERSIST_VERSION`]
+    /// byte then the `aether_data::wire` body.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let body = wire::to_vec(self).unwrap_or_default();
+        let mut out = Vec::with_capacity(1 + body.len());
+        out.push(HOST_PERSIST_VERSION);
+        out.extend_from_slice(&body);
+        out
+    }
+
+    /// Decode a bundle written by [`Self::encode`]. `None` on an empty buffer,
+    /// an unrecognized version byte, or a malformed body — the host boots
+    /// fresh (fail-open) in each case.
+    #[must_use]
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        let (&version, body) = bytes.split_first()?;
+        if version != HOST_PERSIST_VERSION {
+            return None;
+        }
+        wire::from_bytes(body).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    // Tripwire: a bundle round-trips through the versioned frame so a reload
+    // restores the running script from its resident bytes (no fs call) and the
+    // wrapped-child id for the direction check; and an undecodable blob decodes
+    // to `None` so the host boots fresh rather than misreading it.
+    #[test]
+    fn bundle_round_trips_and_rejects_garbage() {
+        let bundle = HostPersist {
+            script_source: ScriptSource::FsRef {
+                namespace: "assets".into(),
+                path: "scripts/knob.wasm".into(),
+            },
+            script_bytes: vec![0, 97, 115, 109],
+            script_state: vec![1, 2, 3, 4],
+            wrapped_child_id: 0xDEAD_BEEF,
+        };
+        let encoded = bundle.encode();
+        assert_eq!(HostPersist::decode(&encoded), Some(bundle));
+
+        // Empty and wrong-version buffers both fail open to `None`.
+        assert_eq!(HostPersist::decode(&[]), None);
+        let mut wrong = encoded;
+        wrong[0] = HOST_PERSIST_VERSION.wrapping_add(1);
+        assert_eq!(HostPersist::decode(&wrong), None);
+    }
+}

--- a/crates/aether-behavior/src/host/slot.rs
+++ b/crates/aether-behavior/src/host/slot.rs
@@ -1,0 +1,397 @@
+//! The `wasmi` embedding and fail-open state machine (ADR-0137, issue 2687).
+//!
+//! One [`wasmi::Engine`] is built per host at `init` with fuel metering on.
+//! A [`ScriptSlot`] is a compiled + instantiated script over that engine: a
+//! fresh `Store` + `Instance` whose linear memory holds the script's
+//! `state_save`/`state_load` state for the script's lifetime, its handled-kind
+//! manifest (the skip-set), and the consecutive-trap counter that drives the
+//! fail-open state machine. Only fuel resets per call.
+//!
+//! **Fail-open.** A trap — fuel exhaustion, a memory fault, a missing export,
+//! a malformed filter output — never propagates: the in-flight mail forwards
+//! untransformed, the failure logs, and a consecutive-trap counter climbs. A
+//! clean call resets it to zero; reaching the threshold disables the script
+//! (pure passthrough) until the next `load_script` / `set_script` replaces it.
+
+use alloc::collections::BTreeSet;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use aether_data::KindId;
+use wasmi::{Config, Engine, Instance, Linker, Memory, Module, Store, TypedFunc};
+
+use crate::abi::unpack_ptr_len;
+use crate::envelope::{self, FilterOutput};
+use crate::manifest;
+
+/// Build the shared per-host [`Engine`] with fuel metering enabled — the
+/// precondition for the per-call fuel budget the fail-open machine relies on.
+#[must_use]
+pub fn build_engine() -> Engine {
+    let mut config = Config::default();
+    config.consume_fuel(true);
+    Engine::new(&config)
+}
+
+/// The outcome of one filter call, from the host's point of view.
+pub enum FilterOutcome {
+    /// The script produced a well-formed output the host drains.
+    Output(FilterOutput),
+    /// Fail-open: a trap or a malformed output — the host forwards the
+    /// in-flight mail untransformed. (Also the value for a call on a disabled
+    /// script, though the host normally short-circuits before calling.)
+    Passthrough,
+}
+
+/// Whether a script is running or has been disabled by the trap threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RunState {
+    Running,
+    Disabled,
+}
+
+/// One compiled, instantiated script plus its fail-open bookkeeping.
+pub struct ScriptSlot {
+    store: Store<()>,
+    #[allow(dead_code)]
+    instance: Instance,
+    memory: Memory,
+    alloc_fn: TypedFunc<(u32, u32, u32, u32), u32>,
+    filter_fn: TypedFunc<(u64, u32, u32), u64>,
+    state_save_fn: Option<TypedFunc<(), u64>>,
+    state_load_fn: Option<TypedFunc<(u32, u32), u32>>,
+    manifest: BTreeSet<KindId>,
+    bytes: Vec<u8>,
+    fuel_per_call: u64,
+    disable_after_traps: u32,
+    consecutive_traps: u32,
+    state: RunState,
+}
+
+impl ScriptSlot {
+    /// Compile + instantiate `bytes` into a fresh `Store`/`Instance` over
+    /// `engine`, parse the exports manifest, and offer `prior_state` (if any)
+    /// to the new instance's `state_load`. Returns `Err(detail)` on a
+    /// validation / instantiation / missing-export failure — the caller keeps
+    /// the prior running slot on `Err`.
+    pub fn instantiate(
+        engine: &Engine,
+        bytes: &[u8],
+        prior_state: Option<&[u8]>,
+        fuel_per_call: u64,
+        disable_after_traps: u32,
+    ) -> Result<Self, String> {
+        let module = Module::new(engine, bytes)
+            .map_err(|error| alloc::format!("module compile: {error}"))?;
+        let manifest = decode_manifest(&module);
+
+        let mut store = Store::new(engine, ());
+        let linker: Linker<()> = Linker::new(engine);
+        let instance = linker
+            .instantiate_and_start(&mut store, &module)
+            .map_err(|error| alloc::format!("instantiate: {error}"))?;
+
+        let memory = instance
+            .get_memory(&store, "memory")
+            .ok_or_else(|| "script exports no `memory`".to_string())?;
+        let alloc_fn = instance
+            .get_typed_func::<(u32, u32, u32, u32), u32>(&store, "alloc")
+            .map_err(|error| alloc::format!("missing `alloc` export: {error}"))?;
+        let filter_fn = instance
+            .get_typed_func::<(u64, u32, u32), u64>(&store, "filter")
+            .map_err(|error| alloc::format!("missing `filter` export: {error}"))?;
+        // `state_save` / `state_load` are optional — a stateless script omits
+        // them, and the host simply carries no migration blob for it.
+        let state_save_fn = instance
+            .get_typed_func::<(), u64>(&store, "state_save")
+            .ok();
+        let state_load_fn = instance
+            .get_typed_func::<(u32, u32), u32>(&store, "state_load")
+            .ok();
+
+        let mut slot = Self {
+            store,
+            instance,
+            memory,
+            alloc_fn,
+            filter_fn,
+            state_save_fn,
+            state_load_fn,
+            manifest,
+            bytes: bytes.to_vec(),
+            fuel_per_call,
+            disable_after_traps,
+            consecutive_traps: 0,
+            state: RunState::Running,
+        };
+
+        if let Some(prior) = prior_state {
+            slot.offer_state(prior);
+        }
+        Ok(slot)
+    }
+
+    /// The resident script's raw bytes (for persistence — the running copy is
+    /// what a reload re-instantiates, no re-fetch).
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Whether the script is disabled (pure passthrough). The host checks this
+    /// before offering lane mail so a disabled script pays no interpreter cost.
+    #[must_use]
+    pub fn is_disabled(&self) -> bool {
+        self.state == RunState::Disabled
+    }
+
+    /// The current consecutive-trap count (test observability).
+    #[cfg(test)]
+    #[must_use]
+    pub fn consecutive_traps(&self) -> u32 {
+        self.consecutive_traps
+    }
+
+    /// Whether `kind` is in the script's handled-kind manifest. An undeclared
+    /// kind is forwarded raw with no interpreter call.
+    #[must_use]
+    pub fn handles(&self, kind: KindId) -> bool {
+        self.manifest.contains(&kind)
+    }
+
+    /// Save the script's migration blob via its `state_save` export. Returns
+    /// an empty vec when the script exports no `state_save` (stateless) or the
+    /// call traps (fail-open — a dehydrate never brings the host down).
+    #[must_use]
+    pub fn save_state(&mut self) -> Vec<u8> {
+        let Some(save) = self.state_save_fn else {
+            return Vec::new();
+        };
+        // `state_save` is unmetered from the fuel budget's point of view — a
+        // dehydrate is not a filter call — but a generous budget still bounds
+        // a pathological serializer.
+        if self.store.set_fuel(self.fuel_per_call).is_err() {
+            return Vec::new();
+        }
+        let Ok(packed) = save.call(&mut self.store, ()) else {
+            return Vec::new();
+        };
+        self.read_packed(packed).unwrap_or_default()
+    }
+
+    /// Offer `blob` to the script's `state_load` export (migration restore).
+    /// A missing export or a trap is ignored (fail-open — an undecodable blob
+    /// leaves the fresh script untouched, mirroring `state_load_serde`).
+    pub fn offer_state(&mut self, blob: &[u8]) {
+        let Some(load) = self.state_load_fn else {
+            return;
+        };
+        let Some((ptr, len)) = self.write_guest(blob) else {
+            return;
+        };
+        let _ = self.store.set_fuel(self.fuel_per_call);
+        let _ = load.call(&mut self.store, (ptr, len));
+    }
+
+    /// Run one fuel-metered filter call for `(kind, bytes)`. Any trap or
+    /// malformed output fails open ([`FilterOutcome::Passthrough`]),
+    /// incrementing the consecutive-trap counter and disabling the script at
+    /// the threshold; a clean call resets the counter.
+    pub fn filter(&mut self, kind: KindId, bytes: &[u8]) -> FilterOutcome {
+        if self.state == RunState::Disabled {
+            return FilterOutcome::Passthrough;
+        }
+        if let Some(output) = self.filter_inner(kind, bytes) {
+            self.consecutive_traps = 0;
+            FilterOutcome::Output(output)
+        } else {
+            self.record_trap();
+            FilterOutcome::Passthrough
+        }
+    }
+
+    /// The wasmi call path, returning `None` on any failure (trap, missing
+    /// region, malformed output) so [`Self::filter`] can fail open uniformly.
+    fn filter_inner(&mut self, kind: KindId, bytes: &[u8]) -> Option<FilterOutput> {
+        // Fuel resets per call — a runaway script traps at the budget rather
+        // than wedging the host.
+        self.store.set_fuel(self.fuel_per_call).ok()?;
+        let (ptr, len) = self.write_guest(bytes)?;
+        let packed = self
+            .filter_fn
+            .call(&mut self.store, (kind.0, ptr, len))
+            .ok()?;
+        let out = self.read_packed(packed)?;
+        envelope::decode(&out)
+    }
+
+    /// Record a trap: bump the counter and disable at the threshold.
+    fn record_trap(&mut self) {
+        self.consecutive_traps = self.consecutive_traps.saturating_add(1);
+        if self.disable_after_traps != 0 && self.consecutive_traps >= self.disable_after_traps {
+            self.state = RunState::Disabled;
+        }
+    }
+
+    /// Allocate a guest region and copy `bytes` into it, returning the guest
+    /// `(ptr, len)`. `None` on a length past `u32`, an alloc trap, or a
+    /// memory-write fault. Returning the `u32` length lets callers pass it to
+    /// the guest export without re-casting `usize`.
+    fn write_guest(&mut self, bytes: &[u8]) -> Option<(u32, u32)> {
+        let len = u32::try_from(bytes.len()).ok()?;
+        // `alloc(old_ptr=0, old_size=0, align=1, new_size=len)` — a fresh
+        // byte region (bytes need no alignment).
+        let ptr = self.alloc_fn.call(&mut self.store, (0, 0, 1, len)).ok()?;
+        self.memory
+            .write(&mut self.store, ptr as usize, bytes)
+            .ok()?;
+        Some((ptr, len))
+    }
+
+    /// Read the `(ptr, len)` a packed guest return points at out of linear
+    /// memory. `None` if the region runs past the memory bound.
+    fn read_packed(&self, packed: u64) -> Option<Vec<u8>> {
+        let (ptr, len) = unpack_ptr_len(packed);
+        let (start, end) = (ptr as usize, ptr as usize + len as usize);
+        let data = self.memory.data(&self.store);
+        data.get(start..end).map(<[u8]>::to_vec)
+    }
+}
+
+/// Read the `aether.behavior.exports` custom section out of a compiled module
+/// and decode it into the handled-kind manifest. A module with no such
+/// section (or an unrecognized version) yields an empty manifest — every kind
+/// is then undeclared and forwarded raw.
+fn decode_manifest(module: &Module) -> BTreeSet<KindId> {
+    for section in module.custom_sections() {
+        if section.name() == manifest::EXPORTS_SECTION {
+            return manifest::decode_exports_manifest(section.data()).collect();
+        }
+    }
+    BTreeSet::new()
+}
+
+// The trapping / passthrough test fixtures are tiny hand-built WAT modules —
+// behavior-script fixtures compiled from Rust are #2688's. Kept beside the
+// slot so the fail-open state machine is exercised where it lives.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{Effect, EffectTarget, Verdict};
+    use crate::host::test_support::{fixed_output_wasm, forward_output, trapping_wasm};
+    use alloc::vec;
+
+    // Tripwire: a trap forwards untransformed and, at exactly
+    // `disable_after_traps` consecutive traps, disables the script — the
+    // fail-open contract a broken script must degrade to (never silence the
+    // widget). Owned logic: the counter + threshold live here.
+    #[test]
+    fn trap_forwards_untransformed_and_disables_at_threshold() {
+        let kind = KindId(0x1000);
+        let engine = build_engine();
+        let mut slot = ScriptSlot::instantiate(&engine, &trapping_wasm(kind), None, 1_000_000, 3)
+            .expect("test setup: trapping module instantiates");
+
+        // First two traps: fail-open passthrough, still running.
+        for expected in 1..=2 {
+            assert!(matches!(
+                slot.filter(kind, b"abc"),
+                FilterOutcome::Passthrough
+            ));
+            assert_eq!(slot.consecutive_traps(), expected);
+            assert!(!slot.is_disabled());
+        }
+        // Third trap hits the threshold and disables.
+        assert!(matches!(
+            slot.filter(kind, b"abc"),
+            FilterOutcome::Passthrough
+        ));
+        assert_eq!(slot.consecutive_traps(), 3);
+        assert!(slot.is_disabled());
+    }
+
+    // Tripwire: a clean call resets the consecutive-trap counter, so a
+    // transient trap never accumulates toward disable across good calls.
+    #[test]
+    fn clean_call_resets_trap_counter() {
+        let kind = KindId(0x2000);
+        let engine = build_engine();
+        let payload = forward_output(b"clean");
+        let mut slot = ScriptSlot::instantiate(
+            &engine,
+            &fixed_output_wasm(kind, &payload),
+            None,
+            1_000_000,
+            3,
+        )
+        .expect("test setup: fixed-output module instantiates");
+
+        // A clean call returns the baked output and holds the counter at 0.
+        match slot.filter(kind, b"in") {
+            FilterOutcome::Output(out) => {
+                assert_eq!(out.verdict, Verdict::Forward(b"clean".to_vec()))
+            }
+            FilterOutcome::Passthrough => panic!("clean script should produce an output"),
+        }
+        assert_eq!(slot.consecutive_traps(), 0);
+        assert!(!slot.is_disabled());
+    }
+
+    // Tripwire: the manifest skip-set is read from the `aether.behavior.exports`
+    // custom section, so a declared kind is `handles()`-true and an undeclared
+    // one false — the host's skip-the-interpreter decision.
+    #[test]
+    fn manifest_reflects_exports_section() {
+        let declared = KindId(0x3000);
+        let engine = build_engine();
+        let payload = forward_output(b"x");
+        let slot = ScriptSlot::instantiate(
+            &engine,
+            &fixed_output_wasm(declared, &payload),
+            None,
+            1_000_000,
+            3,
+        )
+        .expect("test setup: module instantiates");
+        assert!(slot.handles(declared));
+        assert!(!slot.handles(KindId(0x9999)));
+    }
+
+    // Tripwire: an effect-bearing output round-trips through the real wasmi
+    // memory path (alloc + write + call + read + decode), so the host's
+    // packed-pointer read stays wired to the guest's `leak_packed` layout.
+    #[test]
+    fn effect_bearing_output_decodes_through_memory() {
+        let kind = KindId(0x4000);
+        let engine = build_engine();
+        let output = FilterOutput {
+            verdict: Verdict::Consume,
+            effects: vec![Effect {
+                target: EffectTarget::Widget,
+                kind_id: 0xABCD,
+                bytes: vec![1, 2, 3],
+            }],
+        };
+        let mut slot = ScriptSlot::instantiate(
+            &engine,
+            &fixed_output_wasm(kind, &output),
+            None,
+            1_000_000,
+            3,
+        )
+        .expect("test setup: module instantiates");
+        match slot.filter(kind, b"in") {
+            FilterOutcome::Output(out) => assert_eq!(out, output),
+            FilterOutcome::Passthrough => panic!("expected a decoded output"),
+        }
+    }
+
+    // Tripwire: a module that fails to validate keeps no slot — the caller
+    // relies on `Err` to keep the prior running script.
+    #[test]
+    fn bad_bytes_fail_to_instantiate() {
+        let engine = build_engine();
+        let result = ScriptSlot::instantiate(&engine, b"not wasm at all", None, 1_000_000, 3);
+        assert!(result.is_err());
+    }
+}

--- a/crates/aether-behavior/src/host/test_support.rs
+++ b/crates/aether-behavior/src/host/test_support.rs
@@ -1,0 +1,92 @@
+//! Hand-built minimal wasm fixtures for the host-side unit tests (issue
+//! 2687). Behavior-script fixtures compiled from Rust are #2688's; these are
+//! tiny WAT modules parsed inline via `wat`, with no build wiring, so the
+//! fail-open state machine and the swap/rehydrate paths are exercisable under
+//! plain `cargo test`.
+
+use alloc::format;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use aether_data::KindId;
+
+use crate::envelope::{self, FilterOutput, Verdict};
+use crate::manifest;
+
+/// A module whose `filter` always traps (`unreachable`), declaring `handled`
+/// in its exports section. Drives the fail-open trap counter.
+pub(crate) fn trapping_wasm(handled: KindId) -> Vec<u8> {
+    module(
+        r#"(func (export "filter") (param i64 i32 i32) (result i64)
+             unreachable)"#,
+        None,
+        &[handled],
+    )
+}
+
+/// A module whose `filter` returns a fixed, pre-encoded [`FilterOutput`] baked
+/// into a data segment (ignoring its inputs). A clean, counter-resetting call.
+pub(crate) fn fixed_output_wasm(handled: KindId, output: &FilterOutput) -> Vec<u8> {
+    let encoded = envelope::encode(output);
+    let packed = (2048u64 << 32) | (encoded.len() as u64);
+    let body = format!(
+        r#"(func (export "filter") (param i64 i32 i32) (result i64)
+             (i64.const {packed}))"#,
+        packed = packed as i64,
+    );
+    module(&body, Some((2048, &encoded)), &[handled])
+}
+
+/// A `Forward`-the-inbound `FilterOutput` for `bytes` — a passthrough script's
+/// output.
+pub(crate) fn forward_output(bytes: &[u8]) -> FilterOutput {
+    FilterOutput {
+        verdict: Verdict::Forward(bytes.to_vec()),
+        effects: Vec::new(),
+    }
+}
+
+/// Assemble a module: a memory + bump allocator, the caller's `filter`, an
+/// optional data segment, and the exports custom section for `kinds`.
+fn module(filter_body: &str, data: Option<(u32, &[u8])>, kinds: &[KindId]) -> Vec<u8> {
+    let data_wat = data.map_or(String::new(), |(offset, bytes)| {
+        format!(r#"(data (i32.const {offset}) "{}")"#, byte_string(bytes))
+    });
+    let section = custom_section_wat(&exports_section(kinds));
+    let text = format!(
+        r#"(module
+             (memory (export "memory") 1)
+             (global $bump (mut i32) (i32.const 1024))
+             (func (export "alloc") (param i32 i32 i32 i32) (result i32)
+               (local $p i32)
+               (local.set $p (global.get $bump))
+               (global.set $bump (i32.add (global.get $bump) (local.get 3)))
+               (local.get $p))
+             {filter_body}
+             {data_wat}
+             {section})"#,
+    );
+    wat::parse_str(&text).expect("test setup: WAT fixture parses")
+}
+
+fn exports_section(kinds: &[KindId]) -> Vec<u8> {
+    let mut out = vec![manifest::EXPORTS_MANIFEST_VERSION];
+    for k in kinds {
+        out.extend_from_slice(&k.0.to_le_bytes());
+    }
+    out
+}
+
+fn custom_section_wat(bytes: &[u8]) -> String {
+    format!(
+        "(@custom \"{name}\" \"{hex}\")",
+        name = manifest::EXPORTS_SECTION,
+        hex = byte_string(bytes),
+    )
+}
+
+/// Render bytes as a WAT string literal's `\xx` escapes.
+fn byte_string(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("\\{b:02x}")).collect()
+}

--- a/crates/aether-behavior/src/lib.rs
+++ b/crates/aether-behavior/src/lib.rs
@@ -42,6 +42,17 @@ pub mod runtime;
 #[cfg(feature = "runtime")]
 pub use runtime::{Behavior, BehaviorCtx, ChildHandle, PanelHandle, WidgetHandle};
 
+/// The host face (ADR-0137, issue 2687), behind the non-default `host`
+/// feature: [`BehaviorHost`](host::BehaviorHost), the wasm actor that embeds a
+/// `wasmi` interpreter and interposes at a tree slot. Turns on the optional
+/// `aether-actor` / `wasmi` / `aether-capabilities` deps the default face
+/// names none of, so a script build never links them.
+#[cfg(feature = "host")]
+pub mod host;
+
+#[cfg(feature = "host")]
+pub use host::{BehaviorHost, HostConfig};
+
 /// Items the `#[behavior]` macro's generated code names by absolute path,
 /// re-exported so a script depends on `aether-behavior` alone (never a
 /// direct `aether-data` path) for the surface the codegen touches.

--- a/crates/aether-kit/Cargo.toml
+++ b/crates/aether-kit/Cargo.toml
@@ -25,9 +25,19 @@ crate-type = ["cdylib", "rlib"]
 # wasm32 build still produces the full component artifact.
 default = ["runtime"]
 runtime = []
+# ADR-0137 / issue 2687: wrap a stock widget slot in a behavior script host.
+# Forwards to `aether-behavior/host` and lights up the `WidgetKind::BehaviorHost`
+# spawn arm + the host's presence in the module's `export!` set. Non-default so
+# the ordinary kit build links neither `wasmi` nor the host, and is compiled in
+# a separate cargo invocation from behavior-script wasm (issue 2688).
+behavior = ["dep:aether-behavior", "aether-behavior/host"]
 
 [dependencies]
 aether-actor = { path = "../aether-actor" }
+# `behavior`-only: the script host actor + its config vocabulary. Its own
+# marker face is off (`default-features = false`); the `host` feature the kit
+# forwards to turns on exactly the host surface, not the guest `runtime` SDK.
+aether-behavior = { path = "../aether-behavior", default-features = false, optional = true }
 aether-capabilities = { path = "../aether-capabilities", default-features = false, features = ["render", "ui"] }
 aether-data = { path = "../aether-data", features = ["derive"] }
 aether-kinds = { path = "../aether-kinds" }

--- a/crates/aether-kit/src/runtime/mod.rs
+++ b/crates/aether-kit/src/runtime/mod.rs
@@ -60,6 +60,12 @@ pub use world_view::WorldView;
 // module root where `arena` imports them.
 pub(crate) use locomotion::{GRID_H, GRID_W};
 
+// A cdylib carries one `export!` (the shared init/receive FFI entry). The
+// `behavior` feature (ADR-0137, issue 2687) appends `aether-behavior`'s
+// `BehaviorHost` to the exported set so the panel's `WidgetKind::BehaviorHost`
+// arm can spawn it by tag; the two invocations are cfg-exclusive, keeping the
+// ordinary kit build's exported set (and its `aether.kinds` section) unchanged.
+#[cfg(not(feature = "behavior"))]
 aether_actor::export!(
     Locomotion,
     CameraComponent,
@@ -72,4 +78,20 @@ aether_actor::export!(
     ButtonWidget,
     LabelWidget,
     WidgetPanel
+);
+
+#[cfg(feature = "behavior")]
+aether_actor::export!(
+    Locomotion,
+    CameraComponent,
+    MeshViewer,
+    WorldView,
+    Widget,
+    SliderWidget,
+    TextFieldWidget,
+    RadioGroupWidget,
+    ButtonWidget,
+    LabelWidget,
+    WidgetPanel,
+    aether_behavior::BehaviorHost
 );

--- a/crates/aether-kit/src/runtime/widget.rs
+++ b/crates/aether-kit/src/runtime/widget.rs
@@ -37,8 +37,7 @@
 //! on its first `Tick` for the one code path.
 
 use aether_actor::{
-    ActorInitError, Addressable, Manual, OutboundReply, Subname, WasmActor, WasmCtx, WasmInitCtx,
-    actor,
+    ActorInitError, Addressable, Manual, Subname, WasmActor, WasmCtx, WasmInitCtx, actor,
 };
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::render::{DrawSolidQuads, SolidQuad};

--- a/crates/aether-kit/src/runtime/widget_panel.rs
+++ b/crates/aether-kit/src/runtime/widget_panel.rs
@@ -40,8 +40,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use aether_actor::{
-    ActorInitError, Addressable, Manual, OutboundReply, Subname, WasmActor, WasmCtx, WasmInitCtx,
-    actor,
+    ActorInitError, Addressable, Manual, Subname, WasmActor, WasmCtx, WasmInitCtx, actor,
 };
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
@@ -159,6 +158,7 @@ impl WidgetPanel {
                 WidgetKind::Button => decode_child::<ButtonConfig>(spec)
                     .and_then(|config| spawn::<ButtonWidget>(ctx, &spec.subname, &config))
                     .map(|id| (id, row, true, <ButtonWidget as Addressable>::NAMESPACE)),
+                WidgetKind::BehaviorHost => spawn_behavior_host(ctx, spec, row),
                 WidgetKind::Composite => {
                     tracing::warn!(
                         target: "aether_kit",
@@ -368,6 +368,123 @@ where
             None
         }
     }
+}
+
+/// Spawn a [`WidgetKind::BehaviorHost`] slot (issue 2687): decode the
+/// [`BehaviorHostSpec`], map the wrapped widget kind to its type tag, build the
+/// `aether-behavior` `HostConfig`, and spawn the host by tag (#2692) — the host
+/// then spawns the wrapped widget as its own inline child and interposes on the
+/// slot's mail. Returns the placed-tuple shape the other arms produce; `None`
+/// (slot skipped) on an unsupported wrapped kind, a decode failure, or a spawn
+/// error. The panel's per-frame `Collect` is handed to the host as its FRAME
+/// trigger.
+#[cfg(feature = "behavior")]
+fn spawn_behavior_host(
+    ctx: &mut WasmCtx<'_, Manual>,
+    spec: &WidgetChildSpec,
+    row: f32,
+) -> Option<(MailboxId, f32, bool, &'static str)> {
+    use crate::widgets::{BehaviorHostSpec, ScriptRef};
+    use aether_actor::ActorTypeTag;
+    use aether_behavior::HostConfig;
+    use aether_behavior::host::{ChildSpec, ScriptSource};
+
+    let host_spec = decode_child::<BehaviorHostSpec>(spec)?;
+    let Some(type_tag) = wrapped_widget_tag(host_spec.wrapped) else {
+        tracing::warn!(
+            target: "aether_kit",
+            subname = %spec.subname,
+            wrapped = ?host_spec.wrapped,
+            "BehaviorHost cannot wrap this widget kind (container or host); slot skipped",
+        );
+        return None;
+    };
+    let script = match host_spec.script {
+        ScriptRef::None => ScriptSource::None,
+        ScriptRef::Inline(bytes) => ScriptSource::Inline(bytes),
+        ScriptRef::FsRef { namespace, path } => ScriptSource::FsRef { namespace, path },
+    };
+    let fuel_per_call = if host_spec.fuel_per_call != 0 {
+        host_spec.fuel_per_call
+    } else {
+        HostConfig::DEFAULT_FUEL_PER_CALL
+    };
+    let disable_after_traps = if host_spec.disable_after_traps != 0 {
+        host_spec.disable_after_traps
+    } else {
+        HostConfig::DEFAULT_DISABLE_AFTER_TRAPS
+    };
+    let config = HostConfig {
+        child: ChildSpec {
+            // The wrapped widget nests under the host at a slot-unique subname
+            // (the inline model folds children flat, so the discriminator must
+            // be cluster-unique).
+            type_tag,
+            subname: alloc::format!("{}_wrapped", spec.subname),
+            config: host_spec.wrapped_config,
+        },
+        script,
+        fuel_per_call,
+        disable_after_traps,
+        // The panel drives the wrapped slot with `Collect` each frame; hand the
+        // host that kind as its FRAME sentinel trigger.
+        frame_trigger: Collect::ID.0,
+    };
+    let bytes = config.encode_into_bytes();
+    match ctx.spawn_inline_child_by_tag(
+        ActorTypeTag::of::<aether_behavior::BehaviorHost>(),
+        Subname::Named(&spec.subname),
+        &bytes,
+    ) {
+        Ok(id) => Some((
+            id,
+            row,
+            true,
+            <aether_behavior::BehaviorHost as Addressable>::NAMESPACE,
+        )),
+        Err(error) => {
+            tracing::warn!(
+                target: "aether_kit",
+                subname = %spec.subname,
+                ?error,
+                "behavior host spawn failed; slot skipped",
+            );
+            None
+        }
+    }
+}
+
+/// The wrapped widget's actor type tag for the `behavior` spawn arm — the same
+/// `ActorTypeTag::of::<Concrete>()` mapping the direct-widget arms encode, one
+/// per stock widget. A container or a host is not wrappable ⇒ `None`.
+#[cfg(feature = "behavior")]
+fn wrapped_widget_tag(kind: WidgetKind) -> Option<u64> {
+    use aether_actor::ActorTypeTag;
+    let tag = match kind {
+        WidgetKind::Label => ActorTypeTag::of::<LabelWidget>().0,
+        WidgetKind::Slider => ActorTypeTag::of::<SliderWidget>().0,
+        WidgetKind::Radio => ActorTypeTag::of::<RadioGroupWidget>().0,
+        WidgetKind::TextField => ActorTypeTag::of::<TextFieldWidget>().0,
+        WidgetKind::Button => ActorTypeTag::of::<ButtonWidget>().0,
+        WidgetKind::Composite | WidgetKind::BehaviorHost => return None,
+    };
+    Some(tag)
+}
+
+/// The `behavior`-feature-off stub: a `WidgetKind::BehaviorHost` slot needs the
+/// host actor, which is only linked under the kit's `behavior` feature.
+#[cfg(not(feature = "behavior"))]
+fn spawn_behavior_host(
+    _ctx: &mut WasmCtx<'_, Manual>,
+    spec: &WidgetChildSpec,
+    _row: f32,
+) -> Option<(MailboxId, f32, bool, &'static str)> {
+    tracing::warn!(
+        target: "aether_kit",
+        subname = %spec.subname,
+        "WidgetKind::BehaviorHost needs the kit `behavior` feature; slot skipped",
+    );
+    None
 }
 
 /// The reference panel root. Load it as a component (export
@@ -637,5 +754,69 @@ impl WasmActor for WidgetPanel {
     fn on_set_theme(&mut self, ctx: &mut WasmCtx<'_>, set: SetTheme) {
         self.theme = set.theme;
         self.fan_theme(ctx);
+    }
+}
+
+#[cfg(all(test, feature = "behavior"))]
+mod behavior_tests {
+    use super::*;
+    use crate::widgets::{BehaviorHostSpec, ScriptRef};
+    use aether_actor::ActorTypeTag;
+    use aether_data::Kind;
+
+    // Tripwire: the wrapped-widget tag mapping points each stock kind at its
+    // own concrete widget type (not a transposed neighbour) and refuses to
+    // wrap a container or a host. A mis-wired arm would spawn the wrong widget
+    // under a host — silent until the pixels are wrong.
+    #[test]
+    fn wrapped_tag_maps_each_stock_widget_and_rejects_unwrappable() {
+        assert_eq!(
+            wrapped_widget_tag(WidgetKind::Slider),
+            Some(ActorTypeTag::of::<SliderWidget>().0)
+        );
+        assert_eq!(
+            wrapped_widget_tag(WidgetKind::Button),
+            Some(ActorTypeTag::of::<ButtonWidget>().0)
+        );
+        assert_eq!(
+            wrapped_widget_tag(WidgetKind::Label),
+            Some(ActorTypeTag::of::<LabelWidget>().0)
+        );
+        assert_eq!(
+            wrapped_widget_tag(WidgetKind::Radio),
+            Some(ActorTypeTag::of::<RadioGroupWidget>().0)
+        );
+        assert_eq!(
+            wrapped_widget_tag(WidgetKind::TextField),
+            Some(ActorTypeTag::of::<TextFieldWidget>().0)
+        );
+        assert_eq!(wrapped_widget_tag(WidgetKind::Composite), None);
+        assert_eq!(wrapped_widget_tag(WidgetKind::BehaviorHost), None);
+    }
+
+    // Tripwire: a `BehaviorHostSpec` carrying a stock wrapped widget encodes as
+    // its `WidgetChildSpec.config` and decodes back through `decode_child`, so
+    // the panel arm can recover the wrapped kind + script it was handed.
+    #[test]
+    fn host_spec_round_trips_through_child_config() {
+        let spec = BehaviorHostSpec {
+            wrapped: WidgetKind::Slider,
+            wrapped_config: alloc::vec![1, 2, 3],
+            script: ScriptRef::FsRef {
+                namespace: String::from("assets"),
+                path: String::from("scripts/knob.wasm"),
+            },
+            fuel_per_call: 0,
+            disable_after_traps: 0,
+        };
+        let child = WidgetChildSpec {
+            subname: String::from("knob"),
+            kind: WidgetKind::BehaviorHost,
+            origin: [0.0, 0.0],
+            config: spec.encode_into_bytes(),
+        };
+        let decoded = decode_child::<BehaviorHostSpec>(&child).expect("host spec decodes");
+        assert_eq!(decoded.wrapped, WidgetKind::Slider);
+        assert!(matches!(decoded.script, ScriptRef::FsRef { .. }));
     }
 }

--- a/crates/aether-kit/src/widgets.rs
+++ b/crates/aether-kit/src/widgets.rs
@@ -191,6 +191,55 @@ pub enum WidgetKind {
     TextField,
     /// A push button — `config` decodes as [`ButtonConfig`].
     Button,
+    /// A behavior-script host wrapping one stock widget (ADR-0137, issue
+    /// 2687) — `config` decodes as [`BehaviorHostSpec`] (the wrapped widget's
+    /// kind + config plus the script), and the panel spawns the host by tag
+    /// (`aether-behavior`'s `BehaviorHost`) instead of a widget. Only spawnable
+    /// under the kit's `behavior` feature; without it the slot is skipped.
+    BehaviorHost,
+}
+
+/// Where a wrapped host's script comes from — the kit-local mirror of
+/// `aether_behavior`'s `ScriptSource`, carried in a [`BehaviorHostSpec`] so the
+/// trunk (always compiled) names no `aether-behavior` type. The `behavior`
+/// arm maps it across.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+pub enum ScriptRef {
+    /// No script — the host runs wrapper-transparent until one is loaded.
+    #[default]
+    None,
+    /// The script's wasm bytes inline.
+    Inline(Vec<u8>),
+    /// Fetch the script from an `aether.fs` namespace at boot.
+    FsRef {
+        /// The `aether.fs` namespace prefix (`"save"`, `"assets"`, `"config"`).
+        namespace: String,
+        /// The path within the namespace.
+        path: String,
+    },
+}
+
+/// `aether.kit.behavior_host_spec` — the config bytes a [`WidgetChildSpec`]
+/// carries for a [`WidgetKind::BehaviorHost`] slot (issue 2687). It names the
+/// wrapped widget's kind + its own pre-encoded config (the same opaque bytes a
+/// direct widget slot would carry) plus the script and its fuel knobs. Not
+/// recursive — `wrapped` is a plain [`WidgetKind`] discriminant, and
+/// `WidgetKind::BehaviorHost` is a unit variant that references nothing back,
+/// so the `Schema` derive stays acyclic.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.behavior_host_spec")]
+pub struct BehaviorHostSpec {
+    /// The stock widget the host interposes on.
+    pub wrapped: WidgetKind,
+    /// The wrapped widget's own config, pre-encoded (as a direct slot's
+    /// `config` would be).
+    pub wrapped_config: Vec<u8>,
+    /// The behavior script.
+    pub script: ScriptRef,
+    /// Fuel budget per filter call (`0` ⇒ the host default).
+    pub fuel_per_call: u64,
+    /// Consecutive-trap disable threshold (`0` ⇒ the host default).
+    pub disable_after_traps: u32,
 }
 
 /// One child's placement in a compositing node's layout table. `subname`


### PR DESCRIPTION
Closes #2687.

## Summary

Fills the runtime-plus-shared quadrant ADR-0137 identifies: in-cluster code that transforms the mail already flowing through a running inline-actor cluster, without a `load_component` round trip. This lands the host half — the third face of `aether-behavior`, behind a non-default `host` feature that turns on the optional `aether-actor` / `wasmi` / `aether-capabilities` deps the default (script SDK) face names none of, so a behavior cdylib never links them.

`BehaviorHost` is one non-generic wasm `#[actor]` that interposes at a tree slot: it spawns its wrapped child by type tag (#2692) as its own inline child, offers the down-lane and up-lane mail flowing through the slot to a fuel-metered `wasmi` filter call, fails **open** on a trap (passthrough + log + disable after a consecutive-trap threshold), drains effects verdict-then-effects with one-shot echo suppression, handles the `aether.behavior.{load_script,set_script}` control kinds (fs-fetch through `aether.fs`, keeping the prior script on error), and persists one bundle that re-instantiates only its own script on reload — deferring the wrapped child's reconstruction to the composite walk (#2694) so it never double-spawns.

`aether-kit` gains a non-default `behavior` feature forwarding to `aether-behavior/host` plus a `WidgetKind::BehaviorHost` spawn arm that maps a wrapped widget kind to its type tag and spawns the host by tag; the host rides the module `export!` set under the same feature. Stock `aether-kit` keeps zero interpreter footprint (feature off by default).

## Reviewer note — deviations from the scoped plan

The plan framed `aether-actor` as consumed-not-modified, but the interposer needs raw untyped mail forwarding the guest SDK lacked, so three small enabling primitives were added (each routing through existing internals, per build-the-missing-machinery):

- `RelativeMailbox::send_bytes(KindId, &[u8])` — type-erased in-place forward, routes through the same `route_or_enqueue` / `ChainMode::Inherit` path as `send::<K>`.
- `Mail::bytes()` — raw inbound payload, mirrors `decode_kind`'s slice construction with a null-length guard.
- `source_mailbox` promoted onto the generic `WasmCtx<M>` (the `#[fallback]` runs on the `Single` view and needs the inbound source to resolve lane direction); the `OutboundReply` impl delegates to it, and consumers that imported the trait only for it drop the now-unused import.

Two smaller adaptations: `aether-capabilities` joins the `host` feature deps (it owns `FsCapability` / `ReadResult`, named by plan step 7; the boundary tripwire still holds — default face links none of the three), and the FRAME lifecycle trigger is a configurable `frame_trigger: u64` on `HostConfig` (the host cannot name `aether-kit`'s `Collect` kind id, so the kit arm sets it to `Collect::ID`).

## Test plan

Host-side unit coverage for the logic this crate owns (the full live scripted-behavior e2e is #2688):

- fail-open state machine — a trapping script forwards the in-flight mail untransformed, disables at exactly the consecutive-trap threshold, and a clean call resets the counter (driven by hand-built WAT fixtures).
- fallback lane router — undeclared kinds forward with no filter call (call-count probe); direction resolves correctly for source == wrapped-child vs source == parent.
- effect drain — verdict forwards before any effect sends (order probe); a script's write to its own wrapped child is not offered back through its filter (echo suppression); a consumed verdict still drains effects.
- persistence — dehydrate → rehydrate restores the running script from resident bytes with no fs call, and a tripwire asserts `on_rehydrate` issues no spawn call (the defer-to-walk invariant); an undecodable blob boots fresh.

Full workspace validation green: `cargo clippy --workspace --all-targets -D warnings`, `cargo nextest run --workspace` (1985 passed), `cargo doc` under strict rustdoc flags, and wasm32 cross-build of `aether-kit` both default and `--features behavior` (the latter pulls `wasmi` no_std into the deployment target).

## Generated by

`/implement` — agent execution of [scoped issue #2687](https://github.com/iamacoffeepot/aether/issues/2687).
