### PR TITLE
fix(kit): explicit reply class on on_set_cell_points handler

### DIFF
--- a/crates/aether-kit/src/runtime/world_view.rs
+++ b/crates/aether-kit/src/runtime/world_view.rs
@@ -183,7 +183,7 @@ impl WasmActor for WorldView {
     /// authored `Void` that cuts a hole). A short vector leaves the cell's
     /// remaining points inheriting. `capture_frame` to verify the marched
     /// silhouette.
-    #[handler]
+    #[handler::single]
     fn on_set_cell_points(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetCellPoints) {
         let cell = msg.cell();
         self.world.set_cell_points(cell, &msg.points);


### PR DESCRIPTION
`main` does not compile: `on_set_cell_points` in `world_view.rs` carries a bare `#[handler]`, which the explicit-reply-class macro (ADR-0134) rejects. It is a fire-and-forget setter returning the unit reply, identical in shape to its sibling setters `on_set_chunk` and `on_set_view_mode`, so it takes `#[handler::single]` to match.

The break reached `main` because the underlay-point PR was green against a base that predated the explicit-reply-class refactor, then merged behind it without re-testing the interaction (branch protection is not strict). Two green PRs, one red merge.

Unblocks the held draft PRs that all rebase onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)