### PR TITLE
docs(behavior): document the guest filter ABI for hand-authored behavior scripts

### DIFF
--- a/crates/aether-behavior/src/abi.rs
+++ b/crates/aether-behavior/src/abi.rs
@@ -7,6 +7,69 @@
 //! `u64`: the guest-memory pointer in the high 32 bits, the byte length in
 //! the low 32 bits. wasm32 pointers and lengths are 32-bit, so both fit
 //! without loss and the host unpacks the pair with a single shift + mask.
+//!
+//! ## Guest filter ABI reference
+//!
+//! The `#[behavior]` macro emits this ABI for a Rust author, so a Rust
+//! script never touches it directly — but it is also the contract a raw,
+//! hand-authored script (wasm text, or a non-Rust script generator) must
+//! satisfy to instantiate against the wasmi-embedding script host (the
+//! `host` feature's `BehaviorHost`). Rust `u32`/`u64` map to wasm's
+//! `i32`/`i64` (wasm has no unsigned value types), so a WAT author reads
+//! every signature below in `iNN` form.
+//!
+//! **Required exports**
+//!
+//! - `memory` — the linear memory the host reads and writes; resolved with
+//!   `Instance::get_memory(&store, "memory")`. A script that exports no
+//!   `memory` fails to instantiate.
+//! - `alloc: (i32, i32, i32, i32) -> i32` — `(old_ptr, old_size, align,
+//!   new_size) -> ptr`, the `cabi_realloc`-shaped allocator described
+//!   below.
+//! - `filter: (i64, i32, i32) -> i64` — `(kind_id, ptr, len) -> packed`.
+//!   The host writes the inbound mail's encoded bytes into a fresh guest
+//!   region (see `alloc`) and calls `filter` with that region's `(ptr,
+//!   len)` and the mail's `KindId` as `i64`; the return is a packed
+//!   `(ptr, len)` `u64` (see [`pack_ptr_len`] / [`unpack_ptr_len`])
+//!   pointing at the encoded [`crate::envelope::FilterOutput`].
+//!
+//! **Optional exports**
+//!
+//! - `state_save: () -> i64` — returns a packed `(ptr, len)` `u64`
+//!   pointing at the script's serialized migration blob.
+//! - `state_load: (i32, i32) -> i32` — `(ptr, len) -> _`, offered the
+//!   guest region holding a prior migration blob; the return value is
+//!   unused.
+//!
+//! A stateless script omits both — the host resolves them with a fallible
+//! lookup (`Instance::get_typed_func(..).ok()`), so a missing export is not
+//! an instantiation failure, and the host simply carries no migration blob
+//! for that script across a reload.
+//!
+//! **The `alloc` convention.** `alloc` is `cabi_realloc`-shaped:
+//! `(old_ptr, old_size, align, new_size) -> ptr`. The host only ever
+//! requests a *fresh* region for an inbound payload, so it always calls
+//! `alloc(0, 0, 1, len)` — a zero old pointer/size (nothing to grow or
+//! free) and alignment 1 (the payload is raw bytes, no alignment
+//! requirement) — writes `len` bytes at the returned `ptr`, then passes
+//! `(ptr, len)` on to `filter` / `state_load`.
+//!
+//! **The packed return.** `filter` and `state_save` each return a `u64`
+//! built by [`pack_ptr_len`]: the guest-memory pointer in the high 32
+//! bits, the byte length in the low 32. The host reads that region out of
+//! guest linear memory and never frees it — wasm has no memory-shrink
+//! operation, so an unreclaimed guest allocation per call is the accepted
+//! cost of the convention, not a leak to fix.
+//!
+//! **Payload framing.** `filter`'s returned region holds an encoded
+//! [`crate::envelope::FilterOutput`] — see [`crate::envelope::encode`] /
+//! [`crate::envelope::decode`] for the `ENVELOPE_VERSION`-byte-then-wire-body
+//! layout. The handled-kind skip-set the host reads at instantiation time
+//! (not from a guest call) lives in the `aether.behavior.exports` custom
+//! section — see [`crate::manifest::EXPORTS_SECTION`] /
+//! [`crate::manifest::decode_exports_manifest`] for its byte layout. Both
+//! layouts are owned by their respective modules; this reference only
+//! names them.
 
 /// Pack a guest-memory `(ptr, len)` pair into a single `u64` return value:
 /// `(ptr as u64) << 32 | len as u64`.


### PR DESCRIPTION
Closes #2717.

## Summary

The raw guest filter ABI a hand-written behavior script must satisfy was documented in no public surface — the load-bearing detail (required exports, their wasm signatures, the `alloc` calling convention, the `FilterOutput` envelope layout) lived only in the private `host/slot.rs`.

This expands the module-level rustdoc in `crates/aether-behavior/src/abi.rs` with the guest filter ABI reference: required/optional exports and their wasm signatures, the `alloc` convention, the packed return, and intra-doc links to the `envelope` / `manifest` framing types. Chosen over a guide page because `abi.rs` already owns the packed-pointer half and is trunk (compiled under `default-features=false`); the authoring-narrative guide is #2688's scope.

## Test plan

Docs-only. `cargo doc -p aether-behavior` passes with broken-intra-doc-links denied, both with and without `--features host`.

## Generated by

`/implement` — agent execution of scoped issue #2717.
