### PR TITLE
feat(kit): expose a public widget type tag for behavior-host child specs

### DIFF
--- a/crates/aether-behavior/src/host/config.rs
+++ b/crates/aether-behavior/src/host/config.rs
@@ -25,7 +25,9 @@ use serde::{Deserialize, Serialize};
 /// `ActorTypeTag(type_tag)` at the spawn call.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Schema)]
 pub struct ChildSpec {
-    /// `hash(NAMESPACE)` of the wrapped actor type.
+    /// `hash(NAMESPACE)` of the wrapped actor type. For a stock `aether-kit`
+    /// widget, `aether_kit::widgets::WidgetKind::type_tag()` produces this
+    /// value without linking the kit's `runtime` feature.
     pub type_tag: u64,
     /// The wrapped child's subname within the cluster.
     pub subname: String,

--- a/crates/aether-kit/src/runtime/widget_panel.rs
+++ b/crates/aether-kit/src/runtime/widget_panel.rs
@@ -390,7 +390,7 @@ fn spawn_behavior_host(
     use aether_behavior::host::{ChildSpec, ScriptSource};
 
     let host_spec = decode_child::<BehaviorHostSpec>(spec)?;
-    let Some(type_tag) = wrapped_widget_tag(host_spec.wrapped) else {
+    let Some(type_tag) = host_spec.wrapped.type_tag() else {
         tracing::warn!(
             target: "aether_kit",
             subname = %spec.subname,
@@ -452,23 +452,6 @@ fn spawn_behavior_host(
             None
         }
     }
-}
-
-/// The wrapped widget's actor type tag for the `behavior` spawn arm — the same
-/// `ActorTypeTag::of::<Concrete>()` mapping the direct-widget arms encode, one
-/// per stock widget. A container or a host is not wrappable ⇒ `None`.
-#[cfg(feature = "behavior")]
-fn wrapped_widget_tag(kind: WidgetKind) -> Option<u64> {
-    use aether_actor::ActorTypeTag;
-    let tag = match kind {
-        WidgetKind::Label => ActorTypeTag::of::<LabelWidget>().0,
-        WidgetKind::Slider => ActorTypeTag::of::<SliderWidget>().0,
-        WidgetKind::Radio => ActorTypeTag::of::<RadioGroupWidget>().0,
-        WidgetKind::TextField => ActorTypeTag::of::<TextFieldWidget>().0,
-        WidgetKind::Button => ActorTypeTag::of::<ButtonWidget>().0,
-        WidgetKind::Composite | WidgetKind::BehaviorHost => return None,
-    };
-    Some(tag)
 }
 
 /// The `behavior`-feature-off stub: a `WidgetKind::BehaviorHost` slot needs the
@@ -764,34 +747,35 @@ mod behavior_tests {
     use aether_actor::ActorTypeTag;
     use aether_data::Kind;
 
-    // Tripwire: the wrapped-widget tag mapping points each stock kind at its
-    // own concrete widget type (not a transposed neighbour) and refuses to
-    // wrap a container or a host. A mis-wired arm would spawn the wrong widget
+    // Tripwire: `WidgetKind::type_tag` (the trunk accessor the `behavior`
+    // spawn arm now calls directly) points each stock kind at its own
+    // concrete widget type (not a transposed neighbour) and refuses to wrap
+    // a container or a host. A mis-wired arm would spawn the wrong widget
     // under a host — silent until the pixels are wrong.
     #[test]
     fn wrapped_tag_maps_each_stock_widget_and_rejects_unwrappable() {
         assert_eq!(
-            wrapped_widget_tag(WidgetKind::Slider),
+            WidgetKind::Slider.type_tag(),
             Some(ActorTypeTag::of::<SliderWidget>().0)
         );
         assert_eq!(
-            wrapped_widget_tag(WidgetKind::Button),
+            WidgetKind::Button.type_tag(),
             Some(ActorTypeTag::of::<ButtonWidget>().0)
         );
         assert_eq!(
-            wrapped_widget_tag(WidgetKind::Label),
+            WidgetKind::Label.type_tag(),
             Some(ActorTypeTag::of::<LabelWidget>().0)
         );
         assert_eq!(
-            wrapped_widget_tag(WidgetKind::Radio),
+            WidgetKind::Radio.type_tag(),
             Some(ActorTypeTag::of::<RadioGroupWidget>().0)
         );
         assert_eq!(
-            wrapped_widget_tag(WidgetKind::TextField),
+            WidgetKind::TextField.type_tag(),
             Some(ActorTypeTag::of::<TextFieldWidget>().0)
         );
-        assert_eq!(wrapped_widget_tag(WidgetKind::Composite), None);
-        assert_eq!(wrapped_widget_tag(WidgetKind::BehaviorHost), None);
+        assert_eq!(WidgetKind::Composite.type_tag(), None);
+        assert_eq!(WidgetKind::BehaviorHost.type_tag(), None);
     }
 
     // Tripwire: a `BehaviorHostSpec` carrying a stock wrapped widget encodes as

--- a/crates/aether-kit/src/widgets.rs
+++ b/crates/aether-kit/src/widgets.rs
@@ -199,6 +199,35 @@ pub enum WidgetKind {
     BehaviorHost,
 }
 
+impl WidgetKind {
+    /// This stock widget's actor type tag — `hash(NAMESPACE)` of the widget
+    /// actor `self` spawns, the same value `ActorTypeTag::of::<W>().0` would
+    /// produce for the concrete actor type. `None` for the two unwrappable
+    /// variants (`Composite`, `BehaviorHost`), which have no single wrapped
+    /// actor. The trunk-reachable producer for
+    /// `aether_behavior::host::ChildSpec::type_tag` when composing a
+    /// `HostConfig` directly, outside the kit's `WidgetKind::BehaviorHost`
+    /// spawn arm — the concrete widget actor types are `runtime`-gated and
+    /// not re-exported, so this hashes the actor namespace literals
+    /// directly rather than naming the types.
+    #[must_use]
+    // Id-constant definition for stock widget types whose actors are
+    // `runtime`-gated; the runtime tripwire binds it to
+    // `ActorTypeTag::of::<W>()`.
+    #[allow(clippy::disallowed_methods)]
+    pub const fn type_tag(self) -> Option<u64> {
+        let tag = match self {
+            Self::Label => aether_data::mailbox_id_from_name("aether.kit.widget.label").0,
+            Self::Slider => aether_data::mailbox_id_from_name("aether.kit.widget.slider").0,
+            Self::Radio => aether_data::mailbox_id_from_name("aether.kit.widget.radio").0,
+            Self::TextField => aether_data::mailbox_id_from_name("aether.kit.widget.text_field").0,
+            Self::Button => aether_data::mailbox_id_from_name("aether.kit.widget.button").0,
+            Self::Composite | Self::BehaviorHost => return None,
+        };
+        Some(tag)
+    }
+}
+
 /// Where a wrapped host's script comes from — the kit-local mirror of
 /// `aether_behavior`'s `ScriptSource`, carried in a [`BehaviorHostSpec`] so the
 /// trunk (always compiled) names no `aether-behavior` type. The `behavior`


### PR DESCRIPTION
Closes #2716.

## Summary

A consumer wiring an `aether-behavior` `HostConfig` directly (outside `aether-kit`'s `WidgetKind::BehaviorHost` convenience arm) needs `ChildSpec.type_tag` = `hash(NAMESPACE)` of the wrapped widget actor, but the concrete widget actor types are gated behind kit's non-default `runtime` feature and unavailable host-side — so there was no public handle to compute the tag for a stock widget.

This adds a trunk `pub const fn WidgetKind::type_tag(self) -> Option<u64>` that hashes each stock widget's `NAMESPACE` literal (via `mailbox_id_from_name`, under one localized `#[allow(clippy::disallowed_methods)]` with a reason), returning `None` for the unwrappable `Composite` / `BehaviorHost` arms. The panel's internal `wrapped_widget_tag` is deleted in favour of the new accessor, and the existing tripwire test repoints to it as the drift guard. `ChildSpec.type_tag`'s rustdoc gains a cross-reference. Rejected re-exporting the runtime-gated actor types (forces the `runtime` feature) and a crate-wide `of_namespace(&str)` (reopens hand-hashing).

## Test plan

`wrapped_tag_maps_each_stock_widget_and_rejects_unwrappable` binds each variant's `type_tag()` to `ActorTypeTag::of::<Concrete>().0` — the drift tripwire. `cargo test -p aether-kit --features behavior` passes.

## Generated by

`/implement` — agent execution of scoped issue #2716.
