### PR TITLE
fix(capabilities): target the listener address for the rpc server teardown self-connect

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/mod.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/mod.rs
@@ -28,7 +28,7 @@ use super::{HttpInboundReady, HttpServerCapability, HttpServerConfig, HttpServer
 use aether_actor::runtime;
 
 pub use std::collections::HashMap;
-pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, TcpListener, TcpStream};
+pub use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 pub use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 pub use std::sync::{Arc, RwLock, mpsc};
 pub use std::thread;
@@ -82,26 +82,6 @@ pub use websocket::*;
 
 #[cfg(test)]
 mod unit_tests;
-
-/// Reconstructs the teardown self-connect target (see `unwire` below)
-/// from state the runtime already holds — no new state field. The
-/// listener's bound IP equals the configured `bind_addr`'s IP (`bind`
-/// only resolves the *port* when it is `0`), so this pairs that IP with
-/// the resolved `listener_port`. A wildcard bind (`0.0.0.0` / `::`) has
-/// no address a self-connect can land on, so it maps to the matching
-/// loopback instead; an unparseable `bind_addr` falls back to IPv4
-/// loopback.
-fn teardown_connect_addr(bind_addr: &str, listener_port: u16) -> SocketAddr {
-    let ip = bind_addr
-        .parse::<SocketAddr>()
-        .map_or(IpAddr::V4(Ipv4Addr::LOCALHOST), |addr| addr.ip());
-    let ip = match ip {
-        IpAddr::V4(v4) if v4.is_unspecified() => IpAddr::V4(Ipv4Addr::LOCALHOST),
-        IpAddr::V6(v6) if v6.is_unspecified() => IpAddr::V6(Ipv6Addr::LOCALHOST),
-        other => other,
-    };
-    SocketAddr::new(ip, listener_port)
-}
 
 #[runtime]
 impl NativeActor for HttpServerCapability {
@@ -213,7 +193,8 @@ impl NativeActor for HttpServerCapability {
         // their own `unwire` (the chassis tears instanced actors down
         // alongside the caps).
         state.accept_shutdown.store(true, Ordering::Release);
-        let wake_addr = teardown_connect_addr(&state.config.bind_addr, state.listener_port);
+        let wake_addr =
+            crate::shared::net::teardown_connect_addr(&state.config.bind_addr, state.listener_port);
         if let Err(error) = TcpStream::connect_timeout(&wake_addr, Duration::from_millis(100)) {
             tracing::warn!(
                 target: "aether_substrate::http_server",

--- a/crates/aether-capabilities/src/http/server/runtime/mod.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/mod.rs
@@ -54,6 +54,7 @@ use crate::http::kinds::{
     RegisterRoute, RegisterRouteResult, RegisterRouteSelf, UnregisterRoute, UnregisterRouteSelf,
     UnregisterRoutesAll,
 };
+use crate::shared::net::teardown_connect_addr;
 pub use aether_kinds::trace::Settled;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
@@ -193,8 +194,7 @@ impl NativeActor for HttpServerCapability {
         // their own `unwire` (the chassis tears instanced actors down
         // alongside the caps).
         state.accept_shutdown.store(true, Ordering::Release);
-        let wake_addr =
-            crate::shared::net::teardown_connect_addr(&state.config.bind_addr, state.listener_port);
+        let wake_addr = teardown_connect_addr(&state.config.bind_addr, state.listener_port);
         if let Err(error) = TcpStream::connect_timeout(&wake_addr, Duration::from_millis(100)) {
             tracing::warn!(
                 target: "aether_substrate::http_server",

--- a/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
@@ -2,10 +2,9 @@ use super::{
     HttpResponseStreamOpen, OPCODE_BINARY, OPCODE_CONTINUATION, OPCODE_TEXT, WsFrameParse,
     http_date, normalize_prefix, parse_http_method, parse_ws_frame, percent_decode_path,
     reason_phrase, render_stream_head, request_keeps_alive, route_matches, sec_websocket_accept,
-    serialize_ws_frame, sha1, teardown_connect_addr, validate_ws_handshake,
+    serialize_ws_frame, sha1, validate_ws_handshake,
 };
 use crate::http::kinds::{HttpHeader, HttpMethod};
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::{Duration, UNIX_EPOCH};
 
 fn conn_header(value: &str) -> Vec<HttpHeader> {
@@ -357,51 +356,6 @@ fn config_layer_defaults_match_the_named_consts() {
     assert_eq!(
         default.websocket_idle_timeout_millis,
         DEFAULT_WS_IDLE_TIMEOUT_MILLIS
-    );
-}
-
-/// Tripwire: a wildcard bind (`0.0.0.0` / `::`, no routable self-connect
-/// target) maps to the matching loopback family — this is the actual bug
-/// fix (issue #2631), not a mirror of the input.
-#[test]
-fn teardown_connect_addr_maps_wildcard_to_loopback() {
-    assert_eq!(
-        teardown_connect_addr("0.0.0.0:8080", 8080),
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
-    );
-    assert_eq!(
-        teardown_connect_addr("[::]:8080", 8080),
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080)
-    );
-}
-
-/// A specific bind IP (not wildcard) is preserved as-is, paired with the
-/// resolved listener port rather than whatever port `bind_addr` named
-/// (e.g. `0` for an OS-assigned port).
-#[test]
-fn teardown_connect_addr_preserves_specific_ip() {
-    assert_eq!(
-        teardown_connect_addr("192.168.1.5:0", 41_234),
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5)), 41_234)
-    );
-    assert_eq!(
-        teardown_connect_addr("127.0.0.1:8080", 8080),
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
-    );
-}
-
-/// An unparseable `bind_addr` (e.g. a hostname `TcpListener::bind` would
-/// resolve via DNS, which this pure helper does not do) falls back to
-/// IPv4 loopback rather than panicking or propagating the parse error.
-#[test]
-fn teardown_connect_addr_unparseable_falls_back_to_loopback() {
-    assert_eq!(
-        teardown_connect_addr("not-an-address", 9090),
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9090)
-    );
-    assert_eq!(
-        teardown_connect_addr("localhost:9090", 9090),
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9090)
     );
 }
 

--- a/crates/aether-capabilities/src/rpc/server/runtime.rs
+++ b/crates/aether-capabilities/src/rpc/server/runtime.rs
@@ -99,6 +99,7 @@ pub struct RpcServerState {
     /// `NativeInitCtx::mailer()`; the cap is single-threaded
     /// post-ADR-0038 so direct storage is fine.
     pub mailer: Arc<Mailer>,
+    pub bind_addr: String,
     pub listener_port: u16,
     pub accept_shutdown: Arc<AtomicBool>,
     pub accept_thread: Option<JoinHandle<()>>,
@@ -466,6 +467,7 @@ impl NativeActor for RpcServerCapability {
             peer_kind: config.peer_kind,
             self_mailbox: self_id,
             mailer: ctx.mailer(),
+            bind_addr: config.bind_addr.clone(),
             listener_port: port,
             accept_shutdown,
             accept_thread: Some(thread),
@@ -478,11 +480,19 @@ impl NativeActor for RpcServerCapability {
     }
 
     fn unwire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {
-        // Stop the accept thread.
+        // Stop the accept thread; self-connect to unblock its blocking
+        // `accept()`.
         state.accept_shutdown.store(true, Ordering::Release);
-        let addr_str = format!("127.0.0.1:{}", state.listener_port);
-        if let Ok(addr) = addr_str.parse::<SocketAddr>() {
-            let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
+        let wake_addr =
+            crate::shared::net::teardown_connect_addr(&state.bind_addr, state.listener_port);
+        if let Err(error) = TcpStream::connect_timeout(&wake_addr, Duration::from_millis(100)) {
+            tracing::warn!(
+                target: "aether_substrate::rpc",
+                port = state.listener_port,
+                addr = %wake_addr,
+                %error,
+                "rpc server teardown wake self-connect failed; accept-thread join may stall",
+            );
         }
         if let Some(t) = state.accept_thread.take() {
             let _ = t.join();

--- a/crates/aether-capabilities/src/rpc/server/runtime.rs
+++ b/crates/aether-capabilities/src/rpc/server/runtime.rs
@@ -28,6 +28,7 @@
 // struct `RpcServerCapability` is the impl's `Self` type.
 use super::connection::{ConnId, ConnState, InboundEvent, run_reader_loop};
 use super::{PeerKind, RpcInboundReady, RpcServerCapability, RpcServerConfig, Settled};
+use crate::shared::net::teardown_connect_addr;
 use aether_actor::runtime;
 
 // Re-export every substrate / std / cross-crate type the top-level
@@ -467,7 +468,7 @@ impl NativeActor for RpcServerCapability {
             peer_kind: config.peer_kind,
             self_mailbox: self_id,
             mailer: ctx.mailer(),
-            bind_addr: config.bind_addr.clone(),
+            bind_addr: config.bind_addr,
             listener_port: port,
             accept_shutdown,
             accept_thread: Some(thread),
@@ -483,8 +484,7 @@ impl NativeActor for RpcServerCapability {
         // Stop the accept thread; self-connect to unblock its blocking
         // `accept()`.
         state.accept_shutdown.store(true, Ordering::Release);
-        let wake_addr =
-            crate::shared::net::teardown_connect_addr(&state.bind_addr, state.listener_port);
+        let wake_addr = teardown_connect_addr(&state.bind_addr, state.listener_port);
         if let Err(error) = TcpStream::connect_timeout(&wake_addr, Duration::from_millis(100)) {
             tracing::warn!(
                 target: "aether_substrate::rpc",

--- a/crates/aether-capabilities/src/shared/mod.rs
+++ b/crates/aether-capabilities/src/shared/mod.rs
@@ -1,3 +1,5 @@
 //! Shared infrastructure consumed by multiple capabilities but not itself a capability.
 #[cfg(not(target_family = "wasm"))]
 pub mod contentgen;
+#[cfg(not(target_family = "wasm"))]
+pub mod net;

--- a/crates/aether-capabilities/src/shared/net.rs
+++ b/crates/aether-capabilities/src/shared/net.rs
@@ -1,0 +1,73 @@
+//! Shared networking helpers used by more than one server capability.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+/// Reconstructs a teardown self-connect target from state a server
+/// capability already holds — no new state field. The listener's bound
+/// IP equals the configured `bind_addr`'s IP (`bind` only resolves the
+/// *port* when it is `0`), so this pairs that IP with the resolved
+/// `listener_port`. A wildcard bind (`0.0.0.0` / `::`) has no address a
+/// self-connect can land on, so it maps to the matching loopback
+/// instead; an unparseable `bind_addr` falls back to IPv4 loopback.
+pub fn teardown_connect_addr(bind_addr: &str, listener_port: u16) -> SocketAddr {
+    let ip = bind_addr
+        .parse::<SocketAddr>()
+        .map_or(IpAddr::V4(Ipv4Addr::LOCALHOST), |addr| addr.ip());
+    let ip = match ip {
+        IpAddr::V4(v4) if v4.is_unspecified() => IpAddr::V4(Ipv4Addr::LOCALHOST),
+        IpAddr::V6(v6) if v6.is_unspecified() => IpAddr::V6(Ipv6Addr::LOCALHOST),
+        other => other,
+    };
+    SocketAddr::new(ip, listener_port)
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::teardown_connect_addr;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    /// Tripwire: a wildcard bind (`0.0.0.0` / `::`, no routable self-connect
+    /// target) maps to the matching loopback family — this is the actual bug
+    /// fix (issue #2631), not a mirror of the input.
+    #[test]
+    fn teardown_connect_addr_maps_wildcard_to_loopback() {
+        assert_eq!(
+            teardown_connect_addr("0.0.0.0:8080", 8080),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
+        );
+        assert_eq!(
+            teardown_connect_addr("[::]:8080", 8080),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080)
+        );
+    }
+
+    /// A specific bind IP (not wildcard) is preserved as-is, paired with the
+    /// resolved listener port rather than whatever port `bind_addr` named
+    /// (e.g. `0` for an OS-assigned port).
+    #[test]
+    fn teardown_connect_addr_preserves_specific_ip() {
+        assert_eq!(
+            teardown_connect_addr("192.168.1.5:0", 41_234),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5)), 41_234)
+        );
+        assert_eq!(
+            teardown_connect_addr("127.0.0.1:8080", 8080),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
+        );
+    }
+
+    /// An unparseable `bind_addr` (e.g. a hostname `TcpListener::bind` would
+    /// resolve via DNS, which this pure helper does not do) falls back to
+    /// IPv4 loopback rather than panicking or propagating the parse error.
+    #[test]
+    fn teardown_connect_addr_unparseable_falls_back_to_loopback() {
+        assert_eq!(
+            teardown_connect_addr("not-an-address", 9090),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9090)
+        );
+        assert_eq!(
+            teardown_connect_addr("localhost:9090", 9090),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9090)
+        );
+    }
+}

--- a/crates/aether-capabilities/src/shared/net.rs
+++ b/crates/aether-capabilities/src/shared/net.rs
@@ -9,6 +9,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 /// `listener_port`. A wildcard bind (`0.0.0.0` / `::`) has no address a
 /// self-connect can land on, so it maps to the matching loopback
 /// instead; an unparseable `bind_addr` falls back to IPv4 loopback.
+#[must_use]
 pub fn teardown_connect_addr(bind_addr: &str, listener_port: u16) -> SocketAddr {
     let ip = bind_addr
         .parse::<SocketAddr>()


### PR DESCRIPTION
Closes #2645.

## Summary

The rpc server's teardown wake self-connect built its target as a hardcoded `127.0.0.1:{port}` and discarded the connect result — the same wrong-interface bug just fixed in the http server accept thread (#2631): a server bound to `0.0.0.0` or an external interface can miss the loopback wake and hang the `accept()`-thread join silently.

This extracts #2631's `teardown_connect_addr` helper into a shared `shared::net` module (mapping wildcard bind → loopback, preserving a specific bound IP) and reuses it from both caps. `RpcServerState` gains a `bind_addr` field; `unwire` targets the actual bound address and `warn!`s on a failed `connect_timeout` instead of swallowing it. Pub-or-private invariant preserved (helper is `pub` in a private-path module).

## Test plan

The three helper unit tests (`_maps_wildcard_to_loopback`, `_preserves_specific_ip`, `_unparseable_falls_back_to_loopback`) move with the helper into `shared/net.rs`. `cargo check -p aether-capabilities --all-features` clean.

## Generated by

`/implement` — agent execution of scoped issue #2645.
