### PR TITLE
fix(capabilities): apply http framing rejects on the websocket-upgrade path

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/reader.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/reader.rs
@@ -557,25 +557,30 @@ pub fn run_reader_loop(
         } else {
             None
         };
-        if ws_key.is_none() {
-            // Framing rejects for the buffered path (ADR-0128): smuggling
-            // / non-`chunked` codings always, and a lone `chunked` body to
-            // a buffered handler (no length to buffer under).
-            match (head.framing, streaming) {
-                (BodyFraming::Invalid, _) | (BodyFraming::Chunked, false) => {
-                    reject_and_close(&mut stream, sink, conn_id, 411, "length required");
-                    return;
-                }
-                _ => {}
+        // Whether this request will be buffered rather than streamed: a
+        // websocket upgrade always buffers (line ~594 forces the
+        // `else`-branch below) regardless of the `streaming` flag; a
+        // non-upgrade request buffers unless it is both streaming-capable
+        // and not an upgrade (the ADR-0128 streaming exemption). Shared by
+        // both the framing rejects and the body-size cap below so the two
+        // checks read off one determinant.
+        let will_buffer = ws_key.is_some() || !streaming;
+        // Framing rejects, applied on every path — upgrade included
+        // (ADR-0128 + ADR-0129): a websocket handshake carries no body
+        // (RFC 6455), so a smuggling shape or a lone `chunked` body on an
+        // upgrade is anomalous with no length to buffer under, same as on
+        // the non-upgrade path. `Invalid` (smuggling / a non-`chunked`
+        // coding) always rejects; a lone `chunked` body only rejects when
+        // the request will buffer.
+        match (head.framing, will_buffer) {
+            (BodyFraming::Invalid, _) | (BodyFraming::Chunked, true) => {
+                reject_and_close(&mut stream, sink, conn_id, 411, "length required");
+                return;
             }
+            _ => {}
         }
-        // The body-size cap applies whenever the request will be buffered
-        // — a websocket upgrade always buffers (line ~594 forces the
-        // `else`-branch) regardless of the `streaming` flag, so the cap
-        // must not be gated on `ws_key.is_none()`. A non-upgrade request
-        // still keeps the ADR-0128 streaming exemption: only the
-        // `streaming && ws_key.is_none()` combination skips this check.
-        if (ws_key.is_some() || !streaming)
+        // The body-size cap applies whenever the request will be buffered.
+        if will_buffer
             && let BodyFraming::Length(n) = head.framing
             && n > max_request_bytes
         {

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -1185,6 +1185,43 @@ fn oversize_body_on_ws_upgrade_is_413() {
     );
 }
 
+/// A websocket-upgrade request that also carries the request-smuggling
+/// framing shape (both `Content-Length` and `Transfer-Encoding`) is
+/// answered `411` before any dispatch — the same framing reject the
+/// non-upgrade path applies, not skipped because `ws_key.is_some()`.
+///
+/// Tripwire: on `origin/main` this returns non-411 because the framing
+/// reject sits inside `if ws_key.is_none()` and never runs for a valid
+/// upgrade handshake.
+#[test]
+fn smuggling_on_ws_upgrade_is_411() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<EchoHttpHandler>(())
+        .with_actor::<HttpServerCapability>(config_for(
+            <EchoHttpHandler as Addressable>::NAMESPACE,
+            1024,
+        ))
+        .build_passive()
+        .expect("caps boot");
+
+    let response = round_trip(
+        port_of(&chassis),
+        b"GET /ws HTTP/1.1\r\n\
+          Host: localhost\r\n\
+          Upgrade: websocket\r\n\
+          Connection: Upgrade\r\n\
+          Sec-WebSocket-Version: 13\r\n\
+          Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+          Content-Length: 5\r\n\
+          Transfer-Encoding: chunked\r\n\r\nhello",
+    );
+    assert!(
+        response.starts_with("HTTP/1.1 411 "),
+        "expected 411, got: {response:?}",
+    );
+}
+
 /// A non-enumerated method is answered `501` before any dispatch.
 #[test]
 fn unknown_method_is_501() {
@@ -1678,6 +1715,45 @@ fn content_length_with_transfer_encoding_is_411() {
     assert!(
         response.starts_with("HTTP/1.1 411 "),
         "smuggling shape stays 411 even for a streaming handler: {response:?}",
+    );
+}
+
+/// A websocket-upgrade request carrying a lone `Transfer-Encoding: chunked`
+/// body is answered `411`, even against a *streaming* handler that would
+/// otherwise take a lone chunked body on the non-upgrade path
+/// (`chunked_upload_streams_to_streaming_handler`) — the upgrade forces
+/// buffering (RFC 6455: a handshake carries no body), so there is nothing
+/// to buffer under, the sharpest form of the regression.
+///
+/// Tripwire: on `origin/main` this returns non-411 because the framing
+/// reject sits inside `if ws_key.is_none()` and never runs for a valid
+/// upgrade handshake.
+#[test]
+fn chunked_on_ws_upgrade_is_411() {
+    let (registry, mailer) = fresh_substrate();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<StreamingUploadHandler>(())
+        .with_actor::<HttpServerCapability>(request_stream_config_for(
+            <StreamingUploadHandler as Addressable>::NAMESPACE,
+            4,
+        ))
+        .build_passive()
+        .expect("caps boot");
+    let port = port_of(&chassis);
+
+    let response = round_trip(
+        port,
+        b"GET /ws HTTP/1.1\r\n\
+          Host: localhost\r\n\
+          Upgrade: websocket\r\n\
+          Connection: Upgrade\r\n\
+          Sec-WebSocket-Version: 13\r\n\
+          Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+          Transfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n",
+    );
+    assert!(
+        response.starts_with("HTTP/1.1 411 "),
+        "expected 411, got: {response:?}",
     );
 }
 


### PR DESCRIPTION
Closes #2644.

## Summary

The 411 framing rejects (`BodyFraming::Invalid` request-smuggling / a lone `Chunked` body to a buffered handler) sat under the `if ws_key.is_none()` gate, so a request presenting a valid websocket-upgrade handshake could bypass the smuggling / lone-chunked checks — #2630 hoisted the 413 body-size cap out of this gate but deliberately left the framing rejects gated.

This hoists the framing-reject match out of the upgrade gate so it applies regardless of upgrade status (a WS handshake carries no body, so no exemption is warranted), via a shared `will_buffer` bool (`ws_key.is_some() || !streaming`) reused by both the framing reject and the adjacent 413 cap.

## Test plan

Adds `smuggling_on_ws_upgrade_is_411` and `chunked_on_ws_upgrade_is_411`; the four pre-existing framing/streaming tests named in the plan stay green. `cargo test -p aether-capabilities --lib http::server::tests` — 40/40 pass.

## Generated by

`/implement` — agent execution of scoped issue #2644.
