### PR TITLE
docs(guide): add a writing-guest-code decision page

### DIFF
--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -49,7 +49,7 @@
   - [Adding a chassis capability](recipes/adding-a-chassis-capability.md)
   - [Wiring an MCP tool](recipes/wiring-an-mcp-tool.md)
   - [Writing a component](recipes/writing-a-component.md)
-  - [Writing a behavior]()
+  - [Writing a behavior](recipes/writing-a-behavior.md)
   - [Serving HTTP from a component](recipes/serving-http.md)
   - [Debugging a hung settlement](recipes/debugging-a-hung-settlement.md)
 

--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -40,6 +40,7 @@
 # Building with aether
 
 - [Capability module anatomy](capability-anatomy.md)
+- [Writing guest code](writing-guest-code.md)
 - [Recipes](recipes.md)
   - [Adding a config knob](recipes/adding-a-config-knob.md)
   - [Adding a substrate kind](recipes/adding-a-substrate-kind.md)
@@ -48,6 +49,7 @@
   - [Adding a chassis capability](recipes/adding-a-chassis-capability.md)
   - [Wiring an MCP tool](recipes/wiring-an-mcp-tool.md)
   - [Writing a component](recipes/writing-a-component.md)
+  - [Writing a behavior]()
   - [Serving HTTP from a component](recipes/serving-http.md)
   - [Debugging a hung settlement](recipes/debugging-a-hung-settlement.md)
 

--- a/docs/guide/recipes/writing-a-behavior.md
+++ b/docs/guide/recipes/writing-a-behavior.md
@@ -1,0 +1,241 @@
+# Writing a behavior
+
+> **Prereqs:** `cargo` with the `wasm32-unknown-unknown` target to compile your
+> script, and the [MCP harness](../mcp-harness.md) up to attach and drive it. A
+> behavior is a small wasm script the engine interprets in place, so you author
+> and iterate on it the same way you drive the live engine — compile the script,
+> point a host at it, watch it transform mail.
+
+A behavior transforms the mail already flowing past a position in a running actor
+tree — it declares no kinds, owns no mailbox, and is interpreted by a host actor
+that occupies a slot and offers each passing mail to your script. This recipe
+takes an empty crate to a script a host runs: crate setup, the `#[behavior]`
+block, the wasm build, and attaching it. Read [Writing guest code](../writing-guest-code.md)
+first for when to reach for a behavior instead of a component; this recipe assumes
+you've made that call.
+
+> **Verify against current code.** This recipe carries symbol names and file
+> paths — confirm them before following it. The script SDK is
+> `crates/aether-behavior` (its `runtime` module: `Behavior`, `BehaviorCtx`, and
+> the widget/child/panel handles); the `#[behavior]` macro is
+> `crates/aether-behavior-derive`; the host and its config vocabulary are
+> `crates/aether-behavior/src/host/`. If a name below has moved, the fix is part
+> of the work.
+
+## 1. Set up the crate
+
+A behavior script is a `cdylib` that depends on `aether-behavior` and **not** on
+`aether-actor`. That absence is load-bearing: a component is discovered
+structurally by its `aether-actor` dependency, so a script tree that stays clear
+of `aether-actor` never classifies as a component. It also means a script cannot
+share the kind crate a component would — anything that pulls `aether-actor`
+transitively (`aether-kit`, for one) is off-limits.
+
+```toml
+# Cargo.toml
+[package]
+name = "clamp-behavior"
+version = "0.0.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]          # the wasm script artifact
+
+[dependencies]
+aether-behavior = { path = "../aether-behavior" }             # SDK (runtime face, on by default)
+aether-behavior-derive = { path = "../aether-behavior-derive" } # the #[behavior] macro
+aether-data = { path = "../aether-data", default-features = false, features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
+```
+
+Because a script can't depend on the crate that defines the kinds it transforms,
+declare a **local twin** of each kind under the *same* `#[kind(name = "…")]` wire
+name. The name is what the `KindId` and wire bytes derive from, so a twin with the
+matching name decodes the real traffic byte-for-byte. Copy the field shape exactly
+— a drift between your twin and the real kind is a decode mismatch at runtime, not
+a compile error.
+
+```rust
+use serde::{Deserialize, Serialize};
+
+// Twin of aether-kit's slider event — same wire name, so it decodes the
+// real SliderChanged flowing past the host.
+#[derive(Serialize, Deserialize, aether_data::Kind, aether_data::Schema, Clone)]
+#[kind(name = "aether.kit.widget.slider.changed")]
+struct SliderChanged {
+    value: f32,
+    committed: bool,
+}
+```
+
+## 2. Write the `#[behavior]` block
+
+The receive side is one `#[behavior] impl Behavior for C` block — the `#[actor]`
+shape, one tier over. Each `#[on]` method is a handler; the macro infers the kind
+from the method's third parameter, and the parameter's mutability *is* the intent:
+`&mut K` intercepts (the mutated value re-encodes and forwards), `&K` observes.
+`ctx.consume()` drops the in-flight mail. There is no verdict type — mutation and
+`consume` are the whole vocabulary.
+
+```rust
+use aether_behavior::BehaviorCtx;
+use aether_behavior_derive::behavior;
+use serde::{Deserialize, Serialize};
+
+// Authored state: the clamp cap and how many commits we've clamped. The
+// struct's fields ARE the persisted state (serde, carried across a swap).
+#[derive(Default, Serialize, Deserialize)]
+struct Clamp {
+    cap: f32,
+    clamped: u32,
+}
+
+#[behavior]
+impl Behavior for Clamp {
+    // Runs once the mirrors are primed and ctx is live. Seed defaults here.
+    #[on_attach]
+    fn attached(&mut self, _ctx: &mut BehaviorCtx) {
+        if self.cap == 0.0 {
+            self.cap = 0.8;
+        }
+    }
+
+    // Intercept: `&mut SliderChanged`. The mutated event forwards on; a
+    // consumed one does not.
+    #[on]
+    fn on_change(&mut self, ctx: &mut BehaviorCtx, m: &mut SliderChanged) {
+        if !m.committed {
+            ctx.consume(); // drop uncommitted drag noise — it never forwards
+            return;
+        }
+        if m.value > self.cap {
+            m.value = self.cap; // clamp; the forwarded event carries 0.8
+            self.clamped += 1;
+        }
+    }
+}
+```
+
+Three parts earn attention:
+
+- **The macro provides the trait and the markers.** `#[behavior]` rewrites the
+  block to `impl aether_behavior::Behavior`, so you neither import `Behavior` nor
+  the `#[on]` / `#[on_attach]` markers — writing them is enough. The only imports
+  a minimal script needs are `BehaviorCtx` (named in handler signatures) and the
+  `behavior` attribute itself.
+- **State is your struct.** The fields you derive `Serialize` / `Deserialize` on
+  are what persists — the macro's default `state_save` / `state_load` serialize
+  the whole struct, and a script swap offers the old blob to the replacement. A
+  `Default` impl is required (the host constructs the instance lazily). Override
+  `state_save` / `state_load` only for a custom migration.
+- **Reads and effects go through `ctx`.** `ctx.widget().last::<K>()` reads the
+  last value of a kind that flowed past this slot (a decode-once mirror, not a
+  request); `ctx.widget().set(&k)`, `ctx.panel().emit(&k)`, and
+  `ctx.child(path).send(&k)` project effects that the host drains into real
+  cluster sends after your handler returns. A per-frame hook is `#[on_frame]`, and
+  teardown is `#[on_detach]`.
+
+## 3. Build for wasm32
+
+A script is a std `cdylib` — std supplies the allocator and panic handler, so
+there is no `#![no_std]` ceremony.
+
+```console
+$ rustup target add wasm32-unknown-unknown    # once per toolchain
+$ cargo build --target wasm32-unknown-unknown --release -p clamp-behavior
+```
+
+The artifact lands at
+`target/wasm32-unknown-unknown/release/clamp_behavior.wasm` (dashes turned to
+underscores). Release keeps it small — this one is ~50 KiB. The macro emits the
+guest exports (`filter`, `alloc`, `state_save`, `state_load`) and an
+`aether.behavior.exports` custom section listing the kind ids your handlers cover,
+which lets the host skip the interpreter for traffic your script doesn't touch.
+
+## 4. Attach it to a host
+
+A behavior runs inside a **`BehaviorHost`** (`aether.behavior.host`) — a stock
+actor that wraps one child, occupies its slot, and offers the slot's mail to your
+script. The host takes a `HostConfig` naming the wrapped child (by its actor type
+tag), the script source, and the fuel budget. Encode that config with the real
+types — `aether_kit::widgets::WidgetKind::type_tag()` yields a stock widget's tag
+without linking the kit's runtime, and `ScriptSource::Inline` ships the wasm bytes
+directly:
+
+```rust
+use aether_behavior::host::{ChildSpec, HostConfig, ScriptSource};
+use aether_kit::widgets::{SliderConfig, WidgetKind};
+use aether_kit::theme::Theme;
+use aether_data::Kind;
+
+let script = std::fs::read(".../clamp_behavior.wasm")?;
+let slider = SliderConfig { min: 0.0, max: 1.0, step: 0.0, initial: 0.5, theme: Theme::DEFAULT };
+let config = HostConfig {
+    child: ChildSpec {
+        type_tag: WidgetKind::Slider.type_tag().unwrap(),
+        subname: "slider".into(),
+        config: slider.encode_into_bytes(),
+    },
+    script: ScriptSource::Inline(script),
+    fuel_per_call: 0,        // 0 ⇒ the host default (~1M)
+    disable_after_traps: 0,  // 0 ⇒ the host default (3)
+    frame_trigger: 0,        // 0 ⇒ no per-frame hook
+};
+std::fs::write(".../host_config.bin", config.encode_into_bytes())?;
+```
+
+Load the host from a kit build compiled with its `behavior` feature (which pulls
+the interpreter in and exports the host), pointing `config_path` at those bytes:
+
+```text
+upload_component(staged_path = ".../aether_kit.wasm")                    → { hash, name }
+spawn_substrate()                                                        → engine_id
+load_component(engine_id, selector, export = "aether.behavior.host",
+               config_path = ".../host_config.bin")                      → LoadResult
+```
+
+`LoadResult::Ok` means the host came up: the wrapped slider spawned as its inline
+child, and the interpreter instantiated your script. The host now interposes on
+the slot — mail addressed to it is offered to your `#[on]` handlers before it
+forwards to the wrapped child.
+
+In a widget panel you rarely build a `HostConfig` by hand: the panel's declarative
+child specs (see [Drawing your first UI](drawing-ui.md)) carry a
+`WidgetKind::BehaviorHost` slot whose config is a `BehaviorHostSpec` (the wrapped
+widget kind, its config, and the script), and the panel builds the `HostConfig`
+for you. The direct load above is the mechanism under that convenience.
+
+## 5. Swap the script live
+
+The host takes two control kinds so you iterate without reloading it. Rebuild the
+wasm, then swap it in place:
+
+- `aether.behavior.set_script { bytes }` replaces the running script with inline
+  wasm and replies `load_script_result` (`Ok { resident_bytes }` / `Err`) — the
+  fast edit loop.
+- `aether.behavior.load_script { namespace, path }` fetches the replacement from
+  an `aether.fs` namespace instead.
+
+A swap carries your authored state forward: the old script's `state_save` blob is
+offered to the replacement's `state_load`, so a `Clamp` swapped for a new build
+keeps its `clamped` count.
+
+## The firewall: a behavior is not a gate
+
+Every filter call runs under a fuel budget, and on any fault — fuel exhaustion, a
+bad decode, a trap — the host **fails open**: the in-flight mail forwards
+untransformed, the fault is logged, and after `disable_after_traps` consecutive
+faults the script drops to a passthrough until you replace it. A degraded-but-alive
+widget is the correct residue of a broken script. The direct consequence: logic
+that must *block* traffic to be correct cannot be a behavior, because a fault would
+let that traffic straight through. Gate-shaped logic belongs in a component — see
+[Writing guest code](../writing-guest-code.md#a-behavior-is-not-a-gate).
+
+## Where to read more
+
+- When to write a behavior versus a component, and the graduation path between
+  them — [Writing guest code](../writing-guest-code.md).
+- The panel side of attaching a behavior to a widget — [Drawing your first UI](drawing-ui.md).
+- The mechanism: interposition as tree position, the mirror-and-effects model, the
+  fail-open firewall, and the vocabulary boundary —
+  [ADR-0137](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0137-in-cluster-behavior-script-host.md).

--- a/docs/guide/writing-guest-code.md
+++ b/docs/guide/writing-guest-code.md
@@ -1,0 +1,107 @@
+# Writing guest code
+
+There are two ways to run your own code on a running engine, and picking the
+right one is the first decision you make: write a **component** when your code
+needs its own vocabulary, its own mailbox, and its own subscriptions, and write
+a **behavior** when it only needs to transform mail that already flows past a
+spot in a running cluster. A component is a full actor you compile and load; a
+behavior is a small script the engine interprets in place, at a position you
+choose in an existing actor tree. This page draws the line between them so you
+reach for the right surface before you start writing.
+
+## The two axes
+
+Guest code differs along two axes: **when it arrives** — compiled into a module
+ahead of time, or injected while the engine runs — and **where it runs** — in
+its own instance with its own mailbox lineage, or inside an existing cluster
+sharing that cluster's mail path. Three mechanisms sit on those axes:
+
+| Mechanism | When it arrives | Where it runs |
+|---|---|---|
+| `#[actor]` + `export!` inline children | compile time | inside the cluster |
+| `load_component` | runtime | its own instance & lineage |
+| a behavior script | runtime | inside the cluster |
+
+A component authored with `#[actor]` gives you an actor either way you deploy it:
+compiled inline as a child of another actor, it settles mail cascades inside the
+cluster; loaded on its own with `load_component`, it becomes an independent
+instance with its own lineage. Both are the same authoring surface — the actor
+you write, [compiled to wasm](recipes/writing-a-component.md).
+
+A behavior fills the remaining corner: code that arrives at runtime *and* runs
+inside an existing cluster. That corner has no component form — a wasm instance's
+functions are fixed when it is instantiated, so new code cannot be grown into a
+live instance. A behavior instead interposes *around* the actors already there,
+occupying a slot in the tree and transforming the mail that passes through it.
+The forcing case is widget glue: the logic that makes one panel *this* panel
+("when the slider passes 0.8, clamp it and flash the label") is small, changes
+constantly, and belongs at the widget it modifies — too light for a component
+build-and-load cycle every time it changes.
+
+## Component or behavior
+
+The decision follows from what your code needs to touch.
+
+Reach for a **component** when it:
+
+- declares new kinds — a component carries its own `aether.kinds` vocabulary and
+  registers it, so `describe_kinds` and `describe_component` can see it;
+- owns a mailbox others address by name, or subscribes to input streams;
+- runs on its own, addressable across the wire, with its own mail lineage.
+
+Reach for a **behavior** when it:
+
+- transforms kinds that already flow past its position — it declares no new
+  vocabulary and registers nothing;
+- reads and mutates that traffic in place, or emits effects back into the
+  cluster through the widgets around it;
+- is small enough to author, attach, and swap live, without a build-and-load
+  round trip.
+
+A behavior's whole mail surface is the set of kinds already flowing at its slot.
+It reads them through a per-kind mirror (`last::<K>()`), intercepts them by taking
+the mail `&mut` (the mutated value forwards) or observes them by taking it `&K`,
+and emits effects by projecting mail onto the widgets in its subtree. It never
+appears in the mailbox topology — the chain sees the host actor it runs inside,
+and the script's cost lands in that host's handler cost.
+
+## Graduating a behavior to a component
+
+The line is not a wall. A behavior that grows to want its own kind vocabulary,
+its own mailbox, or its own subscriptions has outgrown the shared cell — that is
+exactly the set of things a component provides and a behavior does not. The
+graduation path is `load_component`: lift the logic into an actor, give it the
+vocabulary it now needs, and load it as its own instance. Because the two
+authoring surfaces mirror each other — `#[behavior]` handlers infer their kind
+from a parameter the same way `#[actor]` handlers do, and both carry the same
+lifecycle shape — the concepts you learned writing the behavior carry over, and
+the move is mostly a change of where the code lives, not how it is written.
+
+## A behavior is not a gate
+
+One property is load-bearing enough to state up front: a behavior **fails open**.
+Every script runs under a fuel budget, and on any fault — fuel exhaustion, a
+memory error, a bad decode — the in-flight mail forwards untransformed and the
+failure is logged; after repeated faults the script is disabled into a passthrough
+until it is replaced. A degraded-but-alive widget is the correct residue of a
+broken script, never a dead subtree.
+
+That default has a direct consequence for what you may express as a behavior:
+anything that must *block* traffic to be correct or safe cannot be a behavior,
+because a fault would let that traffic straight through. Gate-shaped logic belongs
+in a real actor, where containment is structural. A behavior is a convenience
+layer over traffic that flowed fine before the script existed — treat it as one.
+
+## Where to read more
+
+- The full end-to-end loop for a component — crate setup, the `#[actor]` block,
+  `export!`, the wasm build, and loading it over MCP —
+  [Writing a component](recipes/writing-a-component.md).
+- How you write an actor at all — its lifecycle, handlers, and addressing by type
+  — [The actor model](foundations/actor-model.md).
+- The mechanism behind behaviors — interposition as tree position, the fuel-metered
+  fail-open firewall, the mirror-and-effects model, and the vocabulary boundary —
+  [ADR-0137](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0137-in-cluster-behavior-script-host.md).
+
+A "Writing a behavior" recipe walking the `#[behavior]` surface end to end lands
+alongside the behavior-script end-to-end fixture.


### PR DESCRIPTION
Closes #2730. Closes #2731.

## Summary

Adds the guide's "Writing guest code" subsection for the behavior system (ADR-0137) — the reader-facing docs the guide was missing entirely. Two pages plus the nav that groups them:

**Decision page (`writing-guest-code.md`)** — draws the two-axis map (when code arrives: compile-time vs runtime; where it runs: own instance vs inside a cluster), places the three mechanisms on it (behaviors fill the runtime-in-cluster corner), states the component-vs-behavior decision by what the code must touch, names the graduation path to load_component, and states the fail-open / not-a-gate property up front.

**Recipe (`recipes/writing-a-behavior.md`)** — walks the `#[behavior]` surface end to end: crate setup with local kind twins (a script can't depend on aether-actor), `#[on]` intercept/observe via `&mut K` vs `&K` plus `ctx.consume`, authored state via serde, the wasm build, attaching through a `BehaviorHost` with an inline script source, and the `set_script` / `load_script` live-swap kinds.

Both are grouped under "Building with aether" and the "Writing a component" recipe sits beside the new one.

## On the scope change

This started as just the decision page, with the recipe split to #2731 gated on #2688 — on the belief that a behavior couldn't be built or attached until #2688 landed the xtask build plumbing. That gate was disproven by building and running the loop live: the whole author→build→attach→run path is already on `main`, so the recipe is written now and #2731 is delivered here rather than deferred. #2688 remains valuable (it adds the standard `xtask dist` build discovery and locks the full panel-observed transform into CI), but it does not block the recipe.

## Test plan

- `mdbook build docs` succeeds; both new pages render and the nav resolves. No Rust touched.
- The recipe's steps are verified against a live substrate over the MCP harness:
  - the fixture `#[behavior]` compiles to a ~50 KiB wasm cdylib (warning-free);
  - `aether-kit` built with its `behavior` feature cross-builds to wasm — the wasmi interpreter compiles inside the guest;
  - a `BehaviorHost` loads the compiled script into wasmi (`LoadResult::Ok`, wrapped slider spawned, no trap logs) and runs it against real `SliderChanged` mail without trapping (traced, both handlers ran to completion).
  - The clamp value semantics (`0.95 → 0.8`, consume of uncommitted events) are covered by `aether-behavior`'s own unit tests; the full panel-observed end-to-end transform assertion is #2688's TestBench gate.

## Generated by

`/implement` — agent execution of [scoped issue #2730](https://github.com/iamacoffeepot/aether/issues/2730), extended to deliver [#2731](https://github.com/iamacoffeepot/aether/issues/2731) after the #2688 gate was disproven by live validation.
