### PR TITLE
feat(actor): opt-in default entry for multi-actor modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "url",
  "uuid",
  "wasmtime",
+ "wat",
  "wgpu",
 ]
 
@@ -329,6 +330,14 @@ dependencies = [
  "bytemuck",
  "serde",
  "tracing",
+]
+
+[[package]]
+name = "aether-test-fixtures-defaultless"
+version = "0.3.0-alpha"
+dependencies = [
+ "aether-actor",
+ "aether-kinds",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,17 @@ members = [
     "crates/aether-capabilities",
     "crates/aether-mcp",
     # Test fixtures — a container dir of single-output crates: one shared
-    # `kinds` rlib plus three component cdylibs (the main bundle and the
-    # typed↔reshaped replace-pair satellites). Listed explicitly (not a
-    # `crates/aether-test-fixtures/*` glob) because Qodana's TOML inspector
-    # can't resolve workspace globs.
+    # `kinds` rlib plus the component cdylibs (the main bundle, the
+    # typed↔reshaped replace-pair satellites, and the ADR-0138 defaultless
+    # multi-actor fixture) and the split-cap native lib. Listed explicitly
+    # (not a `crates/aether-test-fixtures/*` glob) because Qodana's TOML
+    # inspector can't resolve workspace globs.
     "crates/aether-test-fixtures/aether-test-fixtures-kinds",
     "crates/aether-test-fixtures/aether-test-fixtures-bundle",
     "crates/aether-test-fixtures/aether-test-fixtures-stateful-typed",
     "crates/aether-test-fixtures/aether-test-fixtures-stateful-reshaped",
     "crates/aether-test-fixtures/aether-test-fixtures-split-cap",
+    "crates/aether-test-fixtures/aether-test-fixtures-defaultless",
     "xtask",
 ]
 exclude = [

--- a/crates/aether-actor/src/wasm/mod.rs
+++ b/crates/aether-actor/src/wasm/mod.rs
@@ -364,11 +364,23 @@ macro_rules! export {
     ($component:ty) => {
         $crate::__export_internal!($component);
     };
-    // ADR-0096: multi-actor module — two or more `WasmActor` types in one
-    // crate. Requires at least a first + one more so it never shadows
-    // the single-actor arm above.
+    // ADR-0138: multi-actor module with an explicit default entry —
+    // `export!(entry = A, B, C)` designates `A` as the bare-load target
+    // (the export a `load` with no selector instantiates) and keeps it at
+    // the head of the exported set. This arm is ordered before the generic
+    // multi arm so the `entry =` opt-in is matched first; it reproduces the
+    // pre-ADR-0138 behavior with the entry named explicitly.
+    (entry = $entry:ty $(, $rest:ty)* $(,)?) => {
+        $crate::__export_multi_internal!(@entry $entry ; @all $entry $(, $rest)*);
+    };
+    // ADR-0096 / ADR-0138: multi-actor module — two or more `WasmActor`
+    // types in one crate. Requires at least a first + one more so it never
+    // shadows the single-actor arm above. Per ADR-0138 this bare form
+    // designates NO default entry: a `load` with no export selector is a
+    // hard error naming the exports, not an instantiation of `$first` by
+    // list position. Opt into a default with the `entry =` arm above.
     ($first:ty $(, $rest:ty)+ $(,)?) => {
-        $crate::__export_multi_internal!(@entry $first ; @all $first $(, $rest)+);
+        $crate::__export_multi_internal!(@no_entry ; @all $first $(, $rest)+);
     };
 }
 
@@ -851,19 +863,22 @@ macro_rules! __export_internal {
     };
 }
 
-/// ADR-0096: FFI shims for a multi-actor module — `export!(A, B, …)`.
+/// ADR-0096 / ADR-0138: FFI shims for a multi-actor module —
+/// `export!(entry = A, B, …)` or `export!(A, B, …)`.
 ///
 /// One module-level `Slot<Box<dyn ErasedWasmActor>>` holds whichever
 /// exported type the instance became. Two construction entry points:
 ///
 /// - `init_with_config_p32` (the existing 3-arg ABI) constructs the
-///   **entry** type (the first in the `export!` list). A host that
-///   knows nothing about multi-actor modules loads the entry type with
-///   no changes.
+///   **entry** type when the module opted into one (`@entry`). A
+///   defaultless module (`@no_entry`, ADR-0138) instead stages a
+///   "module has no default entry" failure here — the guest-side backstop
+///   for a bare load the host should already have rejected.
 /// - `init_typed_p32` (4-arg, carries an actor-type tag) matches the
 ///   tag against each exported type's `mailbox_id_from_name(NAMESPACE)`
-///   and constructs the selected one. The host calls this once it can
-///   resolve an export selector to a tag (the follow-on PR).
+///   and constructs the selected one. This path is unchanged by ADR-0138:
+///   a named load resolves the same way whether or not the module has a
+///   default entry.
 ///
 /// `receive` / `wire` / `unwire` / `on_dehydrate` / `on_rehydrate` all
 /// route through the boxed `ErasedWasmActor`, so a multi-actor instance
@@ -871,13 +886,112 @@ macro_rules! __export_internal {
 /// one does (ADR-0101). The `aether.kinds.inputs` section carries every
 /// exported type's records, each preceded by an `ActorBoundary`
 /// (ADR-0096), so the host can regroup per type and resolve an export
-/// selector to a tag. The `aether.namespace` section names the
-/// **entry** type — the default mailbox name when the load omits both
-/// an explicit name and an export selector.
+/// selector to a tag.
+///
+/// ADR-0138: the two forms share one `@shared_body` rule (slot, inline
+/// registry, inputs section, `init` / `init_typed`, receive, dehydrate /
+/// rehydrate). They differ in exactly three items, emitted by the `@entry`
+/// / `@no_entry` wrapper rules: the entry form emits the `aether.namespace`
+/// custom section naming the entry type and an `init_with_config_p32` that
+/// constructs it; the no-entry form omits `aether.namespace`, emits the
+/// `aether.no_entry` marker section instead, and stages a failure from
+/// `init_with_config_p32`.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __export_multi_internal {
+    // ADR-0138: multi-actor module WITH a default entry. Emits the
+    // `aether.namespace` section (naming `$entry`) and a 3-arg
+    // `init_with_config_p32` that constructs `$entry`, then the shared body.
     (@entry $entry:ty ; @all $($component:ty),+) => {
+        #[cfg(target_family = "wasm")]
+        #[used]
+        #[unsafe(link_section = "aether.namespace")]
+        static __AETHER_NAMESPACE_SECTION: [u8; <$entry as $crate::Addressable>::NAMESPACE.len()] = {
+            let bytes = <$entry as $crate::Addressable>::NAMESPACE.as_bytes();
+            let mut out = [0u8; <$entry as $crate::Addressable>::NAMESPACE.len()];
+            let mut i = 0;
+            while i < bytes.len() {
+                out[i] = bytes[i];
+                i += 1;
+            }
+            out
+        };
+
+        /// # Safety
+        /// Existing 3-arg init ABI; constructs the entry (opted-in) export.
+        #[cfg(target_family = "wasm")]
+        #[unsafe(export_name = "init_with_config_p32")]
+        pub unsafe extern "C" fn init_with_config(
+            mailbox_id: u64,
+            config_ptr: u32,
+            config_len: u32,
+        ) -> u32 {
+            $crate::wasm::install_guest_logging();
+            let config_bytes: &[u8] = if config_len == 0 {
+                &[]
+            } else {
+                // SAFETY: substrate wrote `config_len` bytes at `config_ptr` (ADR-0090).
+                unsafe {
+                    ::core::slice::from_raw_parts(config_ptr as usize as *const u8, config_len as usize)
+                }
+            };
+            // ADR-0114 addressing amendment: capture the real folded id as the
+            // cluster self-identity (correct at any lineage depth).
+            __AETHER_INLINE.set_self_id(mailbox_id);
+            // Issue 2692: install the by-tag inline-spawn resolver over the
+            // module's full exported set (entry + rest), so any exported actor
+            // can `ctx.spawn_inline_child_by_tag(...)`.
+            __AETHER_INLINE.set_spawn_resolver(
+                $crate::__export_internal!(@spawn_inline_child_by_tag $($component),+),
+            );
+            $crate::__export_multi_internal!(@construct $entry, mailbox_id, config_bytes)
+        }
+
+        $crate::__export_multi_internal!(@shared_body $($component),+);
+    };
+
+    // ADR-0138: multi-actor module WITHOUT a default entry. Omits the
+    // `aether.namespace` section, emits the `aether.no_entry` marker
+    // section, and stages a failure from the 3-arg `init_with_config_p32`
+    // (the guest-side backstop — the host rejects a bare, defaultless load
+    // before it ever reaches this shim). A named load still resolves
+    // through `init_typed_p32` in the shared body.
+    (@no_entry ; @all $($component:ty),+) => {
+        // The section-level no-entry marker (ADR-0138): a single version
+        // byte in `aether.no_entry`, wasm-target-gated exactly like the
+        // `aether.namespace` section the entry form emits. Its presence is
+        // what lets the host distinguish a defaultless multi-actor module
+        // from a legacy single-actor module.
+        #[cfg(target_family = "wasm")]
+        #[used]
+        #[unsafe(link_section = "aether.no_entry")]
+        static __AETHER_NO_ENTRY_SECTION: [u8; 1] = [1u8];
+
+        /// # Safety
+        /// 3-arg init ABI on a defaultless module: there is no entry to
+        /// construct, so stage a failure and return non-zero. This is a
+        /// backstop — the host rejects a bare, defaultless load first.
+        #[cfg(target_family = "wasm")]
+        #[unsafe(export_name = "init_with_config_p32")]
+        pub unsafe extern "C" fn init_with_config(
+            _mailbox_id: u64,
+            _config_ptr: u32,
+            _config_len: u32,
+        ) -> u32 {
+            $crate::wasm::install_guest_logging();
+            $crate::wasm::stage_init_failure(
+                "guest init: module has no default entry (ADR-0138) — load a named export",
+            );
+            1
+        }
+
+        $crate::__export_multi_internal!(@shared_body $($component),+);
+    };
+
+    // ADR-0138: the body shared by `@entry` and `@no_entry` — everything
+    // except the `aether.namespace` / `aether.no_entry` sections and the
+    // 3-arg `init_with_config_p32` shim, which the wrapper rules emit.
+    (@shared_body $($component:ty),+) => {
         static __AETHER_MULTI: $crate::Slot<
             $crate::__macro_internals::Box<dyn $crate::ErasedWasmActor>
         > = $crate::Slot::new();
@@ -953,52 +1067,10 @@ macro_rules! __export_multi_internal {
             out
         };
 
-        #[cfg(target_family = "wasm")]
-        #[used]
-        #[unsafe(link_section = "aether.namespace")]
-        static __AETHER_NAMESPACE_SECTION: [u8; <$entry as $crate::Addressable>::NAMESPACE.len()] = {
-            let bytes = <$entry as $crate::Addressable>::NAMESPACE.as_bytes();
-            let mut out = [0u8; <$entry as $crate::Addressable>::NAMESPACE.len()];
-            let mut i = 0;
-            while i < bytes.len() {
-                out[i] = bytes[i];
-                i += 1;
-            }
-            out
-        };
-
         /// # Safety
-        /// Existing 3-arg init ABI; constructs the entry (first) export.
-        #[cfg(target_family = "wasm")]
-        #[unsafe(export_name = "init_with_config_p32")]
-        pub unsafe extern "C" fn init_with_config(
-            mailbox_id: u64,
-            config_ptr: u32,
-            config_len: u32,
-        ) -> u32 {
-            $crate::wasm::install_guest_logging();
-            let config_bytes: &[u8] = if config_len == 0 {
-                &[]
-            } else {
-                // SAFETY: substrate wrote `config_len` bytes at `config_ptr` (ADR-0090).
-                unsafe {
-                    ::core::slice::from_raw_parts(config_ptr as usize as *const u8, config_len as usize)
-                }
-            };
-            // ADR-0114 addressing amendment: capture the real folded id as the
-            // cluster self-identity (correct at any lineage depth).
-            __AETHER_INLINE.set_self_id(mailbox_id);
-            // Issue 2692: install the by-tag inline-spawn resolver over the
-            // module's full exported set (entry + rest), so any exported actor
-            // can `ctx.spawn_inline_child_by_tag(...)`.
-            __AETHER_INLINE.set_spawn_resolver(
-                $crate::__export_internal!(@spawn_inline_child_by_tag $($component),+),
-            );
-            $crate::__export_multi_internal!(@construct $entry, mailbox_id, config_bytes)
-        }
-
-        /// # Safety
-        /// ADR-0090 legacy zero-config init; forwards to the entry type.
+        /// ADR-0090 legacy zero-config init; forwards to the 3-arg
+        /// `init_with_config` the wrapper rule (`@entry` / `@no_entry`)
+        /// emits — construct the entry, or stage the no-default failure.
         #[cfg(target_family = "wasm")]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn init(mailbox_id: u64) -> u32 {

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -199,6 +199,10 @@ aether-substrate = { path = "../aether-substrate", features = ["test-support"] }
 # `syn` is already deep in the transitive graph
 # (every derive macro pulls it), so this dev-dep is near-free.
 syn = { workspace = true, features = ["full", "visit", "parsing"] }
+# ADR-0138: the `component_manifest` no-entry unit test assembles minimal
+# wasm fixtures (custom sections only) with `wat`, mirroring the
+# substrate's own `kind_manifest` section-reader tests.
+wat = "1"
 
 [lints]
 workspace = true

--- a/crates/aether-capabilities/src/component/runtime/load.rs
+++ b/crates/aether-capabilities/src/component/runtime/load.rs
@@ -78,6 +78,21 @@ impl ComponentHostCapabilityState {
                 Some(aether_data::mailbox_id_from_name(requested).0),
                 Some(requested.clone()),
             )
+        } else if kind_manifest::read_no_entry_marker(&payload.wasm) {
+            // ADR-0138: a defaultless multi-actor module (built with a bare
+            // `export!(A, B, …)`) carries no bare-load entry. An unselected
+            // load is a hard error that names the exports so the caller can
+            // pick one, rather than instantiating an actor by list position.
+            let available: Vec<&str> = actors
+                .iter()
+                .filter_map(|a| a.namespace.as_deref())
+                .collect();
+            return LoadResult::Err {
+                error: format!(
+                    "module has no default entry (ADR-0138): load one of its exports \
+                     by name via the export selector; exported types: {available:?}"
+                ),
+            };
         } else {
             let entry = actors.first();
             (

--- a/crates/aether-capabilities/src/engine/store/manifest.rs
+++ b/crates/aether-capabilities/src/engine/store/manifest.rs
@@ -138,6 +138,15 @@ pub fn component_manifest(wasm: &[u8]) -> Result<ComponentManifest, String> {
     let groups = kind_manifest::read_actor_inputs_from_bytes(wasm)?;
     let module_namespace = kind_manifest::read_namespace_from_bytes(wasm)?;
     let provenance = kind_manifest::read_producers_from_bytes(wasm);
+    // ADR-0138: a defaultless multi-actor module carries the no-entry
+    // marker and omits `aether.namespace`, so it has no bare-load entry.
+    // Otherwise the entry is the module's `aether.namespace` value (the
+    // single-actor namespace or the `export!(entry = …)` opt-in).
+    let default_entry = if kind_manifest::read_no_entry_marker(wasm) {
+        None
+    } else {
+        module_namespace.clone()
+    };
 
     let mut actors: Vec<ComponentActor> = Vec::with_capacity(groups.len());
     for group in groups {
@@ -177,5 +186,50 @@ pub fn component_manifest(wasm: &[u8]) -> Result<ComponentManifest, String> {
         handled_kinds,
         fallback,
         provenance,
+        default_entry,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Assemble a minimal wasm carrying one custom section (the section
+    /// reader only needs the sections; no functions), mirroring the
+    /// substrate's own `kind_manifest` section-reader test fixtures.
+    fn wasm_with_section(section_name: &str, section: &[u8]) -> Vec<u8> {
+        use core::fmt::Write as _;
+        let mut escaped = String::with_capacity(section.len() * 3);
+        for b in section {
+            write!(&mut escaped, "\\{b:02x}").expect("write to String");
+        }
+        let wat =
+            format!(r#"(module (@custom "{section_name}" "{escaped}") (func (export "noop")))"#);
+        wat::parse_str(wat).expect("valid wat")
+    }
+
+    #[test]
+    fn default_entry_tracks_the_no_entry_marker() {
+        // ADR-0138: a single-actor / opted-in module carries its
+        // `aether.namespace` and no marker, so its bare-load entry is that
+        // namespace. A defaultless multi-actor module carries the
+        // `aether.no_entry` marker (and omits `aether.namespace`), so it
+        // has no bare-load entry.
+        let entry = wasm_with_section("aether.namespace", b"aether.probe");
+        assert_eq!(
+            component_manifest(&entry)
+                .expect("manifest reads")
+                .default_entry
+                .as_deref(),
+            Some("aether.probe"),
+        );
+
+        let defaultless = wasm_with_section("aether.no_entry", &[1u8]);
+        assert_eq!(
+            component_manifest(&defaultless)
+                .expect("manifest reads")
+                .default_entry,
+            None,
+        );
+    }
 }

--- a/crates/aether-capabilities/src/engine/store/tests.rs
+++ b/crates/aether-capabilities/src/engine/store/tests.rs
@@ -38,6 +38,8 @@ fn component_manifest(namespace: &str) -> StoredManifest {
         handled_kinds: vec![Tick::ID, Key::ID],
         fallback: false,
         provenance: String::new(),
+        // A single-actor module has an unambiguous bare-load entry.
+        default_entry: Some(namespace.to_owned()),
     })
 }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1084,6 +1084,10 @@ mod engine {
     /// - `fallback` — whether any exported actor declares a `#[fallback]`.
     /// - `provenance` — the wasm `producers` custom section rendered as a
     ///   short string (`"<tool> <version>; …"`), or empty when absent.
+    /// - `default_entry` — the bare-load entry actor's namespace per
+    ///   ADR-0138; `None` for a defaultless multi-actor module (built with
+    ///   a bare `export!(A, B, …)`), `Some(ns)` for a single-actor module
+    ///   or a multi-actor module that opted in via `export!(entry = A, …)`.
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
     pub struct ComponentManifest {
         pub namespaces: Vec<String>,
@@ -1091,6 +1095,8 @@ mod engine {
         pub handled_kinds: Vec<aether_data::KindId>,
         pub fallback: bool,
         pub provenance: String,
+        #[serde(default)]
+        pub default_entry: Option<String>,
     }
 
     /// One exported actor type within a (possibly multi-actor) component
@@ -1262,12 +1268,14 @@ mod control_plane {
         /// MCP encode the config struct to bytes at the edge
         /// (SDK-typed, not wire-typed), matching `wasm`'s `Vec<u8>`.
         pub config: Vec<u8>,
-        /// ADR-0096: which exported actor type to instantiate from a
-        /// multi-actor module, named by its `Addressable::NAMESPACE`. `None`
-        /// loads the **entry** type (the first in the module's
-        /// `export!` list), which is also the only type a single-actor
-        /// module has — so an unset selector preserves the pre-ADR-0096
-        /// load. An export that the module doesn't declare is a clean
+        /// ADR-0096 / ADR-0138: which exported actor type to instantiate
+        /// from a multi-actor module, named by its `Addressable::NAMESPACE`.
+        /// `None` loads the module's **entry** type — the single type a
+        /// single-actor module has, or the `export!(entry = A, …)` opt-in
+        /// on a multi-actor module. A defaultless multi-actor module (a
+        /// bare `export!(A, B, …)`) has no entry, so `None` against it is a
+        /// clean `LoadResult::Err` that names the exports (ADR-0138). An
+        /// export that the module doesn't declare is likewise a clean
         /// `LoadResult::Err`.
         pub export: Option<String>,
     }

--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -79,13 +79,19 @@ pub const OCTIMETERS_PER_TILE: i32 = 256;
 /// tile (`2^8 = 256` octimeters per tile).
 pub const TILE_BITS: u32 = 8;
 
-// A cdylib carries one `export!` (the shared init/receive FFI entry). The
-// entry type is listed first; the macro emits the wasm32 FFI shims and the
-// `aether.kinds` custom section for every listed actor. The `behavior`
-// feature (ADR-0137, issue 2687) appends `aether-behavior`'s `BehaviorHost`
-// so the panel's `WidgetKind::BehaviorHost` arm can spawn it by tag; the two
-// invocations are cfg-exclusive, keeping the ordinary kit build's exported
-// set (and its `aether.kinds` section) unchanged.
+// A cdylib carries one `export!` (the shared init/receive FFI entry); the
+// macro emits the wasm32 FFI shims and the `aether.kinds` custom section for
+// every listed actor. The kit is a subsystem library — a grab-bag of
+// unrelated actors (camera, mesh viewer, world mesher, mover, widget set)
+// each loaded independently — so it is deliberately DEFAULTLESS per ADR-0138:
+// the bare `export!(…)` (no `entry =`) designates no bare-load entry, and
+// every consumer loads a specific actor by its `module@actor` selector. A
+// `load` with no export selector against the kit is a hard error naming the
+// exports, not an instantiation of whichever actor happens to sit first. The
+// `behavior` feature (ADR-0137, issue 2687) appends `aether-behavior`'s
+// `BehaviorHost` so the panel's `WidgetKind::BehaviorHost` arm can spawn it
+// by tag; the two invocations are cfg-exclusive, keeping the ordinary kit
+// build's exported set (and its `aether.kinds` section) unchanged.
 #[cfg(not(feature = "behavior"))]
 aether_actor::export!(
     locomotion::Locomotion,

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -1405,7 +1405,13 @@ impl Mcp {
                 manifest,
                 ..
             }) => {
-                let entry_namespace = manifest.actors.into_iter().next().map(|a| a.namespace);
+                // ADR-0138: the bare-load entry is the manifest's opted-in
+                // `default_entry` (the single-actor namespace or the
+                // `export!(entry = …)` designation), NOT "the first actor
+                // by list position". A defaultless multi-actor module
+                // reports `None`, so replica-name derivation falls through
+                // to `name` / `export`.
+                let entry_namespace = manifest.default_entry;
                 Ok(ResolvedComponent {
                     wasm,
                     export,

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -365,6 +365,80 @@ fn multi_actor_unknown_export_errors() {
     }
 }
 
+/// ADR-0138: a defaultless multi-actor module (a bare `export!(Alpha,
+/// Beta)`, no `entry =`) has no bare-load entry. A `load` with no export
+/// selector is a hard `LoadResult::Err` that names the exports — not an
+/// instantiation of whichever type sits first — while a named
+/// `export: Some("test.defaultless.alpha")` load of the same module
+/// resolves `Ok` through the unchanged ADR-0096 typed-init path.
+#[test]
+fn defaultless_multi_actor_bare_load_errors_named_load_ok() {
+    let Some(wasm_path) = require_runtime("aether_test_fixtures_defaultless") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let wasm = fs::read(&wasm_path).expect("read fixture wasm");
+
+    // Bare load (no selector): a defaultless module rejects it, naming its
+    // exports so the caller can pick one.
+    let bare = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: wasm.clone(),
+                    name: None,
+                    config: Vec::new(),
+                    export: None,
+                },
+            ),
+        )])
+        .expect("bare load sequence");
+    match bare.reply::<LoadResult>("load").expect("decode LoadResult") {
+        LoadResult::Err { error } => {
+            assert!(
+                error.contains("test.defaultless.alpha") && error.contains("test.defaultless.beta"),
+                "a defaultless bare load must name the module's exports; got {error}",
+            );
+        }
+        LoadResult::Ok { name, .. } => {
+            panic!("a bare load of a defaultless module must error, not instantiate {name}")
+        }
+    }
+
+    // Named load: selecting an export by its NAMESPACE resolves as usual.
+    let named = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: None,
+                    config: Vec::new(),
+                    export: Some("test.defaultless.alpha".to_owned()),
+                },
+            ),
+        )])
+        .expect("named load sequence");
+    match named
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { name, .. } => {
+            assert!(
+                name.ends_with(":test.defaultless.alpha"),
+                "a named load of a defaultless module resolves to the selected \
+                 export's NAMESPACE (test.defaultless.alpha); got {name}",
+            );
+        }
+        LoadResult::Err { error } => {
+            panic!("a named load of a defaultless module must succeed; got err {error}")
+        }
+    }
+}
+
 /// ADR-0097: a loaded `RootManager` spawns a `Panel` sibling at runtime
 /// via `ctx.spawn_child::<Panel>`. Pinging `RootManager` triggers the
 /// spawn; the spawned `Panel` registers at

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -75,6 +75,14 @@ pub const LABELS_SECTION: &str = "aether.kinds.labels";
 /// evolution.
 pub const NAMESPACE_SECTION: &str = "aether.namespace";
 
+/// The section name of the ADR-0138 no-entry marker. A defaultless
+/// multi-actor module (`export!(A, B, …)` with no `entry =`) omits the
+/// [`NAMESPACE_SECTION`] and emits this section instead — a single
+/// version byte whose mere presence tells the host the module has no
+/// bare-load default entry, so an unselected load is a hard error naming
+/// the exports rather than an instantiation by list position.
+pub const NO_ENTRY_SECTION: &str = "aether.no_entry";
+
 /// Wire versions accepted in `aether.kinds`. The shape record's bytes
 /// are `Kind::ID` hash input, so a change to their layout regenerates
 /// every id — a deliberate clean break, taken loudly via this version
@@ -196,6 +204,23 @@ pub fn read_namespace_from_bytes(wasm: &[u8]) -> Result<Option<String>, String> 
         }
     }
     Ok(None)
+}
+
+/// Return whether the component carries the ADR-0138 [`NO_ENTRY_SECTION`]
+/// marker — `true` for a defaultless multi-actor module, `false`
+/// otherwise. The payload is a single version byte the host does not
+/// interpret; presence of the section is the whole signal.
+#[must_use]
+pub fn read_no_entry_marker(wasm: &[u8]) -> bool {
+    for payload in Parser::new(0).parse_all(wasm) {
+        let Ok(Payload::CustomSection(reader)) = payload else {
+            continue;
+        };
+        if reader.name() == NO_ENTRY_SECTION {
+            return true;
+        }
+    }
+    false
 }
 
 /// Read the wasm tool-conventions `producers` custom section (ADR-0116,
@@ -796,6 +821,20 @@ mod tests {
         let wasm = wat::parse_str(r#"(module (func (export "noop")))"#).unwrap();
         let descs = read_from_bytes(&wasm).unwrap();
         assert!(descs.is_empty());
+    }
+
+    #[test]
+    fn no_entry_marker_read_by_section_presence() {
+        // Tripwire: pins the ADR-0138 no-entry contract — the marker is
+        // section name `aether.no_entry`, presence-only (the single
+        // payload byte is not interpreted). A module carrying the section
+        // reads `true`; one without reads `false`. Drifting the section
+        // name or making the reader payload-sensitive breaks this.
+        let with = wasm_with_section(NO_ENTRY_SECTION, &[1u8]);
+        assert!(read_no_entry_marker(&with));
+
+        let without = wat::parse_str(r#"(module (func (export "noop")))"#).unwrap();
+        assert!(!read_no_entry_marker(&without));
     }
 
     #[test]

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
@@ -1,10 +1,11 @@
 //! The main test-fixture bundle: the bulk of the workspace's wasm
 //! fixtures consolidated into one ADR-0096 multi-actor module. One
 //! `src/<name>.rs` module per former fixture; a single
-//! `export!(Probe, …)` packs all of them into one cdylib, with `Probe`
-//! the entry so a bare `load` of `aether_test_fixtures_bundle.wasm`
-//! instantiates it. The integration tests load this one wasm and select
-//! an in-bundle actor with `export: Some("<NAMESPACE>")`.
+//! `export!(entry = Probe, …)` packs all of them into one cdylib, with
+//! `Probe` the opted-in default entry (ADR-0138) so a bare `load` of
+//! `aether_test_fixtures_bundle.wasm` instantiates it. The integration
+//! tests load this one wasm and select an in-bundle actor with
+//! `export: Some("<NAMESPACE>")`.
 //!
 //! The `InlineChild` / `InlineDespawnChild` inline children ride in
 //! `inline_child` as types but are absent from the `export!` list — an
@@ -41,12 +42,12 @@ pub use source_observer::SourceObserver;
 pub use stateful_replace::{Counter, Sidecar};
 pub use ui_widget::UiWidget;
 
-// `Probe` is listed first so a bare `load` (no `export` selector)
-// instantiates it, preserving the entry-load contract the probe scenarios
-// rely on. The remaining actors are reachable by their `NAMESPACE`
-// export selector.
+// ADR-0138: `entry = Probe` opts this multi-actor module into `Probe` as
+// its bare-load default, so a `load` with no `export` selector instantiates
+// it — the entry-load contract the probe scenarios rely on. The remaining
+// actors are reachable by their `NAMESPACE` export selector.
 aether_actor::export!(
-    Probe,
+    entry = Probe,
     ProbeWithConfig,
     RootManager,
     Panel,

--- a/crates/aether-test-fixtures/aether-test-fixtures-defaultless/Cargo.toml
+++ b/crates/aether-test-fixtures/aether-test-fixtures-defaultless/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "aether-test-fixtures-defaultless"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# ADR-0138 fixture: a DEFAULTLESS multi-actor module. Two `WasmActor`
+# types (`Alpha`, `Beta`) exported via a bare `export!(Alpha, Beta)` (no
+# `entry =`), so the module designates no bare-load entry — a `load` with
+# no export selector against it is a hard error naming the exports, and a
+# named `export: Some("<NAMESPACE>")` load resolves as usual. Standalone
+# (not in the main bundle, which keeps a `Probe` entry via
+# `export!(entry = …)`) so the bundle's entry-load scenarios stay intact.
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+aether-actor = { path = "../../aether-actor" }
+aether-kinds = { path = "../../aether-kinds" }
+
+[lints]
+workspace = true

--- a/crates/aether-test-fixtures/aether-test-fixtures-defaultless/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-defaultless/src/lib.rs
@@ -1,0 +1,56 @@
+//! ADR-0138 fixture: a defaultless multi-actor module.
+//!
+//! Two `WasmActor` types, `Alpha` and `Beta`, exported via a bare
+//! `export!(Alpha, Beta)` with no `entry =`. Per ADR-0138 that designates
+//! **no** bare-load entry: the module carries the `aether.no_entry` marker
+//! section and omits `aether.namespace`, so the host rejects a `load` with
+//! no export selector (a hard error naming the exports) while a named
+//! `export: Some("test.defaultless.alpha")` / `…beta` load resolves through
+//! the ADR-0096 typed-init path exactly as before.
+//!
+//! Kept out of the main `aether-test-fixtures-bundle` (which opts into a
+//! `Probe` entry via `export!(entry = …)`) so the bundle's entry-load
+//! scenarios stay intact; this crate exists only to exercise the
+//! no-default-entry load path.
+
+// The `#[handler]` methods take `&mut self` to match the dispatch ABI even
+// though these actors are stateless.
+#![allow(clippy::unused_self)]
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_kinds::Ping;
+
+/// First exported type. Not a bare-load default — a defaultless module has
+/// no entry, so it is reachable only by its `NAMESPACE` export selector.
+pub struct Alpha;
+
+#[actor]
+impl WasmActor for Alpha {
+    const NAMESPACE: &'static str = "test.defaultless.alpha";
+
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Alpha)
+    }
+
+    #[handler::single]
+    fn on_ping(&mut self, _ctx: &mut WasmCtx<'_>, _ping: Ping) {}
+}
+
+/// Second exported type, selectable by its `NAMESPACE`.
+pub struct Beta;
+
+#[actor]
+impl WasmActor for Beta {
+    const NAMESPACE: &'static str = "test.defaultless.beta";
+
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Beta)
+    }
+
+    #[handler::single]
+    fn on_ping(&mut self, _ctx: &mut WasmCtx<'_>, _ping: Ping) {}
+}
+
+// ADR-0138: a bare `export!(A, B)` (no `entry =`) is deliberately
+// defaultless — this is the whole point of the fixture.
+aether_actor::export!(Alpha, Beta);


### PR DESCRIPTION
Closes #2735.

## Summary

Implements ADR-0138: a multi-actor module has no default entry unless it opts in. A bare `export!(A, B, C)` no longer promotes the first-listed type to the bare-load entry — it designates no default, so a load with no export selector is a hard `LoadResult::Err` naming the available exports rather than silently instantiating index 0. A module opts into a default with `export!(entry = A, B, C)`; single-actor `export!(X)` is unchanged.

Mechanically, the entry-less multi-actor form omits the `aether.namespace` custom section and emits a new `aether.no_entry` marker section. The macro factors the shared multi-actor body into one `@shared_body` rule; the `@entry` / `@no_entry` wrappers differ only in that section (namespace vs marker) and the 3-arg init shim. The host reads the marker (`read_no_entry_marker`) and rejects a bare defaultless load naming the exports, and a new `ComponentManifest.default_entry` field carries the entry namespace to `aether-mcp`, which mirrors the host in its entry-namespace resolution and replica-name derivation.

The two existing multi-actor sites migrate: the reference kit becomes deliberately defaultless (every consumer already loads it by explicit `module@actor` selector), and the test-fixtures bundle opts into `entry = Probe`. Supersedes the default-entry clause of ADR-0096 §3.

## Test plan

- `read_no_entry_marker` tripwire unit test (section presence true/false) in `kind_manifest.rs`.
- `component_manifest` unit test: `default_entry` is `None` with the marker, `Some(ns)` without.
- New integration test `defaultless_multi_actor_bare_load_errors_named_load_ok` (`test_bench_scenario.rs`): a bare `export: None` load of a defaultless fixture returns `Err` naming both exports; a named `export: Some(ns)` load returns `Ok`. Backed by a new `aether-test-fixtures-defaultless` cdylib (`export!(Alpha, Beta)`, no entry).
- Existing `multi_actor_module_loads_entry_export` (and the other `multi_actor*` bundle tests) stay green — the fixtures bundle keeps its Probe entry via `entry = Probe`.

## Generated by

`/implement` — agent execution of [scoped issue #2735](https://github.com/iamacoffeepot/aether/issues/2735).
