### PR TITLE
chore(workflow): add codex repo skills

### DIFF
--- a/.agents/skills/_shared/claude-to-codex.md
+++ b/.agents/skills/_shared/claude-to-codex.md
@@ -1,0 +1,27 @@
+# Claude-to-Codex Workflow Translation
+
+Use this reference when a Codex repo skill points at an existing `.claude` skill or workflow file.
+
+## Required Read Order
+
+1. Read the Codex skill `SKILL.md`.
+2. Read this translation reference.
+3. Read the referenced `.claude/skills/<name>/SKILL.md` or `.claude/workflows/<name>.js` completely before acting.
+
+## Translation Rules
+
+- Treat the referenced Claude artifact as source material, not executable Codex code.
+- Preserve the repository's phase-label lifecycle: Backlog has no `phase:*`, scoped issues stop at `phase:plan`, approved issues move to `phase:ready`, implementation moves through `phase:executing` and `phase:refine`, and Done is a closed issue.
+- Prefer `gh api` REST forms for GitHub operations whenever a REST endpoint exists. Avoid GraphQL-backed `gh issue create`, `gh issue edit`, `gh pr list`, and `gh pr checks` where the Claude workflow names a REST alternative.
+- Map Claude slash commands to Codex skills. For example, `/scope` means use the `scope` skill, and `/implement` means use the `implement` skill.
+- Map Claude `agent(...)` workflow calls to Codex subagents only when the active skill explicitly asks for subagents or the user explicitly requests delegation.
+- Preserve freshness boundaries. If a Claude workflow says a child agent must not see a diff or implementation detail, spawn a fresh Codex subagent without forked context and pass only the allowed prompt.
+- Map Claude `phase(...)` and `log(...)` calls to concise progress updates in the main Codex thread.
+- Map Claude JSON schemas to required structured return shapes in prose. Validate the returned shape before rolling it up.
+- Map Claude worktree isolation to git worktrees under `.claude/worktrees/issue-<N>` unless the skill explicitly says a temp scratch directory is enough.
+- Do not edit `.claude/` artifacts while executing a Codex port unless the user explicitly asks to change the Claude workflow itself.
+- Do not add Codex hooks as part of a skill run unless the issue being implemented explicitly scopes hook work. Hook semantics and trust review differ between Claude and Codex.
+
+## MCP Notes
+
+The repo's `.mcp.json` names the live engine server `aether-hub`. Codex may expose the same tool family as `mcp__aether-hub__*` when the MCP server is configured and connected. If live engine tools are absent, start `scripts/ensure-tunnel.sh` only when the task requires them, then reconnect MCP in the active Codex surface.

--- a/.agents/skills/adr/SKILL.md
+++ b/.agents/skills/adr/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: adr
+description: "Scaffold a new Aether Architecture Decision Record. Use when a load-bearing architectural decision needs a numbered ADR draft from docs/adr/TEMPLATE.md."
+---
+
+# ADR
+
+Use this Codex skill for ADR scaffolding.
+
+## Source
+
+- Workflow source: `.claude/skills/adr/SKILL.md`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+## Procedure
+
+1. Read both source files completely before acting.
+2. Require a title from the user.
+3. Confirm the target worktree is clean and on up-to-date `main` before creating the ADR branch.
+4. Pick the next `docs/adr/NNNN-*.md` number, copy `docs/adr/TEMPLATE.md`, and fill only the allowed placeholders.
+5. Do not commit, push, or open a PR until the ADR content is written.

--- a/.agents/skills/approve/SKILL.md
+++ b/.agents/skills/approve/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: approve
+description: "Validate an Aether scoped issue at Plan and advance it to Ready. Use after the user approves scope artifacts and before implementation dispatch."
+---
+
+# Approve
+
+Use this Codex skill for the repository's Plan-to-Ready gate.
+
+## Source
+
+- Workflow source: `.claude/skills/approve/SKILL.md`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+## Procedure
+
+1. Read both source files completely before acting.
+2. Validate all gate checks from the source: phase, scoped sections, ADR references, model label, blocked labels, freshness, dependencies, and umbrella integrity.
+3. Treat intended new files in a plan as creations, not removed existing targets, when applying the freshness gate.
+4. If all gates pass and the user has approved, swap the issue to `phase:ready` with REST labels.
+5. Do not dispatch implementation or edit the issue body.

--- a/.agents/skills/bounce/SKILL.md
+++ b/.agents/skills/bounce/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: bounce
+description: "Regress an Aether issue to an earlier phase with a required reason. Use when scope, approval, implementation, or review discovers that Define, Design, or Plan must be redone."
+---
+
+# Bounce
+
+Use this Codex skill for explicit phase regression.
+
+## Source
+
+- Workflow source: `.claude/skills/bounce/SKILL.md`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+## Procedure
+
+1. Read both source files completely before acting.
+2. Require a concrete reason.
+3. Validate the target phase is a regression to Define, Design, or Plan.
+4. Reconcile labels with REST: `phase:bounced` plus the matching `bounce-to:*` label.
+5. Post the required reason as an issue comment.

--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: dogfood
+description: "Run Aether consumer-viewpoint dogfood validation. Use after a feature lands or before un-drafting a PR to have fresh agents consume the public surface, log friction, and optionally judge rendered output."
+---
+
+# Dogfood
+
+Use this Codex skill for the consumer-use trial described by `.claude/workflows/dogfood.js`.
+
+## Source
+
+- Workflow source: `.claude/workflows/dogfood.js`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+Read both before running the workflow.
+
+## Inputs
+
+Accept these values from the user or caller:
+
+- `issue`: landed feature issue or scope text. Required unless `task` is supplied.
+- `diff`: landed diff. Author may read it; Attempt must never receive it.
+- `surface`: public surface pointers, such as guide paths, crates, mail kinds, or MCP tools.
+- `task`: approved task object that skips Author.
+- `medium`: optional forced medium: `drive`, `author`, or `build-layer`.
+
+## Phases
+
+1. Author: create or validate a realistic task with `medium`, `prompt`, `surfaceUnderTest`, and `expectedArtifact`. Use a subagent when the task needs independent framing. The Author may see `issue`, `diff`, and `surface`.
+2. Approval gate: if the authored medium is `author` or `build-layer`, stop and show the proposed task for human approval. Continue only when the user supplies or approves the task.
+3. Attempt: spawn a fresh Codex subagent without forked context. Pass only the approved task and public surface pointers. Do not pass the diff, implementation files, or Author reasoning. Require output with `succeeded`, `summary`, `engineId`, `buildGreen`, and `findings`.
+4. Judge: if `expectedArtifact` is non-null and Attempt leaves an `engineId`, spawn a fresh judge subagent to capture and inspect the frame through the Aether MCP tools, then terminate the substrate.
+5. Rollup: summarize totals, grouped friction, artifact verdict, and soft holds. Do not file follow-up issues from this skill.
+
+## Finding Categories
+
+- `papercut`: awkward composition, surprising default, boilerplate, or rough error.
+- `missing-primitive`: the consumer reached for a capability the engine lacks.
+- `doc-gap`: the consumer could not proceed from docs and public signatures.
+- `blocker`: the task stopped.
+
+Soft-hold on a wrong artifact verdict or any high-severity blocker.

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: implement
+description: "Implement an approved Aether issue in a separate worktree, open a draft PR, and drive CI to green. Use only for phase:ready issues unless the user explicitly requests quick mode."
+---
+
+# Implement
+
+Use this Codex skill for the repository's issue-to-draft-PR workflow.
+
+## Source
+
+- Workflow source: `.claude/skills/implement/SKILL.md`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+## Procedure
+
+1. Read both source files completely before acting.
+2. Verify preconditions: `phase:ready`, exactly one `model:*`, no umbrella sub-issues, an implementation plan, and working `gh` auth with `repo` scope.
+3. Create a dedicated worktree under `.claude/worktrees/issue-<N>` from `origin/main`; do not edit the primary `main` checkout.
+4. Move the issue to `phase:executing` before implementation work starts.
+5. Follow the issue's `## Implementation plan` literally. Deviations are bounces, not freelancing.
+6. Commit the work, run `cargo fmt`, assert a clean worktree, push, and open a draft PR over REST.
+7. Use `scripts/wave-status.sh --wait <pr>` for CI monitoring. Leave successful work at `phase:refine` with the PR still draft.

--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: land
+description: "Land a reviewed Aether draft PR. Use when a CI-green draft PR is approved for release and should be un-drafted, merged, and swept according to repo workflow."
+---
+
+# Land
+
+Use this Codex skill for the repository's post-review landing workflow.
+
+## Source
+
+- Workflow source: `.claude/skills/land/SKILL.md`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+## Procedure
+
+1. Read both source files completely before acting.
+2. Validate PR draft state, CI state, closing issue linkage, and any Qodana-only handling from the source.
+3. Use REST forms wherever available. Use GraphQL only for un-drafting because REST cannot clear draft state.
+4. Do not merge or un-draft unless the user or release process explicitly approves landing.
+5. Sweep worktrees only as described by the source workflow.

--- a/.agents/skills/release-init/SKILL.md
+++ b/.agents/skills/release-init/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: release-init
+description: "Bootstrap Aether release workflow labels. Use to ensure phase, bounce-to, size, and model labels exist for the issue lifecycle."
+---
+
+# Release Init
+
+Use this Codex skill for release label bootstrap.
+
+## Source
+
+- Workflow source: `.claude/skills/release-init/SKILL.md`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+## Procedure
+
+1. Read both source files completely before acting.
+2. Create or reconcile only the labels described by the source.
+3. Use REST `gh api` label operations where available.
+4. Do not alter issues, branches, or PRs beyond the label bootstrap.

--- a/.agents/skills/retrospect/SKILL.md
+++ b/.agents/skills/retrospect/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: retrospect
+description: "Review a session for actionable Aether workflow papercuts. Use to classify session friction and file repo-actionable findings through sketch mechanics after confirmation."
+---
+
+# Retrospect
+
+Use this Codex skill for session-level workflow retrospection.
+
+## Source
+
+- Workflow source: `.claude/skills/retrospect/SKILL.md`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+## Procedure
+
+1. Read both source files completely before acting.
+2. Enumerate candidate papercuts from the current session.
+3. Classify each as file or skip with an explicit reason.
+4. Print the plan and wait for confirmation.
+5. File selected repo-actionable findings through sketch mechanics with the labels required by the source.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: review
+description: "Run Aether pre-land review with specialist lenses. Use to audit a change for spec fidelity, correctness, test integrity, economy, and convention before un-drafting."
+---
+
+# Review
+
+Use this Codex skill for the pre-land review workflow described by `.claude/workflows/review.js`.
+
+## Source
+
+- Workflow source: `.claude/workflows/review.js`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+Read both before running the workflow.
+
+## Inputs
+
+Prefer explicit inputs from the caller:
+
+- `files`: absolute paths for code lenses.
+- `testFiles`: absolute paths for test-integrity review.
+- `issue`: optional issue or scope text for spec-fidelity review.
+- `diffs`: optional per-file diff hunks.
+- `lenses`: optional subset of `spec-fidelity`, `correctness`, `test-integrity`, `economy`, and `convention`.
+
+If explicit files are absent and the current branch is a PR branch, derive a candidate file set from the diff against `origin/main`. Otherwise ask for files rather than guessing.
+
+## Workflow
+
+1. Scope: if `issue` and `diffs` are present, run the whole-change spec-fidelity pass first. Prune clearly out-of-scope files from later passes.
+2. Find: run applicable specialist lenses per file. Use subagents for independent file/lens work when the user or skill run calls for parallel review.
+3. Verify: verify correctness findings even when high confidence. Refute low/medium confidence findings before including them. Challenge clean correctness and test-integrity lenses when useful.
+4. Roll up confirmed findings first, ordered by severity, with file/line references. Separate soft holds, advisory findings, lint candidates, uncertain items, and spared/refuted findings.
+
+## Review Bar
+
+Keep findings only when the proposed fix is strictly better, not merely different. Correctness findings must name a concrete bad path or input. Test-integrity findings must identify owned logic that the test fails to exercise. Convention findings must cite `CLAUDE.md`, an ADR, or a repo rule and should feed future lint candidates.

--- a/.agents/skills/scope-spinoff/SKILL.md
+++ b/.agents/skills/scope-spinoff/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: scope-spinoff
+description: "Spin selected Aether scope side findings into child Backlog issues. Use when an issue has a Side findings section and the user chooses entries to file separately."
+---
+
+# Scope Spinoff
+
+Use this Codex skill for side-finding triage.
+
+## Source
+
+- Workflow source: `.claude/skills/scope-spinoff/SKILL.md`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+## Procedure
+
+1. Read both source files completely before acting.
+2. Read the parent issue's `## Side findings` section.
+3. Ask for selected indices unless the invocation supplies them or requests `--all`.
+4. File each selected finding through sketch mechanics.
+5. Update the parent body only as the source directs, preserving unselected findings and user prose.

--- a/.agents/skills/scope/SKILL.md
+++ b/.agents/skills/scope/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: scope
+description: "Walk an Aether issue from Backlog through Define, Design, and Plan. Use for release scoping that writes Problem statement, Design notes, Implementation plan, and phase/size/model labels."
+---
+
+# Scope
+
+Use this Codex skill for the repository's issue scoping workflow.
+
+## Source
+
+- Workflow source: `.claude/skills/scope/SKILL.md`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+## Procedure
+
+1. Read both source files completely before acting.
+2. Ground reads against fresh `origin/main` as the Claude source requires.
+3. Write only scope-managed issue body sections: `## Problem statement`, `## Design notes`, `## Implementation plan`, `## Sub-issues`, `## Depends on`, and `## Side findings`.
+4. Use REST `gh api` forms for issue body and label updates.
+5. Stop at `phase:plan`; do not approve or implement from this skill.
+6. If the source calls for sweep mode, spawn subagents only after the user confirms the sweep plan.

--- a/.agents/skills/sketch/SKILL.md
+++ b/.agents/skills/sketch/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: sketch
+description: "Capture an idea as a well-formed Aether GitHub issue. Use when filing Backlog issues from rough ideas while preserving the user's words, conventional title/labels, and no phase label."
+---
+
+# Sketch
+
+Use this Codex skill for the repository's idea-to-issue workflow.
+
+## Source
+
+- Workflow source: `.claude/skills/sketch/SKILL.md`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+## Procedure
+
+1. Read both source files completely before filing.
+2. Follow the Claude sketch mechanics, translated for Codex.
+3. File issues over REST with `gh api -X POST repos/iamacoffeepot/aether/issues`.
+4. Preserve the user's sketch verbatim in the `## Description` blockquote.
+5. Apply `type:*` and crate labels inline on creation. Do not add a `phase:*` label.
+6. Do not scope, design, plan, comment, or open a PR.

--- a/.agents/skills/sweep/SKILL.md
+++ b/.agents/skills/sweep/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: sweep
+description: "Reclaim stale Aether local or workflow state. Use for worktree, branch, memory, ADR, or fat-issue sweeps with enumerate, classify, confirm, act, and report."
+---
+
+# Sweep
+
+Use this Codex skill for repository cleanup sweeps.
+
+## Source
+
+- Workflow source: `.claude/skills/sweep/SKILL.md`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+## Procedure
+
+1. Read both source files completely before acting.
+2. Enumerate candidates, classify each by the target's stale signal, print a plan, and wait for confirmation before destructive or state-changing actions.
+3. Use REST GitHub queries where the source requires them.
+4. Never remove dirty, live, open-PR-attached, or ambiguous work without explicit confirmation.
+5. Keep the target-specific semantics from the source for `worktrees`, `branches`, `memory`, `adrs`, `fat`, and `all`.

--- a/.agents/skills/wish/SKILL.md
+++ b/.agents/skills/wish/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: wish
+description: "Run Aether adversity-grounded design ideation. Use to drill from a felt absence into producible plans, including deep-mode driller, skeptic, and synthesis workflows."
+---
+
+# Wish
+
+Use this Codex skill for the repository's design ideation workflow.
+
+## Source
+
+- Skill source: `.claude/skills/wish/SKILL.md`
+- Deep workflow source: `.claude/workflows/wish.js`
+- Translation rules: `../_shared/claude-to-codex.md`
+
+Read all relevant source files before acting. For normal wish work, read the skill source and translation rules. For `--deep`, also read the deep workflow source.
+
+## Core Rules
+
+1. Ground every claimed existing engine surface against current code with `rg`, `git grep`, or file reads. Do not rely on memory for kinds, capabilities, mailboxes, traits, file paths, or signatures.
+2. A wish is not a plan until it is producible with known, verified means within current resources.
+3. Do not file issues or write production code from this skill unless the user asks for a follow-up sketch/scope flow.
+4. Preserve alternatives, doors opened, and doors closed in the wish output.
+
+## Deep Mode
+
+For `/wish --deep`, map the Claude JS workflow to Codex subagents:
+
+1. Generate or accept root wishes from the user-facing wish skill flow.
+2. Maintain the frontier in the main Codex thread.
+3. Spawn fresh driller subagents for bounded nodes. Each driller writes its own `wish.md` and returns `producible`, `summary`, `grounded_surfaces`, and `children`.
+4. For each `producible:true` node, run a skeptic pass before accepting it as terminal.
+5. Synthesize an `index.md` from node summaries and terminal leaves.
+
+Keep the main thread's context focused on frontier state and summaries, not raw driller reasoning.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+Repository guidance for Codex working in Aether.
+
+## Status
+
+Aether is a pre-1.0 Rust 2024 workspace for a game engine whose native substrate hosts wasm actors and native chassis capabilities. Engine actors communicate by mail. Load-bearing design lives in `docs/adr/NNNN-title.md`; the contributor and agent reference is the mdbook source in `docs/guide/`.
+
+Read relevant guide pages and ADRs before changing a subsystem. Prefer current code over prose when they disagree.
+
+## Workflow
+
+- Planned work lives in GitHub issues. Use the repo skills in `.agents/skills/` for sketch, scope, approve, implement, land, sweep, wish, review, and dogfood flows.
+- Existing Claude workflow files in `CLAUDE.md`, `.claude/skills/`, and `.claude/workflows/` remain source material. Codex skills adapt those workflows for Codex surfaces.
+- Do not implement directly in the primary `main` checkout. For issue work, create a separate worktree under `.claude/worktrees/issue-<N>` from `origin/main` and work there.
+- Branches use `type/short-slug` or the issue branch shape from the implement skill, for example `chore/issue-2742-make-repository-codex-friendly`.
+- PR titles and commits use Conventional Commits.
+- Do not push to `main`, force-push reviewed branches, self-merge, or run destructive git commands without explicit user approval.
+- Keep PRs focused: one concept per PR.
+
+## Commands
+
+- Build: `cargo build`
+- Release build: `cargo build --release`
+- Run a crate: `cargo run -p <crate>`
+- Chassis binaries: `cargo run -p aether-substrate-bundle --bin aether-substrate-hub`, `--bin aether-substrate`, or `--bin aether-substrate-headless`
+- Test: `cargo test`
+- Single test: `cargo test <name>`
+- Clippy: `cargo clippy --all-targets -- -D warnings`
+- Format: `cargo fmt`
+- Format check: `cargo fmt -- --check`
+- Check only: `cargo check`
+
+For implementation PRs, this repo uses GitHub Actions as the full build engine. Locally run `cargo fmt` before pushing; let CI run the expensive checks unless the issue explicitly asks for local verification.
+
+## MCP Harness
+
+The Aether MCP endpoint is configured by `.mcp.json` as `aether-hub` at `http://127.0.0.1:8890/mcp`.
+
+Start the local tunnel only when a task needs live engine tools:
+
+```bash
+scripts/ensure-tunnel.sh
+```
+
+Expected MCP tools are the `mcp__aether-hub__*` family, including engine listing, substrate spawn/terminate, component upload/load/replace, mail sending, kind/component description, frame capture, actor logs, and cost inspection. If those tools are missing after starting the tunnel, reconnect MCP in the active Codex surface.
+
+## Coding Rules
+
+- Preserve user changes. Never revert edits you did not make unless the user explicitly asks.
+- Prefer `rg`/`rg --files` for repository search.
+- Use `apply_patch` for manual edits.
+- Avoid section-divider banner comments in source.
+- In load-bearing code, prefer iterative algorithms over recursion unless depth is structurally bounded or capped.
+- In `aether-capabilities/src`, visibility is either `pub` or private; avoid scoped forms such as `pub(crate)`.
+- Spell units out in identifiers (`millis`, `nanos`, `micros`, `bytes`) and do not encode Rust primitive types in names.
+
+## Review Posture
+
+When asked for a review, lead with findings ordered by severity and cite files/lines. Prioritize correctness, regressions, missing tests, and architecture/convention drift over style.


### PR DESCRIPTION
Closes #2742.

## Summary

Adds a Codex-native workflow layer alongside the existing Claude workflow layer so Codex can discover repo guidance and reusable workflow skills. The implementation introduces root `AGENTS.md`, repo-scoped `.agents/skills/*/SKILL.md` entries, and a shared Claude-to-Codex translation reference that preserves the existing Claude workflow boundaries while mapping them onto Codex skills and explicit subagent orchestration.

## Test plan

- `cargo fmt`
- `quick_validate.py <skill-folder>` for every `.agents/skills/*/SKILL.md`
- `rg -n "AGENTS.md|\\.agents/skills|aether-hub|ensure-tunnel" AGENTS.md`
- `rg --files .agents/skills | rg '/SKILL.md$'`

## Generated by

`/implement` - agent execution of [scoped issue #2742](https://github.com/iamacoffeepot/aether/issues/2742).
