### PR TITLE
chore(workflow): port codex guardrail hooks

### DIFF
--- a/.agents/skills/_shared/claude-to-codex.md
+++ b/.agents/skills/_shared/claude-to-codex.md
@@ -18,7 +18,7 @@ Use this reference when a Codex repo skill points at an existing `.claude` skill
 - Preserve freshness boundaries. If a Claude workflow says a child agent must not see a diff or implementation detail, spawn a fresh Codex subagent without forked context and pass only the allowed prompt.
 - Map Claude `phase(...)` and `log(...)` calls to concise progress updates in the main Codex thread.
 - Map Claude JSON schemas to required structured return shapes in prose. Validate the returned shape before rolling it up.
-- Map Claude worktree isolation to git worktrees under `.claude/worktrees/issue-<N>` unless the skill explicitly says a temp scratch directory is enough.
+- Map Claude worktree isolation to Codex-owned git worktrees under `.agents/worktrees/issue-<N>` unless the skill explicitly says a temp scratch directory is enough.
 - Do not edit `.claude/` artifacts while executing a Codex port unless the user explicitly asks to change the Claude workflow itself.
 - Do not add Codex hooks as part of a skill run unless the issue being implemented explicitly scopes hook work. Hook semantics and trust review differ between Claude and Codex.
 

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -16,7 +16,7 @@ Use this Codex skill for the repository's issue-to-draft-PR workflow.
 
 1. Read both source files completely before acting.
 2. Verify preconditions: `phase:ready`, exactly one `model:*`, no umbrella sub-issues, an implementation plan, and working `gh` auth with `repo` scope.
-3. Create a dedicated worktree under `.claude/worktrees/issue-<N>` from `origin/main`; do not edit the primary `main` checkout.
+3. Create a dedicated Codex worktree under `.agents/worktrees/issue-<N>` from `origin/main`; do not edit the primary `main` checkout.
 4. Move the issue to `phase:executing` before implementation work starts.
 5. Follow the issue's `## Implementation plan` literally. Deviations are bounces, not freelancing.
 6. Commit the work, run `cargo fmt`, assert a clean worktree, push, and open a draft PR over REST.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,49 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/bind-session-worktree.sh\"",
+            "timeout": 30,
+            "statusMessage": "Preparing session worktree"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/check-pr-body.sh\"",
+            "timeout": 30,
+            "statusMessage": "Checking PR and issue text"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|apply_patch|Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/check-main-worktree-clean.sh\"",
+            "timeout": 30,
+            "statusMessage": "Checking main checkout"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/check-source-guardrails.sh\"",
+            "timeout": 30,
+            "statusMessage": "Checking source guardrails"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/bind-session-worktree.sh
+++ b/.codex/hooks/bind-session-worktree.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SessionStart hook: best-effort Codex session worktree preparation.
+#
+# A hook subprocess cannot change the parent Codex process cwd. When Codex
+# provides a stable thread/session id, this script creates a detached worktree
+# under .agents/worktrees/codex-<id> and emits model-visible guidance in the
+# same additionalContext shape used by the Claude hook. If Codex ignores that
+# output, the script is still harmless: it either created a usable worktree or
+# stayed silent when no stable id was present.
+
+set -u
+
+input=$(cat)
+
+current_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+git_common_dir=$(git -C "$current_root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+if [[ -n "$git_common_dir" ]]; then
+    main_root=$(dirname "$git_common_dir")
+else
+    main_root="$current_root"
+fi
+
+json_value() {
+    local filter="$1"
+    if command -v jq >/dev/null 2>&1; then
+        printf '%s' "$input" | jq -r "$filter // empty" 2>/dev/null || true
+    fi
+}
+
+session_key=$(
+    json_value '.session_id // .sessionId // .thread_id // .threadId // .conversation_id // .conversationId // .id // .thread.id // .conversation.id'
+)
+
+if [[ -z "$session_key" ]]; then
+    session_key="${CODEX_SESSION_ID:-${CODEX_THREAD_ID:-${CODEX_CONVERSATION_ID:-}}}"
+fi
+
+if [[ -z "$session_key" ]]; then
+    exit 0
+fi
+
+safe_key=$(printf '%s' "$session_key" | tr -cs 'A-Za-z0-9._-' '-' | sed 's/^-//; s/-$//' | cut -c 1-80)
+if [[ -z "$safe_key" ]]; then
+    exit 0
+fi
+
+worktree_dir="$main_root/.agents/worktrees/codex-$safe_key"
+
+if command -v git >/dev/null 2>&1 \
+    && git -C "$main_root" rev-parse --git-dir >/dev/null 2>&1; then
+    if [[ ! -e "$worktree_dir" ]]; then
+        mkdir -p "$(dirname "$worktree_dir")"
+        git -C "$main_root" worktree add --detach "$worktree_dir" origin/main >/dev/null 2>&1 \
+            || git -C "$main_root" worktree add --detach "$worktree_dir" HEAD >/dev/null 2>&1 \
+            || true
+    fi
+fi
+
+if [[ -e "$worktree_dir" ]] && command -v jq >/dev/null 2>&1; then
+    context=$(cat <<EOF
+This Codex session has a prepared git worktree at:
+
+    $worktree_dir
+
+A hook cannot change the parent Codex process cwd. Use that worktree for repo edits, or use the issue-specific worktree required by the Aether implement skill for planned issue work.
+EOF
+)
+    jq -n --arg ctx "$context" \
+        '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+fi
+
+exit 0

--- a/.codex/hooks/check-main-worktree-clean.sh
+++ b/.codex/hooks/check-main-worktree-clean.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# PostToolUse hook: fail if the primary checkout is left dirty.
+
+set -u
+
+if [[ "${AETHER_CODEX_ALLOW_DIRTY_MAIN:-}" == "1" ]]; then
+    exit 0
+fi
+
+current_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[[ -n "$current_root" ]] || exit 0
+
+git_common_dir=$(git -C "$current_root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+[[ -n "$git_common_dir" ]] || exit 0
+
+main_root=$(dirname "$git_common_dir")
+[[ -d "$main_root" ]] || exit 0
+
+dirty=$(git -C "$main_root" status --porcelain 2>/dev/null || true)
+[[ -z "$dirty" ]] && exit 0
+
+{
+    printf '[worktree boundary] the primary checkout is dirty:\n\n'
+    printf '%s\n' "$dirty" | sed 's/^/    /'
+    printf '\n'
+    printf 'Aether Codex issue work should happen in .agents/worktrees/issue-<N>, not the primary checkout.\n'
+    printf 'Revert the primary checkout change or intentionally bypass this hook with AETHER_CODEX_ALLOW_DIRTY_MAIN=1.\n'
+} >&2
+
+exit 2

--- a/.codex/hooks/check-pr-body.sh
+++ b/.codex/hooks/check-pr-body.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# PreToolUse hook for GitHub PR/issue text published from Bash.
+
+set -u
+
+input=$(cat)
+
+jq_value() {
+    local filter="$1"
+    if command -v jq >/dev/null 2>&1; then
+        printf '%s' "$input" | jq -r "$filter // empty" 2>/dev/null || true
+    fi
+}
+
+command=$(
+    jq_value '.tool_input.command // .tool_input.cmd // .input.command // .input.cmd // .arguments.command // .arguments.cmd // .params.command // .params.cmd // .command // .cmd'
+)
+
+case "$command" in
+    *"gh pr create"*|*"gh pr edit"*|*"gh issue create"*|*"gh issue edit"*) ;;
+    *) exit 0 ;;
+esac
+
+is_pr_cmd=0
+is_issue_cmd=0
+case "$command" in
+    *"gh pr create"*|*"gh pr edit"*) is_pr_cmd=1 ;;
+esac
+if (( is_pr_cmd == 0 )); then
+    case "$command" in
+        *"gh issue create"*|*"gh issue edit"*) is_issue_cmd=1 ;;
+    esac
+fi
+
+override_line=$(printf '%s' "$command" | grep -oE 'pr-body-ok:[^\n]*' | head -1 || true)
+allowed=""
+if [[ -n "$override_line" ]]; then
+    rest=${override_line#pr-body-ok:}
+    rest=${rest# }
+    prefix=${rest%%[[:space:]-]*}
+    allowed=$(printf '%s' "$prefix" | tr '[:upper:]' '[:lower:]' | grep -oE '[a-e]' | tr '\n' ',' | sed 's/,$//' || true)
+    if [[ -z "$allowed" ]]; then
+        printf 'pr-body-ok override needs at least one pattern letter (a/b/c/d/e), e.g. `<!-- pr-body-ok: d - reason -->`\n' >&2
+        exit 2
+    fi
+fi
+
+body_file=$(printf '%s' "$command" | grep -oE -- '--body-file[ =]+[^ ]+' | sed -E 's/^--body-file[ =]+//' | tr -d '"' | tr -d "'")
+body_content=""
+if [[ -n "$body_file" && -f "$body_file" ]]; then
+    body_content=$(cat "$body_file")
+fi
+
+body_inline=$(printf '%s' "$command" | grep -oE -- "--body[ =]+(\"[^\"]*\"|'[^']*')" | head -1 || true)
+if [[ -n "$body_inline" ]]; then
+    body_inline=${body_inline#*--body}
+    body_inline=${body_inline# }
+    body_inline=${body_inline#=}
+    body_inline=${body_inline# }
+    body_inline=${body_inline%\'}
+    body_inline=${body_inline#\'}
+    body_inline=${body_inline%\"}
+    body_inline=${body_inline#\"}
+fi
+
+body_heredoc=$(printf '%s' "$command" | awk '/<<.*EOF/ { grab=1; next } grab && /^[[:space:]]*EOF[[:space:]]*$/ { grab=0; next } grab { print }')
+body_corpus=$(printf '%s\n%s\n%s' "$body_content" "$body_inline" "$body_heredoc")
+
+issues=()
+
+if [[ ",$allowed," != *",a,"* ]] && printf '%s' "$body_corpus" | grep -qE '\\[`$]'; then
+    issues+=("Pattern A: backslash-escaped backtick or dollar - drop the backslash; quoted heredocs pass them through literally")
+fi
+
+if [[ ",$allowed," != *",d,"* ]] && printf '%s' "$body_corpus" | grep -qE '\$[^ \(0-9][^$]*\$'; then
+    issues+=("Pattern D: dollar-delimited text renders as LaTeX math on GitHub - use backticks for inline code")
+fi
+
+title_match=$(printf '%s' "$command" | grep -oE -- "--title[ =]+(\"[^\"]*\"|'[^']*')" || true)
+title=""
+if [[ -n "$title_match" ]]; then
+    title=${title_match#*--title}
+    title=${title# }
+    title=${title#=}
+    title=${title# }
+    title=${title%\'}
+    title=${title#\'}
+    title=${title%\"}
+    title=${title#\"}
+fi
+
+if [[ ",$allowed," != *",c,"* ]] && [[ -n "$title" && "$title" == *:* ]]; then
+    subject=${title#*:}
+    subject=${subject# }
+    first=${subject:0:1}
+    if [[ "$first" =~ [A-Z] ]]; then
+        issues+=("Pattern C: PR/issue title subject starts uppercase ('$first') - CI rejects it")
+    fi
+fi
+
+valid_scope() {
+    local scope="$1"
+    local root
+    root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+    case " ci docs adr qodana repo release workflow guide " in
+        *" $scope "*) return 0 ;;
+    esac
+
+    if [[ -f "$root/Cargo.toml" ]] && grep -qE "name[[:space:]]*=[[:space:]]*\"aether-$scope\"" "$root"/crates/*/Cargo.toml 2>/dev/null; then
+        return 0
+    fi
+
+    if [[ -f "$root/crates/aether-$scope/Cargo.toml" ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+if [[ ",$allowed," != *",e,"* ]] && (( is_issue_cmd == 1 )) && [[ -n "$title" ]]; then
+    title_re='^(feat|fix|chore|docs|perf|refactor|flake)\(([a-z0-9-]+)(/[a-z0-9-]+)?\):[[:space:]].+$'
+    if [[ "$title" =~ $title_re ]]; then
+        scope="${BASH_REMATCH[2]}"
+        if ! valid_scope "$scope"; then
+            issues+=("Pattern E: issue title scope '$scope' is not a known crate or meta-scope")
+        fi
+    else
+        issues+=("Pattern E: issue title must match {type}({crate}): subject; allowed types: feat, fix, chore, docs, perf, refactor, flake")
+    fi
+fi
+
+if (( ${#issues[@]} )); then
+    {
+        printf 'PR/issue text pre-flight failed:\n'
+        for issue in "${issues[@]}"; do
+            printf '  - %s\n' "$issue"
+        done
+        printf '\nRules reference:\n'
+        printf '  - Issue title: {type}({scope}): <subject>. Types: feat fix chore docs perf refactor flake.\n'
+        printf '  - PR title: conventional-commit shape with a lowercase subject.\n'
+        printf '  - Scope is a crate name OR a meta-scope: ci docs adr qodana repo release workflow guide.\n'
+        printf '  - Body: no backslash before a backtick/dollar; no dollar-delimited math span.\n'
+        printf '\nTo override deliberately, include `<!-- pr-body-ok: <letters> - <reason> -->` (letters: a/c/d/e).\n'
+    } >&2
+    exit 2
+fi
+
+exit 0

--- a/.codex/hooks/check-source-guardrails.sh
+++ b/.codex/hooks/check-source-guardrails.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# PostToolUse hook for source-level guardrails that can be read from git diff.
+
+set -u
+
+root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[[ -n "$root" ]] || exit 0
+
+tmp=$(mktemp "${TMPDIR:-/tmp}/aether-codex-guardrails.XXXXXX")
+cleanup() { rm -f "$tmp"; }
+trap cleanup EXIT
+
+issues=()
+
+source_file() {
+    case "$1" in
+        *.rs|*.ts|*.tsx|*.js|*.py|*.sh|*.go|*.c|*.cpp|*.h) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+check_untracked_file() {
+    local file="$1"
+    local path="$root/$file"
+
+    source_file "$file" || return 0
+    [[ -f "$path" ]] || return 0
+
+    if awk '
+        /^[[:space:]]*(\/\/|#)[[:space:]]*[-=*]{3,}/ && !/(\/\/|#) ?DIVIDER_OK:/ {
+            found = 1
+        }
+        END { exit found ? 0 : 1 }
+    ' "$path"; then
+        issues+=("no-divider-comments: untracked file $file contains section-divider comment lines; use normal comments or split the file")
+    fi
+
+    if [[ "$file" == */host_fns.rs || "$file" == "host_fns.rs" ]]; then
+        if awk '
+            /HOST_FN_OK:/ { override = 1 }
+            /linker\.func_wrap\(/ { added = 1 }
+            END { exit (added && !override) ? 0 : 1 }
+        ' "$path"; then
+            issues+=("host_fns.rs: untracked file $file adds linker.func_wrap without HOST_FN_OK; most new capabilities should land as mail sinks")
+        fi
+    fi
+}
+
+check_diff() {
+    local diff="$1"
+    [[ -n "$diff" ]] || return 0
+
+    printf '%s' "$diff" > "$tmp"
+
+    if awk '
+        /^\+\+\+ b\// {
+            file = substr($0, 7)
+            next
+        }
+        /^\+[^+]/ {
+            line = substr($0, 2)
+            if (file ~ /\.(rs|ts|tsx|js|py|sh|go|c|cpp|h)$/ && line ~ /^[[:space:]]*(\/\/|#)[[:space:]]*[-=*]{3,}/ && line !~ /(\/\/|#) ?DIVIDER_OK:/) {
+                found = 1
+            }
+        }
+        END { exit found ? 0 : 1 }
+    ' "$tmp"; then
+        issues+=("no-divider-comments: this diff adds section-divider comment lines; use normal comments or split the file")
+    fi
+
+    while IFS= read -r file; do
+        source_file "$file" || continue
+        [[ "$file" == */host_fns.rs || "$file" == "host_fns.rs" ]] || continue
+        if awk -v target="$file" '
+            /^\+\+\+ b\// {
+                file = substr($0, 7)
+                in_file = (file == target)
+                next
+            }
+            in_file && /^\+[^+]/ {
+                line = substr($0, 2)
+                if (line ~ /HOST_FN_OK:/) {
+                    override = 1
+                }
+                if (line ~ /linker\.func_wrap\(/) {
+                    added = 1
+                }
+            }
+            END { exit (added && !override) ? 0 : 1 }
+        ' "$tmp"; then
+            issues+=("host_fns.rs: this diff adds linker.func_wrap without HOST_FN_OK; most new capabilities should land as mail sinks")
+        fi
+    done < <(awk '/^\+\+\+ b\// { print substr($0, 7) }' "$tmp" | sort -u)
+}
+
+unstaged=$(git -C "$root" diff --no-ext-diff --unified=0 -- . 2>/dev/null || true)
+staged=$(git -C "$root" diff --cached --no-ext-diff --unified=0 -- . 2>/dev/null || true)
+check_diff "$(printf '%s\n%s\n' "$unstaged" "$staged")"
+
+while IFS= read -r file; do
+    check_untracked_file "$file"
+done < <(git -C "$root" ls-files --others --exclude-standard 2>/dev/null || true)
+
+if (( ${#issues[@]} )); then
+    {
+        printf 'Source guardrail check failed:\n'
+        for issue in "${issues[@]}"; do
+            printf '  - %s\n' "$issue"
+        done
+    } >&2
+    exit 2
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 .claude/worktrees/
+.agents/worktrees/
 .claude/skills/*
 !.claude/skills/adr/
 !.claude/skills/approve/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Read relevant guide pages and ADRs before changing a subsystem. Prefer current c
 
 - Planned work lives in GitHub issues. Use the repo skills in `.agents/skills/` for sketch, scope, approve, implement, land, sweep, wish, review, and dogfood flows.
 - Existing Claude workflow files in `CLAUDE.md`, `.claude/skills/`, and `.claude/workflows/` remain source material. Codex skills adapt those workflows for Codex surfaces.
-- Do not implement directly in the primary `main` checkout. For issue work, create a separate worktree under `.claude/worktrees/issue-<N>` from `origin/main` and work there.
+- Do not implement directly in the primary `main` checkout. For Codex issue work, create a separate worktree under `.agents/worktrees/issue-<N>` from `origin/main` and work there. Legacy Claude workflow files may still reference `.claude/worktrees/`.
 - Branches use `type/short-slug` or the issue branch shape from the implement skill, for example `chore/issue-2742-make-repository-codex-friendly`.
 - PR titles and commits use Conventional Commits.
 - Do not push to `main`, force-push reviewed branches, self-merge, or run destructive git commands without explicit user approval.
@@ -32,6 +32,20 @@ Read relevant guide pages and ADRs before changing a subsystem. Prefer current c
 - Check only: `cargo check`
 
 For implementation PRs, this repo uses GitHub Actions as the full build engine. Locally run `cargo fmt` before pushing; let CI run the expensive checks unless the issue explicitly asks for local verification.
+
+## Codex Hooks
+
+Project-local Codex hooks live in `.codex/hooks.json` and `.codex/hooks/`.
+Because Codex trust-records hook definitions, new or changed hooks may need
+review through `/hooks` before they run.
+
+The SessionStart hook can prepare a per-session worktree under
+`.agents/worktrees/` when Codex exposes a stable session or thread id, but a
+hook subprocess cannot change Codex's cwd. Planned issue work still follows the
+implement skill and edits `.agents/worktrees/issue-<N>`.
+
+Codex hooks are guardrails, not a new local preflight or CI surface. Do not add
+hook tests or CI hook jobs unless a scoped issue explicitly asks for them.
 
 ## MCP Harness
 

--- a/docs/guide/local-verification.md
+++ b/docs/guide/local-verification.md
@@ -10,6 +10,12 @@ cargo fmt
 
 A formatting slip is the one CI red worth catching locally — instant to fix and the cheapest failure to avoid. Everything heavier is CI's job.
 
+Codex sessions may also load project hooks from `.codex/hooks.json` after you
+trust them with `/hooks`. Those hooks are interactive guardrails for the local
+agent loop, including the best-effort `.agents/worktrees/` helper and
+source/text checks; they are not a required local preflight and they do not add
+a separate CI hook-test surface.
+
 ## Watching CI
 
 Open your PR as a draft, then watch the checks and fix a red as soon as it surfaces rather than waiting for the whole run to finish:


### PR DESCRIPTION
Closes #2744.

## Summary
- add project-local Codex hook config and guardrail scripts for session worktree guidance, PR/issue text checks, dirty-main detection, and source guardrails
- route Codex-owned worktrees to `.agents/worktrees/` and ignore that directory
- update Codex workflow docs and skill wrapper without adding hook tests or CI hook jobs

## Test plan
- `jq empty .codex/hooks.json`
- `bash -n .codex/hooks/bind-session-worktree.sh .codex/hooks/check-pr-body.sh .codex/hooks/check-main-worktree-clean.sh .codex/hooks/check-source-guardrails.sh`
- manual PR/issue hook smoke: valid text passes; uppercase title subjects and dollar-math spans fail
- temp-repo SessionStart smoke: helper creates `.agents/worktrees/codex-smoke-2744`
- `bash .codex/hooks/check-source-guardrails.sh`
- `bash .codex/hooks/check-main-worktree-clean.sh`
- `cargo fmt`

## Generated by
`$implement` - agent execution of scoped issue #2744.
