### PR TITLE
docs(adr): reconcile shipped ADR statuses from Proposed to Accepted

### DIFF
--- a/docs/adr/0126-master-reverb-send.md
+++ b/docs/adr/0126-master-reverb-send.md
@@ -1,6 +1,6 @@
 # ADR-0126: Master reverb send on the audio mixer
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — master reverb send in the `aether.audio` capability; `crates/aether-capabilities/src/audio/runtime/reverb.rs`)
 - **Date:** 2026-07-03
 
 ## Context

--- a/docs/adr/0127-per-note-pan-and-per-sender-gain.md
+++ b/docs/adr/0127-per-note-pan-and-per-sender-gain.md
@@ -1,6 +1,6 @@
 # ADR-0127: Per-note pan and per-sender gain for the synth mixer
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — per-note pan + per-sender gain in the `aether.audio` capability; `crates/aether-capabilities/src/audio/runtime/{voice,synth}.rs`)
 - **Date:** 2026-07-03
 
 ## Context

--- a/docs/adr/0129-http-server-websocket-upgrade.md
+++ b/docs/adr/0129-http-server-websocket-upgrade.md
@@ -1,6 +1,6 @@
 # ADR-0129: HTTP server websocket upgrade
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — HTTP websocket upgrade in the `aether.http` server capability; `crates/aether-capabilities/src/http/server/runtime/websocket.rs`)
 - **Amended by:** ADR-0132 — the data-phase kinds (`WebSocketMessage`, `WebSocketClose`) carry an explicit `stream_id` and outbound mail routes by it; the causal-chain-root routing this ADR describes for outbound messages is superseded.
 - **Date:** 2026-07-03
 

--- a/docs/adr/0130-http-server-route-registration.md
+++ b/docs/adr/0130-http-server-route-registration.md
@@ -1,6 +1,6 @@
 # ADR-0130: HTTP Server Route Registration
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — HTTP server route registration in the `aether.http` server capability; `crates/aether-capabilities/src/http/server/mod.rs`)
 - **Date:** 2026-07-03
 
 Extends **ADR-0108** (the `aether.http.server` capability), realizing the routing refinements its §Follow-on parked. Mirrors the declare-interest-by-mail model of **ADR-0021** / **ADR-0083** (input-stream subscriptions) and rides the shared lifecycle `wire` hook of iamacoffeepot/aether#2048. Composes unchanged with **ADR-0128** (response streaming) and **ADR-0129** (websocket upgrade), both of which act downstream of dispatch, keyed by the request's correlation.

--- a/docs/adr/0132-explicit-stream-id-for-websocket-messages.md
+++ b/docs/adr/0132-explicit-stream-id-for-websocket-messages.md
@@ -1,6 +1,6 @@
 # ADR-0132: Explicit Stream Id for Websocket Messages
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — explicit `stream_id` on websocket messages; `crates/aether-capabilities/src/http/server/runtime/websocket.rs`)
 - **Date:** 2026-07-04
 
 Amends **ADR-0129** (HTTP server websocket upgrade): replaces its causal-chain-root routing for data-phase websocket mail with an explicit `stream_id` carried on the wire, the correlation posture **ADR-0128** established for mid-session mail on short chains.

--- a/docs/adr/0133-reply-based-stream-handles-for-the-http-server-data-phase.md
+++ b/docs/adr/0133-reply-based-stream-handles-for-the-http-server-data-phase.md
@@ -1,6 +1,6 @@
 # ADR-0133: Reply-Based Stream Handles for the HTTP Server Data Phase
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — reply-based stream handles for the HTTP server data phase; `crates/aether-capabilities/src/http/stream.rs`)
 - **Date:** 2026-07-04
 
 Amends **ADR-0128** (response streaming), **ADR-0129** (websocket upgrade), and **ADR-0132** (explicit stream id): replaces their handler→cap addressing — the typed singleton send at `HttpServerCapability` — with a durable stream handle that addresses whoever actually dispatched the stream to the handler. The payload `stream_id` keying ADR-0132 established is unchanged. Builds on the causal-chain model of **ADR-0080** and the reply machinery of **ADR-0013** / **ADR-0017**.

--- a/docs/adr/0134-multi-reply-class-and-explicit-handler-classes.md
+++ b/docs/adr/0134-multi-reply-class-and-explicit-handler-classes.md
@@ -1,6 +1,6 @@
 # ADR-0134: Multi Reply Class and Explicit Handler Classes
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — multi reply class + explicit `#[handler::{single,multi,manual}]` classes in `aether-actor-derive`; amends ADR-0112)
 - **Date:** 2026-07-05
 
 Amends **ADR-0112** (handler reply classes): the reserved `stream` class is renamed **multi** and goes live on the detached-emission model **ADR-0133** established for the HTTP server data phase, and the bare `#[handler]` default is removed — every mail handler spells its reply class. Builds on the causal-chain model of **ADR-0080** and the settlement discharge of **ADR-0106**.

--- a/docs/adr/0135-sharded-http-server-dispatch.md
+++ b/docs/adr/0135-sharded-http-server-dispatch.md
@@ -1,6 +1,6 @@
 # ADR-0135: Sharded HTTP Server Dispatch
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — sharded HTTP server dispatch; `crates/aether-capabilities/src/http/server/shard/`)
 - **Date:** 2026-07-05
 
 Restructures the `aether.http.server` capability's request path for throughput. Amends **ADR-0108** (the single-actor dispatch topology of §5, the trust-cap enforcement seat of §6) and **ADR-0128** (which actor answers the reader's streaming decision in §4). The streaming, websocket, and routing wire contracts (ADR-0128/0129/0130/0132/0133) are unchanged — this ADR moves work between actors and threads; it does not change any kind, any handler-visible semantics, or any external mail surface.

--- a/docs/adr/0136-http-route-target-sets.md
+++ b/docs/adr/0136-http-route-target-sets.md
@@ -1,6 +1,6 @@
 # ADR-0136: HTTP Route Target Sets
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — HTTP route target sets / `#[router(shared)]`; `crates/aether-capabilities/src/http/server/runtime/routing.rs`)
 - **Date:** 2026-07-05
 
 Amends **ADR-0130** (HTTP route registration): a route's target grows from one mailbox to a set of member mailboxes that N handler instances opt into together, with per-request selection spreading load across live members. Registration, conflict, and dead-target semantics otherwise stand. Builds on the sharded dispatch of **ADR-0135**.

--- a/docs/adr/0138-opt-in-default-entry-for-multi-actor-modules.md
+++ b/docs/adr/0138-opt-in-default-entry-for-multi-actor-modules.md
@@ -1,6 +1,6 @@
 # ADR-0138: Opt-in Default Entry for Multi-Actor Modules
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — opt-in default entry for multi-actor modules; `crates/aether-capabilities/src/component/runtime/load.rs`, #2736)
 - **Date:** 2026-07-07
 
 ## Context


### PR DESCRIPTION
`/sweep adrs` surfaced ten ADRs recorded as Proposed whose implementation had already shipped and was citing them from source — the status line simply never caught up. Each is flipped to Accepted with a one-line pointer to the shipping code.

| ADR | Evidence |
|-----|----------|
| 0126 master reverb send | audio/runtime/reverb.rs |
| 0127 per-note pan + per-sender gain | audio/runtime/{voice,synth}.rs |
| 0129 HTTP websocket upgrade | http/server/runtime/websocket.rs |
| 0130 HTTP server route registration | http/server/mod.rs |
| 0132 explicit stream_id on websocket messages | http/server/runtime/websocket.rs |
| 0133 reply-based stream handles | http/stream.rs |
| 0134 multi reply class + explicit handler classes | aether-actor-derive (amends ADR-0112) |
| 0135 sharded HTTP server dispatch | http/server/shard/ |
| 0136 HTTP route target sets / router(shared) | http/server/runtime/routing.rs |
| 0138 opt-in default entry | component/runtime/load.rs, #2736 |

Held for the user's read (not in this PR):
- ADR-0137 (behavior host) — core shipped but the panel e2e gate (#2688) is still open.
- ADR-0034 (hub-as-substrate) — Phase 2 "in progress" wording may be stale in the other direction (no hub-router component), left for a judgment call.

Surface-and-flip only; no code or decision content changed, only the recorded status lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)