### PR TITLE
fix(aether-behavior-derive): surface decode failures as filter faults

### DIFF
--- a/crates/aether-behavior-derive/src/lib.rs
+++ b/crates/aether-behavior-derive/src/lib.rs
@@ -303,6 +303,8 @@ fn build_dispatch_body(handlers: &[Handler]) -> TokenStream2 {
                     <#k as ::aether_behavior::__macro_internals::Kind>::decode_from_bytes(__aether_bytes)
                 {
                     #call
+                } else {
+                    __aether_ctx.__fault();
                 }
                 return;
             }

--- a/crates/aether-behavior-derive/tests/behavior.rs
+++ b/crates/aether-behavior-derive/tests/behavior.rs
@@ -79,6 +79,13 @@ fn dispatch<K: Kind>(limiter: &mut Limiter, kind: &K) -> Verdict {
     ctx.__into_output().verdict
 }
 
+fn dispatch_faulted<K: Kind>(limiter: &mut Limiter, bytes: &[u8]) -> bool {
+    let mut mirrors = MirrorStore::default();
+    let mut ctx = BehaviorCtx::__new_inbound(&mut mirrors, K::ID, bytes);
+    limiter.__aether_behavior_dispatch(&mut ctx, K::ID, bytes);
+    ctx.__faulted()
+}
+
 /// A `&mut K` handler's mutation is the verdict: the forwarded bytes are
 /// the re-encoded, mutated kind — not the inbound original.
 #[test]
@@ -128,7 +135,8 @@ fn consume_drops_the_in_flight_mail() {
 fn consume_wins_over_the_intercept_re_encode() {
     let mut gate = Gate::default();
     let bytes = Gauge { value: 250 }.encode_into_bytes();
-    let mut ctx = BehaviorCtx::__new_inbound(Gauge::ID, &bytes);
+    let mut mirrors = MirrorStore::default();
+    let mut ctx = BehaviorCtx::__new_inbound(&mut mirrors, Gauge::ID, &bytes);
     gate.__aether_behavior_dispatch(&mut ctx, Gauge::ID, &bytes);
     let verdict = ctx.__into_output().verdict;
     // Tripwire: the macro's unconditional __forward_mutated after an
@@ -158,6 +166,21 @@ fn undeclared_kind_falls_through_untouched() {
     };
     assert_eq!(bytes, inbound.encode_into_bytes());
     assert_eq!(limiter.hits, 0, "no handler ran");
+}
+
+/// Malformed bytes for a declared kind are surfaced as a fault instead of
+/// silently returning the default pass-through output.
+#[test]
+fn declared_kind_decode_failure_faults_the_context() {
+    let mut limiter = Limiter { cap: 100, hits: 0 };
+    let malformed = dispatch_faulted::<Gauge>(&mut limiter, b"\xff\xff");
+    assert!(malformed);
+    assert_eq!(limiter.hits, 0, "malformed payload never reaches handler");
+
+    let valid_bytes = Gauge { value: 12 }.encode_into_bytes();
+    let valid = dispatch_faulted::<Gauge>(&mut limiter, &valid_bytes);
+    assert!(!valid);
+    assert_eq!(limiter.hits, 1, "valid payload still reaches handler");
 }
 
 /// The emitted exports manifest lists exactly the `#[on]` kind ids — the

--- a/crates/aether-behavior/src/host/slot.rs
+++ b/crates/aether-behavior/src/host/slot.rs
@@ -228,6 +228,11 @@ impl ScriptSlot {
     /// Record a trap: bump the counter and disable at the threshold.
     fn record_trap(&mut self) {
         self.consecutive_traps = self.consecutive_traps.saturating_add(1);
+        tracing::warn!(
+            target: "aether_behavior",
+            consecutive = self.consecutive_traps,
+            "behavior filter failed open — forwarding untransformed"
+        );
         if self.disable_after_traps != 0 && self.consecutive_traps >= self.disable_after_traps {
             self.state = RunState::Disabled;
         }
@@ -279,7 +284,8 @@ mod tests {
     use super::*;
     use crate::envelope::{Effect, EffectTarget, Verdict};
     use crate::host::test_support::{
-        conditional_trap_wasm, fixed_output_wasm, forward_output, stateful_wasm, trapping_wasm,
+        conditional_trap_wasm, empty_return_wasm, fixed_output_wasm, forward_output, stateful_wasm,
+        trapping_wasm,
     };
     use alloc::vec;
 
@@ -309,6 +315,31 @@ mod tests {
             FilterOutcome::Passthrough
         ));
         assert_eq!(slot.consecutive_traps(), 3);
+        assert!(slot.is_disabled());
+    }
+
+    // Tripwire: an undecodable output (including the guest's empty return for
+    // a declared-kind decode failure) takes the same fail-open trap path.
+    #[test]
+    fn empty_return_counts_as_trap_and_disables_at_threshold() {
+        let kind = KindId(0x1001);
+        let engine = build_engine();
+        let mut slot =
+            ScriptSlot::instantiate(&engine, &empty_return_wasm(kind), None, 1_000_000, 2)
+                .expect("test setup: empty-return module instantiates");
+
+        assert!(matches!(
+            slot.filter(kind, b"malformed"),
+            FilterOutcome::Passthrough
+        ));
+        assert_eq!(slot.consecutive_traps(), 1);
+        assert!(!slot.is_disabled());
+
+        assert!(matches!(
+            slot.filter(kind, b"malformed"),
+            FilterOutcome::Passthrough
+        ));
+        assert_eq!(slot.consecutive_traps(), 2);
         assert!(slot.is_disabled());
     }
 

--- a/crates/aether-behavior/src/host/test_support.rs
+++ b/crates/aether-behavior/src/host/test_support.rs
@@ -25,6 +25,17 @@ pub(crate) fn trapping_wasm(handled: KindId) -> Vec<u8> {
     )
 }
 
+/// A module whose `filter` returns an empty packed buffer. The host rejects
+/// this as undecodable output and records a fail-open trap.
+pub(crate) fn empty_return_wasm(handled: KindId) -> Vec<u8> {
+    module(
+        r#"(func (export "filter") (param i64 i32 i32) (result i64)
+             (i64.const 0))"#,
+        None,
+        &[handled],
+    )
+}
+
 /// A module whose `filter` returns a fixed, pre-encoded [`FilterOutput`] baked
 /// into a data segment (ignoring its inputs). A clean, counter-resetting call.
 pub(crate) fn fixed_output_wasm(handled: KindId, output: &FilterOutput) -> Vec<u8> {

--- a/crates/aether-behavior/src/runtime/mod.rs
+++ b/crates/aether-behavior/src/runtime/mod.rs
@@ -102,6 +102,7 @@ pub struct MirrorStore {
 /// handle reads. The host builds one per `filter` call and drains it after.
 pub struct BehaviorCtx<'m> {
     inbound: Vec<u8>,
+    fault: bool,
     verdict: VerdictState,
     effects: Vec<Effect>,
     mirrors: &'m mut MirrorStore,
@@ -117,6 +118,7 @@ impl<'m> BehaviorCtx<'m> {
     pub fn __new_inbound(mirrors: &'m mut MirrorStore, kind_id: KindId, bytes: &[u8]) -> Self {
         let ctx = Self {
             inbound: bytes.to_vec(),
+            fault: false,
             verdict: VerdictState::ForwardOriginal,
             effects: Vec::new(),
             mirrors,
@@ -162,6 +164,19 @@ impl<'m> BehaviorCtx<'m> {
         if !matches!(self.verdict, VerdictState::Consume) {
             self.verdict = VerdictState::ForwardMutated(bytes);
         }
+    }
+
+    /// Mark this filter call as faulted so the host counts it as fail-open.
+    #[doc(hidden)]
+    pub fn __fault(&mut self) {
+        self.fault = true;
+    }
+
+    /// Whether this filter call should surface as a host-visible fault.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __faulted(&self) -> bool {
+        self.fault
     }
 
     /// Consume the ctx into the wire [`FilterOutput`] the host drains.
@@ -347,6 +362,12 @@ pub fn run_filter(
 ) -> Vec<u8> {
     let mut ctx = BehaviorCtx::__new_inbound(mirrors, kind_id, inbound);
     dispatch(&mut ctx);
+    if ctx.__faulted() {
+        // `envelope::decode` returns `None` for empty buffers, while every
+        // well-formed output writes at least the version byte; use that
+        // existing host fault path for declared-kind decode failures.
+        return Vec::new();
+    }
     encode(&ctx.__into_output())
 }
 


### PR DESCRIPTION
Closes #2757.

## Summary

Routes declared-kind decode failures through the behavior fault path so malformed handled mail fails open and counts as a trap instead of looking like a clean passthrough.

Adds a shared host warning at the trap choke point and coverage for both the generated guest dispatch fault and host empty-return trap accounting.

## Test plan

- `cargo fmt`
- `cargo test -p aether-behavior-derive --test behavior`
- `cargo test -p aether-behavior -F host empty_return_counts_as_trap_and_disables_at_threshold`

## Generated by

`/implement` — agent execution of [scoped issue #2757](https://github.com/iamacoffeepot/aether/issues/2757).
