### PR TITLE
fix(aether-behavior-derive): detect duplicate handler kind ids

### DIFF
--- a/crates/aether-behavior-derive/src/lib.rs
+++ b/crates/aether-behavior-derive/src/lib.rs
@@ -189,6 +189,7 @@ fn expand_behavior(item: ItemImpl) -> syn::Result<TokenStream2> {
 
     let dispatch = build_dispatch_body(&handlers);
     let manifest = build_exports_manifest(&handlers);
+    let dup_id_guard = build_dup_id_guard(&handlers);
     let lifecycle_overrides = lifecycle_hooks.iter().map(|h| {
         let method = &h.method;
         let trait_method = h.hook.trait_method();
@@ -225,6 +226,7 @@ fn expand_behavior(item: ItemImpl) -> syn::Result<TokenStream2> {
         }
 
         #exports
+        #dup_id_guard
     })
 }
 
@@ -346,6 +348,35 @@ fn build_exports_manifest(handlers: &[Handler]) -> TokenStream2 {
             #( #copy_blocks )*
             let _ = pos;
             out
+        };
+    }
+}
+
+/// Const-eval guard for same-id handlers that token-level conflict checks
+/// cannot see, such as aliases or alternate paths to the same `Kind`.
+fn build_dup_id_guard(handlers: &[Handler]) -> TokenStream2 {
+    let handler_count = handlers.len();
+    let ids = handlers.iter().map(|h| {
+        let k = &h.kind_ty;
+        quote! {
+            <#k as ::aether_behavior::__macro_internals::Kind>::ID.0
+        }
+    });
+
+    quote! {
+        const _: () = {
+            const __AETHER_HANDLER_IDS: [u64; #handler_count] = [ #( #ids ),* ];
+            let mut i = 0;
+            while i < #handler_count {
+                let mut j = i + 1;
+                while j < #handler_count {
+                    if __AETHER_HANDLER_IDS[i] == __AETHER_HANDLER_IDS[j] {
+                        panic!("two #[on] handlers resolve to the same kind id");
+                    }
+                    j += 1;
+                }
+                i += 1;
+            }
         };
     }
 }

--- a/crates/aether-behavior-derive/tests/trybuild.rs
+++ b/crates/aether-behavior-derive/tests/trybuild.rs
@@ -9,4 +9,5 @@ fn ui() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/pass_behavior.rs");
     t.compile_fail("tests/ui/fail_bad_handler_signature.rs");
+    t.compile_fail("tests/ui/fail_duplicate_kind_id.rs");
 }

--- a/crates/aether-behavior-derive/tests/ui/fail_duplicate_kind_id.rs
+++ b/crates/aether-behavior-derive/tests/ui/fail_duplicate_kind_id.rs
@@ -1,0 +1,33 @@
+// Two handlers can use different spellings for the same kind type. Token
+// equality misses this, so the generated const duplicate-id guard must fail.
+#![allow(unused)]
+
+use aether_behavior::{Behavior, BehaviorCtx};
+use aether_behavior_derive::{behavior, on};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.behavior.duplicate_id.gauge")]
+struct Gauge {
+    value: u32,
+}
+
+type GaugeAlias = Gauge;
+
+#[derive(Default, Serialize, Deserialize)]
+struct Clamp;
+
+#[behavior]
+impl Behavior for Clamp {
+    #[on]
+    fn clamp(&mut self, _ctx: &mut BehaviorCtx, gauge: &Gauge) {
+        let _ = gauge;
+    }
+
+    #[on]
+    fn clamp_alias(&mut self, _ctx: &mut BehaviorCtx, gauge: &GaugeAlias) {
+        let _ = gauge;
+    }
+}
+
+fn main() {}

--- a/crates/aether-behavior-derive/tests/ui/fail_duplicate_kind_id.stderr
+++ b/crates/aether-behavior-derive/tests/ui/fail_duplicate_kind_id.stderr
@@ -1,0 +1,5 @@
+error[E0080]: evaluation panicked: two #[on] handlers resolve to the same kind id
+  --> tests/ui/fail_duplicate_kind_id.rs:20:1
+   |
+20 | #[behavior]
+   | ^^^^^^^^^^^ evaluation of `_` failed here


### PR DESCRIPTION
Closes #2759.

## Summary

Adds a const-eval duplicate kind-id guard to the `#[behavior]` macro so aliases or alternate paths resolving to the same `Kind::ID` fail at compile time.

Keeps the existing token-level conflict check for precise diagnostics and adds a trybuild fixture for the alias case the token check cannot catch.

## Test plan

- `cargo fmt`
- `TRYBUILD=overwrite cargo test -p aether-behavior-derive --test trybuild`
- `cargo test -p aether-behavior-derive --test trybuild`

## Generated by

`/implement` — agent execution of [scoped issue #2759](https://github.com/iamacoffeepot/aether/issues/2759).
