### PR TITLE
fix(aether-behavior-derive): reject async lifecycle hooks

### DIFF
--- a/crates/aether-behavior-derive/src/lib.rs
+++ b/crates/aether-behavior-derive/src/lib.rs
@@ -164,6 +164,7 @@ fn expand_behavior(item: ItemImpl) -> syn::Result<TokenStream2> {
             });
             inherent_items.push(ImplItem::Fn(method));
         } else if let Some(idx) = lifecycle_idx {
+            reject_async(&method.sig, "lifecycle hooks run synchronously")?;
             let hook = Lifecycle::from_attr(&method.attrs[idx]).expect("checked present");
             method.attrs.remove(idx);
             lifecycle_hooks.push(LifecycleHook {
@@ -173,6 +174,7 @@ fn expand_behavior(item: ItemImpl) -> syn::Result<TokenStream2> {
             inherent_items.push(ImplItem::Fn(method));
         } else if matches!(name.as_str(), "on_attach" | "on_frame" | "on_detach") {
             // A directly-named lifecycle override stays in `impl Behavior`.
+            reject_async(&method.sig, "lifecycle hooks run synchronously")?;
             trait_overrides.push(ImplItem::Fn(method));
         } else if name == "state_save" {
             has_state_save = true;
@@ -260,6 +262,16 @@ fn extract_handler_kind(sig: &syn::Signature) -> syn::Result<(Type, bool)> {
     };
     let intercepts = reference.mutability.is_some();
     Ok(((*reference.elem).clone(), intercepts))
+}
+
+fn reject_async(sig: &syn::Signature, target: &str) -> syn::Result<()> {
+    if let Some(asyncness) = &sig.asyncness {
+        return Err(syn::Error::new_spanned(
+            asyncness,
+            format!("#[behavior] {target} - remove `async`"),
+        ));
+    }
+    Ok(())
 }
 
 /// The kind-id if-chain. Sentinel arms route lifecycle to the `Behavior`

--- a/crates/aether-behavior-derive/tests/trybuild.rs
+++ b/crates/aether-behavior-derive/tests/trybuild.rs
@@ -8,5 +8,7 @@
 fn ui() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/pass_behavior.rs");
+    t.compile_fail("tests/ui/fail_async_lifecycle.rs");
+    t.compile_fail("tests/ui/fail_async_lifecycle_named_override.rs");
     t.compile_fail("tests/ui/fail_bad_handler_signature.rs");
 }

--- a/crates/aether-behavior-derive/tests/ui/fail_async_lifecycle.rs
+++ b/crates/aether-behavior-derive/tests/ui/fail_async_lifecycle.rs
@@ -1,0 +1,16 @@
+#![allow(unused)]
+
+use aether_behavior::{Behavior, BehaviorCtx};
+use aether_behavior_derive::{behavior, on_attach};
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+struct Hooks;
+
+#[behavior]
+impl Behavior for Hooks {
+    #[on_attach]
+    async fn setup(&mut self, _ctx: &mut BehaviorCtx) {}
+}
+
+fn main() {}

--- a/crates/aether-behavior-derive/tests/ui/fail_async_lifecycle.stderr
+++ b/crates/aether-behavior-derive/tests/ui/fail_async_lifecycle.stderr
@@ -1,0 +1,5 @@
+error: #[behavior] lifecycle hooks run synchronously - remove `async`
+  --> tests/ui/fail_async_lifecycle.rs:13:5
+   |
+13 |     async fn setup(&mut self, _ctx: &mut BehaviorCtx) {}
+   |     ^^^^^

--- a/crates/aether-behavior-derive/tests/ui/fail_async_lifecycle_named_override.rs
+++ b/crates/aether-behavior-derive/tests/ui/fail_async_lifecycle_named_override.rs
@@ -1,0 +1,15 @@
+#![allow(unused)]
+
+use aether_behavior::{Behavior, BehaviorCtx};
+use aether_behavior_derive::behavior;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+struct Hooks;
+
+#[behavior]
+impl Behavior for Hooks {
+    async fn on_frame(&mut self, _ctx: &mut BehaviorCtx) {}
+}
+
+fn main() {}

--- a/crates/aether-behavior-derive/tests/ui/fail_async_lifecycle_named_override.stderr
+++ b/crates/aether-behavior-derive/tests/ui/fail_async_lifecycle_named_override.stderr
@@ -1,0 +1,5 @@
+error: #[behavior] lifecycle hooks run synchronously - remove `async`
+  --> tests/ui/fail_async_lifecycle_named_override.rs:12:5
+   |
+12 |     async fn on_frame(&mut self, _ctx: &mut BehaviorCtx) {}
+   |     ^^^^^


### PR DESCRIPTION
Closes #2756.

## Summary

Rejects async behavior lifecycle hooks at macro expansion time so attach, frame, and detach hooks cannot silently drop returned futures.

Covers both marker attributes and directly named lifecycle overrides with trybuild fixtures.

## Test plan

- `TRYBUILD=overwrite cargo test -p aether-behavior-derive --test trybuild`
- `cargo test -p aether-behavior-derive --test trybuild`
- `cargo fmt`

## Generated by

`/implement` — agent execution of [scoped issue #2756](https://github.com/iamacoffeepot/aether/issues/2756).
