### PR TITLE
fix(aether-behavior-derive): reject async behavior handlers

### DIFF
--- a/crates/aether-behavior-derive/src/lib.rs
+++ b/crates/aether-behavior-derive/src/lib.rs
@@ -237,6 +237,10 @@ fn expand_behavior(item: ItemImpl) -> syn::Result<TokenStream2> {
 /// (intercept); the referenced type is the kind, the mutability is the
 /// intent.
 fn extract_handler_kind(sig: &syn::Signature) -> syn::Result<(Type, bool)> {
+    reject_async(
+        sig,
+        "#[on] handlers are synchronous - the dispatch table calls them as statements",
+    )?;
     if sig.inputs.len() != 3 {
         return Err(syn::Error::new_spanned(
             sig,

--- a/crates/aether-behavior-derive/tests/behavior.rs
+++ b/crates/aether-behavior-derive/tests/behavior.rs
@@ -128,7 +128,8 @@ fn consume_drops_the_in_flight_mail() {
 fn consume_wins_over_the_intercept_re_encode() {
     let mut gate = Gate::default();
     let bytes = Gauge { value: 250 }.encode_into_bytes();
-    let mut ctx = BehaviorCtx::__new_inbound(Gauge::ID, &bytes);
+    let mut mirrors = MirrorStore::default();
+    let mut ctx = BehaviorCtx::__new_inbound(&mut mirrors, Gauge::ID, &bytes);
     gate.__aether_behavior_dispatch(&mut ctx, Gauge::ID, &bytes);
     let verdict = ctx.__into_output().verdict;
     // Tripwire: the macro's unconditional __forward_mutated after an

--- a/crates/aether-behavior-derive/tests/trybuild.rs
+++ b/crates/aether-behavior-derive/tests/trybuild.rs
@@ -10,6 +10,7 @@ fn ui() {
     t.pass("tests/ui/pass_behavior.rs");
     t.compile_fail("tests/ui/fail_async_lifecycle.rs");
     t.compile_fail("tests/ui/fail_async_lifecycle_named_override.rs");
+    t.compile_fail("tests/ui/fail_async_handler.rs");
     t.compile_fail("tests/ui/fail_bad_handler_signature.rs");
     t.compile_fail("tests/ui/fail_duplicate_kind_id.rs");
 }

--- a/crates/aether-behavior-derive/tests/ui/fail_async_handler.rs
+++ b/crates/aether-behavior-derive/tests/ui/fail_async_handler.rs
@@ -1,0 +1,24 @@
+#![allow(unused)]
+
+use aether_behavior::{Behavior, BehaviorCtx};
+use aether_behavior_derive::{behavior, on};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.behavior.gauge")]
+struct Gauge {
+    value: u32,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct Clamp;
+
+#[behavior]
+impl Behavior for Clamp {
+    #[on]
+    async fn clamp(&mut self, _ctx: &mut BehaviorCtx, gauge: &mut Gauge) {
+        gauge.value = 0;
+    }
+}
+
+fn main() {}

--- a/crates/aether-behavior-derive/tests/ui/fail_async_handler.stderr
+++ b/crates/aether-behavior-derive/tests/ui/fail_async_handler.stderr
@@ -1,0 +1,5 @@
+error: #[behavior] #[on] handlers are synchronous - the dispatch table calls them as statements - remove `async`
+  --> tests/ui/fail_async_handler.rs:19:5
+   |
+19 |     async fn clamp(&mut self, _ctx: &mut BehaviorCtx, gauge: &mut Gauge) {
+   |     ^^^^^


### PR DESCRIPTION
Closes #2758.

## Summary

Rejects async `#[on]` behavior handlers at macro expansion time so generated dispatch cannot silently construct and drop a future.

Adds trybuild coverage for the async-handler diagnostic.

## Test plan

- `TRYBUILD=overwrite cargo test -p aether-behavior-derive --test trybuild`
- `cargo test -p aether-behavior-derive --test trybuild`
- `cargo fmt`

## Generated by

`/implement` — agent execution of [scoped issue #2758](https://github.com/iamacoffeepot/aether/issues/2758).
