### PR TITLE
chore(behavior): tighten behavior host regression tests

### DIFF
--- a/crates/aether-behavior/src/host/actor.rs
+++ b/crates/aether-behavior/src/host/actor.rs
@@ -567,9 +567,28 @@ mod tests {
     // rather than misreading it — the host keeps whatever `init` set.
     #[test]
     fn rehydrate_with_garbage_boots_fresh() {
-        let mut host = host(ScriptSource::None);
+        let kind = KindId(0x6789);
+        let resident = fixed_output_wasm(kind, &forward_output(b"resident"));
+        let mut host = host(ScriptSource::Inline(resident.clone()));
+        host.wrapped_child = Some(MailboxId(0xBEEF));
+
+        let before = host.slot.as_ref().map(|slot| slot.bytes().to_vec());
+        let before_source = host.script_source.clone();
         host.apply_rehydrate(b"garbage blob");
-        assert!(host.slot.is_none());
-        assert!(host.wrapped_child.is_none());
+        let after = host.slot.as_ref().map(|slot| slot.bytes().to_vec());
+
+        assert_eq!(
+            after, before,
+            "garbage rehydrate must keep the resident slot"
+        );
+        assert_eq!(
+            host.wrapped_child,
+            Some(MailboxId(0xBEEF)),
+            "garbage rehydrate must not clobber the wrapped child",
+        );
+        assert_eq!(
+            host.script_source, before_source,
+            "garbage rehydrate must keep the init-time script source",
+        );
     }
 }

--- a/crates/aether-behavior/src/host/drain.rs
+++ b/crates/aether-behavior/src/host/drain.rs
@@ -241,6 +241,8 @@ mod tests {
             verdict: Verdict::Forward(vec![0]),
             effects: vec![
                 effect(EffectTarget::Widget, 42),
+                effect(EffectTarget::Child("slider".into()), 7),
+                effect(EffectTarget::Widget, 42),
                 effect(EffectTarget::Panel, 99),
             ],
         };
@@ -249,7 +251,11 @@ mod tests {
 
         // The panel effect provoked no armed echo.
         assert!(!guard.take(KindId(99)));
-        // The first up-lane 42 (the echo) is suppressed; the second is not.
+        // Child-targeted effects arm an echo just like widget-targeted ones.
+        assert!(guard.take(KindId(7)));
+        assert!(!guard.take(KindId(7)));
+        // A kind armed twice suppresses twice, then clears.
+        assert!(guard.take(KindId(42)));
         assert!(guard.take(KindId(42)));
         assert!(!guard.take(KindId(42)));
         assert!(guard.is_empty());

--- a/crates/aether-behavior/src/host/slot.rs
+++ b/crates/aether-behavior/src/host/slot.rs
@@ -278,7 +278,9 @@ fn decode_manifest(module: &Module) -> BTreeSet<KindId> {
 mod tests {
     use super::*;
     use crate::envelope::{Effect, EffectTarget, Verdict};
-    use crate::host::test_support::{fixed_output_wasm, forward_output, trapping_wasm};
+    use crate::host::test_support::{
+        conditional_trap_wasm, fixed_output_wasm, forward_output, stateful_wasm, trapping_wasm,
+    };
     use alloc::vec;
 
     // Tripwire: a trap forwards untransformed and, at exactly
@@ -314,20 +316,28 @@ mod tests {
     // transient trap never accumulates toward disable across good calls.
     #[test]
     fn clean_call_resets_trap_counter() {
-        let kind = KindId(0x2000);
+        let trap_kind = KindId(0x2000);
+        let clean_kind = KindId(0x2001);
         let engine = build_engine();
         let payload = forward_output(b"clean");
         let mut slot = ScriptSlot::instantiate(
             &engine,
-            &fixed_output_wasm(kind, &payload),
+            &conditional_trap_wasm(clean_kind, trap_kind, &payload),
             None,
             1_000_000,
             3,
         )
-        .expect("test setup: fixed-output module instantiates");
+        .expect("test setup: conditional-trap module instantiates");
 
-        // A clean call returns the baked output and holds the counter at 0.
-        match slot.filter(kind, b"in") {
+        assert!(matches!(
+            slot.filter(trap_kind, b"in"),
+            FilterOutcome::Passthrough
+        ));
+        assert_eq!(slot.consecutive_traps(), 1);
+        assert!(!slot.is_disabled());
+
+        // A clean call returns the baked output and resets the counter to 0.
+        match slot.filter(clean_kind, b"in") {
             FilterOutcome::Output(out) => {
                 assert_eq!(out.verdict, Verdict::Forward(b"clean".to_vec()))
             }
@@ -393,5 +403,68 @@ mod tests {
         let engine = build_engine();
         let result = ScriptSlot::instantiate(&engine, b"not wasm at all", None, 1_000_000, 3);
         assert!(result.is_err());
+    }
+
+    // Tripwire: `state_save` reads the packed `(ptr, len)` region the script
+    // returns, falling back to the baked default before any `state_load`.
+    #[test]
+    fn save_state_reads_stateful_fixture_default_blob() {
+        let engine = build_engine();
+        let handled = KindId(0x5000);
+        let default_blob = b"default state";
+        let mut slot = ScriptSlot::instantiate(
+            &engine,
+            &stateful_wasm(handled, default_blob),
+            None,
+            1_000_000,
+            3,
+        )
+        .expect("test setup: stateful module instantiates");
+
+        assert_eq!(slot.save_state(), default_blob);
+    }
+
+    // Tripwire: a missing `state_save` export is fail-open and yields no blob.
+    #[test]
+    fn save_state_without_export_returns_empty_vec() {
+        let engine = build_engine();
+        let handled = KindId(0x5001);
+        let output = forward_output(b"stateless");
+        let mut slot = ScriptSlot::instantiate(
+            &engine,
+            &fixed_output_wasm(handled, &output),
+            None,
+            1_000_000,
+            3,
+        )
+        .expect("test setup: stateless module instantiates");
+
+        assert!(slot.save_state().is_empty());
+    }
+
+    // Tripwire: a missing `state_load` export is a no-op; the fresh script
+    // stays runnable after an offered prior-state blob.
+    #[test]
+    fn offer_state_without_export_is_no_op() {
+        let engine = build_engine();
+        let handled = KindId(0x5002);
+        let output = forward_output(b"still running");
+        let mut slot = ScriptSlot::instantiate(
+            &engine,
+            &fixed_output_wasm(handled, &output),
+            None,
+            1_000_000,
+            3,
+        )
+        .expect("test setup: stateless module instantiates");
+
+        slot.offer_state(b"ignored");
+
+        match slot.filter(handled, b"in") {
+            FilterOutcome::Output(out) => {
+                assert_eq!(out.verdict, Verdict::Forward(b"still running".to_vec()))
+            }
+            FilterOutcome::Passthrough => panic!("missing state_load should stay fail-open"),
+        }
     }
 }

--- a/crates/aether-behavior/src/host/test_support.rs
+++ b/crates/aether-behavior/src/host/test_support.rs
@@ -38,6 +38,56 @@ pub(crate) fn fixed_output_wasm(handled: KindId, output: &FilterOutput) -> Vec<u
     module(&body, Some((2048, &encoded)), &[handled])
 }
 
+/// A module whose `filter` traps on `trap_kind` and otherwise returns a fixed,
+/// pre-encoded [`FilterOutput`]. Lets tests witness a trap before a clean call.
+pub(crate) fn conditional_trap_wasm(
+    handled: KindId,
+    trap_kind: KindId,
+    output: &FilterOutput,
+) -> Vec<u8> {
+    let encoded = envelope::encode(output);
+    let packed = (2048u64 << 32) | (encoded.len() as u64);
+    let body = format!(
+        r#"(func (export "filter") (param i64 i32 i32) (result i64)
+             (if (result i64)
+               (i64.eq (local.get 0) (i64.const {trap_kind}))
+               (then unreachable)
+               (else (i64.const {packed}))))"#,
+        trap_kind = trap_kind.0 as i64,
+        packed = packed as i64,
+    );
+    module(&body, Some((2048, &encoded)), &[handled, trap_kind])
+}
+
+/// A module whose `state_load` remembers the offered `(ptr, len)` region and
+/// whose `state_save` returns that region packed, or a baked default when no
+/// prior state was offered yet.
+pub(crate) fn stateful_wasm(handled: KindId, default_state: &[u8]) -> Vec<u8> {
+    let filter_output = envelope::encode(&forward_output(b"stateful"));
+    let filter_packed = (3072u64 << 32) | (filter_output.len() as u64);
+    let body = format!(
+        r#"(global $state_ptr (mut i32) (i32.const 2048))
+           (global $state_len (mut i32) (i32.const {default_len}))
+           (func (export "filter") (param i64 i32 i32) (result i64)
+             (i64.const {filter_packed}))
+           (func (export "state_load") (param $ptr i32) (param $len i32) (result i32)
+             (global.set $state_ptr (local.get $ptr))
+             (global.set $state_len (local.get $len))
+             (i32.const 0))
+           (func (export "state_save") (result i64)
+             (i64.or
+               (i64.shl (i64.extend_i32_u (global.get $state_ptr)) (i64.const 32))
+               (i64.extend_i32_u (global.get $state_len))))"#,
+        default_len = default_state.len(),
+        filter_packed = filter_packed as i64,
+    );
+    module_with_data(
+        &body,
+        &[(2048, default_state), (3072, &filter_output)],
+        &[handled],
+    )
+}
+
 /// A `Forward`-the-inbound `FilterOutput` for `bytes` — a passthrough script's
 /// output.
 pub(crate) fn forward_output(bytes: &[u8]) -> FilterOutput {
@@ -50,9 +100,18 @@ pub(crate) fn forward_output(bytes: &[u8]) -> FilterOutput {
 /// Assemble a module: a memory + bump allocator, the caller's `filter`, an
 /// optional data segment, and the exports custom section for `kinds`.
 fn module(filter_body: &str, data: Option<(u32, &[u8])>, kinds: &[KindId]) -> Vec<u8> {
-    let data_wat = data.map_or(String::new(), |(offset, bytes)| {
-        format!(r#"(data (i32.const {offset}) "{}")"#, byte_string(bytes))
-    });
+    match data {
+        Some(data) => module_with_data(filter_body, &[data], kinds),
+        None => module_with_data(filter_body, &[], kinds),
+    }
+}
+
+fn module_with_data(filter_body: &str, data: &[(u32, &[u8])], kinds: &[KindId]) -> Vec<u8> {
+    let data_wat = data
+        .iter()
+        .map(|(offset, bytes)| format!(r#"(data (i32.const {offset}) "{}")"#, byte_string(bytes)))
+        .collect::<Vec<_>>()
+        .join("\n             ");
     let section = custom_section_wat(&exports_section(kinds));
     let text = format!(
         r#"(module


### PR DESCRIPTION
Closes #2748.

## Summary

Tightens behavior host regression coverage so the existing tests actually exercise trap reset, rehydrate freshness, echo guard child/multiset behavior, and host state save/load fail-open paths.

Adds reusable host test support for stateful wasm fixtures that later fixes can build on.

## Test plan

- `cargo fmt`
- `cargo test -p aether-behavior --features host`

## Generated by

`/implement` — agent execution of [scoped issue #2748](https://github.com/iamacoffeepot/aether/issues/2748).
