### PR TITLE
fix(behavior): preserve script state during restore

### DIFF
--- a/crates/aether-behavior-derive/tests/behavior.rs
+++ b/crates/aether-behavior-derive/tests/behavior.rs
@@ -128,7 +128,8 @@ fn consume_drops_the_in_flight_mail() {
 fn consume_wins_over_the_intercept_re_encode() {
     let mut gate = Gate::default();
     let bytes = Gauge { value: 250 }.encode_into_bytes();
-    let mut ctx = BehaviorCtx::__new_inbound(Gauge::ID, &bytes);
+    let mut mirrors = MirrorStore::default();
+    let mut ctx = BehaviorCtx::__new_inbound(&mut mirrors, Gauge::ID, &bytes);
     gate.__aether_behavior_dispatch(&mut ctx, Gauge::ID, &bytes);
     let verdict = ctx.__into_output().verdict;
     // Tripwire: the macro's unconditional __forward_mutated after an

--- a/crates/aether-behavior/src/host/slot.rs
+++ b/crates/aether-behavior/src/host/slot.rs
@@ -186,10 +186,12 @@ impl ScriptSlot {
         let Some(load) = self.state_load_fn else {
             return;
         };
+        if self.store.set_fuel(self.fuel_per_call).is_err() {
+            return;
+        }
         let Some((ptr, len)) = self.write_guest(blob) else {
             return;
         };
-        let _ = self.store.set_fuel(self.fuel_per_call);
         let _ = load.call(&mut self.store, (ptr, len));
     }
 
@@ -424,11 +426,32 @@ mod tests {
         assert_eq!(slot.save_state(), default_blob);
     }
 
+    // Tripwire: `offer_state` must set fuel before guest `alloc`, or the
+    // prior-state blob never reaches `state_load` and `state_save` comes back
+    // empty on restore.
+    #[test]
+    fn offer_state_round_trips_prior_blob_through_restore() {
+        let engine = build_engine();
+        let handled = KindId(0x5001);
+        let default_blob = b"default state";
+        let prior_blob = b"persist me";
+        let mut slot = ScriptSlot::instantiate(
+            &engine,
+            &stateful_wasm(handled, default_blob),
+            Some(prior_blob),
+            1_000_000,
+            3,
+        )
+        .expect("test setup: stateful module instantiates");
+
+        assert_eq!(slot.save_state(), prior_blob);
+    }
+
     // Tripwire: a missing `state_save` export is fail-open and yields no blob.
     #[test]
     fn save_state_without_export_returns_empty_vec() {
         let engine = build_engine();
-        let handled = KindId(0x5001);
+        let handled = KindId(0x5002);
         let output = forward_output(b"stateless");
         let mut slot = ScriptSlot::instantiate(
             &engine,
@@ -447,7 +470,7 @@ mod tests {
     #[test]
     fn offer_state_without_export_is_no_op() {
         let engine = build_engine();
-        let handled = KindId(0x5002);
+        let handled = KindId(0x5003);
         let output = forward_output(b"still running");
         let mut slot = ScriptSlot::instantiate(
             &engine,


### PR DESCRIPTION
Closes #2747.

## Summary

Moves fuel setup ahead of the guest allocation path in `ScriptSlot::offer_state`, allowing prior state blobs to reach `state_load` during restore.

Adds a state round-trip regression test with a self-contained wasm fixture.

## Test plan

- `cargo fmt`
- `cargo test -p aether-behavior --features host offer_state_round_trips_prior_blob_through_restore -- --nocapture`

## Generated by

`/implement` — agent execution of [scoped issue #2747](https://github.com/iamacoffeepot/aether/issues/2747).
