### PR TITLE
fix(behavior): persist mirrors across filter calls

### DIFF
--- a/crates/aether-behavior-derive/src/lib.rs
+++ b/crates/aether-behavior-derive/src/lib.rs
@@ -387,6 +387,11 @@ fn build_guest_exports(self_ty: &Type) -> TokenStream2 {
             static __AETHER_BEHAVIOR_SLOT:
                 ::aether_behavior::__macro_internals::Slot<#self_ty> =
                 ::aether_behavior::__macro_internals::Slot::new();
+            static __AETHER_BEHAVIOR_MIRRORS:
+                ::aether_behavior::__macro_internals::Slot<
+                    ::aether_behavior::__macro_internals::MirrorStore
+                > =
+                ::aether_behavior::__macro_internals::Slot::new();
 
             #[used]
             #[unsafe(link_section = "aether.behavior.exports")]
@@ -423,7 +428,9 @@ fn build_guest_exports(self_ty: &Type) -> TokenStream2 {
                 let __aether_bytes =
                     unsafe { ::aether_behavior::__macro_internals::read_guest_slice(ptr, len) };
                 let __aether_instance = __AETHER_BEHAVIOR_SLOT.get_or_default();
+                let __aether_mirrors = __AETHER_BEHAVIOR_MIRRORS.get_or_default();
                 let __aether_encoded = ::aether_behavior::__macro_internals::run_filter(
+                    __aether_mirrors,
                     __aether_kind,
                     __aether_bytes,
                     |__aether_ctx| {

--- a/crates/aether-behavior-derive/tests/behavior.rs
+++ b/crates/aether-behavior-derive/tests/behavior.rs
@@ -8,6 +8,7 @@
 
 use aether_behavior::envelope::Verdict;
 use aether_behavior::manifest::decode_exports_manifest;
+use aether_behavior::runtime::MirrorStore;
 use aether_behavior::{Behavior, BehaviorCtx};
 use aether_behavior_derive::behavior;
 use aether_data::{Kind, KindId};
@@ -57,7 +58,8 @@ impl Behavior for Limiter {
 
 fn dispatch<K: Kind>(limiter: &mut Limiter, kind: &K) -> Verdict {
     let bytes = kind.encode_into_bytes();
-    let mut ctx = BehaviorCtx::__new_inbound(K::ID, &bytes);
+    let mut mirrors = MirrorStore::default();
+    let mut ctx = BehaviorCtx::__new_inbound(&mut mirrors, K::ID, &bytes);
     limiter.__aether_behavior_dispatch(&mut ctx, K::ID, &bytes);
     ctx.__into_output().verdict
 }

--- a/crates/aether-behavior/src/host/actor.rs
+++ b/crates/aether-behavior/src/host/actor.rs
@@ -254,11 +254,7 @@ impl WasmActor for BehaviorHost {
             return;
         }
 
-        let declared = self
-            .slot
-            .as_ref()
-            .is_some_and(|slot| !slot.is_disabled() && slot.handles(kind));
-        if !declared {
+        if !self.offers_kind_to_script(kind) {
             self.forward_raw(&*ctx, is_up, kind, bytes);
             return;
         }
@@ -275,6 +271,12 @@ impl BehaviorHost {
     /// source — the parent, or a sourceless dispatch — is down-lane.
     fn lane_is_up(&self, source: Option<MailboxId>) -> bool {
         matches!((source, self.wrapped_child), (Some(s), Some(w)) if s == w)
+    }
+
+    fn offers_kind_to_script(&self, kind: KindId) -> bool {
+        self.slot.as_ref().is_some_and(|slot| {
+            !slot.is_disabled() && (slot.handles(kind) || self.config.is_mirror_kind(kind))
+        })
     }
 
     /// Compile + instantiate `bytes`, carrying the prior script's `state_save`
@@ -475,6 +477,7 @@ mod tests {
     use crate::host::config::ChildSpec;
     use crate::host::test_support::{fixed_output_wasm, forward_output};
     use aether_actor::Lifecycle;
+    use aether_actor::wasm::{NO_INBOUND_SOURCE, inline::Registry};
     use alloc::string::ToString;
     use alloc::vec::Vec;
 
@@ -489,6 +492,7 @@ mod tests {
             fuel_per_call: HostConfig::DEFAULT_FUEL_PER_CALL,
             disable_after_traps: HostConfig::DEFAULT_DISABLE_AFTER_TRAPS,
             frame_trigger: 0,
+            mirror_kinds: Vec::new(),
         }
     }
 
@@ -510,6 +514,36 @@ mod tests {
         // With no wrapped child every source reads down-lane.
         host.wrapped_child = None;
         assert!(!host.lane_is_up(Some(MailboxId(0xC0FFEE))));
+    }
+
+    // Tripwire: low-rate mirror kinds are still offered to SDK dispatch even
+    // when the script manifest does not declare a handler for that kind. Once
+    // admitted, the fixture returns a passthrough output for the same bytes.
+    #[test]
+    fn mirror_kind_bypasses_manifest_skip() {
+        let declared = KindId(0x1234);
+        let mirror_kind = KindId(0x5678);
+        let script = fixed_output_wasm(declared, &forward_output(b"mirror"));
+        let mut host = host(ScriptSource::Inline(script));
+        host.config.mirror_kinds = alloc::vec![mirror_kind.0];
+
+        let slot = host.slot.as_ref().expect("test setup: script resident");
+        assert!(slot.handles(declared));
+        assert!(!slot.handles(mirror_kind));
+        assert!(host.offers_kind_to_script(mirror_kind));
+
+        let registry = Registry::new();
+        let mut ctx = WasmCtx::__new(0x10, &registry, NO_INBOUND_SOURCE);
+        assert!(
+            host.run_filter_and_drain(
+                ctx.as_single(),
+                false,
+                Some(mirror_kind),
+                mirror_kind,
+                b"mirror",
+            ),
+            "the undeclared mirror kind should reach guest dispatch"
+        );
     }
 
     // Tripwire: a failed swap (bad bytes) keeps the prior running script and

--- a/crates/aether-behavior/src/host/config.rs
+++ b/crates/aether-behavior/src/host/config.rs
@@ -75,6 +75,9 @@ pub struct HostConfig {
     /// keeps no `aether-kit` dependency — the kit arm sets this to its own
     /// `Collect` id.
     pub frame_trigger: u64,
+    /// Low-rate mirror-kind ids always offered to SDK dispatch even when the
+    /// script manifest does not declare a handler for them.
+    pub mirror_kinds: Vec<u64>,
 }
 
 impl HostConfig {
@@ -89,6 +92,12 @@ impl HostConfig {
     #[must_use]
     pub fn frame_trigger_kind(&self) -> Option<KindId> {
         (self.frame_trigger != 0).then_some(KindId(self.frame_trigger))
+    }
+
+    /// Whether `kind` belongs to the configured always-offer mirror set.
+    #[must_use]
+    pub fn is_mirror_kind(&self, kind: KindId) -> bool {
+        self.mirror_kinds.contains(&kind.0)
     }
 }
 

--- a/crates/aether-behavior/src/lib.rs
+++ b/crates/aether-behavior/src/lib.rs
@@ -67,7 +67,7 @@ pub mod __macro_internals {
 
     #[cfg(feature = "runtime")]
     pub use crate::runtime::{
-        Behavior, BehaviorCtx, Slot, run_filter, state_load_serde, state_save_serde,
+        Behavior, BehaviorCtx, MirrorStore, Slot, run_filter, state_load_serde, state_save_serde,
     };
     #[cfg(all(feature = "runtime", target_family = "wasm"))]
     pub use crate::runtime::{leak_packed, read_guest_slice, realloc_bytes};

--- a/crates/aether-behavior/src/runtime/mod.rs
+++ b/crates/aether-behavior/src/runtime/mod.rs
@@ -89,55 +89,59 @@ enum VerdictState {
     Consume,
 }
 
-/// The pure filter-call context handed to every handler. Accumulates
-/// effects and the verdict, and carries the decode-once mirror each handle
-/// reads. The host builds one per `filter` call and drains it after.
-pub struct BehaviorCtx {
-    inbound: Vec<u8>,
-    verdict: VerdictState,
-    effects: Vec<Effect>,
+/// Persistent last-value mirrors for one behavior-script instance.
+#[derive(Default)]
+pub struct MirrorStore {
     widget_mirror: Mirror,
     panel_mirror: Mirror,
     child_mirrors: BTreeMap<String, Mirror>,
 }
 
-impl BehaviorCtx {
+/// The pure filter-call context handed to every handler. Accumulates
+/// effects and the verdict, and borrows the decode-once mirror store each
+/// handle reads. The host builds one per `filter` call and drains it after.
+pub struct BehaviorCtx<'m> {
+    inbound: Vec<u8>,
+    verdict: VerdictState,
+    effects: Vec<Effect>,
+    mirrors: &'m mut MirrorStore,
+}
+
+impl<'m> BehaviorCtx<'m> {
     /// Build a ctx for an inbound `filter` call, seeding the widget mirror
     /// from the inbound kind (the kind flowing through the interposition
     /// updates the mirror before handler dispatch, ADR-0137). A sentinel
     /// kind carries no payload, so it seeds nothing.
     #[doc(hidden)]
     #[must_use]
-    pub fn __new_inbound(kind_id: KindId, bytes: &[u8]) -> Self {
-        let mut ctx = Self {
+    pub fn __new_inbound(mirrors: &'m mut MirrorStore, kind_id: KindId, bytes: &[u8]) -> Self {
+        let ctx = Self {
             inbound: bytes.to_vec(),
             verdict: VerdictState::ForwardOriginal,
             effects: Vec::new(),
-            widget_mirror: Mirror::default(),
-            panel_mirror: Mirror::default(),
-            child_mirrors: BTreeMap::new(),
+            mirrors,
         };
         if !sentinel::is_sentinel(kind_id) {
-            ctx.widget_mirror.update(kind_id, bytes.to_vec());
+            ctx.mirrors.widget_mirror.update(kind_id, bytes.to_vec());
         }
         ctx
     }
 
     /// The wrapped widget the host interposes on.
     #[must_use]
-    pub fn widget(&mut self) -> WidgetHandle<'_> {
+    pub fn widget(&mut self) -> WidgetHandle<'_, 'm> {
         WidgetHandle { ctx: self }
     }
 
     /// The parent lane.
     #[must_use]
-    pub fn panel(&mut self) -> PanelHandle<'_> {
+    pub fn panel(&mut self) -> PanelHandle<'_, 'm> {
         PanelHandle { ctx: self }
     }
 
     /// A named child in the host's subtree, addressed path-relative.
     #[must_use]
-    pub fn child(&mut self, path: &str) -> ChildHandle<'_> {
+    pub fn child(&mut self, path: &str) -> ChildHandle<'_, 'm> {
         ChildHandle {
             ctx: self,
             path: String::from(path),
@@ -178,18 +182,18 @@ impl BehaviorCtx {
 
 /// Handle to the wrapped widget: intercept-time writes (`set`), the mirror
 /// read (`last`), and a replay request (`report`).
-pub struct WidgetHandle<'c> {
-    ctx: &'c mut BehaviorCtx,
+pub struct WidgetHandle<'c, 'm> {
+    ctx: &'c mut BehaviorCtx<'m>,
 }
 
-impl WidgetHandle<'_> {
+impl WidgetHandle<'_, '_> {
     /// Write a kind to the widget. The effect is drained into a real send
     /// after the filter returns; the write also integrates into the mirror
     /// so a later `last::<K>()` reflects the script's own write (echo
     /// suppression, truthful mirror).
     pub fn set<K: Kind + 'static>(&mut self, value: &K) {
         let bytes = value.encode_into_bytes();
-        self.ctx.widget_mirror.update(K::ID, bytes.clone());
+        self.ctx.mirrors.widget_mirror.update(K::ID, bytes.clone());
         self.ctx.effects.push(Effect {
             target: EffectTarget::Widget,
             kind_id: K::ID.0,
@@ -199,7 +203,7 @@ impl WidgetHandle<'_> {
 
     /// The last value the widget emitted for `K`, decoded once.
     pub fn last<K: Kind + 'static>(&mut self) -> Option<&K> {
-        self.ctx.widget_mirror.last::<K>()
+        self.ctx.mirrors.widget_mirror.last::<K>()
     }
 
     /// Ask the widget to re-emit its observable kinds up-lane. The reply is
@@ -215,17 +219,18 @@ impl WidgetHandle<'_> {
 
 /// Handle to a named child: a send (`send`), the mirror read (`last`), and a
 /// replay request (`report`).
-pub struct ChildHandle<'c> {
-    ctx: &'c mut BehaviorCtx,
+pub struct ChildHandle<'c, 'm> {
+    ctx: &'c mut BehaviorCtx<'m>,
     path: String,
 }
 
-impl ChildHandle<'_> {
+impl ChildHandle<'_, '_> {
     /// Send a kind to the child. Drained into a real cluster send after the
     /// filter returns; the write integrates into the child's mirror.
     pub fn send<K: Kind + 'static>(&mut self, value: &K) {
         let bytes = value.encode_into_bytes();
         self.ctx
+            .mirrors
             .child_mirrors
             .entry(self.path.clone())
             .or_default()
@@ -239,7 +244,11 @@ impl ChildHandle<'_> {
 
     /// The last value the child emitted for `K`, decoded once.
     pub fn last<K: Kind + 'static>(&mut self) -> Option<&K> {
-        self.ctx.child_mirrors.get_mut(&self.path)?.last::<K>()
+        self.ctx
+            .mirrors
+            .child_mirrors
+            .get_mut(&self.path)?
+            .last::<K>()
     }
 
     /// Ask the child to re-emit its observable kinds up-lane.
@@ -253,16 +262,16 @@ impl ChildHandle<'_> {
 }
 
 /// Handle to the parent lane: emit up (`emit`) and the mirror read (`last`).
-pub struct PanelHandle<'c> {
-    ctx: &'c mut BehaviorCtx,
+pub struct PanelHandle<'c, 'm> {
+    ctx: &'c mut BehaviorCtx<'m>,
 }
 
-impl PanelHandle<'_> {
+impl PanelHandle<'_, '_> {
     /// Emit a kind up the parent lane. Drained into a real send after the
     /// filter returns; the write integrates into the panel mirror.
     pub fn emit<K: Kind + 'static>(&mut self, value: &K) {
         let bytes = value.encode_into_bytes();
-        self.ctx.panel_mirror.update(K::ID, bytes.clone());
+        self.ctx.mirrors.panel_mirror.update(K::ID, bytes.clone());
         self.ctx.effects.push(Effect {
             target: EffectTarget::Panel,
             kind_id: K::ID.0,
@@ -272,7 +281,7 @@ impl PanelHandle<'_> {
 
     /// The last value seen on the parent lane for `K`, decoded once.
     pub fn last<K: Kind + 'static>(&mut self) -> Option<&K> {
-        self.ctx.panel_mirror.last::<K>()
+        self.ctx.mirrors.panel_mirror.last::<K>()
     }
 }
 
@@ -284,18 +293,18 @@ impl PanelHandle<'_> {
 /// `state_save_serde` / `state_load_serde`) unless the author overrides them.
 pub trait Behavior: Sized {
     /// Runs post-restore with mirrors primed and ctx available.
-    fn on_attach(&mut self, ctx: &mut BehaviorCtx) {
+    fn on_attach(&mut self, ctx: &mut BehaviorCtx<'_>) {
         let _ = ctx;
     }
 
     /// Per-frame work, dispatched on the SDK-owned frame sentinel (no kit
     /// coupling).
-    fn on_frame(&mut self, ctx: &mut BehaviorCtx) {
+    fn on_frame(&mut self, ctx: &mut BehaviorCtx<'_>) {
         let _ = ctx;
     }
 
     /// Best-effort teardown as the script leaves its position.
-    fn on_detach(&mut self, ctx: &mut BehaviorCtx) {
+    fn on_detach(&mut self, ctx: &mut BehaviorCtx<'_>) {
         let _ = ctx;
     }
 
@@ -331,11 +340,12 @@ pub fn state_load_serde<T: DeserializeOwned>(slot: &mut T, bytes: &[u8]) {
 /// `leak_packed`; host tests drive [`BehaviorCtx`] directly.
 #[must_use]
 pub fn run_filter(
+    mirrors: &mut MirrorStore,
     kind_id: KindId,
     inbound: &[u8],
-    dispatch: impl FnOnce(&mut BehaviorCtx),
+    dispatch: impl FnOnce(&mut BehaviorCtx<'_>),
 ) -> Vec<u8> {
-    let mut ctx = BehaviorCtx::__new_inbound(kind_id, inbound);
+    let mut ctx = BehaviorCtx::__new_inbound(mirrors, kind_id, inbound);
     dispatch(&mut ctx);
     encode(&ctx.__into_output())
 }

--- a/crates/aether-behavior/src/runtime/tests.rs
+++ b/crates/aether-behavior/src/runtime/tests.rs
@@ -3,7 +3,7 @@ use alloc::string::String;
 use aether_data::Kind;
 use serde::{Deserialize, Serialize};
 
-use super::BehaviorCtx;
+use super::{BehaviorCtx, MirrorStore, run_filter};
 use crate::envelope::{EffectTarget, Verdict};
 
 #[derive(
@@ -29,7 +29,8 @@ struct Label {
 #[test]
 fn drain_reports_verdict_then_ordered_effects() {
     let inbound = Slider { value: 5 }.encode_into_bytes();
-    let mut ctx = BehaviorCtx::__new_inbound(Slider::ID, &inbound);
+    let mut mirrors = MirrorStore::default();
+    let mut ctx = BehaviorCtx::__new_inbound(&mut mirrors, Slider::ID, &inbound);
 
     ctx.widget().set(&Slider { value: 8 });
     ctx.child("row/label").send(&Label {
@@ -65,14 +66,16 @@ fn drain_reports_verdict_then_ordered_effects() {
 #[test]
 fn forward_carries_original_then_mutated_bytes() {
     let inbound = Slider { value: 5 }.encode_into_bytes();
+    let mut original_mirrors = MirrorStore::default();
 
-    let original = BehaviorCtx::__new_inbound(Slider::ID, &inbound);
+    let original = BehaviorCtx::__new_inbound(&mut original_mirrors, Slider::ID, &inbound);
     assert_eq!(
         original.__into_output().verdict,
         Verdict::Forward(inbound.clone())
     );
 
-    let mut mutated = BehaviorCtx::__new_inbound(Slider::ID, &inbound);
+    let mut mutated_mirrors = MirrorStore::default();
+    let mut mutated = BehaviorCtx::__new_inbound(&mut mutated_mirrors, Slider::ID, &inbound);
     let reencoded = Slider { value: 9 }.encode_into_bytes();
     mutated.__forward_mutated(reencoded.clone());
     assert_eq!(mutated.__into_output().verdict, Verdict::Forward(reencoded));
@@ -84,11 +87,31 @@ fn forward_carries_original_then_mutated_bytes() {
 #[test]
 fn mirror_decodes_inbound_and_invalidates_on_update() {
     let inbound = Slider { value: 5 }.encode_into_bytes();
-    let mut ctx = BehaviorCtx::__new_inbound(Slider::ID, &inbound);
+    let mut mirrors = MirrorStore::default();
+    let mut ctx = BehaviorCtx::__new_inbound(&mut mirrors, Slider::ID, &inbound);
 
     assert_eq!(ctx.widget().last::<Slider>(), Some(&Slider { value: 5 }));
 
     // Own write updates the mirror; the cached decode must be dropped.
     ctx.widget().set(&Slider { value: 9 });
     assert_eq!(ctx.widget().last::<Slider>(), Some(&Slider { value: 9 }));
+}
+
+#[test]
+fn run_filter_preserves_mirror_across_calls() {
+    let slider = Slider { value: 7 }.encode_into_bytes();
+    let label = Label {
+        text: String::from("later"),
+    }
+    .encode_into_bytes();
+    let mut mirrors = MirrorStore::default();
+
+    let _ = run_filter(&mut mirrors, Slider::ID, &slider, |_| {});
+
+    let mut observed = None;
+    let _ = run_filter(&mut mirrors, Label::ID, &label, |ctx| {
+        observed = ctx.widget().last::<Slider>().cloned();
+    });
+
+    assert_eq!(observed, Some(Slider { value: 7 }));
 }

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -417,6 +417,20 @@ fn spawn_behavior_host(
         // The panel drives the wrapped slot with `Collect` each frame; hand the
         // host that kind as its FRAME sentinel trigger.
         frame_trigger: Collect::ID.0,
+        mirror_kinds: vec![
+            LabelConfig::ID.0,
+            SliderConfig::ID.0,
+            TextFieldConfig::ID.0,
+            ButtonConfig::ID.0,
+            RadioConfig::ID.0,
+            SliderChanged::ID.0,
+            TextCommitted::ID.0,
+            ButtonClicked::ID.0,
+            RadioSelected::ID.0,
+            FocusGained::ID.0,
+            FocusLost::ID.0,
+            crate::widget::ChildrenChanged::ID.0,
+        ],
     };
     let bytes = config.encode_into_bytes();
     match ctx.spawn_inline_child_by_tag(


### PR DESCRIPTION
Closes #2752.

## Summary

Persists behavior mirrors across filter calls by moving mirror state into a long-lived `MirrorStore` threaded through runtime dispatch and guest exports.

Also lets configured mirror kinds reach SDK dispatch even when they are not declared handler kinds, so mirror state can be maintained without disabling manifest skips for all traffic.

## Test plan

- `cargo fmt`
- `cargo fmt -- --check`
- `cargo test -p aether-behavior`
- `cargo test -p aether-behavior --features host`
- `cargo test -p aether-behavior-derive`
- `cargo clippy --all-targets -- -D warnings`

## Generated by

`/implement` — agent execution of [scoped issue #2752](https://github.com/iamacoffeepot/aether/issues/2752).
