### PR TITLE
refactor(behavior): re-export the #[behavior] macros so guests depend on one crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ name = "aether-behavior"
 version = "0.3.0-alpha"
 dependencies = [
  "aether-actor",
+ "aether-behavior-derive",
  "aether-capabilities",
  "aether-data",
  "serde",

--- a/crates/aether-behavior/Cargo.toml
+++ b/crates/aether-behavior/Cargo.toml
@@ -25,7 +25,7 @@ license.workspace = true
 # so `host` never feature-unifies into a script's build graph.
 [features]
 default = ["runtime"]
-runtime = []
+runtime = ["dep:aether-behavior-derive"]
 # ADR-0137 / issue 2687: the in-cluster behavior script host. Pulls the
 # actor SDK (the host is a wasm `#[actor]`), the `wasmi` interpreter it
 # embeds (no_std, built-in fuel metering), the capability crate for the
@@ -36,6 +36,9 @@ host = ["dep:aether-actor", "dep:wasmi", "dep:aether-capabilities", "dep:tracing
 [dependencies]
 aether-data = { path = "../aether-data", default-features = false, features = ["derive"] }
 serde = { workspace = true, default-features = false, features = ["alloc", "derive"] }
+# Home of the `#[behavior]` authoring macros, re-exported from this crate's
+# runtime face so guests depend on one crate.
+aether-behavior-derive = { path = "../aether-behavior-derive", optional = true }
 
 # `host`-only optional deps. `dep:`-gated so the default face's dependency
 # tree names none of them (the crate-boundary tripwire: `cargo tree -p

--- a/crates/aether-behavior/src/lib.rs
+++ b/crates/aether-behavior/src/lib.rs
@@ -24,8 +24,8 @@
 //!   drain logic, and the `#[behavior]` macro's guest exports (`alloc` /
 //!   `filter` / `state_save` / `state_load`) are emitted only on `wasm`.
 //!
-//! Authoring lives in the sibling `aether-behavior-derive` crate; a script
-//! lists both.
+//! Authoring lives in the sibling `aether-behavior-derive` crate, re-exported
+//! here so a script depends on `aether-behavior` alone.
 
 #![no_std]
 
@@ -39,6 +39,10 @@ pub mod sentinel;
 #[cfg(feature = "runtime")]
 pub mod runtime;
 
+/// The behavior authoring macros, re-exported on the runtime face so guest
+/// crates depend on `aether-behavior` alone.
+#[cfg(feature = "runtime")]
+pub use aether_behavior_derive::{behavior, on, on_attach, on_detach, on_frame};
 #[cfg(feature = "runtime")]
 pub use runtime::{Behavior, BehaviorCtx, ChildHandle, PanelHandle, WidgetHandle};
 

--- a/docs/guide/recipes/writing-a-behavior.md
+++ b/docs/guide/recipes/writing-a-behavior.md
@@ -43,7 +43,6 @@ crate-type = ["cdylib"]          # the wasm script artifact
 
 [dependencies]
 aether-behavior = { path = "../aether-behavior" }             # SDK (runtime face, on by default)
-aether-behavior-derive = { path = "../aether-behavior-derive" } # the #[behavior] macro
 aether-data = { path = "../aether-data", default-features = false, features = ["derive"] }
 serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
 ```
@@ -79,7 +78,7 @@ from the method's third parameter, and the parameter's mutability *is* the inten
 
 ```rust
 use aether_behavior::BehaviorCtx;
-use aether_behavior_derive::behavior;
+use aether_behavior::behavior;
 use serde::{Deserialize, Serialize};
 
 // Authored state: the clamp cap and how many commits we've clamped. The


### PR DESCRIPTION
Closes #2737.

## Summary

Re-exports the `#[behavior]` authoring macros from `aether-behavior` under the runtime feature so behavior guests can depend on one crate.

Updates the writing-a-behavior recipe to show the single-dependency shape and keeps trunk/host faces clear of the proc-macro dependency.

## Test plan

- `cargo fmt`
- `cargo fmt -- --check`
- `cargo build -p aether-behavior`
- `cargo build -p aether-behavior --no-default-features`
- `cargo build -p aether-behavior --no-default-features --features host`
- `cargo clippy --all-targets -- -D warnings`

## Generated by

`/implement` — agent execution of [scoped issue #2737](https://github.com/iamacoffeepot/aether/issues/2737).
