### PR TITLE
fix(behavior): resolve child effect paths through subtrees

### DIFF
--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -118,6 +118,20 @@ impl RelativeMailbox<'_> {
         self.id
     }
 
+    /// Resolve a sendable handle to this relative's inline child whose
+    /// subname is `name`, preserving the original addresser for any send
+    /// through the returned handle. This is the multi-hop continuation of
+    /// [`WasmCtx::child`].
+    #[must_use]
+    pub fn child(&self, name: &str) -> Option<Self> {
+        let id = self.inline.child_of(self.id, name)?;
+        Some(RelativeMailbox {
+            id,
+            sender: self.sender,
+            inline: self.inline,
+        })
+    }
+
     /// Send `payload` to this relative, routed in place through the cluster
     /// membrane (queue + drain) — no scheduler hop. Inherits the handler's
     /// in-flight causal chain (the default, ADR-0080 §7); the local path
@@ -1380,9 +1394,11 @@ mod tests {
         let registry = Registry::new();
         let root = 0x7100_u64;
         registry.set_self_id(root);
-        // Install a child of the root keyed by a synthetic alias; record the
-        // root as its parent (what `spawn_inline_child` would record).
+        // Install a child of the root keyed by a synthetic alias, then a
+        // grandchild under it. Record each parent the way `spawn_inline_child`
+        // would.
         let widget = MailboxId(0x7101);
+        let label = MailboxId(0x7102);
         install_inline_child::<SucceedingChild>(
             &registry,
             widget,
@@ -1394,6 +1410,17 @@ mod tests {
             (),
         )
         .expect("a succeeding init installs the inline child");
+        install_inline_child::<SucceedingChild>(
+            &registry,
+            label,
+            0,
+            String::from("label"),
+            false,
+            widget.0,
+            Vec::new(),
+            (),
+        )
+        .expect("a succeeding init installs the inline grandchild");
 
         let ctx: WasmCtx<'_, Manual> = WasmCtx::__new(root, &registry, NO_INBOUND_SOURCE);
 
@@ -1409,6 +1436,18 @@ mod tests {
         assert!(
             ctx.child("missing").is_none(),
             "a missing subname resolves to None",
+        );
+        let grandchild = child
+            .child("label")
+            .expect("the grandchild resolves relative to the child handle");
+        assert_eq!(
+            grandchild.mailbox_id(),
+            label,
+            "handle-relative child walk reaches the grandchild",
+        );
+        assert!(
+            child.child("missing").is_none(),
+            "a missing grandchild segment resolves to None",
         );
 
         // The resolved relative is a cluster member, so a send routes in

--- a/crates/aether-behavior/src/host/actor.rs
+++ b/crates/aether-behavior/src/host/actor.rs
@@ -451,7 +451,7 @@ impl DrainSink for LaneSink<'_, '_> {
             } => {
                 let relative = match target {
                     EffectTarget::Widget => self.ctx.child(self.wrapped_subname),
-                    EffectTarget::Child(path) => self.ctx.child(&path),
+                    EffectTarget::Child(path) => resolve_child_path(self.ctx, &path),
                     EffectTarget::Panel => self.ctx.parent(),
                 };
                 (relative, kind_id, bytes)
@@ -467,6 +467,21 @@ impl DrainSink for LaneSink<'_, '_> {
             );
         }
     }
+}
+
+fn resolve_child_path<'a>(
+    ctx: &WasmCtx<'a>,
+    path: &str,
+) -> Option<aether_actor::RelativeMailbox<'a>> {
+    let mut segments = path.split('/');
+    let first = segments.next().filter(|segment| !segment.is_empty())?;
+    segments.try_fold(ctx.child(first)?, |relative, segment| {
+        if segment.is_empty() {
+            None
+        } else {
+            relative.child(segment)
+        }
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #2750.

## Summary

Adds relative child navigation from an existing mailbox and uses it to resolve behavior child-effect paths through wrapped subtrees.

Single-segment child sends remain unchanged, while slash-separated descendants now walk from the wrapped child rather than matching only direct host children.

## Test plan

- `cargo test -p aether-actor ctx_relative_verbs_resolve_and_route_in_place`
- `cargo test -p aether-behavior --features host lane_direction_resolves_against_wrapped_child`
- `cargo fmt`

## Generated by

`/implement` — agent execution of [scoped issue #2750](https://github.com/iamacoffeepot/aether/issues/2750).
