### PR TITLE
flake(capabilities): stabilize http route conflict ownership test

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/routing.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/routing.rs
@@ -78,3 +78,136 @@ pub fn validate_route_mailbox(registry: &Registry, id: MailboxId) -> Result<(), 
         None => Err(format!("unknown mailbox id {id:?}")),
     }
 }
+
+/// Claim `(prefix, method)` for `mailbox` in `routes`, dispatching as
+/// `kind` (ADR-0130), or join its shared member set (ADR-0136).
+/// Exclusive (`shared: false`): a key held by anyone else is answered
+/// `Err`; the same sole mailbox re-claiming its own key is an
+/// idempotent `Ok` that updates `kind` — so a component re-running
+/// `wire` after `replace_component` re-registers cleanly (its
+/// `MailboxId` is stable). Shared (`shared: true`): joins the key's
+/// member set when the set is shared and the `kind` matches;
+/// re-registering an existing membership is an idempotent `Ok`. Mixing
+/// exclusive and shared on one key, or joining with a different `kind`,
+/// is a conflict `Err` either way.
+///
+/// The winner of two conflicting claims is whichever reaches the table
+/// first; this is a pure function of the table's contents, so a caller
+/// that needs a deterministic winner must sequence the claims itself.
+///
+/// # Panics
+/// Panics if the route-table `RwLock` is poisoned — fail-fast per
+/// ADR-0063 (a poisoned table means a supervisor or shard already
+/// panicked mid-read/write).
+pub fn register_route(
+    routes: &SharedRoutes,
+    prefix: &str,
+    method: Option<HttpMethod>,
+    kind: KindId,
+    mailbox: MailboxId,
+    shared: bool,
+) -> RegisterRouteResult {
+    let prefix = match normalize_prefix(prefix) {
+        Ok(prefix) => prefix,
+        Err(error) => return RegisterRouteResult::Err { error },
+    };
+    let mut routes = routes.write().expect("route table lock poisoned");
+    if let Some(existing) = routes
+        .iter_mut()
+        .find(|r| r.prefix == prefix && r.method == method)
+    {
+        // Exclusive re-claim by the sole holder stays the idempotent
+        // kind-updating Ok it always was.
+        if !shared && !existing.shared && existing.members == [mailbox] {
+            existing.kind = kind;
+            return RegisterRouteResult::Ok;
+        }
+        if shared != existing.shared {
+            return RegisterRouteResult::Err {
+                error: format!(
+                    "route ({prefix:?}, {method:?}) is {}; a {} registration cannot \
+                     join it (ADR-0136: spreading is a joint opt-in)",
+                    if existing.shared {
+                        "a shared member set"
+                    } else {
+                        "exclusively claimed"
+                    },
+                    if shared { "shared" } else { "exclusive" },
+                ),
+            };
+        }
+        if !shared {
+            return RegisterRouteResult::Err {
+                error: format!(
+                    "route ({prefix:?}, {method:?}) already claimed by mailbox {:?}",
+                    existing.members[0],
+                ),
+            };
+        }
+        if existing.kind != kind {
+            return RegisterRouteResult::Err {
+                error: format!(
+                    "route ({prefix:?}, {method:?}) member set dispatches kind {:?}; a \
+                     member registering kind {kind:?} cannot join (ADR-0136)",
+                    existing.kind,
+                ),
+            };
+        }
+        if !existing.members.contains(&mailbox) {
+            existing.members.push(mailbox);
+        }
+        return RegisterRouteResult::Ok;
+    }
+    routes.push(Route {
+        prefix,
+        method,
+        kind,
+        shared,
+        members: vec![mailbox],
+    });
+    RegisterRouteResult::Ok
+}
+
+/// Release `mailbox`'s membership in the `(prefix, method)` route
+/// (ADR-0136); the last member's release drops the route. Idempotent —
+/// releasing a route that isn't held (or a set the mailbox never
+/// joined) is still `Ok`, mirroring the input cap's unsubscribe
+/// semantics.
+///
+/// # Panics
+/// Panics if the route-table `RwLock` is poisoned — fail-fast per
+/// ADR-0063.
+pub fn unregister_route(
+    routes: &SharedRoutes,
+    prefix: &str,
+    method: Option<HttpMethod>,
+    mailbox: MailboxId,
+) -> RegisterRouteResult {
+    let prefix = match normalize_prefix(prefix) {
+        Ok(prefix) => prefix,
+        Err(error) => return RegisterRouteResult::Err { error },
+    };
+    let mut routes = routes.write().expect("route table lock poisoned");
+    for route in routes.iter_mut() {
+        if route.prefix == prefix && route.method == method {
+            route.members.retain(|m| *m != mailbox);
+        }
+    }
+    routes.retain(|r| !r.members.is_empty());
+    RegisterRouteResult::Ok
+}
+
+/// Release every route membership held by `mailbox` (ADR-0130's
+/// `UnregisterRoutesAll`, ADR-0136 set semantics); sets it empties drop
+/// entirely.
+///
+/// # Panics
+/// Panics if the route-table `RwLock` is poisoned — fail-fast per
+/// ADR-0063.
+pub fn unregister_routes_all(routes: &SharedRoutes, mailbox: MailboxId) {
+    let mut routes = routes.write().expect("route table lock poisoned");
+    for route in routes.iter_mut() {
+        route.members.retain(|m| *m != mailbox);
+    }
+    routes.retain(|r| !r.members.is_empty());
+}

--- a/crates/aether-capabilities/src/http/server/runtime/state.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/state.rs
@@ -262,65 +262,7 @@ impl HttpSupervisorState {
         mailbox: MailboxId,
         shared: bool,
     ) -> RegisterRouteResult {
-        let prefix = match normalize_prefix(prefix) {
-            Ok(prefix) => prefix,
-            Err(error) => return RegisterRouteResult::Err { error },
-        };
-        let mut routes = self.routes.write().expect("route table lock poisoned");
-        if let Some(existing) = routes
-            .iter_mut()
-            .find(|r| r.prefix == prefix && r.method == method)
-        {
-            // Exclusive re-claim by the sole holder stays the idempotent
-            // kind-updating Ok it always was.
-            if !shared && !existing.shared && existing.members == [mailbox] {
-                existing.kind = kind;
-                return RegisterRouteResult::Ok;
-            }
-            if shared != existing.shared {
-                return RegisterRouteResult::Err {
-                    error: format!(
-                        "route ({prefix:?}, {method:?}) is {}; a {} registration cannot \
-                         join it (ADR-0136: spreading is a joint opt-in)",
-                        if existing.shared {
-                            "a shared member set"
-                        } else {
-                            "exclusively claimed"
-                        },
-                        if shared { "shared" } else { "exclusive" },
-                    ),
-                };
-            }
-            if !shared {
-                return RegisterRouteResult::Err {
-                    error: format!(
-                        "route ({prefix:?}, {method:?}) already claimed by mailbox {:?}",
-                        existing.members[0],
-                    ),
-                };
-            }
-            if existing.kind != kind {
-                return RegisterRouteResult::Err {
-                    error: format!(
-                        "route ({prefix:?}, {method:?}) member set dispatches kind {:?}; a \
-                         member registering kind {kind:?} cannot join (ADR-0136)",
-                        existing.kind,
-                    ),
-                };
-            }
-            if !existing.members.contains(&mailbox) {
-                existing.members.push(mailbox);
-            }
-            return RegisterRouteResult::Ok;
-        }
-        routes.push(Route {
-            prefix,
-            method,
-            kind,
-            shared,
-            members: vec![mailbox],
-        });
-        RegisterRouteResult::Ok
+        register_route(&self.routes, prefix, method, kind, mailbox, shared)
     }
 
     /// Release `mailbox`'s membership in the `(prefix, method)` route
@@ -338,18 +280,7 @@ impl HttpSupervisorState {
         method: Option<HttpMethod>,
         mailbox: MailboxId,
     ) -> RegisterRouteResult {
-        let prefix = match normalize_prefix(prefix) {
-            Ok(prefix) => prefix,
-            Err(error) => return RegisterRouteResult::Err { error },
-        };
-        let mut routes = self.routes.write().expect("route table lock poisoned");
-        for route in routes.iter_mut() {
-            if route.prefix == prefix && route.method == method {
-                route.members.retain(|m| *m != mailbox);
-            }
-        }
-        routes.retain(|r| !r.members.is_empty());
-        RegisterRouteResult::Ok
+        unregister_route(&self.routes, prefix, method, mailbox)
     }
 
     /// Release every route membership held by `mailbox` (ADR-0130's
@@ -360,11 +291,7 @@ impl HttpSupervisorState {
     /// Panics if the route-table `RwLock` is poisoned — fail-fast per
     /// ADR-0063.
     pub fn unregister_routes_all(&mut self, mailbox: MailboxId) {
-        let mut routes = self.routes.write().expect("route table lock poisoned");
-        for route in routes.iter_mut() {
-            route.members.retain(|m| *m != mailbox);
-        }
-        routes.retain(|r| !r.members.is_empty());
+        unregister_routes_all(&self.routes, mailbox);
     }
 }
 

--- a/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
@@ -1,8 +1,9 @@
 use super::{
-    HttpResponseStreamOpen, OPCODE_BINARY, OPCODE_CONTINUATION, OPCODE_TEXT, WsFrameParse,
-    http_date, normalize_prefix, parse_http_method, parse_ws_frame, percent_decode_path,
-    reason_phrase, render_stream_head, request_keeps_alive, route_matches, sec_websocket_accept,
-    serialize_ws_frame, sha1, validate_ws_handshake,
+    Arc, HttpResponseStreamOpen, KindId, MailboxId, OPCODE_BINARY, OPCODE_CONTINUATION,
+    OPCODE_TEXT, RegisterRouteResult, RwLock, SharedRoutes, WsFrameParse, http_date,
+    normalize_prefix, parse_http_method, parse_ws_frame, percent_decode_path, reason_phrase,
+    register_route, render_stream_head, request_keeps_alive, route_matches, sec_websocket_accept,
+    serialize_ws_frame, sha1, unregister_route, unregister_routes_all, validate_ws_handshake,
 };
 use crate::http::kinds::{HttpHeader, HttpMethod};
 use std::time::{Duration, UNIX_EPOCH};
@@ -357,6 +358,216 @@ fn config_layer_defaults_match_the_named_consts() {
         default.websocket_idle_timeout_millis,
         DEFAULT_WS_IDLE_TIMEOUT_MILLIS
     );
+}
+
+/// Route-table registration and conflict resolution (ADR-0130 /
+/// ADR-0136). These exercise `register_route` / `unregister_route` /
+/// `unregister_routes_all` directly against a bare `SharedRoutes` — no
+/// chassis, no mail, no boot — so the conflict-resolution branches are
+/// pinned deterministically, with no dependence on the order two
+/// independent actors' registration mail happens to reach the table.
+mod route_registration {
+    use super::{
+        Arc, KindId, MailboxId, RegisterRouteResult, RwLock, SharedRoutes, register_route,
+        unregister_route, unregister_routes_all,
+    };
+    use crate::http::kinds::HttpMethod;
+
+    fn fresh_routes() -> SharedRoutes {
+        Arc::new(RwLock::new(Vec::new()))
+    }
+
+    #[track_caller]
+    fn expect_ok(result: RegisterRouteResult) {
+        assert!(
+            matches!(result, RegisterRouteResult::Ok),
+            "expected Ok, got {result:?}",
+        );
+    }
+
+    #[track_caller]
+    fn expect_err_containing(result: RegisterRouteResult, needle: &str) {
+        match result {
+            RegisterRouteResult::Err { error } => assert!(
+                error.contains(needle),
+                "error {error:?} does not contain {needle:?}",
+            ),
+            RegisterRouteResult::Ok => panic!("expected Err containing {needle:?}, got Ok"),
+        }
+    }
+
+    /// Snapshot the sole route's `(members, kind, shared)`, asserting the
+    /// table holds exactly one route — the shape every case below checks.
+    fn only_route(routes: &SharedRoutes) -> (Vec<MailboxId>, KindId, bool) {
+        let table = routes.read().expect("route table lock");
+        assert_eq!(
+            table.len(),
+            1,
+            "expected exactly one route, got {}",
+            table.len(),
+        );
+        let route = &table[0];
+        let snapshot = (route.members.clone(), route.kind, route.shared);
+        drop(table);
+        snapshot
+    }
+
+    /// Tripwire: the exclusive-conflict branch — a second exclusive
+    /// claimant of an already-held key is rejected and the first
+    /// claimant keeps the route unchanged. This is the boot-order-free
+    /// core of the invariant the retired async `conflicting_claim_*`
+    /// integration test raced on: the winner is whoever registers first,
+    /// full stop, so a deterministic winner comes from ordering the
+    /// calls, not from any table-internal tie-break.
+    #[test]
+    fn exclusive_conflict_first_claimant_keeps_route() {
+        let routes = fresh_routes();
+        let (first, second) = (MailboxId(1), MailboxId(2));
+        let (kind_a, kind_b) = (KindId(100), KindId(200));
+
+        expect_ok(register_route(&routes, "/dup", None, kind_a, first, false));
+        expect_err_containing(
+            register_route(&routes, "/dup", None, kind_b, second, false),
+            "already claimed by mailbox",
+        );
+
+        assert_eq!(only_route(&routes), (vec![first], kind_a, false));
+    }
+
+    /// Tripwire: the sole-holder idempotent re-claim branch — the same
+    /// exclusive mailbox re-registering its own key is `Ok` and updates
+    /// `kind` without growing the member set, so a component re-running
+    /// `wire` after `replace_component` re-registers cleanly.
+    #[test]
+    fn exclusive_reclaim_by_holder_updates_kind() {
+        let routes = fresh_routes();
+        let holder = MailboxId(1);
+        let (kind_a, kind_b) = (KindId(100), KindId(200));
+
+        expect_ok(register_route(&routes, "/dup", None, kind_a, holder, false));
+        expect_ok(register_route(&routes, "/dup", None, kind_b, holder, false));
+
+        assert_eq!(only_route(&routes), (vec![holder], kind_b, false));
+    }
+
+    /// Tripwire: the `(prefix, method)` compound key — a claim on one
+    /// method does not conflict with a claim on another method at the
+    /// same prefix, so both land as distinct routes.
+    #[test]
+    fn distinct_method_same_prefix_is_not_a_conflict() {
+        let routes = fresh_routes();
+        let (a, b) = (MailboxId(1), MailboxId(2));
+        let kind = KindId(100);
+
+        expect_ok(register_route(
+            &routes,
+            "/m",
+            Some(HttpMethod::Get),
+            kind,
+            a,
+            false,
+        ));
+        expect_ok(register_route(
+            &routes,
+            "/m",
+            Some(HttpMethod::Post),
+            kind,
+            b,
+            false,
+        ));
+
+        assert_eq!(routes.read().expect("route table lock").len(), 2);
+    }
+
+    /// Tripwire: the shared/exclusive mismatch branch, both directions —
+    /// a shared claim cannot join an exclusively-held key, and an
+    /// exclusive claim cannot take a shared member set; each rejection
+    /// leaves the contested route as its holder(s) left it.
+    #[test]
+    fn shared_and_exclusive_claims_do_not_mix() {
+        // Shared claim onto an exclusive key: rejected, stays exclusive.
+        let excl = fresh_routes();
+        let (a, b) = (MailboxId(1), MailboxId(2));
+        let kind = KindId(100);
+        expect_ok(register_route(&excl, "/k", None, kind, a, false));
+        expect_err_containing(
+            register_route(&excl, "/k", None, kind, b, true),
+            "exclusively claimed",
+        );
+        assert_eq!(only_route(&excl), (vec![a], kind, false));
+
+        // Exclusive claim onto a shared key: rejected, stays shared.
+        let shared = fresh_routes();
+        expect_ok(register_route(&shared, "/k", None, kind, a, true));
+        expect_err_containing(
+            register_route(&shared, "/k", None, kind, b, false),
+            "shared member set",
+        );
+        assert_eq!(only_route(&shared), (vec![a], kind, true));
+    }
+
+    /// Tripwire: the kind-mismatch branch on a shared join — a member
+    /// registering a different dispatch kind cannot join the set, and
+    /// the existing set is untouched.
+    #[test]
+    fn shared_join_with_mismatched_kind_is_rejected() {
+        let routes = fresh_routes();
+        let (a, b) = (MailboxId(1), MailboxId(2));
+        let (kind_a, kind_b) = (KindId(100), KindId(200));
+
+        expect_ok(register_route(&routes, "/pool", None, kind_a, a, true));
+        expect_err_containing(
+            register_route(&routes, "/pool", None, kind_b, b, true),
+            "cannot join",
+        );
+
+        assert_eq!(only_route(&routes), (vec![a], kind_a, true));
+    }
+
+    /// Tripwire: the shared-join admit branch — a matching shared claim
+    /// (same key, same kind) grows the member set in registration order,
+    /// and re-registering an existing membership is an idempotent `Ok`
+    /// that does not duplicate the member.
+    #[test]
+    fn matching_shared_claims_accumulate_members() {
+        let routes = fresh_routes();
+        let (a, b) = (MailboxId(1), MailboxId(2));
+        let kind = KindId(100);
+
+        expect_ok(register_route(&routes, "/pool", None, kind, a, true));
+        expect_ok(register_route(&routes, "/pool", None, kind, b, true));
+        // Idempotent re-registration of an existing member.
+        expect_ok(register_route(&routes, "/pool", None, kind, a, true));
+
+        assert_eq!(only_route(&routes), (vec![a, b], kind, true));
+    }
+
+    /// Tripwire: unregistration release + drop-when-empty — releasing one
+    /// member of a shared set leaves the rest serving, and releasing the
+    /// last member drops the route entirely; `unregister_routes_all`
+    /// clears every route a mailbox holds.
+    #[test]
+    fn unregister_releases_members_and_drops_empty_routes() {
+        let routes = fresh_routes();
+        let (a, b) = (MailboxId(1), MailboxId(2));
+        let kind = KindId(100);
+        expect_ok(register_route(&routes, "/pool", None, kind, a, true));
+        expect_ok(register_route(&routes, "/pool", None, kind, b, true));
+
+        // One member leaves; the set survives with the rest.
+        expect_ok(unregister_route(&routes, "/pool", None, a));
+        assert_eq!(only_route(&routes), (vec![b], kind, true));
+
+        // The last member leaves; the route is dropped.
+        expect_ok(unregister_route(&routes, "/pool", None, b));
+        assert!(routes.read().expect("route table lock").is_empty());
+
+        // unregister_routes_all clears every route the mailbox holds.
+        expect_ok(register_route(&routes, "/x", None, kind, a, false));
+        expect_ok(register_route(&routes, "/y", None, kind, a, false));
+        unregister_routes_all(&routes, a);
+        assert!(routes.read().expect("route table lock").is_empty());
+    }
 }
 
 mod wake_coalescing {

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -15,13 +15,11 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use test_handlers::{
-    ApiRouteHandler, ApiV2Handler, DupFirstHandler, DupSecondHandler, EchoHttpHandler,
-    ExclusiveMacroFirstHandler, ExclusiveMacroSecondHandler, ExclusivePoolHandler,
-    ExtractRouteHandler, FixedBodyHttpHandler, FloodHttpHandler, MethodAnyHandler,
-    MethodPostHandler, STREAM_CHUNK_COUNT, SharedAlphaHandler, SharedBetaHandler,
-    SharedDupJoinHandler, SharedMacroPoolHandler, SharedWrongKindHandler, SilentHttpHandler,
-    StreamHttpHandler, StreamingUploadHandler, TmpRouteHandler, WiredRouteHandler,
-    stream_chunk_body,
+    ApiRouteHandler, ApiV2Handler, EchoHttpHandler, ExclusiveMacroFirstHandler,
+    ExclusiveMacroSecondHandler, ExtractRouteHandler, FixedBodyHttpHandler, FloodHttpHandler,
+    MethodAnyHandler, MethodPostHandler, STREAM_CHUNK_COUNT, SharedAlphaHandler, SharedBetaHandler,
+    SharedMacroPoolHandler, SilentHttpHandler, StreamHttpHandler, StreamingUploadHandler,
+    TmpRouteHandler, WiredRouteHandler, stream_chunk_body,
 };
 
 mod test_handlers {
@@ -300,74 +298,10 @@ mod test_handlers {
         "/m"
     );
 
-    /// A raw-surface routed handler that hand-writes its `wire`
-    /// registration with the generic request kind and replies `200` with
-    /// a fixed tag body. The conflict-`Err` and idempotent double-claim
-    /// tests key on the protocol directly, so they stay on this raw
-    /// surface rather than the macro's — a macro regression cannot then
-    /// mask a registration-semantics regression.
-    macro_rules! raw_routed_handler {
-        ($ty:ident, $state:ident, $namespace:literal, $tag:literal,
-         [$(($method:expr, $prefix:literal)),+ $(,)?]) => {
-            pub struct $ty;
-            pub struct $state;
-
-            #[actor(singleton)]
-            impl NativeActor for $ty {
-                type State = $state;
-                type Config = ();
-                const NAMESPACE: &'static str = $namespace;
-
-                fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<$state, BootError> {
-                    Ok($state)
-                }
-
-                fn wire(_state: &mut $state, ctx: &mut NativeCtx<'_>) {
-                    $(ctx.actor::<HttpServerCapability>().send(&RegisterRouteSelf {
-                        prefix: $prefix.to_string(),
-                        method: $method,
-                        kind: <HttpServerRequest as Kind>::ID,
-                        shared: false,
-                    });)+
-                }
-
-                #[handler::single]
-                fn on_request(
-                    _state: &mut Self::State,
-                    _ctx: &mut NativeCtx<'_>,
-                    _request: HttpServerRequest,
-                ) -> HttpServerResponse {
-                    HttpServerResponse {
-                        status: 200,
-                        headers: Vec::new(),
-                        body: $tag.to_vec(),
-                    }
-                }
-            }
-        };
-    }
-
-    // The first claimant sends its `/dup` claim twice, pinning the
-    // idempotent same-mailbox re-claim (both `Ok`) alongside the
-    // cross-mailbox conflict the second claimant loses.
-    raw_routed_handler!(
-        DupFirstHandler,
-        DupFirstHandlerState,
-        "aether.http.test_route_dup_first",
-        b"first",
-        [(None, "/dup"), (None, "/dup")]
-    );
-    raw_routed_handler!(
-        DupSecondHandler,
-        DupSecondHandlerState,
-        "aether.http.test_route_dup_second",
-        b"second",
-        [(None, "/dup"), (None, "/second")]
-    );
-
-    /// Like [`raw_routed_handler!`] but every claim registers
-    /// `shared: true` with the given dispatch kind (ADR-0136) — the
-    /// member-set opt-in the shared-route tests exercise.
+    /// A routed handler whose `wire` registers each claim `shared: true`
+    /// with the given dispatch kind (ADR-0136) — the member-set opt-in
+    /// the shared-route tests exercise. Replies `200` with a fixed tag
+    /// body.
     macro_rules! shared_routed_handler {
         ($ty:ident, $state:ident, $namespace:literal, $tag:literal, $kind:ty,
          [$(($method:expr, $prefix:literal)),+ $(,)?]) => {
@@ -410,9 +344,10 @@ mod test_handlers {
     }
 
     // The /pool member set (ADR-0136): two shared claimants that both
-    // serve, one kind-mismatched shared claimant and one exclusive
-    // claimant that are both rejected without touching their other
-    // routes.
+    // serve, exercised over the wire by
+    // `shared_route_spreads_across_members`. The shared/exclusive
+    // conflict matrix these once paired with is now covered
+    // deterministically in `runtime::unit_tests::route_registration`.
     shared_routed_handler!(
         SharedAlphaHandler,
         SharedAlphaHandlerState,
@@ -428,29 +363,6 @@ mod test_handlers {
         b"beta",
         HttpServerRequest,
         [(None, "/pool")]
-    );
-    shared_routed_handler!(
-        SharedWrongKindHandler,
-        SharedWrongKindHandlerState,
-        "aether.http.test_route_shared_wrong_kind",
-        b"wrong-kind",
-        HttpRequestChunk,
-        [(None, "/pool")]
-    );
-    shared_routed_handler!(
-        SharedDupJoinHandler,
-        SharedDupJoinHandlerState,
-        "aether.http.test_route_shared_dup_join",
-        b"shared-dup",
-        HttpServerRequest,
-        [(None, "/dup"), (None, "/shared-ok")]
-    );
-    raw_routed_handler!(
-        ExclusivePoolHandler,
-        ExclusivePoolHandlerState,
-        "aether.http.test_route_excl_pool",
-        b"excl-pool",
-        [(None, "/pool"), (None, "/excl-ok")]
     );
 
     /// A `#[http::router(shared)]` handler (issue 2625) — the typed
@@ -1934,29 +1846,6 @@ fn method_specific_route_beats_agnostic() {
     );
 }
 
-/// A `(prefix, method)` key already claimed by another mailbox is
-/// rejected: the first claimant keeps the route, and the rejected
-/// claimant's other registrations are unaffected (ADR-0130). Boot
-/// order makes the winner deterministic — `DupFirstHandler` wires
-/// before `DupSecondHandler`.
-#[test]
-fn conflicting_claim_is_rejected_first_claimant_keeps_route() {
-    let chassis = routed_chassis!(DupFirstHandler, DupSecondHandler);
-    let port = port_of(&chassis);
-
-    // `/second` live proves DupSecondHandler's registrations (sent
-    // after DupFirstHandler's, in boot order) have been processed —
-    // including its rejected `/dup` claim.
-    poll_body(
-        port,
-        b"GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n",
-        "second",
-    );
-
-    let dup = round_trip(port, b"GET /dup HTTP/1.1\r\nHost: localhost\r\n\r\n");
-    assert_eq!(body_of(&dup), "first", "first claimant keeps the route");
-}
-
 /// A bare `#[http::router]` impl still registers exclusive (issue 2625
 /// regression guard on the default): `ExclusiveMacroFirstHandler` and
 /// `ExclusiveMacroSecondHandler` both claim `/macro-excl` through the
@@ -2256,66 +2145,6 @@ fn shared_route_spreads_across_members() {
         (3, 3),
         "round-robin alternation over 6 requests"
     );
-}
-
-/// The ADR-0136 conflict matrix: a shared claim cannot join an
-/// exclusively-held key, an exclusive claim cannot take a shared set,
-/// and a kind-mismatched shared claim cannot join — each rejection
-/// leaves the loser's other routes serving and the contested route
-/// unchanged.
-#[test]
-fn mixed_and_mismatched_claims_are_rejected() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<HttpServerCapability>(HttpServerConfig {
-            bind_addr: "127.0.0.1:0".to_string(),
-            handler_mailbox: <FixedBodyHttpHandler as Addressable>::NAMESPACE.to_string(),
-            request_timeout_millis: 5_000,
-            dispatch_shards: 1,
-            ..HttpServerConfig::default()
-        })
-        .with_actor::<FixedBodyHttpHandler>(())
-        // Boot order fixes who holds what: /dup exclusive first; the
-        // /pool shared pair before the wrong-kind and exclusive
-        // challengers.
-        .with_actor::<DupFirstHandler>(())
-        .with_actor::<SharedAlphaHandler>(())
-        .with_actor::<SharedBetaHandler>(())
-        .with_actor::<SharedWrongKindHandler>(())
-        .with_actor::<SharedDupJoinHandler>(())
-        .with_actor::<ExclusivePoolHandler>(())
-        .build_passive()
-        .expect("caps boot");
-    let port = port_of(&chassis);
-
-    // The last-booted challenger's accepted route being live proves
-    // every earlier registration (including the rejected ones) has
-    // been processed.
-    poll_body(
-        port,
-        b"GET /excl-ok HTTP/1.1\r\nHost: localhost\r\n\r\n",
-        "excl-pool",
-    );
-    poll_body(
-        port,
-        b"GET /shared-ok HTTP/1.1\r\nHost: localhost\r\n\r\n",
-        "shared-dup",
-    );
-
-    // Shared join on the exclusive /dup: rejected, holder keeps it.
-    let dup = round_trip(port, b"GET /dup HTTP/1.1\r\nHost: localhost\r\n\r\n");
-    assert_eq!(body_of(&dup), "first", "exclusive holder keeps /dup");
-
-    // Wrong-kind shared join and exclusive take of /pool: rejected —
-    // only alpha/beta ever serve it.
-    for _ in 0..6 {
-        let response = round_trip(port, b"GET /pool HTTP/1.1\r\nHost: localhost\r\n\r\n");
-        let body = body_of(&response);
-        assert!(
-            body == "alpha" || body == "beta",
-            "/pool must stay with the shared pair; got {body:?}",
-        );
-    }
 }
 
 /// A macro route composes with a hand-written `wire`: the macro appends

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -6,6 +6,7 @@ use aether_data::Kind as KindTrait;
 use aether_data::KindId;
 use aether_substrate::Mail;
 use aether_substrate::Subname;
+use aether_substrate::actor::native::NativeActor;
 use aether_substrate::chassis::builder::{Builder, PassiveChassis};
 use aether_substrate::testing::{TestChassis, fresh_substrate};
 use std::io::{self, Read, Write};
@@ -845,6 +846,52 @@ fn config_for(handler: &str, max_request_bytes: usize) -> HttpServerConfig {
     }
 }
 
+/// Boot a passive chassis holding one handler actor `H` plus the HTTP
+/// server cap under `config` — the single-handler shape most server
+/// tests share. Multi-handler and cap-only boots stay explicit at their
+/// call sites.
+fn boot_chassis<H>(config: HttpServerConfig) -> PassiveChassis<TestChassis>
+where
+    H: NativeActor<Config = ()>,
+{
+    let (registry, mailer) = fresh_substrate();
+    Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<H>(())
+        .with_actor::<HttpServerCapability>(config)
+        .build_passive()
+        .expect("caps boot")
+}
+
+/// [`boot_chassis`] with `H` as its own `handler_mailbox` under a
+/// buffered [`config_for`] config (`max_request_bytes`).
+fn boot_buffered<H>(max_request_bytes: usize) -> PassiveChassis<TestChassis>
+where
+    H: NativeActor<Config = ()>,
+{
+    boot_chassis::<H>(config_for(<H as Addressable>::NAMESPACE, max_request_bytes))
+}
+
+/// [`boot_chassis`] with `H` under a response-streaming [`stream_config_for`]
+/// config (credit `window`).
+fn boot_response_stream<H>(window: u32) -> PassiveChassis<TestChassis>
+where
+    H: NativeActor<Config = ()>,
+{
+    boot_chassis::<H>(stream_config_for(<H as Addressable>::NAMESPACE, window))
+}
+
+/// [`boot_chassis`] with `H` under a request-streaming
+/// [`request_stream_config_for`] config (credit `window`).
+fn boot_request_stream<H>(window: u32) -> PassiveChassis<TestChassis>
+where
+    H: NativeActor<Config = ()>,
+{
+    boot_chassis::<H>(request_stream_config_for(
+        <H as Addressable>::NAMESPACE,
+        window,
+    ))
+}
+
 /// Server config for the streaming tests (ADR-0128): a small credit window
 /// so a multi-chunk response must replenish credit repeatedly, and a flood
 /// overruns it fast.
@@ -968,15 +1015,7 @@ fn body_of(response: &str) -> &str {
 /// well-formed HTTP/1.1, carrying the parsed path / query / method.
 #[test]
 fn get_round_trips_to_handler() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            1024,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<EchoHttpHandler>(1024);
 
     let response = round_trip(
         port_of(&chassis),
@@ -1015,15 +1054,7 @@ fn get_round_trips_to_handler() {
 /// A POST round-trips the body verbatim to the handler.
 #[test]
 fn post_round_trips_body() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            1024,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<EchoHttpHandler>(1024);
 
     let response = round_trip(
         port_of(&chassis),
@@ -1044,15 +1075,7 @@ fn post_round_trips_body() {
 /// `413` before any dispatch.
 #[test]
 fn oversize_body_is_413() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            8,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<EchoHttpHandler>(8);
 
     let response = round_trip(
         port_of(&chassis),
@@ -1071,15 +1094,7 @@ fn oversize_body_is_413() {
 /// request rather than being skipped because `ws_key.is_some()`.
 #[test]
 fn oversize_body_on_ws_upgrade_is_413() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            8,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<EchoHttpHandler>(8);
 
     let response = round_trip(
         port_of(&chassis),
@@ -1107,15 +1122,7 @@ fn oversize_body_on_ws_upgrade_is_413() {
 /// upgrade handshake.
 #[test]
 fn smuggling_on_ws_upgrade_is_411() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            1024,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<EchoHttpHandler>(1024);
 
     let response = round_trip(
         port_of(&chassis),
@@ -1137,15 +1144,7 @@ fn smuggling_on_ws_upgrade_is_411() {
 /// A non-enumerated method is answered `501` before any dispatch.
 #[test]
 fn unknown_method_is_501() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            1024,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<EchoHttpHandler>(1024);
 
     let response = round_trip(
         port_of(&chassis),
@@ -1211,15 +1210,7 @@ fn response_less_chain_is_502() {
 /// raw.
 #[test]
 fn percent_encoded_path_is_decoded() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            1024,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<EchoHttpHandler>(1024);
 
     let response = round_trip(
         port_of(&chassis),
@@ -1242,15 +1233,7 @@ fn percent_encoded_path_is_decoded() {
 /// incremental path — see `chunked_upload_streams_to_streaming_handler`).
 #[test]
 fn transfer_encoding_is_411() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            1024,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<EchoHttpHandler>(1024);
 
     let response = round_trip(
         port_of(&chassis),
@@ -1266,15 +1249,7 @@ fn transfer_encoding_is_411() {
 /// Continue` before the final response.
 #[test]
 fn expect_continue_gets_100_continue() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            1024,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<EchoHttpHandler>(1024);
 
     let response = round_trip(
         port_of(&chassis),
@@ -1295,15 +1270,7 @@ fn expect_continue_gets_100_continue() {
 /// to the same handler still returns the body.
 #[test]
 fn head_response_suppresses_body() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<FixedBodyHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <FixedBodyHttpHandler as Addressable>::NAMESPACE,
-            1024,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<FixedBodyHttpHandler>(1024);
     let port = port_of(&chassis);
 
     let head_response = round_trip(port, b"HEAD /x HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -1339,20 +1306,15 @@ fn head_response_suppresses_body() {
 /// because no single shard is at the ceiling.
 #[test]
 fn over_capacity_connection_is_503() {
-    let (registry, mailer) = fresh_substrate();
     let max_connections = 2;
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(HttpServerConfig {
-            bind_addr: "127.0.0.1:0".to_string(),
-            handler_mailbox: <EchoHttpHandler as Addressable>::NAMESPACE.to_string(),
-            request_timeout_millis: 5_000,
-            max_connections,
-            dispatch_shards: 2,
-            ..HttpServerConfig::default()
-        })
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_chassis::<EchoHttpHandler>(HttpServerConfig {
+        bind_addr: "127.0.0.1:0".to_string(),
+        handler_mailbox: <EchoHttpHandler as Addressable>::NAMESPACE.to_string(),
+        request_timeout_millis: 5_000,
+        max_connections,
+        dispatch_shards: 2,
+        ..HttpServerConfig::default()
+    });
 
     let port = port_of(&chassis);
 
@@ -1397,18 +1359,13 @@ fn over_capacity_connection_is_503() {
 /// connections.
 #[test]
 fn connections_distribute_across_shards() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(HttpServerConfig {
-            bind_addr: "127.0.0.1:0".to_string(),
-            handler_mailbox: <EchoHttpHandler as Addressable>::NAMESPACE.to_string(),
-            request_timeout_millis: 5_000,
-            dispatch_shards: 2,
-            ..HttpServerConfig::default()
-        })
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_chassis::<EchoHttpHandler>(HttpServerConfig {
+        bind_addr: "127.0.0.1:0".to_string(),
+        handler_mailbox: <EchoHttpHandler as Addressable>::NAMESPACE.to_string(),
+        request_timeout_millis: 5_000,
+        dispatch_shards: 2,
+        ..HttpServerConfig::default()
+    });
 
     let port = port_of(&chassis);
 
@@ -1453,16 +1410,8 @@ fn connections_distribute_across_shards() {
 /// many refills, not just the initial grant.
 #[test]
 fn streamed_response_reassembles_across_credit_window() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<StreamHttpHandler>(())
-        .with_actor::<HttpServerCapability>(stream_config_for(
-            <StreamHttpHandler as Addressable>::NAMESPACE,
-            // Window well below the chunk count so credit must replenish.
-            8,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    // Window well below the chunk count so credit must replenish.
+    let chassis = boot_response_stream::<StreamHttpHandler>(8);
 
     let response = round_trip(
         port_of(&chassis),
@@ -1495,16 +1444,8 @@ fn streamed_response_reassembles_across_credit_window() {
 /// the window unbounded.
 #[test]
 fn over_window_flood_tears_the_stream_down() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<FloodHttpHandler>(())
-        .with_actor::<HttpServerCapability>(stream_config_for(
-            <FloodHttpHandler as Addressable>::NAMESPACE,
-            // Tiny window so the flood overruns credit within a few chunks.
-            2,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    // Tiny window so the flood overruns credit within a few chunks.
+    let chassis = boot_response_stream::<FloodHttpHandler>(2);
 
     let response = round_trip(
         port_of(&chassis),
@@ -1542,15 +1483,7 @@ fn request_stream_config_for(handler: &str, window: u32) -> HttpServerConfig {
 /// window forces credit to replenish across hundreds of chunks.
 #[test]
 fn large_upload_streams_past_the_buffered_cap() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<StreamingUploadHandler>(())
-        .with_actor::<HttpServerCapability>(request_stream_config_for(
-            <StreamingUploadHandler as Addressable>::NAMESPACE,
-            4,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_request_stream::<StreamingUploadHandler>(4);
     let port = port_of(&chassis);
 
     // Well past DEFAULT_MAX_REQUEST_BYTES (1 MiB) — a buffered handler would
@@ -1575,15 +1508,7 @@ fn large_upload_streams_past_the_buffered_cap() {
 /// reassembling the body across frames (ADR-0128).
 #[test]
 fn chunked_upload_streams_to_streaming_handler() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<StreamingUploadHandler>(())
-        .with_actor::<HttpServerCapability>(request_stream_config_for(
-            <StreamingUploadHandler as Addressable>::NAMESPACE,
-            4,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_request_stream::<StreamingUploadHandler>(4);
     let port = port_of(&chassis);
 
     // "hello" (5) + " world" (6) = 11 body bytes across two chunks.
@@ -1609,15 +1534,7 @@ fn chunked_upload_streams_to_streaming_handler() {
 /// ambiguous pair.
 #[test]
 fn content_length_with_transfer_encoding_is_411() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<StreamingUploadHandler>(())
-        .with_actor::<HttpServerCapability>(request_stream_config_for(
-            <StreamingUploadHandler as Addressable>::NAMESPACE,
-            4,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_request_stream::<StreamingUploadHandler>(4);
     let port = port_of(&chassis);
 
     let response = round_trip(
@@ -1642,15 +1559,7 @@ fn content_length_with_transfer_encoding_is_411() {
 /// upgrade handshake.
 #[test]
 fn chunked_on_ws_upgrade_is_411() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<StreamingUploadHandler>(())
-        .with_actor::<HttpServerCapability>(request_stream_config_for(
-            <StreamingUploadHandler as Addressable>::NAMESPACE,
-            4,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_request_stream::<StreamingUploadHandler>(4);
     let port = port_of(&chassis);
 
     let response = round_trip(
@@ -1677,15 +1586,7 @@ fn chunked_on_ws_upgrade_is_411() {
 /// take a chunked body.
 #[test]
 fn buffered_handler_keeps_the_unstreamed_path() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(request_stream_config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            4,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_request_stream::<EchoHttpHandler>(4);
     let port = port_of(&chassis);
 
     let response = round_trip(
@@ -1960,21 +1861,16 @@ fn macro_router_shared_opt_in_joins_a_member_set() {
 /// and B times out empty.
 #[test]
 fn stalled_peer_does_not_block_sibling_connections() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(HttpServerConfig {
-            bind_addr: "127.0.0.1:0".to_string(),
-            handler_mailbox: <EchoHttpHandler as Addressable>::NAMESPACE.to_string(),
-            // Short: the stalled write parks within milliseconds, and
-            // teardown waits out at most one response deadline.
-            request_timeout_millis: 2_000,
-            max_request_bytes: 32 * 1024 * 1024,
-            dispatch_shards: 1,
-            ..HttpServerConfig::default()
-        })
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_chassis::<EchoHttpHandler>(HttpServerConfig {
+        bind_addr: "127.0.0.1:0".to_string(),
+        handler_mailbox: <EchoHttpHandler as Addressable>::NAMESPACE.to_string(),
+        // Short: the stalled write parks within milliseconds, and
+        // teardown waits out at most one response deadline.
+        request_timeout_millis: 2_000,
+        max_request_bytes: 32 * 1024 * 1024,
+        dispatch_shards: 1,
+        ..HttpServerConfig::default()
+    });
     let port = port_of(&chassis);
 
     // Connection A: a 16 MiB echo whose response the client never
@@ -2211,20 +2107,27 @@ fn keep_alive_config_for(handler: &str, keep_alive_timeout_millis: u64) -> HttpS
 /// it (a pipelined next response) in `carry` for the following call. Panics
 /// on EOF mid-response, so a test that expects the connection to close reads
 /// one response and then asserts EOF separately.
-fn read_one_response(stream: &mut TcpStream, carry: &mut Vec<u8>) -> String {
-    let mut chunk = [0u8; 4096];
-    let head_end = loop {
+/// Read from `stream` into `carry` until the blank line terminating the
+/// HTTP response head is buffered; return the byte index just past it.
+/// Shared by the buffered and chunked response readers.
+fn read_response_head(stream: &mut TcpStream, carry: &mut Vec<u8>, chunk: &mut [u8]) -> usize {
+    loop {
         if let Some(pos) = carry.windows(4).position(|window| window == b"\r\n\r\n") {
-            break pos + 4;
+            return pos + 4;
         }
-        let n = stream.read(&mut chunk).expect("read response head");
+        let n = stream.read(chunk).expect("read response head");
         assert!(
             n > 0,
             "eof before response head; buffered: {:?}",
             String::from_utf8_lossy(carry),
         );
         carry.extend_from_slice(&chunk[..n]);
-    };
+    }
+}
+
+fn read_one_response(stream: &mut TcpStream, carry: &mut Vec<u8>) -> String {
+    let mut chunk = [0u8; 4096];
+    let head_end = read_response_head(stream, carry, &mut chunk);
     let content_length = content_length_of(&carry[..head_end]);
     while carry.len() < head_end + content_length {
         let n = stream.read(&mut chunk).expect("read response body");
@@ -2259,18 +2162,7 @@ fn content_length_of(head: &[u8]) -> usize {
 /// case.
 fn read_one_chunked_response(stream: &mut TcpStream, carry: &mut Vec<u8>) -> String {
     let mut chunk = [0u8; 4096];
-    let head_end = loop {
-        if let Some(pos) = carry.windows(4).position(|window| window == b"\r\n\r\n") {
-            break pos + 4;
-        }
-        let n = stream.read(&mut chunk).expect("read response head");
-        assert!(
-            n > 0,
-            "eof before response head; buffered: {:?}",
-            String::from_utf8_lossy(carry),
-        );
-        carry.extend_from_slice(&chunk[..n]);
-    };
+    let head_end = read_response_head(stream, carry, &mut chunk);
     let terminator = b"0\r\n\r\n";
     let body_end = loop {
         if let Some(pos) = carry[head_end..]
@@ -2308,15 +2200,7 @@ fn assert_closed(stream: &mut TcpStream) {
 /// over-read bytes across the resume signal.
 #[test]
 fn keep_alive_serves_sequential_requests_on_one_socket() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            1024,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<EchoHttpHandler>(1024);
     let port = port_of(&chassis);
 
     let mut stream =
@@ -2385,15 +2269,7 @@ fn keep_alive_serves_sequential_requests_on_one_socket() {
 /// fail against the pre-fix behavior.
 #[test]
 fn keep_alive_reuses_socket_after_streamed_response() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<StreamHttpHandler>(())
-        .with_actor::<HttpServerCapability>(stream_config_for(
-            <StreamHttpHandler as Addressable>::NAMESPACE,
-            8,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_response_stream::<StreamHttpHandler>(8);
     let port = port_of(&chassis);
 
     let mut stream =
@@ -2448,15 +2324,7 @@ fn keep_alive_reuses_socket_after_streamed_response() {
 /// ends, exactly like the buffered path.
 #[test]
 fn streamed_response_honors_explicit_connection_close() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<StreamHttpHandler>(())
-        .with_actor::<HttpServerCapability>(stream_config_for(
-            <StreamHttpHandler as Addressable>::NAMESPACE,
-            8,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_response_stream::<StreamHttpHandler>(8);
     let port = port_of(&chassis);
 
     let mut stream =
@@ -2483,15 +2351,7 @@ fn streamed_response_honors_explicit_connection_close() {
 /// response carries `Connection: close` and the server closes the socket.
 #[test]
 fn http_1_0_defaults_to_close() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            1024,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_buffered::<EchoHttpHandler>(1024);
     let port = port_of(&chassis);
 
     let mut stream =
@@ -2522,15 +2382,10 @@ fn http_1_0_defaults_to_close() {
 /// pinning the reader thread for the full request timeout.
 #[test]
 fn idle_kept_alive_connection_closes_after_timeout() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EchoHttpHandler>(())
-        .with_actor::<HttpServerCapability>(keep_alive_config_for(
-            <EchoHttpHandler as Addressable>::NAMESPACE,
-            300,
-        ))
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_chassis::<EchoHttpHandler>(keep_alive_config_for(
+        <EchoHttpHandler as Addressable>::NAMESPACE,
+        300,
+    ));
     let port = port_of(&chassis);
 
     let mut stream =


### PR DESCRIPTION
Closes #2782.

## Summary

The route-conflict ownership tests (`conflicting_claim_is_rejected_first_claimant_keeps_route` and `mixed_and_mismatched_claims_are_rejected`) booted two handlers that each claimed `/dup` from their own `wire` hook and asserted the first-booted handler kept the route, assuming boot order pinned the winner. It doesn't: the two claims arrive from two independent mailboxes during the same boot, and same-tick cross-sender registration-mail ordering into the shared route table is not guaranteed — when the second claimant won the race the route served `"second"` and the assertion failed (the observed intermittent red on #2769).

This extracts the route-table registration logic (`register_route` and the `unregister` siblings) out of `HttpSupervisorState` — where it was a method on a struct owning a live listener, mailer, and threads, exercisable only through the full async chassis — into free functions over `&SharedRoutes` in `routing.rs`, next to the other pure route-table functions (`best_route`, `route_matches`, `normalize_prefix`). The supervisor methods become behavior-preserving delegates. The conflict matrix is then covered by deterministic unit tests in `runtime::unit_tests::route_registration`, calling `register_route` directly against a bare `SharedRoutes` — no boot, no mail, no ordering dependence — which is the honest home for logic this crate owns (`register_route` previously had no unit coverage; the flaky integration tests were compensating).

With the conflict decision covered deterministically, the two boot-order-racy integration tests and their now-unused fixtures are deleted. No wire-level coverage is lost: dispatch of a claimed route stays covered by `routed_prefix_dispatches_as_registered_kind`, and shared-set round-robin by `shared_route_spreads_across_members` (which waits for the complete member set and so is order-independent).

## Test plan

- New deterministic unit tests in `runtime::unit_tests::route_registration` pin: exclusive first-claimant-wins rejection, idempotent same-mailbox re-claim (kind update, no second member), the `(prefix, method)` compound key, shared-vs-exclusive mismatch both directions, kind-mismatched shared join, matching shared-claim member accrual + idempotent re-registration, and unregister release / drop-when-empty / `unregister_routes_all`.
- Surviving async integration tests (`route_registered_mid_connection_serves_next_request`, `shared_route_spreads_across_members`, `self_unregister_releases_route`, `routed_prefix_dispatches_as_registered_kind`) are the behavior-preserving regression guard for the delegation.
- Verified locally: `cargo clippy -p aether-capabilities --all-targets -- -D warnings` clean; `cargo test -p aether-capabilities --lib http::server` green (27 unit + 38 integration).

## Generated by

`/implement` — agent execution of [scoped issue #2782](https://github.com/iamacoffeepot/aether/issues/2782).
