### PR TITLE
chore(workflow): add codex mcp hub config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+[mcp_servers.aether-hub]
+url = "http://127.0.0.1:8890/mcp"
+startup_timeout_sec = 20
+tool_timeout_sec = 600

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,9 @@ hook tests or CI hook jobs unless a scoped issue explicitly asks for them.
 
 ## MCP Harness
 
-The Aether MCP endpoint is configured by `.mcp.json` as `aether-hub` at `http://127.0.0.1:8890/mcp`.
+The Aether MCP endpoint is configured for Codex in `.codex/config.toml` and
+for MCP clients that read `.mcp.json` as `aether-hub` at
+`http://127.0.0.1:8890/mcp`.
 
 Start the local tunnel only when a task needs live engine tools:
 
@@ -57,7 +59,11 @@ Start the local tunnel only when a task needs live engine tools:
 scripts/ensure-tunnel.sh
 ```
 
-Expected MCP tools are the `mcp__aether-hub__*` family, including engine listing, substrate spawn/terminate, component upload/load/replace, mail sending, kind/component description, frame capture, actor logs, and cost inspection. If those tools are missing after starting the tunnel, reconnect MCP in the active Codex surface.
+Expected MCP tools are the `mcp__aether-hub__*` family, including engine
+listing, substrate spawn/terminate, component upload/load/replace, mail
+sending, kind/component description, frame capture, actor logs, and cost
+inspection. If those tools are missing after starting the tunnel, reconnect MCP
+in the active Codex surface with `/mcp`.
 
 ## Coding Rules
 

--- a/docs/guide/mcp-harness.md
+++ b/docs/guide/mcp-harness.md
@@ -60,6 +60,10 @@ yourself with `scripts/ensure-tunnel.sh`: it's idempotent (a no-op if `:8890` is
 already bound, otherwise it launches the tunnel detached). Ports and the rest are in
 `CLAUDE.md`'s MCP-harness section, which is the operational reference for the stack.
 
+Codex sessions in a trusted checkout pick up the `aether-hub` MCP server from
+`.codex/config.toml`; if the `mcp__aether-hub__*` tools are missing after the
+tunnel starts, run `/mcp` in the active Codex surface to reconnect them.
+
 ## The session loop
 
 Everything is keyed by `engine_id`. A session has a recognizable arc:


### PR DESCRIPTION
Closes #2786.

## Summary

Add Codex-native project MCP configuration for the Aether hub endpoint and clarify the harness bring-up docs for Codex sessions.

## Test plan

- `cargo fmt`
- `git diff --check`

## Generated by

`/implement` — agent execution of scoped issue #2786.