### PR TITLE
fix(actor): parent nested by-tag inline spawns to the spawner, not the cluster root

### DIFF
--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -574,7 +574,14 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
         let Some(resolver) = self.inline.spawn_resolver() else {
             return Err(SpawnError::UnknownActorTag(tag));
         };
-        resolver(self.inline, tag, is_counter, &full_subname, config_bytes)
+        resolver(
+            self.inline,
+            self.mailbox,
+            tag,
+            is_counter,
+            &full_subname,
+            config_bytes,
+        )
     }
 
     /// ADR-0114: tear down an **inline child** spawned by
@@ -1587,6 +1594,7 @@ mod tests {
     /// as the generated resolver's tag-match fall-through does.
     fn stub_resolver(
         registry: &Registry,
+        parent: u64,
         tag: ActorTypeTag,
         is_counter: bool,
         full_subname: &str,
@@ -1596,6 +1604,7 @@ mod tests {
             let alias = MailboxId(0xABCD_0001);
             spawn_one_child::<StubChild>(
                 registry,
+                parent,
                 alias,
                 tag.0,
                 String::from(full_subname),
@@ -1611,6 +1620,7 @@ mod tests {
     /// tests install it to prove the guard runs before any resolver call.
     fn panicking_resolver(
         _registry: &Registry,
+        _parent: u64,
         _tag: ActorTypeTag,
         _is_counter: bool,
         _full_subname: &str,
@@ -1647,6 +1657,38 @@ mod tests {
             STUB_INIT_CONFIG.get(),
             Some(0x1234_5678),
             "the config bytes were decoded and threaded into the child's init",
+        );
+    }
+
+    /// Issue 2789: a by-tag inline spawn records the **spawner** as the
+    /// child's parent, not the cluster root — so a nested by-tag spawn (an
+    /// inline child spawning its own child, e.g. the behavior host wrapping
+    /// a widget) is reachable through the spawner's `ctx.child` /
+    /// `ctx.parent`. The spawner's own id (`0x5AFE`) is set distinct from
+    /// the cluster root (`0x1111`) so the assertion fails against the old
+    /// `registry.self_id()` behavior. Owned logic: the by-tag spawn's
+    /// parent recording, mirroring the typed `spawn_inline_child` path.
+    #[test]
+    fn spawn_inline_child_by_tag_parents_to_the_spawner_not_the_root() {
+        let registry = Registry::new();
+        registry.set_self_id(0x1111);
+        registry.set_spawn_resolver(stub_resolver);
+        STUB_INIT_CONFIG.set(None);
+
+        let spawner = 0x5AFE_u64;
+        let ctx: WasmCtx<'_, Manual> = WasmCtx::__new(spawner, &registry, NO_INBOUND_SOURCE);
+        let alias = ctx
+            .spawn_inline_child_by_tag(
+                ActorTypeTag::of::<StubChild>(),
+                Subname::Named("nested"),
+                &StubConfig { value: 1 }.encode_into_bytes(),
+            )
+            .expect("a known tag spawns its exported type");
+
+        assert_eq!(
+            registry.parent_of(alias),
+            Some(MailboxId(spawner)),
+            "the by-tag child's recorded parent is the spawner, not the cluster root",
         );
     }
 

--- a/crates/aether-actor/src/wasm/inline/compose.rs
+++ b/crates/aether-actor/src/wasm/inline/compose.rs
@@ -266,13 +266,19 @@ where
 /// `init` + insert core (issue 2690 made reconstruct decode from the slot's
 /// retained bytes too), differing only in the absence of an `on_rehydrate`
 /// state restore (a fresh spawn has no prior state). The child's logical
-/// parent is recorded as the cluster root (`registry.self_id()`), matching
-/// the flat-alias model reconstruct re-derives.
+/// parent is recorded as `parent` — the id of the actor that issued the
+/// spawn, threaded down from [`WasmCtx::spawn_inline_child_by_tag`] so a
+/// *nested* by-tag spawn (an inline child spawning its own child, e.g. the
+/// behavior host wrapping a widget) parents the new child to that spawning
+/// actor rather than the cluster root, which is what lets the spawner's
+/// `ctx.child` resolve it (issue 2688). A top-level spawn passes the root's
+/// own id, so the flat-alias model is unchanged there.
 ///
 /// Returns [`SpawnError::InitFailed`] when `A::Config` cannot decode from
 /// `config_bytes` or `A::init` returns `Err`.
 pub fn spawn_one_child<A>(
     registry: &Registry,
+    parent: u64,
     alias: MailboxId,
     type_tag: u64,
     full_subname: String,
@@ -299,7 +305,7 @@ where
         type_tag,
         full_subname,
         is_counter,
-        registry.self_id(),
+        parent,
         config_bytes.to_vec(),
         config,
     )

--- a/crates/aether-actor/src/wasm/inline/mod.rs
+++ b/crates/aether-actor/src/wasm/inline/mod.rs
@@ -172,13 +172,20 @@ pub(crate) enum ChainMode {
 /// non-capturing tag-match the macro emits over the module's exported type
 /// set — the same set [`crate::export!`]'s `@reconstruct_child` arm walks —
 /// so it coerces cleanly and stores in a `Cell`. Given the module's
-/// registry, a runtime [`ActorTypeTag`], the resolved `(is_counter,
-/// subname)` pair, and the child's config bytes, its matched branch
-/// allocates the alias and runs the shared decode + init core on the
-/// selected type; a tag matching none returns
-/// [`SpawnError::UnknownActorTag`].
+/// registry, the spawning actor's real folded id (`parent`), a runtime
+/// [`ActorTypeTag`], the resolved `(is_counter, subname)` pair, and the
+/// child's config bytes, its matched branch allocates the alias and runs
+/// the shared decode + init core on the selected type; a tag matching none
+/// returns [`SpawnError::UnknownActorTag`].
+///
+/// `parent` is threaded from the caller because a by-tag spawn can be
+/// *nested* — an inline child (e.g. the behavior host) spawning its own
+/// child by tag — and the new child's recorded parent must be that
+/// spawning actor, not the cluster root, so relative addressing
+/// (`ctx.child` / `ctx.parent`) resolves it. The typed
+/// [`WasmCtx::spawn_inline_child`] path passes the same `self.mailbox`.
 pub type SpawnByTagFn =
-    fn(&Registry, ActorTypeTag, bool, &str, &[u8]) -> Result<MailboxId, SpawnError>;
+    fn(&Registry, u64, ActorTypeTag, bool, &str, &[u8]) -> Result<MailboxId, SpawnError>;
 
 /// The per-component inline-child registry (ADR-0114 decision #3), keyed
 /// by each child's alias [`MailboxId`]. The [`crate::export!`] macro emits

--- a/crates/aether-actor/src/wasm/mod.rs
+++ b/crates/aether-actor/src/wasm/mod.rs
@@ -835,6 +835,7 @@ macro_rules! __export_internal {
     // `UnknownActorTag` *before* any allocation, so no host alias is orphaned.
     (@spawn_inline_child_by_tag $($candidate:ty),+) => {
         |__aether_registry: &$crate::wasm::inline::Registry,
+         __aether_parent: u64,
          __aether_tag: $crate::ActorTypeTag,
          __aether_is_counter: bool,
          __aether_subname: &str,
@@ -848,6 +849,7 @@ macro_rules! __export_internal {
                     );
                     return $crate::wasm::inline::compose::spawn_one_child::<$candidate>(
                         __aether_registry,
+                        __aether_parent,
                         __aether_alias,
                         __aether_tag.0,
                         $crate::__macro_internals::String::from(__aether_subname),


### PR DESCRIPTION
Closes #2789.

## Summary

A nested by-tag inline spawn parented its child to the cluster root instead of the spawning actor, so the spawner's `ctx.child(subname)` couldn't resolve the child it just spawned.

The tag-dispatched inline spawn core `spawn_one_child` (`crates/aether-actor/src/wasm/inline/compose.rs`) recorded the new child's logical parent as `registry.self_id()` — the cluster root — whereas the typed `WasmCtx::spawn_inline_child` correctly records `self.mailbox` (the spawning actor). For a top-level spawn the two agree (the spawner *is* the root), so the bug is invisible there. For a **nested** by-tag spawn — an inline child spawning its own child by tag, e.g. `BehaviorHost::wire` spawning its wrapped widget — the child is mis-parented to the root and the spawner's relative addressing (`ctx.child` / `ctx.parent`) can't find it.

`SpawnByTagFn` never received the spawner's id, so `spawn_one_child` had nothing to record but `registry.self_id()`. The fix threads the spawner's real folded id (`self.mailbox`) from `WasmCtx::spawn_inline_child_by_tag` through `SpawnByTagFn` → `spawn_one_child` → `install_inline_child`, mirroring the typed path; the `export!`-generated resolver (`crates/aether-actor/src/wasm/mod.rs`) forwards it. Top-level spawns pass the root's own id, so the flat-alias model is unchanged there.

Surfaced while implementing #2688 (the behavior-script e2e gate), whose scenario provably cannot pass without it — the same "grounding assumed a complete primitive" shape #2746 fixed on the wire-lifecycle axis. This lands first; #2688 rebases onto it as the pure fixtures/xtask/scenario PR.

**Follow-up (not in this PR):** `reconstruct_one_child` (the `replace_component` reload twin) parents to `registry.self_id()` the same way, so a hot-reload of a cluster with a nested by-tag child mis-parents it. That path is not exercised here and its fix is larger (the dehydrate bundle must carry each child's recorded parent) — its own issue.

## Test plan

`spawn_inline_child_by_tag_parents_to_the_spawner_not_the_root` — a new owned-logic tripwire in `aether-actor`'s `wasm::ctx` tests: spawns a child by tag from a ctx whose own id (`0x5AFE`, the spawner) is distinct from the cluster root (`0x1111`), and asserts `registry.parent_of(alias)` is the spawner, not the root (the assertion fails against the pre-fix `registry.self_id()` behavior). `cargo test -p aether-actor` green; `cargo clippy -p aether-actor --all-targets -- -D warnings` clean. The full e2e proof rides #2688's TestBench scenario.

## Generated by

`/implement` — split out of [#2688](https://github.com/iamacoffeepot/aether/issues/2688) as a prerequisite fix.
