### PR TITLE
chore(workflow): document local verification cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Read relevant guide pages and ADRs before changing a subsystem. Prefer current c
 - Format check: `cargo fmt -- --check`
 - Check only: `cargo check`
 
-For implementation PRs, this repo uses GitHub Actions as the full build engine. Locally run `cargo fmt` before pushing; let CI run the expensive checks unless the issue explicitly asks for local verification.
+For implementation PRs, this repo uses GitHub Actions as the full build engine. Locally run `cargo fmt` before pushing; let CI run the expensive checks unless the issue explicitly asks for local verification. If a user explicitly asks for full local build, test, or dist verification, report the result and then note that `target/` and generated `dist/` artifacts can be large, so clean them up when they are no longer needed or ask before preserving them.
 
 ## Codex Hooks
 

--- a/docs/guide/local-verification.md
+++ b/docs/guide/local-verification.md
@@ -8,7 +8,7 @@ Before you push, run one command:
 cargo fmt
 ```
 
-A formatting slip is the one CI red worth catching locally — instant to fix and the cheapest failure to avoid. Everything heavier is CI's job.
+A formatting slip is the one CI red worth catching locally — instant to fix and the cheapest failure to avoid. Everything heavier is CI's job unless the user explicitly asks for the full local verification pass. In that case, run `cargo build --workspace --all-features`, `cargo test --workspace --all-features`, and `cargo xtask dist`, then reclaim the resulting `target/` and `dist/` artifacts once they are no longer needed.
 
 Codex sessions may also load project hooks from `.codex/hooks.json` after you
 trust them with `/hooks`. Those hooks are interactive guardrails for the local


### PR DESCRIPTION
Closes #2785.

## Summary

Documents the cleanup expectation for explicit full local verification runs. Codex workflow guidance now says to report full local build/test/dist results, then reclaim or ask before preserving large `target/` and generated `dist/` artifacts.

## Test plan

- `cargo fmt`
- `git diff --check -- AGENTS.md docs/guide/local-verification.md`

## Generated by

`/implement` — agent execution of [scoped issue #2785](https://github.com/iamacoffeepot/aether/issues/2785).
