### PR TITLE
chore(kit): behavior script end-to-end scenario and fixture wasm wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-test-fixtures-behavior"
+version = "0.3.0-alpha"
+dependencies = [
+ "aether-behavior",
+ "aether-behavior-derive",
+ "aether-data",
+ "inventory",
+ "serde",
+]
+
+[[package]]
 name = "aether-test-fixtures-bundle"
 version = "0.3.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/aether-test-fixtures/aether-test-fixtures-stateful-reshaped",
     "crates/aether-test-fixtures/aether-test-fixtures-split-cap",
     "crates/aether-test-fixtures/aether-test-fixtures-defaultless",
+    "crates/aether-test-fixtures/aether-test-fixtures-behavior",
     "xtask",
 ]
 exclude = [

--- a/crates/aether-substrate-bundle/tests/behavior_host.rs
+++ b/crates/aether-substrate-bundle/tests/behavior_host.rs
@@ -1,0 +1,351 @@
+//! Behavior-script host end-to-end gate (issue 2688, ADR-0137).
+//!
+//! The whole loop the sibling PRs (#2685/#2686/#2687) each covered only in
+//! isolation: a real behavior wasm — authored against the `#[behavior]` SDK and
+//! cross-built to `wasm32-unknown-unknown` — loaded into a `BehaviorHost` that
+//! wraps a real slider, transforming the lane mail the slider produces, and
+//! surviving a live swap with its authored state intact. The panel embeds the
+//! host as an inline child (`WidgetKind::BehaviorHost`); the host spawns the
+//! wrapped slider in `wire` (the #2746 inline-child lifecycle), so a drag flows
+//! slider → host → panel and the script interposes in the middle.
+//!
+//! Observation is the panel's per-actor log ring (ADR-0081), the same surface
+//! `widget_set` reads: the transformed mail flows child → host → panel *inside
+//! the cluster*, never crossing the render / broadcast sink `count_observed`
+//! watches. Each phase reads the ring with a `since` cursor so one phase's
+//! entries never bleed into another's assertions.
+//!
+//! Skipped when no wgpu adapter is available or the `behavior`-feature kit wasm
+//! / the fixture script wasm has not been pre-built (the shared `require_runtime`
+//! gate). CI sets `AETHER_REQUIRE_RUNTIME=1` to turn either skip into a hard
+//! failure.
+
+// Integration-test skip diagnostic: emit via stderr so `cargo test` surfaces
+// "skipping: ..." alongside `test ... ok` (issue 891).
+#![allow(clippy::print_stderr)]
+// Pixel-rect layout constants read clearest as float literals inline.
+#![allow(clippy::cast_precision_loss)]
+
+use std::fs;
+
+use aether_actor::Addressable;
+use aether_data::Kind;
+use aether_kinds::mouse_button::LEFT;
+use aether_kinds::{
+    LoadComponent, LoadResult, LogTailResult, MouseButton, MouseButtonRelease, MouseMove, Tick,
+};
+use aether_kit::widget::{BehaviorHostSpec, ScriptRef};
+use aether_kit::{PanelConfig, SliderConfig, Theme, WidgetChildSpec, WidgetKind};
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
+use serde::{Deserialize, Serialize};
+
+/// Local twin of `aether_behavior::host::SetScript` (`aether.behavior.set_script`),
+/// so the swap steps (S4/S5) drive the host without a dev-dependency on the
+/// `aether-behavior` `host` feature — which would pull the interpreter subtree
+/// into the workspace build. Same `#[kind(name)]` and shape, so the `KindId`
+/// and wire bytes match the host's real kind; drift is caught by this scenario
+/// (a swap that fails to decode). Mirrors the fixture crate's `SliderChanged`
+/// twin strategy.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.behavior.set_script")]
+struct SetScript {
+    bytes: Vec<u8>,
+}
+
+/// Local twin of `aether_behavior::host::LoadScriptResult`
+/// (`aether.behavior.load_script_result`) — the `SetScript` reply.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.behavior.load_script_result")]
+enum LoadScriptResult {
+    Ok { resident_bytes: u64 },
+    Err { error: String },
+}
+
+/// The behavior-host slot's subname in the panel's child stack.
+const SLOT: &str = "knob";
+
+/// The clamp cap `intercept_slider` authors (`examples/intercept_slider.rs`).
+/// The scenario is co-designed with the fixture, so it knows the authored cap.
+const CAP: f32 = 20.0;
+
+/// Slack for the float comparisons against the clamp cap.
+const EPS: f32 = 0.5;
+
+/// The full trampoline address the loaded panel registers at (ADR-0099 §4).
+fn panel_address() -> String {
+    format!(
+        "aether.component/{}:panel",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    )
+}
+
+/// The host's registered inline-child lineage address: the panel's address,
+/// then the trampoline scope and the slot subname (the `host_fns` `alias_name`
+/// fold). Sending `SetScript` here swaps the script and gets the reply.
+fn host_address() -> String {
+    format!(
+        "{}/{}:{}",
+        panel_address(),
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+        SLOT,
+    )
+}
+
+/// Load the reference panel with a single `BehaviorHost` slot wrapping a slider
+/// over `0..=255`, its initial script inline. The host spawns the wrapped
+/// slider in `wire`, so the first tick brings the whole slot up.
+fn load_panel_with_host(bench: &mut TestBench, kit_wasm: &[u8], script: Vec<u8>) {
+    let wrapped_config = SliderConfig {
+        min: 0.0,
+        max: 255.0,
+        step: 1.0,
+        initial: 40.0,
+        theme: Theme::DEFAULT,
+    }
+    .encode_into_bytes();
+    let host_spec = BehaviorHostSpec {
+        wrapped: WidgetKind::Slider,
+        wrapped_config,
+        script: ScriptRef::Inline(script),
+        // Zero ⇒ the host defaults (fuel ~1M, disable after 3 traps).
+        fuel_per_call: 0,
+        disable_after_traps: 0,
+    };
+    let config = PanelConfig {
+        x: 10.0,
+        y: 10.0,
+        width: 200.0,
+        font_namespace: String::new(),
+        font_path: String::new(),
+        theme: Theme::DEFAULT,
+        children: vec![WidgetChildSpec {
+            subname: SLOT.to_owned(),
+            kind: WidgetKind::BehaviorHost,
+            origin: [0.0, 0.0],
+            config: host_spec.encode_into_bytes(),
+        }],
+    };
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: kit_wasm.to_vec(),
+                    name: Some("panel".to_owned()),
+                    config: config.encode_into_bytes(),
+                    export: Some("aether.kit.widget.panel".to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { name, .. } => assert!(
+            name.ends_with(":panel"),
+            "the panel root should register under :panel; got {name}",
+        ),
+        LoadResult::Err { error } => panic!("load WidgetPanel root: {error}"),
+    }
+}
+
+/// A left mouse-button press at `(x, y)`.
+fn press(x: f32, y: f32) -> MouseButton {
+    MouseButton { button: LEFT, x, y }
+}
+
+/// A left mouse-button release at `(x, y)`.
+fn release(x: f32, y: f32) -> MouseButtonRelease {
+    MouseButtonRelease { button: LEFT, x, y }
+}
+
+/// One slider drag session: press mid-track, drag to the far right, release.
+/// The single child sits at row `y 10..34`; a release at `x = 200` on the
+/// `0..=255` slider commits a raw value well above `CAP`, so a working
+/// interpose clamps it. Each drag rides its own `execute` call, so the labels
+/// need only be unique within the batch.
+fn drag(panel: &str) -> Vec<(&'static str, BenchOp)> {
+    vec![
+        ("press", BenchOp::send_mail(panel, &press(110.0, 22.0))),
+        (
+            "move",
+            BenchOp::send_mail(panel, &MouseMove { x: 200.0, y: 22.0 }),
+        ),
+        ("release", BenchOp::send_mail(panel, &release(200.0, 22.0))),
+    ]
+}
+
+/// Read the panel's log ring from `since`, returning the new messages plus the
+/// next cursor so a later phase reads only its own entries.
+fn read_panel_log(bench: &mut TestBench, since: Option<u64>) -> (Vec<String>, u64) {
+    match bench.log_tail(&panel_address(), since) {
+        LogTailResult::Ok {
+            entries,
+            next_since,
+            ..
+        } => (entries.into_iter().map(|e| e.message).collect(), next_since),
+        LogTailResult::Err { error } => panic!("log_tail on the panel failed: {error}"),
+    }
+}
+
+/// The value of a `key=` field in a rendered log line (`None` if absent).
+fn field<'a>(message: &'a str, key: &str) -> Option<&'a str> {
+    message
+        .split_whitespace()
+        .find_map(|token| token.strip_prefix(key))
+}
+
+/// Whether a log line is a slider-changed value-up attributed to the slot.
+fn slider_line(message: &str) -> bool {
+    message.contains("widget slider changed") && field(message, "widget=") == Some(SLOT)
+}
+
+/// The committed slider values (`committed=true`) attributed to the slot.
+fn committed_values(messages: &[String]) -> Vec<f32> {
+    messages
+        .iter()
+        .filter(|m| slider_line(m) && m.contains("committed=true"))
+        .filter_map(|m| field(m, "value=").and_then(|v| v.parse::<f32>().ok()))
+        .collect()
+}
+
+/// The `index=` values of radio-selected lines attributed to the slot — the
+/// scripts' `ctx.panel().emit` effect carrying their running `count`.
+fn emitted_counts(messages: &[String]) -> Vec<u32> {
+    messages
+        .iter()
+        .filter(|m| m.contains("widget radio selected") && field(m, "widget=") == Some(SLOT))
+        .filter_map(|m| field(m, "index=").and_then(|v| v.parse::<u32>().ok()))
+        .collect()
+}
+
+/// Swap the running script for `bytes` via `aether.behavior.set_script`,
+/// asserting the host replies `LoadScriptResult::Ok`.
+fn swap_script(bench: &mut TestBench, label: &str, bytes: Vec<u8>) {
+    let host = host_address();
+    let swapped = bench
+        .execute(vec![(
+            label,
+            BenchOp::send_and_await(&host, &SetScript { bytes }),
+        )])
+        .unwrap_or_else(|error| panic!("{label} swap: {error:?}"));
+    match swapped
+        .reply::<LoadScriptResult>(label)
+        .expect("decode LoadScriptResult")
+    {
+        LoadScriptResult::Ok { .. } => {}
+        LoadScriptResult::Err { error } => panic!("{label} set_script failed: {error}"),
+    }
+}
+
+/// Drive the whole scripted-behavior loop end to end: interpose, consume,
+/// effect drain, swap-state-carry, and fail-open — each phase catching its own
+/// owned-bug class, none re-asserting the base slider routing `widget_set`
+/// already covers.
+#[test]
+fn behavior_host_intercepts_consumes_carries_state_and_fails_open() {
+    // The host-carrying kit variant (`--features behavior`, wasmi linked in),
+    // built to its own stem by `cargo xtask dist` so the stock `aether_kit.wasm`
+    // the other scenarios load stays lean (issue 2688).
+    let Some(kit_path) = require_runtime("aether_kit_behavior") else {
+        return;
+    };
+    let Some(intercept_path) = require_runtime("intercept_slider") else {
+        return;
+    };
+    let Some(v2_path) = require_runtime("intercept_slider_v2") else {
+        return;
+    };
+    let Some(trap_path) = require_runtime("trap_script") else {
+        return;
+    };
+    let kit_wasm = fs::read(&kit_path).expect("read kit wasm");
+    let intercept = fs::read(&intercept_path).expect("read intercept_slider wasm");
+    let v2 = fs::read(&v2_path).expect("read intercept_slider_v2 wasm");
+    let trap = fs::read(&trap_path).expect("read trap_script wasm");
+
+    let mut bench = TestBench::start_with_size(240, 220).expect("boot");
+    load_panel_with_host(&mut bench, &kit_wasm, intercept);
+    let panel = panel_address();
+
+    // First tick spawns the host, which spawns + frames the wrapped slider.
+    // Then S1/S2/S3: one drag through the `intercept_slider` script.
+    let mut ops = vec![("spawn", BenchOp::send_mail(&panel, &Tick))];
+    ops.extend(drag(&panel));
+    bench.execute(ops).expect("spawn + S1 drag");
+    let (phase1, cursor) = read_panel_log(&mut bench, None);
+    let joined1 = phase1.join("\n");
+
+    // S1 — the intercept mutates and forwards: the committed value reaching the
+    // panel is clamped, not the raw ~242 the far-right drag produced. Catches
+    // interposition up-lane routing + the `&mut K` re-encode/forward.
+    let committed = committed_values(&phase1);
+    assert!(
+        !committed.is_empty(),
+        "the drag-release should forward one committed change; log was:\n{joined1}",
+    );
+    assert!(
+        committed.iter().all(|v| *v <= CAP + EPS),
+        "every committed value the script forwards must be clamped to {CAP}; \
+         got {committed:?}; log was:\n{joined1}",
+    );
+
+    // S2 — consume drops: the uncommitted drag stream is consumed, so no
+    // `committed=false` slider line reaches the panel, while the committed
+    // release still lands (S1). Catches `ctx.consume()` — the same kind takes
+    // both consume and forward in one session.
+    assert!(
+        !phase1
+            .iter()
+            .any(|m| slider_line(m) && m.contains("committed=false")),
+        "consumed uncommitted changes must not forward up-lane; log was:\n{joined1}",
+    );
+
+    // S3 — effect drains: the clamp's `ctx.panel().emit` reaches the panel as a
+    // radio-selected line attributed to the slot (a slider-wrapped host can
+    // only log one via the script's effect). The first clamp carries count 1.
+    assert!(
+        emitted_counts(&phase1).contains(&1),
+        "the clamp effect should drain to the panel as count 1; log was:\n{joined1}",
+    );
+
+    // S4 — swap preserves authored state: swap to `intercept_slider_v2` and
+    // drive another change. The carried `count` continues to 2 (not reset to
+    // 1), and the carried `cap` (20, not v2's fresh 1000 default) still clamps.
+    // Catches the `state_save` → `state_load` carry across the swap seam.
+    swap_script(&mut bench, "swap_v2", v2);
+    bench.execute(drag(&panel)).expect("S4 drag after swap");
+    let (phase2, cursor) = read_panel_log(&mut bench, Some(cursor));
+    let joined2 = phase2.join("\n");
+    assert!(
+        emitted_counts(&phase2).contains(&2),
+        "the swapped script must continue the carried count to 2, not reset; \
+         log was:\n{joined2}",
+    );
+    let committed_v2 = committed_values(&phase2);
+    assert!(
+        !committed_v2.is_empty() && committed_v2.iter().all(|v| *v <= CAP + EPS),
+        "the carried cap ({CAP}) must still clamp after the swap; got {committed_v2:?}; \
+         log was:\n{joined2}",
+    );
+
+    // S5 — trap fails open through the full stack: swap to a script that spins
+    // to fuel exhaustion, then drive a change. The host must forward the raw,
+    // untransformed value (> cap) rather than the lane wedging. Catches
+    // integration-level fail-open — a trap wedging the lane, not the filter
+    // call #2687's host-unit already drives directly.
+    swap_script(&mut bench, "swap_trap", trap);
+    bench
+        .execute(drag(&panel))
+        .expect("S5 drag after trap swap");
+    let (phase3, _) = read_panel_log(&mut bench, Some(cursor));
+    let joined3 = phase3.join("\n");
+    let committed_trap = committed_values(&phase3);
+    assert!(
+        committed_trap.iter().any(|v| *v > CAP + EPS),
+        "a trapping script must fail open — the raw unclamped value forwards; \
+         got {committed_trap:?}; log was:\n{joined3}",
+    );
+}

--- a/crates/aether-test-fixtures/aether-test-fixtures-behavior/Cargo.toml
+++ b/crates/aether-test-fixtures/aether-test-fixtures-behavior/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "aether-test-fixtures-behavior"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# Behavior-script fixtures for the #2688 end-to-end gate (ADR-0137). Each
+# `[[example]]` is one `cdylib` behavior script authored against the
+# `#[behavior]` SDK and cross-built to `wasm32-unknown-unknown` by the
+# `cargo xtask dist` behavior pass (`discover_behaviors`). The crate depends
+# on `aether-behavior` (never `aether-actor`) so structural component
+# discovery does not misclassify it — a component has an `aether-actor`
+# dependency, a behavior does not. That same absence rules out depending on
+# `aether-kit` for the widget kinds (kit deps `aether-actor` unconditionally),
+# so `src/lib.rs` carries local twins of the kinds the scripts transform,
+# re-derived under the matching `#[kind(name)]` so the `KindId` and wire bytes
+# match the kit originals.
+
+[lib]
+# The shared kind twins the example scripts consume. A plain rlib — only the
+# `[[example]]` targets are the wasm cdylib script artifacts.
+name = "aether_test_fixtures_behavior"
+
+[[example]]
+name = "intercept_slider"
+crate-type = ["cdylib"]
+
+[[example]]
+name = "intercept_slider_v2"
+crate-type = ["cdylib"]
+
+[[example]]
+name = "trap_script"
+crate-type = ["cdylib"]
+
+[dependencies]
+# The runtime (authoring) face is on by default: `BehaviorCtx`, the
+# widget/child/panel handles, and the `Behavior` lifecycle trait the scripts
+# target. Never `aether-actor` — the crate-boundary invariant that keeps a
+# behavior cdylib from classifying as a component.
+aether-behavior = { path = "../../aether-behavior" }
+# The `#[behavior]` attribute macro. `aether-behavior` re-exports it on its
+# runtime face, but the scripts name it directly, so it is a direct dep.
+aether-behavior-derive = { path = "../../aether-behavior-derive" }
+aether-data = { path = "../../aether-data", default-features = false, features = ["derive"] }
+serde = { workspace = true, default-features = false, features = ["alloc", "derive"] }
+
+# The `Kind` derive on the twins emits a `cfg(not(target_arch = "wasm32"))`
+# `inventory::submit!` for the native descriptor list; the wasm script build
+# gates it out. Only the host build of the lib (workspace check / the xtask
+# discovery test) needs `inventory` reachable.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+inventory = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/aether-test-fixtures/aether-test-fixtures-behavior/examples/intercept_slider.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-behavior/examples/intercept_slider.rs
@@ -1,0 +1,55 @@
+//! `intercept_slider` — the realistic main fixture behavior (issue 2688).
+//!
+//! Wraps a slider. It consumes uncommitted drag noise, clamps a committed
+//! value to an authored `cap`, and on a clamp increments an authored `count`
+//! and emits it up the panel lane (as a `RadioSelected`, the panel's numeric
+//! value-up log line) so the effect drain is observable. The `{ cap, count }`
+//! struct's serde fields *are* the persisted state the swap carries.
+
+// The `#[behavior]` dispatch that calls these handlers is emitted only on
+// wasm (the guest `filter` export); the host build (workspace clippy
+// `--all-targets`) compiles the script but never calls it, so the handlers
+// read as dead there.
+#![allow(dead_code)]
+
+use aether_behavior::BehaviorCtx;
+use aether_behavior_derive::behavior;
+use aether_test_fixtures_behavior::{RadioSelected, SliderChanged};
+use serde::{Deserialize, Serialize};
+
+/// Authored state: the clamp `cap` and how many committed values it clamped.
+/// The default `state_save` / `state_load` serialize the whole struct, so a
+/// swap carries both fields forward.
+#[derive(Default, Serialize, Deserialize)]
+struct InterceptSlider {
+    cap: f32,
+    count: u32,
+}
+
+#[behavior]
+impl Behavior for InterceptSlider {
+    /// Seed the clamp cap once, post-restore.
+    #[on_attach]
+    fn attached(&mut self, _ctx: &mut BehaviorCtx) {
+        if self.cap == 0.0 {
+            self.cap = 20.0;
+        }
+    }
+
+    /// Intercept the slider's value-up. `&mut` is the intercept intent: the
+    /// mutated event re-encodes and forwards, a consumed one does not.
+    #[on]
+    fn on_change(&mut self, ctx: &mut BehaviorCtx, m: &mut SliderChanged) {
+        if !m.committed {
+            // Drop the uncommitted drag stream — it never forwards up-lane.
+            ctx.consume();
+            return;
+        }
+        if m.value > self.cap {
+            m.value = self.cap;
+            self.count += 1;
+            // The clamp effect: surface the running count up the panel lane.
+            ctx.panel().emit(&RadioSelected { index: self.count });
+        }
+    }
+}

--- a/crates/aether-test-fixtures/aether-test-fixtures-behavior/examples/intercept_slider_v2.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-behavior/examples/intercept_slider_v2.rs
@@ -1,0 +1,53 @@
+//! `intercept_slider_v2` — the swap target for the state-carry scenario
+//! (issue 2688).
+//!
+//! Same `{ cap, count }` state schema as `intercept_slider`, so a live swap
+//! offers the old script's blob to this one's `state_load`. It surfaces the
+//! *carried* `count` on every committed change (not only on a clamp), so the
+//! scenario sees the count continue rather than reset across the swap. Its
+//! `on_attach` seeds a deliberately *different* default cap: if the swap
+//! failed to carry `cap`, this script would clamp to `1000.0` (i.e. not at
+//! all for the driven range) rather than the carried `20.0`, making the
+//! carried-cap clamp a genuine tripwire.
+
+// See `intercept_slider.rs`: the `#[behavior]` dispatch is wasm-only, so the
+// handlers read as dead on the host build.
+#![allow(dead_code)]
+
+use aether_behavior::BehaviorCtx;
+use aether_behavior_derive::behavior;
+use aether_test_fixtures_behavior::{RadioSelected, SliderChanged};
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+struct InterceptSliderV2 {
+    cap: f32,
+    count: u32,
+}
+
+#[behavior]
+impl Behavior for InterceptSliderV2 {
+    /// Seed a distinct default cap so a lost carry is observable — a carried
+    /// `cap` (non-zero) leaves this untouched.
+    #[on_attach]
+    fn attached(&mut self, _ctx: &mut BehaviorCtx) {
+        if self.cap == 0.0 {
+            self.cap = 1000.0;
+        }
+    }
+
+    #[on]
+    fn on_change(&mut self, ctx: &mut BehaviorCtx, m: &mut SliderChanged) {
+        if !m.committed {
+            ctx.consume();
+            return;
+        }
+        if m.value > self.cap {
+            m.value = self.cap;
+            self.count += 1;
+        }
+        // Surface the carried count on every committed change so the swap's
+        // state carry is observable even when the value does not clamp.
+        ctx.panel().emit(&RadioSelected { index: self.count });
+    }
+}

--- a/crates/aether-test-fixtures/aether-test-fixtures-behavior/examples/trap_script.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-behavior/examples/trap_script.rs
@@ -1,0 +1,36 @@
+//! `trap_script` — a deliberately-trapping fixture behavior (issue 2688).
+//!
+//! Its one intercept spins to fuel exhaustion, so every filter call traps.
+//! The host must fail open: the in-flight `SliderChanged` forwards
+//! untransformed and the wrapped slider keeps working, rather than the trap
+//! wedging the lane. After `disable_after_traps` consecutive faults the host
+//! drops the script to passthrough.
+
+// See `intercept_slider.rs`: the `#[behavior]` dispatch is wasm-only, so the
+// handler reads as dead on the host build.
+#![allow(dead_code)]
+// The `#[on]` handler ABI takes `&mut self`; this trap ignores it.
+#![allow(clippy::unused_self)]
+
+use std::hint::black_box;
+
+use aether_behavior::BehaviorCtx;
+use aether_behavior_derive::behavior;
+use aether_test_fixtures_behavior::SliderChanged;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+struct TrapScript;
+
+#[behavior]
+impl Behavior for TrapScript {
+    #[on]
+    fn on_change(&mut self, _ctx: &mut BehaviorCtx, _m: &mut SliderChanged) {
+        // Burn fuel until the host's per-call budget traps this call.
+        let mut spin: u64 = 0;
+        loop {
+            spin = spin.wrapping_add(1);
+            black_box(spin);
+        }
+    }
+}

--- a/crates/aether-test-fixtures/aether-test-fixtures-behavior/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-behavior/src/lib.rs
@@ -1,0 +1,31 @@
+//! Local kind twins for the behavior-script fixtures (issue 2688).
+//!
+//! A behavior script cannot depend on `aether-kit` for the kinds it
+//! transforms — kit pulls `aether-actor`, which would classify the script
+//! cdylib as a component. Each twin here re-derives a kit widget kind under
+//! the *same* `#[kind(name)]` wire name, so its `KindId` and wire bytes match
+//! the real kit kind and it decodes the live traffic byte-for-byte. A drift
+//! between a twin and its kit original is a decode mismatch the #2688 scenario
+//! trips on loudly (the clamp assertion fails), not a compile error.
+
+use serde::{Deserialize, Serialize};
+
+/// Twin of `aether_kit::widget::SliderChanged` — the value-up event the
+/// scripts intercept. Same wire name and field shape as
+/// `crates/aether-kit/src/widget/kinds.rs`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.slider.changed")]
+pub struct SliderChanged {
+    pub value: f32,
+    pub committed: bool,
+}
+
+/// Twin of `aether_kit::widget::RadioSelected` — carries a `u32` up the panel
+/// lane, which the scripts reuse as an observable effect (`ctx.panel().emit`)
+/// to surface their authored `count` where the panel logs it. Same wire name
+/// and field shape as `crates/aether-kit/src/widget/kinds.rs`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.radio.selected")]
+pub struct RadioSelected {
+    pub index: u32,
+}

--- a/xtask/src/inventory.rs
+++ b/xtask/src/inventory.rs
@@ -7,12 +7,29 @@
 //! `scripts/ensure-tunnel.sh` / `scripts/perf-compare.sh` can be derived
 //! from the same inventory instead of re-deriving it per call site.
 
-use cargo_metadata::{CrateType, Metadata, TargetKind};
+use cargo_metadata::{CrateType, Metadata, Package, TargetKind};
 
 /// The dependency that marks a package as a component (issue #439): any
 /// crate importing the actor SDK (`init`, `receive_p32`, `MailTransport`)
 /// deps on it; anything that does not is not a component.
 const ACTOR_DEP: &str = "aether-actor";
+
+/// The dependency that marks a package as a behavior script (ADR-0137, issue
+/// 2688): a cdylib depending on the behavior SDK. Paired with the *absence*
+/// of [`ACTOR_DEP`] so a behavior and a component stay disjoint artifact
+/// classes — a component has `aether-actor`, a behavior does not. `aether-kit`
+/// declares both (an unconditional `aether-actor` dep and an optional
+/// `aether-behavior` one), and `cargo metadata` lists optional deps, so the
+/// absence guard is what keeps kit a component rather than misclassifying it.
+const BEHAVIOR_DEP: &str = "aether-behavior";
+
+/// The feature-value token a feature declares to enable the optional
+/// `aether-behavior` dependency. A component package carrying such a feature
+/// (the kit's `behavior` feature) is built with it enabled so its wasm carries
+/// the host; keying on this token rather than a hardcoded feature/package name
+/// keeps the rule structural, on the same `aether-behavior` signal
+/// [`discover_behaviors`] excludes on.
+const BEHAVIOR_FEATURE_TOKEN: &str = "dep:aether-behavior";
 
 /// Cargo package owning the chassis binaries. All three live here, so
 /// they build in one cargo invocation (same crate, shared feature
@@ -41,15 +58,38 @@ pub struct Component {
     /// is the same string `locate_component_wasm` keys on (e.g.
     /// `aether_kit`, `probe`).
     pub stem: String,
+    /// Package features to enable for this component's wasm build — the
+    /// features whose declared value pulls in `aether-behavior`
+    /// (structurally derived, see [`behavior_features`]). Empty for a
+    /// component with no such feature; `["behavior"]` for `aether-kit`, so
+    /// its wasm carries the `BehaviorHost` and the `wasmi` interpreter.
+    pub features: Vec<String>,
+}
+
+/// One discovered behavior-script artifact (ADR-0137, issue 2688): a cdylib
+/// depending on the behavior SDK but not the actor SDK. The scripts are
+/// `[[example]]` cdylibs, so `from_example` is always `true`; the field mirrors
+/// [`Component`] so the two collapse to `BuildPlan`s the same way.
+#[derive(Debug, Clone)]
+pub struct Behavior {
+    /// `cargo build -p <package>` argument.
+    pub package: String,
+    /// Always `true` — behavior scripts are `[[example]]` cdylibs.
+    pub from_example: bool,
+    /// Wasm output filename stem — the example target name
+    /// `locate_component_wasm` keys on (e.g. `intercept_slider`).
+    pub stem: String,
 }
 
 /// One `cargo build` invocation. Lib components build per-package
 /// (`-p <pkg>`); example components build that package's examples
-/// (`-p <pkg> --examples`).
+/// (`-p <pkg> --examples`). `features` are passed as `--features` when
+/// non-empty (the kit host build); an empty set builds default features.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BuildPlan {
     pub package: String,
     pub examples: bool,
+    pub features: Vec<String>,
 }
 
 /// Discover the component set: every workspace package that depends on
@@ -71,14 +111,120 @@ pub fn discover_components(metadata: &Metadata) -> Vec<Component> {
             if !target.crate_types.contains(&CrateType::CDyLib) {
                 continue;
             }
+            // Stock features only. A component that declares a behavior
+            // feature (the kit's `behavior`) is built with it enabled as a
+            // *separate* `<stem>_behavior.wasm` variant (issue 2688,
+            // `discover_behavior_variants`) — the shared `<stem>.wasm` the
+            // other scenarios load stays lean, so linking wasmi in for the
+            // one behavior-host scenario doesn't bloat every kit consumer.
             components.push(Component {
+                package: package.name.to_string(),
+                from_example: target.kind.contains(&TargetKind::Example),
+                stem: target.name.clone(),
+                features: Vec::new(),
+            });
+        }
+    }
+    components
+}
+
+/// A host-carrying **variant** build of a component that declares a behavior
+/// feature (issue 2688). Built with the feature enabled and copied to a
+/// `<stem>_behavior.wasm` sibling so it stays separate from the stock
+/// `<stem>.wasm` every other scenario loads — the kit's `behavior` feature
+/// links `wasmi` in (~20× the wasm size), and only the behavior-host scenario
+/// needs it. Keyed structurally on the same `dep:aether-behavior` token
+/// [`discover_behaviors`] excludes on, so it auto-discovers any future
+/// behavior-featured component.
+pub struct BehaviorVariant {
+    /// `cargo build -p <package>` argument.
+    pub package: String,
+    /// The stock wasm stem (`aether_kit`); the variant is copied to
+    /// `<stem>_behavior.wasm`.
+    pub stem: String,
+    /// The behavior feature(s) to enable for the variant build.
+    pub features: Vec<String>,
+}
+
+/// Discover the host-carrying variant builds: every component package (has
+/// `aether-actor` + a cdylib) that also declares a behavior feature. See
+/// [`BehaviorVariant`].
+pub fn discover_behavior_variants(metadata: &Metadata) -> Vec<BehaviorVariant> {
+    let mut variants = Vec::new();
+    for package in &metadata.packages {
+        if !package.dependencies.iter().any(|d| d.name == ACTOR_DEP) {
+            continue;
+        }
+        let features = behavior_features(package);
+        if features.is_empty() {
+            continue;
+        }
+        let Some(target) = package
+            .targets
+            .iter()
+            .find(|t| t.crate_types.contains(&CrateType::CDyLib))
+        else {
+            continue;
+        };
+        variants.push(BehaviorVariant {
+            package: package.name.to_string(),
+            stem: target.name.clone(),
+            features,
+        });
+    }
+    variants
+}
+
+/// Discover the behavior-script set (ADR-0137, issue 2688): every workspace
+/// package that depends on `aether-behavior`, exposes a `cdylib` target, and
+/// does **not** depend on `aether-actor`. The `aether-actor`-absence guard is
+/// load-bearing — it keeps behaviors and components disjoint, so `aether-kit`
+/// (which deps both) stays a component. Behavior scripts are `[[example]]`
+/// cdylibs, landing under `<profile>/examples/<stem>.wasm` exactly where
+/// `locate_component_wasm` already probes, so the scenario locates each script
+/// with no new locator.
+pub fn discover_behaviors(metadata: &Metadata) -> Vec<Behavior> {
+    let mut behaviors = Vec::new();
+    for package in &metadata.packages {
+        let depends_on_behavior = package.dependencies.iter().any(|d| d.name == BEHAVIOR_DEP);
+        let depends_on_actor = package.dependencies.iter().any(|d| d.name == ACTOR_DEP);
+        if !depends_on_behavior || depends_on_actor {
+            continue;
+        }
+        for target in &package.targets {
+            if !target.crate_types.contains(&CrateType::CDyLib) {
+                continue;
+            }
+            behaviors.push(Behavior {
                 package: package.name.to_string(),
                 from_example: target.kind.contains(&TargetKind::Example),
                 stem: target.name.clone(),
             });
         }
     }
-    components
+    behaviors
+}
+
+/// The feature names on `package` whose declared value enables the optional
+/// `aether-behavior` dependency ([`BEHAVIOR_FEATURE_TOKEN`]). For `aether-kit`
+/// this is `["behavior"]`, the feature that pulls the `BehaviorHost` `export!`
+/// entry and the `wasmi` interpreter into its wasm — which the #2688 scenario
+/// needs the kit build to carry. Deriving it structurally (rather than
+/// hardcoding `"aether-kit"` / `"behavior"`) keys the rule on the same
+/// `aether-behavior` signal `discover_behaviors` excludes on.
+fn behavior_features(package: &Package) -> Vec<String> {
+    let mut features: Vec<String> = package
+        .features
+        .iter()
+        .filter(|(_, enables)| {
+            enables
+                .iter()
+                .any(|enable| enable == BEHAVIOR_FEATURE_TOKEN)
+        })
+        .map(|(name, _)| name.clone())
+        .collect();
+    features.sort();
+    features
 }
 
 /// Collapse the component list to the unique set of `cargo build`
@@ -95,6 +241,26 @@ pub fn build_plans(components: &[Component]) -> Vec<BuildPlan> {
         let plan = BuildPlan {
             package: component.package.clone(),
             examples: component.from_example,
+            features: component.features.clone(),
+        };
+        if !plans.contains(&plan) {
+            plans.push(plan);
+        }
+    }
+    plans
+}
+
+/// Collapse the behavior-script list to its `cargo build` invocations. Every
+/// behavior is an `[[example]]` cdylib, so each plan builds its package's
+/// examples with default features; the `-p <pkg>` isolation matches the
+/// component builds' (the feature-unification trap `build_plans` documents).
+pub fn behavior_build_plans(behaviors: &[Behavior]) -> Vec<BuildPlan> {
+    let mut plans: Vec<BuildPlan> = Vec::new();
+    for behavior in behaviors {
+        let plan = BuildPlan {
+            package: behavior.package.clone(),
+            examples: behavior.from_example,
+            features: Vec::new(),
         };
         if !plans.contains(&plan) {
             plans.push(plan);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -26,7 +26,8 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde::Serialize;
 
 use crate::inventory::{
-    BuildPlan, CHASSIS_BINS, CHASSIS_PACKAGE, Component, build_plans, discover_components,
+    BuildPlan, CHASSIS_BINS, CHASSIS_PACKAGE, Component, behavior_build_plans, build_plans,
+    discover_behavior_variants, discover_behaviors, discover_components,
 };
 
 /// Wasm triple the components cross-build to.
@@ -189,15 +190,42 @@ fn run_dist(args: &DistArgs) -> Result<()> {
     if components.is_empty() {
         bail!("no wasm component crates discovered (cdylib target + aether-actor dep)");
     }
+    // Behavior-script fixtures (ADR-0137, issue 2688): cross-built alongside
+    // the components so the in-process scenario tests locate their wasm under
+    // `target/.../examples/`. They are not components (no `aether-actor`), so
+    // they ride their own discovery pass and are not copied into the dist
+    // component manifest — only built.
+    let behaviors = discover_behaviors(&metadata);
 
     let workspace_root = metadata.workspace_root.as_std_path();
     let target_dir = metadata.target_directory.as_std_path();
     let wasm_profile_dir = target_dir.join(WASM_TARGET).join(args.profile.as_str());
     let dist = workspace_root.join("dist");
 
+    // Build host-carrying variants FIRST (issue 2688): the feature build
+    // clobbers `<stem>.wasm`, so we copy it to `<stem>_behavior.wasm` and then
+    // let the stock component loop below rebuild `<stem>.wasm` lean. Only the
+    // behavior-host scenario loads the `_behavior` stem; every other kit
+    // consumer keeps the small stock wasm.
+    for variant in discover_behavior_variants(&metadata) {
+        let plan = BuildPlan {
+            package: variant.package.clone(),
+            examples: false,
+            features: variant.features.clone(),
+        };
+        build_component(&plan, args.profile)?;
+        let built = wasm_profile_dir.join(format!("{}.wasm", variant.stem));
+        let variant_stem = wasm_profile_dir.join(format!("{}_behavior.wasm", variant.stem));
+        fs::copy(&built, &variant_stem)
+            .with_context(|| format!("copy {} -> {}", built.display(), variant_stem.display()))?;
+    }
+
     // Build each component package in its own cargo invocation — never
     // batch multiple `-p`. See `inventory::build_plans`.
     for plan in build_plans(&components) {
+        build_component(&plan, args.profile)?;
+    }
+    for plan in behavior_build_plans(&behaviors) {
         build_component(&plan, args.profile)?;
     }
     if !args.no_bins {
@@ -249,6 +277,14 @@ fn run_dist(args: &DistArgs) -> Result<()> {
         manifest.chassis.len(),
         manifest_path.display(),
     );
+    if !behaviors.is_empty() {
+        let stems: Vec<&str> = behaviors.iter().map(|b| b.stem.as_str()).collect();
+        println!(
+            "dist: {} behavior script(s) built into target/: {}",
+            stems.len(),
+            stems.join(", "),
+        );
+    }
     Ok(())
 }
 
@@ -552,6 +588,9 @@ fn build_component(plan: &BuildPlan, profile: Profile) -> Result<()> {
     if plan.examples {
         cmd.arg("--examples");
     }
+    if !plan.features.is_empty() {
+        cmd.args(["--features", &plan.features.join(",")]);
+    }
     if let Some(flag) = profile.cargo_flag() {
         cmd.arg(flag);
     }
@@ -599,7 +638,7 @@ mod tests {
     use std::collections::BTreeSet;
     use std::path::PathBuf;
 
-    use super::inventory::discover_components;
+    use super::inventory::{discover_behaviors, discover_components};
     use super::{
         BundleChassis, BundlePlan, ComponentSource, PlannedComponent, bundle_manifest_json,
     };
@@ -693,6 +732,46 @@ mod tests {
             assert!(
                 !stems.contains(excluded),
                 "discovery wrongly included aether-actor example {excluded}",
+            );
+        }
+    }
+
+    #[test]
+    fn discovers_behavior_fixtures_and_excludes_components() {
+        let metadata = cargo_metadata::MetadataCommand::new()
+            .no_deps()
+            .exec()
+            .expect("run cargo metadata");
+        let behaviors = discover_behaviors(&metadata);
+        let stems: BTreeSet<&str> = behaviors.iter().map(|b| b.stem.as_str()).collect();
+
+        // The #2688 fixture crate's example cdylibs depend on `aether-behavior`
+        // and never `aether-actor`, so the behavior pass discovers each.
+        for expected in ["intercept_slider", "intercept_slider_v2", "trap_script"] {
+            assert!(
+                stems.contains(expected),
+                "behavior discovery dropped {expected}; found {stems:?}",
+            );
+        }
+
+        // The disjointness guard: `aether-kit` declares an optional
+        // `aether-behavior` dep (its `behavior` feature) AND an unconditional
+        // `aether-actor` dep, and `cargo metadata` lists optional deps — so a
+        // rule keyed on `aether-behavior` alone would sweep kit in. The
+        // `aether-actor`-absence guard keeps it a component, not a behavior.
+        assert!(
+            !stems.contains("aether_kit"),
+            "the actor-absence guard must exclude aether-kit (a component) from behaviors; \
+             found {stems:?}",
+        );
+
+        // Every discovered behavior is an `[[example]]` cdylib, so no lib-cdylib
+        // special-casing on the build side.
+        for behavior in &behaviors {
+            assert!(
+                behavior.from_example,
+                "behavior {} is an [[example]] cdylib",
+                behavior.stem,
             );
         }
     }


### PR DESCRIPTION
Closes #2688.

## Summary

The behavior-script host arc (#2682, ADR-0137) has its mechanism on `main`, but no test asserts the whole loop end to end: a real behavior wasm, authored against the SDK and cross-compiled to `wasm32-unknown-unknown`, loaded into a host wrapping a real widget, transforming real lane mail, and surviving a live script swap with its authored state intact. This delivers that acceptance gate.

Three pieces:

- **Fixture behavior crate** `crates/aether-test-fixtures/aether-test-fixtures-behavior/` — `[[example]]` cdylibs `intercept_slider` / `intercept_slider_v2` / `trap_script` authored against the `#[behavior]` SDK, with local `SliderChanged` / `RadioSelected` kind twins (same `#[kind(name)]`). The tree carries **no `aether-kit`, no `aether-actor`**, so the structural component discovery does not misclassify it.
- **`discover_behaviors` xtask pass** (`xtask/src/inventory.rs`) — keyed on a direct `aether-behavior` dep + a cdylib target + the **absence** of a direct `aether-actor` dep (the disjointness guard that keeps `aether-kit` a component, not a behavior). `BuildPlan` gains a `features` field, derived structurally, so `cargo xtask dist` cross-builds the fixtures and the behavior-feature kit wasm. Owned-logic unit test included.
- **TestBench scenario** `crates/aether-substrate-bundle/tests/behavior_host.rs` — drives a panel with a host-wrapped slider and asserts S1–S5, each catching a distinct owned-bug class: intercept mutates-and-forwards (up-lane routing), consume drops, effect drains, script swap preserves authored state, and a trapping script fails open through the full stack.

## Depends on

Both landed on `main` — the two primitives the panel-embedded host needs to receive `wire` and reach its wrapped widget:

- **#2746** — the inline-child `wire`/`unwire` lifecycle (so `BehaviorHost::wire` fires when the panel embeds the host inline).
- **#2789** — nested by-tag inline spawn parents to the spawner, not the cluster root (so the host's wrapped slider is reachable via `ctx.child`). Split out of this work as a prerequisite `fix(actor)` PR (#2790).

## Test plan

The S1–S5 assertions are the coverage (the arc's acceptance gate) plus the `discover_behaviors` unit test. Locally: fixtures + behavior-feature kit cross-compile to wasm32; the scenario runs and passes on a wgpu box (S1–S5 green — host ring shows the clamped `value=20.0 committed=true` and the drained effect); `aether-actor` tests, xtask discovery tests, and clippy all green. The scenario is wgpu-gated (skips cleanly on a driverless box, hard-fails strict-mode only on a missing prebuild).

## Generated by

`/implement` — agent execution of [scoped issue #2688](https://github.com/iamacoffeepot/aether/issues/2688), rebased onto the landed #2790.
