### PR TITLE
chore(substrate-bundle): make fleetbench dist precondition clearer

### DIFF
--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -223,14 +223,14 @@ struct ManifestView {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) enum DistManifestClassification {
+pub enum DistManifestClassification {
     Available { relative_path: String },
     MissingStem,
     Unparseable,
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) enum DistComponentGuardOutcome {
+pub enum DistComponentGuardOutcome {
     Available,
     Skip(String),
     RequireRuntime(String),
@@ -1159,7 +1159,7 @@ fn dist_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../dist")
 }
 
-pub(crate) fn classify_dist_manifest(raw: &str, stem: &str) -> DistManifestClassification {
+pub fn classify_dist_manifest(raw: &str, stem: &str) -> DistManifestClassification {
     let manifest: ManifestView = match serde_json::from_str(raw) {
         Ok(manifest) => manifest,
         Err(_) => return DistManifestClassification::Unparseable,
@@ -1168,8 +1168,9 @@ pub(crate) fn classify_dist_manifest(raw: &str, stem: &str) -> DistManifestClass
         .components
         .get(stem)
         .cloned()
-        .map(|relative_path| DistManifestClassification::Available { relative_path })
-        .unwrap_or(DistManifestClassification::MissingStem)
+        .map_or(DistManifestClassification::MissingStem, |relative_path| {
+            DistManifestClassification::Available { relative_path }
+        })
 }
 
 fn dist_component_message(stem: &str, manifest_path: &Path, detail: &str) -> String {
@@ -1183,10 +1184,10 @@ fn require_runtime_enabled() -> bool {
     env::var("AETHER_REQUIRE_RUNTIME").is_ok()
 }
 
-pub(crate) fn dist_component_guard_outcome(
+pub fn dist_component_guard_outcome(
     stem: &str,
     manifest_path: &Path,
-    classification: DistManifestClassification,
+    classification: &DistManifestClassification,
     require_runtime: bool,
 ) -> DistComponentGuardOutcome {
     let unavailable = |detail: &str| {
@@ -1248,7 +1249,7 @@ fn dist_component_guard_for_requirement(
         DistComponentRequirement::StemMissing => dist_component_guard_outcome(
             stem,
             manifest_path,
-            DistManifestClassification::MissingStem,
+            &DistManifestClassification::MissingStem,
             require_runtime,
         ),
     }

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -222,6 +222,27 @@ struct ManifestView {
     components: BTreeMap<String, String>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum DistManifestClassification {
+    Available { relative_path: String },
+    MissingStem,
+    Unparseable,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum DistComponentGuardOutcome {
+    Available,
+    Skip(String),
+    RequireRuntime(String),
+}
+
+enum DistComponentRequirement {
+    Available(PathBuf),
+    ManifestAbsent,
+    ManifestUnreadable(String),
+    StemMissing,
+}
+
 /// The three `LoadResult::Ok` fields a loaded component exposes:
 /// the assigned trampoline `mailbox_id` (the [`replace`](FleetBench::replace)
 /// target), the rendered ADR-0099 lineage `addr`, and the advertised
@@ -1138,45 +1159,150 @@ fn dist_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../dist")
 }
 
-/// Manifest-presence guard for the `FleetBench` tests that load component
-/// wasm. Returns `true` when `dist/manifest.json` is present (the test
-/// proceeds); returns `false` when it's absent so the caller can
-/// early-return as a skip — except under `AETHER_REQUIRE_RUNTIME` (which
-/// CI sets), where a missing manifest panics so a missing
-/// `cargo xtask dist` pre-build can't pass silently. Mirrors
-/// `headless_autoload.rs`'s pre-built-wasm skip/require convention (issue
-/// 891): a bare `cargo nextest run` in a worktree that hasn't run
-/// `cargo xtask dist` skips instead of reporting hard failures that read
-/// as regressions.
-///
-/// [`read_component_wasm`] itself keeps its panic: past this guard the
-/// manifest is present, and a manifest that exists but is missing a
-/// requested stem (a stale dist, not an unbuilt one) is a real test bug.
-#[must_use]
-pub fn dist_manifest_present() -> bool {
-    let manifest_path = dist_dir().join("manifest.json");
-    if manifest_path.exists() {
-        return true;
+pub(crate) fn classify_dist_manifest(raw: &str, stem: &str) -> DistManifestClassification {
+    let manifest: ManifestView = match serde_json::from_str(raw) {
+        Ok(manifest) => manifest,
+        Err(_) => return DistManifestClassification::Unparseable,
+    };
+    manifest
+        .components
+        .get(stem)
+        .cloned()
+        .map(|relative_path| DistManifestClassification::Available { relative_path })
+        .unwrap_or(DistManifestClassification::MissingStem)
+}
+
+fn dist_component_message(stem: &str, manifest_path: &Path, detail: &str) -> String {
+    format!(
+        "component stem {stem:?} unavailable via {}; {detail}; run `cargo xtask dist` to build the component wasm + manifest, then remove generated `dist/` once it is no longer needed",
+        manifest_path.display(),
+    )
+}
+
+fn require_runtime_enabled() -> bool {
+    env::var("AETHER_REQUIRE_RUNTIME").is_ok()
+}
+
+pub(crate) fn dist_component_guard_outcome(
+    stem: &str,
+    manifest_path: &Path,
+    classification: DistManifestClassification,
+    require_runtime: bool,
+) -> DistComponentGuardOutcome {
+    let unavailable = |detail: &str| {
+        let message = dist_component_message(stem, manifest_path, detail);
+        if require_runtime {
+            DistComponentGuardOutcome::RequireRuntime(message)
+        } else {
+            DistComponentGuardOutcome::Skip(message)
+        }
+    };
+    match classification {
+        DistManifestClassification::Available { .. } => DistComponentGuardOutcome::Available,
+        DistManifestClassification::MissingStem => unavailable("stem is missing from the manifest"),
+        DistManifestClassification::Unparseable => {
+            unavailable("manifest is unreadable or does not parse as dist metadata")
+        }
     }
-    assert!(
-        env::var("AETHER_REQUIRE_RUNTIME").is_err(),
-        "AETHER_REQUIRE_RUNTIME set but {} is absent; \
-         run `cargo xtask dist` to build the component wasm + manifest",
-        manifest_path.display(),
-    );
-    eprintln!(
-        "skipping: {} absent; \
-         run `cargo xtask dist` first to build the component wasm + manifest",
-        manifest_path.display(),
-    );
-    false
+}
+
+fn dist_component_requirement(stem: &str) -> DistComponentRequirement {
+    let dist = dist_dir();
+    let manifest_path = dist.join("manifest.json");
+    let raw = match fs::read_to_string(&manifest_path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            return DistComponentRequirement::ManifestAbsent;
+        }
+        Err(e) => return DistComponentRequirement::ManifestUnreadable(e.to_string()),
+    };
+    match classify_dist_manifest(&raw, stem) {
+        DistManifestClassification::Available { relative_path } => {
+            DistComponentRequirement::Available(dist.join(relative_path))
+        }
+        DistManifestClassification::MissingStem => DistComponentRequirement::StemMissing,
+        DistManifestClassification::Unparseable => DistComponentRequirement::ManifestUnreadable(
+            "manifest does not parse as dist metadata".to_owned(),
+        ),
+    }
+}
+
+fn dist_component_guard_for_requirement(
+    stem: &str,
+    manifest_path: &Path,
+    requirement: DistComponentRequirement,
+    require_runtime: bool,
+) -> DistComponentGuardOutcome {
+    let unavailable = |detail: &str| {
+        let message = dist_component_message(stem, manifest_path, detail);
+        if require_runtime {
+            DistComponentGuardOutcome::RequireRuntime(message)
+        } else {
+            DistComponentGuardOutcome::Skip(message)
+        }
+    };
+    match requirement {
+        DistComponentRequirement::Available(_) => DistComponentGuardOutcome::Available,
+        DistComponentRequirement::ManifestAbsent => unavailable("manifest is absent"),
+        DistComponentRequirement::ManifestUnreadable(detail) => unavailable(&detail),
+        DistComponentRequirement::StemMissing => dist_component_guard_outcome(
+            stem,
+            manifest_path,
+            DistManifestClassification::MissingStem,
+            require_runtime,
+        ),
+    }
+}
+
+fn component_wasm_path_result(stem: &str) -> Result<PathBuf, String> {
+    let manifest_path = dist_dir().join("manifest.json");
+    match dist_component_requirement(stem) {
+        DistComponentRequirement::Available(path) => Ok(path),
+        DistComponentRequirement::ManifestAbsent => Err(dist_component_message(
+            stem,
+            &manifest_path,
+            "manifest is absent",
+        )),
+        DistComponentRequirement::ManifestUnreadable(detail) => {
+            Err(dist_component_message(stem, &manifest_path, &detail))
+        }
+        DistComponentRequirement::StemMissing => Err(dist_component_message(
+            stem,
+            &manifest_path,
+            "stem is missing from the manifest",
+        )),
+    }
+}
+
+/// Stem-aware dist precondition guard for `FleetBench` tests that load
+/// component wasm. Returns `true` when the manifest exists, parses, and
+/// contains `stem`; returns `false` after printing a `skipping:` line
+/// locally when the precondition is not met. Under
+/// `AETHER_REQUIRE_RUNTIME`, the same actionable message panics so a
+/// missing or stale `cargo xtask dist` pre-build can't pass silently.
+#[must_use]
+pub fn dist_component_available(stem: &str) -> bool {
+    let manifest_path = dist_dir().join("manifest.json");
+    match dist_component_guard_for_requirement(
+        stem,
+        &manifest_path,
+        dist_component_requirement(stem),
+        require_runtime_enabled(),
+    ) {
+        DistComponentGuardOutcome::Available => true,
+        DistComponentGuardOutcome::Skip(message) => {
+            eprintln!("skipping: {message}");
+            false
+        }
+        DistComponentGuardOutcome::RequireRuntime(message) => panic!("{message}"),
+    }
 }
 
 /// Read a component wasm by stem through `dist/manifest.json` (the
 /// #1445 dist tree). Panics with a `cargo xtask dist` hint if the
 /// manifest is absent — the harness can't locate component wasm without
-/// it. Tests guard their load path with [`dist_manifest_present`] so a
-/// missing manifest skips rather than reaching this panic.
+/// it. Tests guard their load path with [`dist_component_available`] so a
+/// missing manifest or stale stem skips rather than reaching this panic.
 pub fn read_component_wasm(stem: &str) -> Vec<u8> {
     let wasm_path = component_wasm_path(stem);
     fs::read(&wasm_path)
@@ -1186,22 +1312,9 @@ pub fn read_component_wasm(stem: &str) -> Vec<u8> {
 /// The absolute on-disk path of a component wasm by stem, resolved through
 /// `dist/manifest.json` (the #1445 dist tree) — the staged path the
 /// ADR-0116 `upload_component` reads. Tests guard with
-/// [`dist_manifest_present`] before reaching this. Panics with a
-/// `cargo xtask dist` hint if the manifest is absent or the stem is
+/// [`dist_component_available`] before reaching this. Panics with a
+/// `cargo xtask dist` hint if the manifest is absent, unreadable, or the stem is
 /// missing.
 pub fn component_wasm_path(stem: &str) -> PathBuf {
-    let dist = dist_dir();
-    let manifest_path = dist.join("manifest.json");
-    let raw = fs::read_to_string(&manifest_path).unwrap_or_else(|e| {
-        panic!(
-            "reading {} ({e}); run `cargo xtask dist` first to build the component wasm + manifest",
-            manifest_path.display(),
-        )
-    });
-    let manifest: ManifestView =
-        serde_json::from_str(&raw).expect("test setup: dist/manifest.json parses");
-    let rel = manifest.components.get(stem).unwrap_or_else(|| {
-        panic!("component stem {stem:?} is not in dist/manifest.json; run `cargo xtask dist`")
-    });
-    dist.join(rel)
+    component_wasm_path_result(stem).unwrap_or_else(|message| panic!("{message}"))
 }

--- a/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
@@ -21,7 +21,9 @@ mod tests {
         UploadComponentResult,
     };
 
-    use crate::fleetbench::{FleetBench, component_wasm_path, dist_manifest_present, poll_until};
+    use crate::fleetbench::{
+        FleetBench, component_wasm_path, dist_component_available, poll_until,
+    };
 
     /// The probe fixture's declared `Addressable::NAMESPACE` (distinct from the
     /// `probe` wasm stem).
@@ -136,7 +138,7 @@ mod tests {
     /// identical re-upload, and replaces by hash.
     #[test]
     fn fleetbench_uploads_resolves_loads_and_replaces_a_component() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let probe_path = component_wasm_path("aether_test_fixtures_bundle")
@@ -222,7 +224,7 @@ mod tests {
     /// resolve hub-local, stage the bytes, and spawn with the manifest.
     #[test]
     fn fleetbench_boots_a_component_set_from_a_selector_manifest() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let probe_path = component_wasm_path("aether_test_fixtures_bundle")

--- a/crates/aether-substrate-bundle/tests/fleetbench_describe.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_describe.rs
@@ -11,7 +11,7 @@ mod tests {
     use aether_data::Kind;
     use aether_kinds::{DescribeComponent, DescribeComponentResult, Key, Tick};
 
-    use crate::fleetbench::{FleetBench, dist_manifest_present};
+    use crate::fleetbench::{FleetBench, dist_component_available};
 
     /// Load the `probe` component, then send `aether.component.describe`
     /// addressed by the lineage name `load` hands back and assert the reply
@@ -21,7 +21,7 @@ mod tests {
     /// `ComponentCapabilities` it retained at load, not the lossy projection.
     #[test]
     fn fleetbench_describe_resolves_caps_by_lineage_name() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let mut bench = FleetBench::start();
@@ -73,7 +73,7 @@ mod tests {
     /// fail-fast negative path.
     #[test]
     fn fleetbench_describe_unknown_name_errs() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let mut bench = FleetBench::start();

--- a/crates/aether-substrate-bundle/tests/fleetbench_dist_precondition.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_dist_precondition.rs
@@ -1,0 +1,65 @@
+mod fleetbench;
+
+mod tests {
+    use std::path::Path;
+
+    use crate::fleetbench::{
+        DistComponentGuardOutcome, DistManifestClassification, classify_dist_manifest,
+        dist_component_guard_outcome,
+    };
+
+    #[test]
+    fn manifest_with_bundle_stem_is_available() {
+        let manifest = r#"{
+            "components": {
+                "aether_test_fixtures_bundle": "components/aether_test_fixtures_bundle.wasm"
+            }
+        }"#;
+        assert!(matches!(
+            classify_dist_manifest(manifest, "aether_test_fixtures_bundle"),
+            DistManifestClassification::Available { .. }
+        ));
+    }
+
+    #[test]
+    fn manifest_missing_bundle_stem_is_classified() {
+        let manifest = r#"{
+            "components": {
+                "aether_kit": "components/aether_kit.wasm"
+            }
+        }"#;
+        assert_eq!(
+            classify_dist_manifest(manifest, "aether_test_fixtures_bundle"),
+            DistManifestClassification::MissingStem,
+        );
+    }
+
+    #[test]
+    fn missing_stem_skips_locally_and_panics_when_runtime_is_required() {
+        let manifest_path = Path::new("/tmp/dist/manifest.json");
+        let local = dist_component_guard_outcome(
+            "aether_test_fixtures_bundle",
+            manifest_path,
+            DistManifestClassification::MissingStem,
+            false,
+        );
+        let required = dist_component_guard_outcome(
+            "aether_test_fixtures_bundle",
+            manifest_path,
+            DistManifestClassification::MissingStem,
+            true,
+        );
+
+        let DistComponentGuardOutcome::Skip(skip_message) = local else {
+            panic!("missing stem should skip locally");
+        };
+        let DistComponentGuardOutcome::RequireRuntime(panic_message) = required else {
+            panic!("missing stem should require runtime under AETHER_REQUIRE_RUNTIME");
+        };
+        assert_eq!(skip_message, panic_message);
+        assert!(skip_message.contains("aether_test_fixtures_bundle"));
+        assert!(skip_message.contains("/tmp/dist/manifest.json"));
+        assert!(skip_message.contains("cargo xtask dist"));
+        assert!(skip_message.contains("remove generated `dist/`"));
+    }
+}

--- a/crates/aether-substrate-bundle/tests/fleetbench_dist_precondition.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_dist_precondition.rs
@@ -40,13 +40,13 @@ mod tests {
         let local = dist_component_guard_outcome(
             "aether_test_fixtures_bundle",
             manifest_path,
-            DistManifestClassification::MissingStem,
+            &DistManifestClassification::MissingStem,
             false,
         );
         let required = dist_component_guard_outcome(
             "aether_test_fixtures_bundle",
             manifest_path,
-            DistManifestClassification::MissingStem,
+            &DistManifestClassification::MissingStem,
             true,
         );
 

--- a/crates/aether-substrate-bundle/tests/fleetbench_inline_child.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_inline_child.rs
@@ -22,7 +22,7 @@ mod tests {
         INLINE_WHO_PARENT, InlineEcho, InlineProbe,
     };
 
-    use crate::fleetbench::{FleetBench, dist_manifest_present};
+    use crate::fleetbench::{FleetBench, dist_component_available};
 
     /// Load `inline_child`, address its inline child by the rendered
     /// lineage name over the wire, and assert the child replied
@@ -33,7 +33,7 @@ mod tests {
     /// home over the real RPC stack.
     #[test]
     fn fleetbench_inline_child_handles_mail_to_its_lineage_address() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let mut bench = FleetBench::start();
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn fleetbench_inline_configured_child_state_survives_replace() {
         const BUMPS: u32 = 3;
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let mut bench = FleetBench::start();

--- a/crates/aether-substrate-bundle/tests/fleetbench_load.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_load.rs
@@ -11,7 +11,7 @@ mod tests {
     use aether_data::Kind;
     use aether_kinds::{LoadComponent, LoadResult};
 
-    use crate::fleetbench::{FleetBench, dist_manifest_present};
+    use crate::fleetbench::{FleetBench, dist_component_available};
 
     /// Load the `probe` component and assert `LoadResult.name` is the
     /// `/`-rendered lineage
@@ -24,7 +24,7 @@ mod tests {
     /// round-trip, exercising the benchmark-ready trace object.
     #[test]
     fn fleetbench_loads_probe_at_its_lineage_address() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let mut bench = FleetBench::start();

--- a/crates/aether-substrate-bundle/tests/fleetbench_logs.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_logs.rs
@@ -9,7 +9,7 @@ mod fleetbench;
 mod tests {
     use aether_kinds::LogTailResult;
 
-    use crate::fleetbench::{FleetBench, dist_manifest_present, poll_until};
+    use crate::fleetbench::{FleetBench, dist_component_available, poll_until};
 
     /// `info` in the `0 = trace .. 4 = error` level mapping shared
     /// across `aether.log.*`.
@@ -22,7 +22,7 @@ mod tests {
     /// walk.
     #[test]
     fn fleetbench_actor_logs_surface_the_probe_first_tick_entry() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let mut bench = FleetBench::start();

--- a/crates/aether-substrate-bundle/tests/fleetbench_mail.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_mail.rs
@@ -17,7 +17,7 @@ mod tests {
     use aether_kinds::trace::DispatchTraced;
     use aether_test_fixtures_kinds::{ConfigEcho, ConfigQuery, ProbeConfig};
 
-    use crate::fleetbench::{FleetBench, dist_manifest_present};
+    use crate::fleetbench::{FleetBench, dist_component_available};
 
     /// Ping-pong (verify-first, the #1451 deferral): load
     /// `ProbeWithConfig` from the `probe` bundle with a seeded `ProbeConfig`, send it a
@@ -34,7 +34,7 @@ mod tests {
     /// mail rows.
     #[test]
     fn fleetbench_pingpong_echoes_typed_config() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let mut bench = FleetBench::start();

--- a/crates/aether-substrate-bundle/tests/fleetbench_matrix_sweep.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_matrix_sweep.rs
@@ -34,7 +34,7 @@ mod tests {
     use aether_kinds::{LogEntry, LogTailResult};
     use aether_test_fixtures_kinds::{CollectMatrix, MatrixReport, RunMatrix};
 
-    use crate::fleetbench::{FleetBench, dist_manifest_present};
+    use crate::fleetbench::{FleetBench, dist_component_available};
 
     /// Drive the full cluster-addressing matrix over the wire and assert
     /// every cell: in-cluster delivery + the source each recipient read,
@@ -42,7 +42,7 @@ mod tests {
     /// log.
     #[test]
     fn fleetbench_matrix_sweep_covers_every_addressing_cell() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let mut bench = FleetBench::start();

--- a/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
@@ -15,7 +15,7 @@ mod tests {
     use aether_kit::camera::CameraCreate;
     use aether_test_fixtures_kinds::SetRender;
 
-    use crate::fleetbench::{FleetBench, dist_manifest_present};
+    use crate::fleetbench::{FleetBench, dist_component_available};
 
     /// Load `probe` (handlers `SetRender` + `Tick`), then `replace`
     /// it with `aether-kit`'s non-entry `aether.camera` export (selector
@@ -30,7 +30,7 @@ mod tests {
     /// the live mailbox afterward.
     #[test]
     fn fleetbench_replaces_probe_with_camera_at_a_stable_address() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let mut bench = FleetBench::start();
@@ -104,7 +104,7 @@ mod tests {
     /// wire, not just the in-process path.
     #[test]
     fn fleetbench_replace_targets_a_non_entry_export() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let mut bench = FleetBench::start();

--- a/crates/aether-substrate-bundle/tests/replace_drop_reply_routing.rs
+++ b/crates/aether-substrate-bundle/tests/replace_drop_reply_routing.rs
@@ -18,7 +18,7 @@ mod tests {
         DropComponent, DropResult, LoadComponent, LoadResult, ReplaceComponent, ReplaceResult,
     };
 
-    use crate::fleetbench::{FleetBench, dist_manifest_present, read_component_wasm};
+    use crate::fleetbench::{FleetBench, dist_component_available, read_component_wasm};
 
     /// Load the `probe` component, then drive a `ReplaceComponent`
     /// and a `DropComponent` to its cap over the real wire and assert
@@ -29,7 +29,7 @@ mod tests {
     /// reply set came back empty.
     #[test]
     fn forwarded_replace_and_drop_route_their_reply() {
-        if !dist_manifest_present() {
+        if !dist_component_available("aether_test_fixtures_bundle") {
             return;
         }
         let mut bench = FleetBench::start();


### PR DESCRIPTION
Closes #2784.

## Summary

Makes the FleetBench dist precondition stem-aware instead of treating a present `dist/manifest.json` as enough. The shared guard now distinguishes missing, unreadable, and stale manifests; local runs skip with an actionable diagnostic, while `AETHER_REQUIRE_RUNTIME=1` panics with the same recovery text.

## Test plan

- `cargo fmt`
- `git diff --check -- crates/aether-substrate-bundle/tests/fleetbench/mod.rs crates/aether-substrate-bundle/tests/fleetbench_dist_precondition.rs`
- CI will run the narrow and workspace tests.

## Generated by

`/implement` — agent execution of [scoped issue #2784](https://github.com/iamacoffeepot/aether/issues/2784).
