### PR TITLE
flake(substrate-bundle): stabilize fleetbench component store isolation

### DIFF
--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -39,8 +39,9 @@ use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use aether_capabilities::rpc::{
     Hello, HelloAck, MailEnvelope, MailboxAddress, PeerKind, RpcServerCapability, RpcServerConfig,
@@ -141,6 +142,8 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// slow-but-healthy fork that registers late is not called dead.
 /// Overridable via `AETHER_FLEETBENCH_POLL_SECS`.
 const DEFAULT_POLL_SECS: u64 = 30;
+
+static STORE_ROOT_NONCE: AtomicU64 = AtomicU64::new(0);
 
 /// Resolve the in-test poll budget from `AETHER_FLEETBENCH_POLL_SECS`
 /// (default [`DEFAULT_POLL_SECS`]; `0` → wait forever).
@@ -1086,15 +1089,30 @@ impl Drop for FleetBench {
 /// `boot_hub` as `EngineConfig::engine_store_root` (ADR-0090) — not an
 /// env var — so the cap resolves it at `EngineServer::init`.
 fn isolate_store_root() -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_nanos());
-    // Each `FleetBench` in a process gets a fresh `nanos`-tagged root, so
-    // a concurrent bench in the same process can't collide either.
-    //
-    // The hub's binary store (ADR-0115) is isolated under `root/binaries`
-    // too, but that dir rides `EngineConfig::binary_store_dir` (ADR-0090).
-    env::temp_dir().join(format!("aether-fleetbench-{}-{nanos}", process::id()))
+    let temp_dir = env::temp_dir();
+    loop {
+        let nonce = STORE_ROOT_NONCE.fetch_add(1, Ordering::Relaxed);
+        // Each `FleetBench` in a process gets a fresh nonce-tagged root,
+        // and `create_dir` claims it before `boot_hub` opens
+        // `root/binaries`, so a concurrent same-process bench can't race on
+        // the path.
+        //
+        // The hub's binary store (ADR-0115) is isolated under
+        // `root/binaries` too, but that dir rides
+        // `EngineConfig::binary_store_dir` (ADR-0090).
+        let root = temp_dir.join(format!("aether-fleetbench-{}-{nonce}", process::id()));
+        match fs::create_dir(&root) {
+            Ok(()) => return root,
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => continue,
+            Err(e) => {
+                panic!("test setup: creating store root {} ({e})", root.display())
+            }
+        }
+    }
+}
+
+pub(crate) fn allocate_store_root_for_test() -> PathBuf {
+    isolate_store_root()
 }
 
 /// Boot a hub-shaped passive chassis: a forwarding `RpcServerCapability`

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -1103,7 +1103,7 @@ fn isolate_store_root() -> PathBuf {
         let root = temp_dir.join(format!("aether-fleetbench-{}-{nonce}", process::id()));
         match fs::create_dir(&root) {
             Ok(()) => return root,
-            Err(e) if e.kind() == ErrorKind::AlreadyExists => continue,
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {}
             Err(e) => {
                 panic!("test setup: creating store root {} ({e})", root.display())
             }
@@ -1111,7 +1111,7 @@ fn isolate_store_root() -> PathBuf {
     }
 }
 
-pub(crate) fn allocate_store_root_for_test() -> PathBuf {
+pub fn allocate_store_root_for_test() -> PathBuf {
     isolate_store_root()
 }
 

--- a/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
@@ -8,9 +8,11 @@
 mod fleetbench;
 
 mod tests {
+    use std::collections::BTreeSet;
     use std::env;
     use std::fs;
     use std::process;
+    use std::thread;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use aether_actor::Addressable;
@@ -22,7 +24,8 @@ mod tests {
     };
 
     use crate::fleetbench::{
-        FleetBench, component_wasm_path, dist_component_available, poll_until,
+        FleetBench, allocate_store_root_for_test, component_wasm_path, dist_component_available,
+        poll_until,
     };
 
     /// The probe fixture's declared `Addressable::NAMESPACE` (distinct from the
@@ -130,6 +133,42 @@ mod tests {
             "an identical re-upload dedups to the same hash"
         );
         hash
+    }
+
+    #[test]
+    fn fleetbench_store_roots_are_unique_and_created_before_use() {
+        const THREADS: usize = 8;
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| thread::spawn(allocate_store_root_for_test))
+            .collect();
+        let roots: Vec<_> = handles
+            .into_iter()
+            .map(|handle| {
+                handle
+                    .join()
+                    .expect("store-root allocator thread should not panic")
+            })
+            .collect();
+
+        let unique: BTreeSet<_> = roots.iter().cloned().collect();
+        assert_eq!(
+            unique.len(),
+            roots.len(),
+            "each allocator call should return a unique root: {roots:?}",
+        );
+        for root in &roots {
+            assert!(
+                root.is_dir(),
+                "the allocator should create the root before returning it: {}",
+                root.display(),
+            );
+        }
+        for root in roots {
+            fs::remove_dir_all(&root).unwrap_or_else(|e| {
+                panic!("cleanup of store root {} failed ({e})", root.display())
+            });
+        }
     }
 
     /// Upload the probe component by staged path, then assert the store

--- a/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
@@ -135,13 +135,18 @@ mod tests {
         hash
     }
 
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "infra test spawns same-process allocator threads to force contention"
+    )]
     #[test]
     fn fleetbench_store_roots_are_unique_and_created_before_use() {
         const THREADS: usize = 8;
 
-        let handles: Vec<_> = (0..THREADS)
-            .map(|_| thread::spawn(allocate_store_root_for_test))
-            .collect();
+        let mut handles = Vec::with_capacity(THREADS);
+        for _ in 0..THREADS {
+            handles.push(thread::spawn(allocate_store_root_for_test));
+        }
         let roots: Vec<_> = handles
             .into_iter()
             .map(|handle| {


### PR DESCRIPTION
Closes #2783.

## Summary

Makes FleetBench scratch-root allocation exclusive and collision-proof within a test process. Store roots are now claimed with a process id plus atomic nonce and `create_dir` retry loop before the hub opens its binary/component stores, preventing concurrent benches from sharing or deleting another bench's component bytes.

## Test plan

- `cargo fmt`
- CI will run the FleetBench component-store and workspace tests.

## Generated by

`/implement` — agent execution of [scoped issue #2783](https://github.com/iamacoffeepot/aether/issues/2783).
