### PR TITLE
chore(ci): optimize cranelift in dev profile and trim disk reclaim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,19 +123,25 @@ jobs:
   # triples CI time without catching anything new. See ADR-0035 § CI
   # matrix scope.
   test:
-    name: Test (workspace, linux)
+    name: Test (workspace, linux, shard ${{ matrix.partition }}/2)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    # A warm-cache run is ~13 min (cargo xtask dist + the lightweight
-    # build/run + the heavy serial pass), so the old 15-min cap left
-    # almost no margin: under runner-load variance the heavy step ran
-    # into the wall and the job was cancelled mid-run ("The operation
-    # was canceled", no test failure). Cap at 30 — roughly 2× the warm
-    # run — so variance no longer trips it, while a genuine hang still
-    # can't eat the default 6h quota. Splitting the heavy pass into its
-    # own job to cut the warm time back down is tracked separately.
+    # The suite is sharded 2-way by nextest's deterministic name-hash
+    # partition (iamacoffeepot/aether#2803): each shard compiles the
+    # workspace against the shared rust-cache and runs half the tests,
+    # so the wall clock is setup + compile + half the execution. A
+    # build-once/nextest-archive split would serialize build -> run
+    # and ship multi-GB test binaries between jobs, which is slower
+    # end-to-end than two concurrent warm-cache compiles. A warm shard
+    # is ~8 min; cap at 30 so runner-load variance never cancels a
+    # healthy run mid-flight while a genuine hang still can't eat the
+    # default 6h quota.
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [ 1, 2 ]
     env:
       # Use mold to reduce peak link memory and speed up the test
       # build — keeps the linker OOM (collect2: ld terminated with
@@ -220,8 +226,13 @@ jobs:
       # steady-state cap.
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
+      # hash partitioning assigns each test to a shard by a stable hash
+      # of its name — every test runs in exactly one shard regardless of
+      # how many binaries it spans, and the slow substrate-bundle
+      # integration tests spread statistically instead of clumping.
       - name: Run tests (workspace, parallel)
         run: cargo nextest run --all-features --profile ci
+          --partition 'hash:${{ matrix.partition }}/2'
         env:
           AETHER_REQUIRE_RUNTIME: "1"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,17 +163,23 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
-      # Reclaim ~20–30 GB by removing preinstalled Android / .NET /
+      # Reclaim ~19 GB by removing preinstalled Android / .NET /
       # Haskell tooling that the build never uses. Runs before the
       # rust-toolchain step so cargo's own build artifacts have the
       # most headroom. Swap is kept (swap-storage: false) to avoid
-      # degrading the linker under memory pressure.
+      # degrading the linker under memory pressure. large-packages and
+      # docker-images default to 'true' and are the slow half of the
+      # step (apt purges — most of its wall clock for ~6 GB), so they
+      # are pinned off; the three kept categories are fast rm -rf's
+      # (iamacoffeepot/aether#2803).
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           android: 'true'
           dotnet: 'true'
           haskell: 'true'
+          large-packages: 'false'
+          docker-images: 'false'
           swap-storage: 'false'
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,20 @@ tracing = { version = "0.1", default-features = false }
 wasmtime = "44"
 wgpu = "29.0.1"
 
+# Optimize the cranelift compiler even in dev/test builds. Every wasm
+# component load runs a full cranelift compile of the module, and
+# unoptimized cranelift is ~10-30x slower — ~15s per module in CI, which
+# put the substrate-bundle integration suite at ~44 minutes of CPU time
+# (iamacoffeepot/aether#2803). Test-target dependencies build under the
+# dev profile, so this covers `cargo test` / nextest locally and in CI.
+# The one-time optimized rebuild of these two crates is held by the CI
+# rust-cache and only recurs on a wasmtime version bump.
+[profile.dev.package.cranelift-codegen]
+opt-level = 3
+
+[profile.dev.package.regalloc2]
+opt-level = 3
+
 [workspace.lints.rust]
 # Phase 5 of iamacoffeepot/aether#913 swept ~244 RsUnnecessaryQualifications
 # findings across the workspace. Enabling rustc's matching lint here at


### PR DESCRIPTION
Closes #2803.

## Summary

The `Test (workspace, linux)` job is CI's critical path (~18.5 min). 74 `aether-substrate-bundle` integration tests consume 2620 of the suite's 2702 CPU-seconds, and their durations scale linearly with the number of wasm modules they load (~15s per load): each load is a full cranelift compile, and with no `[profile]` section in the workspace manifest cranelift itself builds unoptimized — roughly 10-30x slower than optimized. nextest is process-per-test, so every test recompiles every module it loads.

Three changes:

- `opt-level = 3` for `cranelift-codegen` and `regalloc2` under `[profile.dev.package.*]`. Test-target dependencies build with the dev profile, so this covers nextest in CI and local test runs. rust-cache holds the one-time optimized rebuild; it only recurs on a wasmtime version bump.
- Pin the `Free disk space` step's `large-packages` / `docker-images` categories off. They default to `true` without the workflow asking, and are the slow apt-purge half of the step (~40s of ~68s on the last green run) for only ~6 GB of the ~25 GB reclaimed. The kept android/.NET/Haskell categories are fast `rm -rf`s covering ~19 GB.
- Shard the test job 2-way via nextest's deterministic name-hash partition (`--partition hash:N/2`). Each shard compiles against the shared rust-cache and runs half the suite; hash assignment spreads the slow substrate-bundle integration tests statistically. Chosen over a build-once/nextest-archive split, which would serialize build -> run and ship multi-GB test binaries between jobs — slower end-to-end than two concurrent warm-cache compiles.

## Test plan

CI itself is the measurement, against the ~18.5 min `Test (workspace, linux)` baseline. Measured on this branch: cranelift opt alone cut nextest execution 837s -> 413s (suite CPU 2702s -> 1640s) and the disk step 2m42s -> 17s, for a 14m02s cold job; the shard commit's run shows the warm sharded number. `ci-pass` aggregates the matrix through the existing `needs.test.result`, so the merge gate is unchanged.

## Generated by

`/implement --quick` — agent execution of [issue #2803](https://github.com/iamacoffeepot/aether/issues/2803).
