### PR TITLE
chore(ci): remove guardrail hook-tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,6 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
-  hook-tests:
-    name: Guardrail hook tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: bash .claude/hooks/tests/run.sh
-
   clippy:
     name: Clippy
     needs: changes
@@ -340,14 +333,13 @@ jobs:
   ci-pass:
     name: CI pass
     if: always()
-    needs: [ changes, fmt, hook-tests, clippy, docs, marker-build, test, desktop, qodana ]
+    needs: [ changes, fmt, clippy, docs, marker-build, test, desktop, qodana ]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
         run: |
           echo "changes: ${{ needs.changes.result }}"
           echo "fmt:     ${{ needs.fmt.result }}"
-          echo "hook-tests: ${{ needs.hook-tests.result }}"
           echo "clippy:  ${{ needs.clippy.result }}"
           echo "docs:    ${{ needs.docs.result }}"
           echo "marker-build: ${{ needs.marker-build.result }}"
@@ -357,7 +349,6 @@ jobs:
           fail=0
           [[ "${{ needs.changes.result }}" == "success" ]] || fail=1
           [[ "${{ needs.fmt.result }}"     == "success" ]] || fail=1
-          [[ "${{ needs.hook-tests.result }}" == "success" ]] || fail=1
           [[ "${{ needs.clippy.result }}"  == "success" || "${{ needs.clippy.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.docs.result }}"    == "success" || "${{ needs.docs.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.marker-build.result }}" == "success" || "${{ needs.marker-build.result }}" == "skipped" ]] || fail=1


### PR DESCRIPTION
Closes #2806.

## Summary

Removes the `hook-tests` CI job and its `ci-pass` aggregator wiring. The job ran `bash .claude/hooks/tests/run.sh` on every PR to regression-test the local `.claude/hooks/*` guardrail scripts (worktree-boundary, worktree-clean, session-worktree lock lifecycle). Those hooks are dev-machine harness tooling, not shipped engine code, and never run inside the product's CI-gated paths — gating a protected merge on them is misplaced. The test script stays in the repo for local/manual runs; only the CI job and its four aggregator touch points are removed.

`Guardrail hook tests` is not an individually required status check — the required gate is the `CI pass` aggregator — so removing the job does not wedge the merge gate.

## Test plan

YAML-only change. CI validates the workflow parses and `CI pass` still gates the required jobs.

## Generated by

`/implement --quick` — agent execution of #2806.
