### PR TITLE
fix(ci): trigger builds on xtask and tooling config changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,26 @@ jobs:
           filters: |
             code:
               - 'crates/**'
+              - 'xtask/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              - 'clippy.toml'
+              - '.cargo/**'
+              - '.config/**'
               - '.github/workflows/**'
             # Qodana's gate is the code set plus its own config, so a
             # qodana.yaml edit still triggers a scan even though it
             # changes no Rust.
             qodana:
               - 'crates/**'
+              - 'xtask/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              - 'clippy.toml'
+              - '.cargo/**'
+              - '.config/**'
               - '.github/workflows/**'
               - 'qodana.yaml'
 


### PR DESCRIPTION
Closes #2807.

## Summary

The `changes` paths-filter gated clippy/docs/marker/test/qodana on a `code` set that omitted several files CI jobs load at runtime, so editing them skipped the very job that consumes them — a silent false-green into the required merge gate. Adds the missing paths to both the `code` and `qodana` filters:

- `xtask/**` — the `test` job runs `cargo xtask dist` to pre-build component wasm for the ADR-0067 scenario tests; a pure `xtask/src/` logic change previously did not rerun tests.
- `.config/**` — the `test` job runs `cargo nextest run --profile ci`, reading `.config/nextest.toml`.
- `clippy.toml` — the `clippy` job's disallowed-methods config.
- `.cargo/**` — cargo build config affecting every build.

Under-triggering is the dangerous direction: it skips a job that should run, passing the merge gate on unvalidated changes. Directory globs (`.config/**`, `.cargo/**`, `xtask/**`) match the existing `crates/**` style and stay correct as new config files are added.

## Test plan

YAML-only change. This PR touches `.github/workflows/**` (already in the filter) so it exercises the full job set itself.

## Generated by

`/implement --quick` — agent execution of #2807.
