### PR TITLE
chore(workflow): map model tags to gpt equivalents

### DIFF
--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -160,11 +160,11 @@ For each sub-phase: read inputs, write the corresponding body section, and recon
     | while read -r l; do gh api -X DELETE "repos/iamacoffeepot/aether/issues/<n>/labels/$l"; done \
     && gh api -X POST "repos/iamacoffeepot/aether/issues/<n>/labels" -f "labels[]=size:<x>"
   ```
-- **Model routing (required)** — every issue leaves Plan with exactly one `model:*` label; `/approve` refuses an unlabelled issue. The label names the model the dispatched agent runs — there is no inherit-the-dispatcher fallback. Stamp it over the same REST `…/labels` endpoints as the size mirror, in the same step. Pick by the work, defaulting cheap:
-  - `model:haiku` — trivial text-only work: doc links, label fixes, one-line config tweaks.
-  - `model:sonnet` — the default for mechanical work fully specified by the plan (typically S, and an M whose plan reads as executable verbatim).
-  - `model:opus` — the implementation itself requires non-obvious judgment: cross-crate L work, design-adjacent changes, plans with open exploration.
-  - `model:fable` — never stamped by `/scope`; reserved for a human pinning the top tier explicitly.
+- **Model routing (required)** — every issue leaves Plan with exactly one `model:*` label; `/approve` refuses an unlabelled issue. The label names the tier the dispatched agent runs — there is no inherit-the-dispatcher fallback. Each tag names a tier, not one vendor's model: a Claude agent reads the Claude column, a Codex agent reads the GPT column, and the label stays the same either way. Stamp it over the same REST `…/labels` endpoints as the size mirror, in the same step. Pick by the work, defaulting cheap:
+  - `model:haiku` — trivial text-only work: doc links, label fixes, one-line config tweaks. GPT equivalent: `gpt-5-mini`.
+  - `model:sonnet` — the default for mechanical work fully specified by the plan (typically S, and an M whose plan reads as executable verbatim). GPT equivalent: `gpt-5`.
+  - `model:opus` — the implementation itself requires non-obvious judgment: cross-crate L work, design-adjacent changes, plans with open exploration. GPT equivalent: `gpt-5-codex`.
+  - `model:fable` — never stamped by `/scope`; reserved for a human pinning the top tier explicitly. GPT equivalent: `gpt-5-pro`.
 
   The gate encodes a size-asymmetry: a downward misjudgment costs more as size grows, so an M/L `model:sonnet` demands a plan that reads as executable verbatim — when in doubt at M or L, stamp `model:opus`. Note the choice and a one-clause reason inline in the `## Implementation plan` section.
 - **Phase label**: leave at `phase:plan`. This is the resting state awaiting `/approve`.


### PR DESCRIPTION
## Summary

Codex now works alongside Claude in this repo, so the `model:*` dispatch tags need to read for both agents. Each tag names a tier, not one vendor's model — a Claude agent reads the Claude column, a Codex agent reads the GPT column, and the single-`model:*`-per-issue gate stays intact.

Annotates each tier with its GPT/Codex equivalent across both surfaces where the tag is documented:

| tier | GPT equivalent |
|---|---|
| `model:haiku` | `gpt-5-mini` |
| `model:sonnet` | `gpt-5` |
| `model:opus` | `gpt-5-codex` |
| `model:fable` | `gpt-5-pro` |

- `.claude/skills/scope/SKILL.md` — the canonical model-routing table gains a GPT-equivalent per tier plus a lead sentence framing the tag as vendor-neutral.
- GitHub `model:*` label descriptions — rewritten to carry `GPT ≈ …` (applied directly via the labels API; not part of this diff).

## Test plan

- `cargo fmt`
- `git diff --check`