### PR TITLE
feat(actor): expose reply correlation ids

### DIFF
--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -146,7 +146,7 @@ pub mod __macro_internals {
 /// capability authors need only `aether-actor` in their dep list; the
 /// full macro surface is available from here.
 pub use aether_actor_derive::{actor, capability, fallback, handler, local, runtime};
-pub use aether_data::{Kind, KindId as DataKindId, MailboxId, Schema};
+pub use aether_data::{Kind, KindId as DataKindId, MailboxId, RequestId, Schema};
 // ADR-0119: the `#[derive(Singleton)]` / `#[derive(Instanced)]` /
 // `#[derive(Embeddable)]` proc-macros are retired. Cardinality is the
 // `Addressable::Resolver`, and the `Singleton` / `Instanced` marker traits

--- a/crates/aether-actor/src/wasm/bridge/mail.rs
+++ b/crates/aether-actor/src/wasm/bridge/mail.rs
@@ -9,7 +9,8 @@
 //! and localizes `unsafe` to one audited site per FFI op. `send_mail`
 //! pushes a typed payload at a recipient mailbox; `reply_mail` routes to
 //! the originator of the mail currently being dispatched; `prev_correlation`
-//! reads the correlation id the host minted for the most-recent `send_mail`.
+//! reads the correlation id the host minted for the most-recent `send_mail`;
+//! `reply_correlation` reads the current inbound reply's echoed correlation.
 //!
 //! Correlation is universal — every send mints a correlation id so a
 //! handler can match the reply to the request it sent. It's a property
@@ -127,6 +128,15 @@ pub fn prev_correlation() -> u64 {
     // the `#[cfg(target_family = "wasm")]` import gate enforces
     // (the host-target stub panics rather than returning garbage).
     unsafe { raw::prev_correlation() }
+}
+
+/// Correlation id echoed on the reply currently being dispatched.
+/// Returns `0` when the inbound mail is not a reply envelope.
+#[must_use]
+pub fn reply_correlation() -> u64 {
+    // SAFETY: `raw::reply_correlation` takes no arguments and reads a
+    // host-side scalar set for the active dispatch.
+    unsafe { raw::reply_correlation() }
 }
 
 /// ADR-0097: stage a sibling-spawn request and return the new

--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -14,7 +14,7 @@
 use core::marker::PhantomData;
 use core::ptr;
 
-use aether_data::{Kind, MailboxId, mailbox_id_from_name};
+use aether_data::{Kind, MailboxId, RequestId, Source, mailbox_id_from_name};
 
 use crate::mail::ReplyHandle;
 use crate::mail::mailbox::{KindId, Mailbox, resolve, resolve_mailbox};
@@ -261,6 +261,10 @@ pub struct WasmCtx<'a, M: ReplyMode = Single> {
     /// [`MailboxId::NONE`] (`0`) means no peer-component origin — a session,
     /// remote-engine, or broadcast mail, or a lifecycle hook with no inbound.
     source: u64,
+    /// Whether this ctx came from a top-level host dispatch. Cluster-drained
+    /// in-place dispatches carry no host correlation, so `in_reply_to` must
+    /// not read the outer dispatch's ambient host scalar.
+    host_dispatch: bool,
     /// ADR-0114: the per-component inline-child registry the
     /// [`Self::spawn_inline_child`] / [`Self::despawn_inline_child`] verbs
     /// drive. The `export!` membrane threads in the component's emitted
@@ -302,6 +306,24 @@ impl<'a> WasmCtx<'a, Manual> {
             mailbox,
             sender: None,
             source,
+            host_dispatch: true,
+            inline,
+            _borrow: PhantomData,
+            _mode: PhantomData,
+        }
+    }
+
+    /// Not part of the public API; inline-cluster drains build ctxs through
+    /// here so `in_reply_to()` does not read the outer host dispatch's stale
+    /// reply-correlation scalar.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __new_local_dispatch(mailbox: u64, inline: &'a Registry, source: u64) -> Self {
+        Self {
+            mailbox,
+            sender: None,
+            source,
+            host_dispatch: false,
             inline,
             _borrow: PhantomData,
             _mode: PhantomData,
@@ -372,6 +394,19 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
     #[must_use]
     pub fn source_mailbox(&self) -> Option<MailboxId> {
         (self.source != MailboxId::NONE.0).then_some(MailboxId(self.source))
+    }
+
+    /// Correlation id of the request this inbound reply answers.
+    ///
+    /// Returns `None` for ordinary request mail, uncorrelated replies, and
+    /// inline-cluster drained dispatches.
+    #[must_use]
+    pub fn in_reply_to(&self) -> Option<RequestId> {
+        if !self.host_dispatch {
+            return None;
+        }
+        let correlation = mail::reply_correlation();
+        (correlation != Source::NO_CORRELATION).then_some(RequestId(correlation))
     }
 
     /// The component's own mailbox id — the value the substrate uses to
@@ -1187,7 +1222,6 @@ mod tests {
         ActorTypeTag, Emit, Manual, Multi, NO_INBOUND_SOURCE, Registry, Single, SpawnError,
         WasmCtx, install_inline_child,
     };
-    use crate::Addressable;
     use crate::mail::{Mail, PriorState};
     use crate::model::Subname;
     use crate::wasm::inline::RouteDecision;
@@ -1195,7 +1229,8 @@ mod tests {
         InlineChildToReconstruct, reconstruct_one_child, spawn_one_child,
     };
     use crate::wasm::{ActorInitError, ErasedWasmActor, WasmActor, WasmDropCtx, WasmInitCtx};
-    use aether_data::{Kind, MailboxId};
+    use crate::{Addressable, HandlesKind, WasmActorMailbox};
+    use aether_data::{Kind, MailboxId, Source};
     use alloc::string::String;
     use alloc::vec::Vec;
     use core::cell::Cell;
@@ -1320,6 +1355,18 @@ mod tests {
         );
     }
 
+    #[test]
+    fn local_dispatch_ctx_never_reads_host_reply_correlation() {
+        let registry = Registry::new();
+        let ctx: WasmCtx<'_, Manual> =
+            WasmCtx::__new_local_dispatch(0x10, &registry, NO_INBOUND_SOURCE);
+        assert_eq!(
+            ctx.in_reply_to(),
+            None,
+            "cluster-drained dispatches carry no host correlation",
+        );
+    }
+
     /// ADR-0134: `emit` on a `Multi<K>` ctx routes a detached mail at the
     /// threaded dispatch source, and a sourceless dispatch drops the
     /// emission. The source is set to a cluster member (the self id) so the
@@ -1402,6 +1449,8 @@ mod tests {
             unreachable!("the despawn test never dispatches this child")
         }
     }
+
+    impl HandlesKind<()> for SucceedingChild {}
 
     impl ErasedWasmActor for SucceedingChild {
         fn erased_namespace(&self) -> &'static str {
@@ -1512,6 +1561,33 @@ mod tests {
             registry.queued_len(),
             1,
             "a send to a resolved relative enqueues locally — no scheduler hop",
+        );
+    }
+
+    #[test]
+    fn send_tracked_local_route_returns_no_correlation_sentinel() {
+        let registry = Registry::new();
+        let root = 0x7100_u64;
+        registry.set_self_id(root);
+        let child = MailboxId(0x7101);
+        install_inline_child::<SucceedingChild>(
+            &registry,
+            child,
+            0,
+            String::from("widget"),
+            false,
+            root,
+            Vec::new(),
+            (),
+        )
+        .expect("install inline child");
+
+        let mailbox = WasmActorMailbox::<SucceedingChild>::__new(child.0, root, &registry);
+        let request = mailbox.send_tracked(&());
+        assert_eq!(
+            request.0,
+            Source::NO_CORRELATION,
+            "local inline sends have no host-minted request id",
         );
     }
 

--- a/crates/aether-actor/src/wasm/inline/mod.rs
+++ b/crates/aether-actor/src/wasm/inline/mod.rs
@@ -602,7 +602,7 @@ where
     let id = MailboxId(recipient);
     match registry.take(id) {
         Some(mut child) => {
-            let mut ctx = WasmCtx::__new(recipient, registry, source);
+            let mut ctx = WasmCtx::__new_local_dispatch(recipient, registry, source);
             let rc = child.erased_dispatch(&mut ctx, mail);
             registry.reinsert(id, child);
             rc

--- a/crates/aether-actor/src/wasm/mailbox.rs
+++ b/crates/aether-actor/src/wasm/mailbox.rs
@@ -22,10 +22,11 @@
 
 use core::marker::PhantomData;
 
-use aether_data::{ActorId, Kind, MailboxId, Tag, fold_lineage, with_tag};
+use aether_data::{ActorId, Kind, MailboxId, RequestId, Source, Tag, fold_lineage, with_tag};
 
 use crate::model::{Addressable, HandlesKind};
-use crate::wasm::inline::{ChainMode, Registry};
+use crate::wasm::bridge::mail;
+use crate::wasm::inline::{ChainMode, Registry, RouteDecision};
 
 /// Phantom-typed receiver-actor handle for FFI guests, built by
 /// [`crate::wasm::WasmCtx::actor`] / [`crate::wasm::WasmCtx::resolve_actor`].
@@ -155,6 +156,33 @@ impl<R: Addressable> WasmActorMailbox<'_, R> {
             ChainMode::Inherit,
             self.sender,
         );
+    }
+
+    /// Send a request and return the correlation id the host minted for it.
+    ///
+    /// Inline-cluster local sends never leave the guest, so no host correlation
+    /// exists for them. That path warn-logs and returns the no-correlation
+    /// sentinel rather than reading a stale `prev_correlation_p32` value.
+    #[must_use]
+    pub fn send_tracked<K>(&self, payload: &K) -> RequestId
+    where
+        R: HandlesKind<K>,
+        K: Kind,
+    {
+        match self.inline.route_decision(self.mailbox) {
+            RouteDecision::Local { .. } => {
+                tracing::warn!(
+                    kind = <K as Kind>::NAME,
+                    recipient = self.mailbox,
+                    "send_tracked on an inline-cluster local route has no host correlation",
+                );
+                RequestId(Source::NO_CORRELATION)
+            }
+            RouteDecision::Remote => {
+                self.send(payload);
+                RequestId(mail::prev_correlation())
+            }
+        }
     }
 
     /// Send a slice of payloads as a contiguous batch. Cast-only —

--- a/crates/aether-actor/src/wasm/mailbox.rs
+++ b/crates/aether-actor/src/wasm/mailbox.rs
@@ -170,7 +170,7 @@ impl<R: Addressable> WasmActorMailbox<'_, R> {
         K: Kind,
     {
         match self.inline.route_decision(self.mailbox) {
-            RouteDecision::Local { .. } => {
+            RouteDecision::Local => {
                 tracing::warn!(
                     kind = <K as Kind>::NAME,
                     recipient = self.mailbox,

--- a/crates/aether-actor/src/wasm/mod.rs
+++ b/crates/aether-actor/src/wasm/mod.rs
@@ -667,7 +667,7 @@ macro_rules! __export_internal {
                     // — the slot was present for the top-level dispatch above.
                     let instance = unsafe { __AETHER_COMPONENT.get_mut() }
                         .expect("instance present for the cluster-queue drain");
-                    let mut ctx = $crate::WasmCtx::__new(mailbox_id, &__AETHER_INLINE, __aether_source);
+                    let mut ctx = $crate::WasmCtx::__new_local_dispatch(mailbox_id, &__AETHER_INLINE, __aether_source);
                     instance.__aether_dispatch(&mut ctx, __aether_mail)
                 }
             });
@@ -1225,7 +1225,7 @@ macro_rules! __export_multi_internal {
                     // iteration's borrow has dropped (the membrane returned).
                     let instance = unsafe { __AETHER_MULTI.get_mut() }
                         .expect("instance present for the cluster-queue drain");
-                    let mut ctx = $crate::WasmCtx::__new(mailbox_id, &__AETHER_INLINE, __aether_source);
+                    let mut ctx = $crate::WasmCtx::__new_local_dispatch(mailbox_id, &__AETHER_INLINE, __aether_source);
                     instance.erased_dispatch(&mut ctx, __aether_mail)
                 }
             });

--- a/crates/aether-actor/src/wasm/raw.rs
+++ b/crates/aether-actor/src/wasm/raw.rs
@@ -62,6 +62,10 @@ unsafe extern "C" {
     /// of this kind."
     #[link_name = "prev_correlation_p32"]
     pub fn prev_correlation() -> u64;
+    /// Issue 2791: return the current inbound reply's echoed correlation id.
+    /// Returns `0` when the dispatch is not a reply envelope.
+    #[link_name = "reply_correlation_p32"]
+    pub fn reply_correlation() -> u64;
     /// Issue 525 Phase 4b / issue 531: stage a `ActorInitError` message
     /// for the substrate to surface in `LoadResult::Err` after the
     /// guest's `init` returns non-zero. The `export!` macro is the
@@ -201,6 +205,21 @@ pub unsafe fn save_state(_version: u32, _ptr: u32, _len: u32) -> u32 {
 #[must_use]
 pub unsafe fn prev_correlation() -> u64 {
     panic!("aether-actor: prev_correlation called outside the FFI guest");
+}
+
+/// Host-side stub for the FFI `aether::reply_correlation` import.
+/// Always panics — callers outside the FFI guest are misusing the SDK.
+///
+/// # Safety
+/// FFI-import stub; the wasm32 variant is `unsafe extern "C"`.
+///
+/// # Panics
+/// Always panics — fail-fast per ADR-0063: the host build of the SDK
+/// has no FFI host to call, so any invocation is a bug.
+#[cfg(not(target_family = "wasm"))]
+#[must_use]
+pub unsafe fn reply_correlation() -> u64 {
+    panic!("aether-actor: reply_correlation called outside the FFI guest");
 }
 
 /// Host-side stub for the FFI `aether::init_failed` import.

--- a/crates/aether-capabilities/src/fs/kinds.rs
+++ b/crates/aether-capabilities/src/fs/kinds.rs
@@ -48,11 +48,11 @@ pub struct Read {
 }
 
 /// Reply to `Read`. Both arms echo the `namespace` + `path` from
-/// the originating `Read` so the caller can correlate the reply
-/// to its source request without threading a pending-op queue or
-/// allocating correlation ids — operation identity comes from the
-/// reply kind itself (`aether.fs.read_result`), target identity
-/// from the echoed fields. `Ok` carries the full file contents;
+/// the originating `Read` as domain context and for compatibility
+/// with callers that group by file identity. A caller that can have
+/// duplicate in-flight reads for the same path should use the
+/// request id returned by `send_tracked` and match it against
+/// `ctx.in_reply_to()` instead. `Ok` carries the full file contents;
 /// `Err` carries an `FsError` variant.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.fs.read_result")]
@@ -82,13 +82,13 @@ pub struct Write {
     pub bytes: Vec<u8>,
 }
 
-/// Reply to `Write`. Both arms echo `namespace` + `path` for
-/// correlation; the request's `bytes` field is *not* echoed so the
-/// reply payload stays small even when the write was megabytes
-/// (correlation needs the identity of the write, not its contents).
-/// `Err` carries an `FsError` — `Forbidden` for read-only
-/// namespaces (e.g. `assets://`), `AdapterError` for disk-full /
-/// permission / rename failures.
+/// Reply to `Write`. Both arms echo `namespace` + `path` as domain
+/// context; the request's `bytes` field is *not* echoed so the reply
+/// payload stays small even when the write was megabytes. Duplicate
+/// in-flight writes to the same path should be matched by
+/// `send_tracked` / `ctx.in_reply_to()`. `Err` carries an `FsError`
+/// — `Forbidden` for read-only namespaces (e.g. `assets://`),
+/// `AdapterError` for disk-full / permission / rename failures.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.fs.write_result")]
 pub enum WriteResult {
@@ -131,12 +131,14 @@ pub struct Copy {
     pub to: NamespaceAddr,
 }
 
-/// Reply to `Copy`. Both arms echo `from` + `to` for correlation;
+/// Reply to `Copy`. Both arms echo `from` + `to` as domain context;
 /// no bytes are echoed so the reply stays small regardless of file
-/// size. `Err` carries an `FsError` — `NotFound` if `from` is absent
-/// on the host, `Forbidden` for a read-only destination namespace or
-/// a `to.path` that contains `..` / a leading `/`, `UnknownNamespace`
-/// if `to.namespace` was not registered.
+/// size. Duplicate in-flight copies with the same endpoints should be
+/// matched by `send_tracked` / `ctx.in_reply_to()`. `Err` carries an
+/// `FsError` — `NotFound` if `from` is absent on the host,
+/// `Forbidden` for a read-only destination namespace or a `to.path`
+/// that contains `..` / a leading `/`, `UnknownNamespace` if
+/// `to.namespace` was not registered.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.fs.copy_result")]
 pub enum CopyResult {
@@ -162,10 +164,11 @@ pub struct Delete {
     pub path: String,
 }
 
-/// Reply to `Delete`. Both arms echo `namespace` + `path` for
-/// correlation. `Ok` on successful removal; `Err` on any
-/// adapter-reported failure, including `NotFound` for a file that
-/// wasn't there to delete.
+/// Reply to `Delete`. Both arms echo `namespace` + `path` as domain
+/// context. Duplicate in-flight deletes for the same path should be
+/// matched by `send_tracked` / `ctx.in_reply_to()`. `Ok` on
+/// successful removal; `Err` on any adapter-reported failure,
+/// including `NotFound` for a file that wasn't there to delete.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.fs.delete_result")]
 pub enum DeleteResult {
@@ -192,7 +195,9 @@ pub struct List {
 }
 
 /// Reply to `List`. Both arms echo the originating `namespace` +
-/// `prefix` for correlation. `Ok` carries the matching entry
+/// `prefix` as domain context. Duplicate in-flight lists for the same
+/// prefix should be matched by `send_tracked` / `ctx.in_reply_to()`.
+/// `Ok` carries the matching entry
 /// names — bare file/dir names, not fully-qualified paths — so the
 /// caller composes `{prefix}{entry}` when turning an entry back
 /// into a read. Empty `entries` means "namespace exists, nothing
@@ -304,11 +309,12 @@ pub struct FsFetch {
     pub transforms: Vec<TransformId>,
 }
 
-/// Reply to `FsFetch`. Both arms echo `namespace` + `path` for
-/// correlation. `Ok` carries the folded output bytes (`data`) and
-/// the `output_kind` of the last transform (`None` when `transforms`
-/// was empty, i.e. a raw-read). `Err` carries a structured
-/// `FsFetchError`.
+/// Reply to `FsFetch`. Both arms echo `namespace` + `path` as domain
+/// context. Duplicate in-flight fetches for the same path should be
+/// matched by `send_tracked` / `ctx.in_reply_to()`. `Ok` carries the
+/// folded output bytes (`data`) and the `output_kind` of the last
+/// transform (`None` when `transforms` was empty, i.e. a raw-read).
+/// `Err` carries a structured `FsFetchError`.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.fs.fetch_result")]
 pub enum FsFetchResult {

--- a/crates/aether-data/src/ids.rs
+++ b/crates/aether-data/src/ids.rs
@@ -139,6 +139,15 @@ pub const fn type_name_for_type_id(type_id: u64) -> Option<&'static str> {
     }
 }
 
+/// Request/reply correlation id minted by the sending actor.
+///
+/// This is the correlation half of [`crate::MailId`]. Within one actor and
+/// one substrate run it is monotonic and unique; `0` is the shared
+/// no-correlation sentinel (`crate::Source::NO_CORRELATION`).
+#[repr(transparent)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RequestId(pub u64);
+
 /// Routing token for any mailbox — component or substrate-owned sink.
 /// Carries the ADR-0029 deterministic name hash with ADR-0064 tag
 /// bits in the high nibble. `#[repr(transparent)]` over `u64` so

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -60,7 +60,7 @@ pub use hash::{
     validate_scope_path,
 };
 pub use ids::{
-    ActorId, DagId, KindId, MailboxId, ThreadId, TransformId, tag_for_type_id,
+    ActorId, DagId, KindId, MailboxId, RequestId, ThreadId, TransformId, tag_for_type_id,
     type_name_for_type_id,
 };
 pub use mail::{MailId, Source, SourceAddr};

--- a/crates/aether-substrate-bundle/tests/reply_correlation.rs
+++ b/crates/aether-substrate-bundle/tests/reply_correlation.rs
@@ -1,0 +1,103 @@
+//! Issue 2791: end-to-end guard for exact request/reply demux in wasm guests.
+//!
+//! The `test.fs_demux` fixture sends two identical `aether.fs.read` requests
+//! to the same namespace/path. The fs replies echo identical payload fields, so
+//! the guest can only distinguish them by the envelope request id returned from
+//! `send_tracked` and later surfaced by `WasmCtx::in_reply_to()`.
+
+// Skip diagnostics emit via stderr so `cargo nextest` surfaces a visible
+// "skipping: ..." line alongside `test ... ok`.
+#![allow(clippy::print_stderr)]
+
+// Pin the fixture rlib so its `inventory::submit!` `KindDescriptor`
+// entries are present in this test binary.
+#[allow(unused_imports)]
+use aether_test_fixtures_kinds as _;
+
+use std::fs;
+
+use aether_actor::Addressable;
+use aether_capabilities::ComponentHostCapability;
+use aether_data::{Kind, MailboxId};
+use aether_kinds::{LoadComponent, LoadResult};
+use aether_substrate_bundle::test_bench::{
+    BenchOp, TestBench,
+    test_helpers::{init_save_sandbox, require_runtime, test_namespace_roots, write_fixture},
+};
+use aether_test_fixtures_kinds::{FsDemuxReport, RunFsDemux};
+
+const FIXTURE_CRATE: &str = "aether_test_fixtures_bundle";
+
+fn load_fs_demux(bench: &mut TestBench, wasm: Vec<u8>, name: &str) -> (MailboxId, String) {
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                ComponentHostCapability::NAMESPACE,
+                &LoadComponent {
+                    wasm,
+                    name: Some(name.to_owned()),
+                    config: Vec::new(),
+                    export: Some("test.fs_demux".to_owned()),
+                },
+            ),
+        )])
+        .expect("load fs_demux");
+
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok {
+            mailbox_id,
+            name: full_name,
+            ..
+        } => (mailbox_id, full_name),
+        LoadResult::Err { error } => panic!("load_component {name}: {error}"),
+    }
+}
+
+#[test]
+fn same_payload_fs_replies_demux_by_request_id() {
+    let Some(wasm_path) = require_runtime(FIXTURE_CRATE) else {
+        return;
+    };
+
+    let sandbox = init_save_sandbox("reply-correlation");
+    let mut bench = match TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+    {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
+            return;
+        }
+    };
+
+    let path = write_fixture("same-payload.txt", b"same path, same reply payload");
+    let wasm = fs::read(&wasm_path).expect("read fs_demux wasm");
+    let (_, fixture_addr) = load_fs_demux(&mut bench, wasm, "fs-demux");
+    let baseline = bench.count_observed(FsDemuxReport::NAME);
+
+    bench
+        .execute(vec![(
+            "trigger",
+            BenchOp::send_mail(
+                &fixture_addr,
+                &RunFsDemux {
+                    namespace: "save".to_owned(),
+                    path,
+                },
+            ),
+        )])
+        .expect("RunFsDemux to fixture");
+
+    assert_eq!(
+        bench.count_observed(FsDemuxReport::NAME) - baseline,
+        1,
+        "fixture did not report both same-payload fs replies as request-id matched; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -27,7 +27,7 @@ use core::marker::PhantomData;
 use core::ptr;
 
 use crate::actor::native::mailbox::NativeActorMailbox;
-use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
+use aether_data::{Kind, KindId, MailId, MailboxId, RequestId, mailbox_id_from_name};
 
 use crate::actor::monitor::MonitorHandle;
 use crate::actor::native::binding::NativeBinding;
@@ -606,6 +606,18 @@ impl<M: ReplyMode> NativeCtx<'_, M> {
         match self.source.addr {
             SourceAddr::Component(id) => Some(id),
             _ => None,
+        }
+    }
+
+    /// Correlation id of the request this inbound reply answers.
+    #[must_use]
+    pub fn in_reply_to(&self) -> Option<RequestId> {
+        if matches!(self.source.addr, SourceAddr::None)
+            && self.source.correlation_id != Source::NO_CORRELATION
+        {
+            Some(RequestId(self.source.correlation_id))
+        } else {
+            None
         }
     }
 

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -145,6 +145,11 @@ pub struct ComponentCtx {
     /// threaded (ADR-0038 actor-per-component), so the counter is
     /// never touched from multiple threads.
     correlation_counter: Cell<u64>,
+    /// Current inbound reply correlation exposed through
+    /// `reply_correlation_p32`. Set only for reply envelopes
+    /// (`SourceAddr::None` plus a non-zero correlation) during
+    /// [`Component::deliver`], then cleared after the guest returns.
+    reply_correlation: Cell<u64>,
     /// ADR-0080 §5 in-flight inbound `MailId`. Set by
     /// [`Component::deliver`] before invoking the guest's
     /// `receive_p32` shim so any [`ComponentCtx::send`] the guest
@@ -236,6 +241,7 @@ impl ComponentCtx {
             init_failure: None,
             binding: None,
             correlation_counter: Cell::new(1),
+            reply_correlation: Cell::new(Source::NO_CORRELATION),
             in_flight_mail_id: Cell::new(MailId::NONE),
             in_flight_root: Cell::new(MailId::NONE),
             reply_lineage_counter: Cell::new(REPLY_LINEAGE_BASE),
@@ -306,6 +312,12 @@ impl ComponentCtx {
         // last one. `.saturating_sub(1)` covers the pre-send case
         // where counter is still `1` (initial) → returns `0`.
         self.correlation_counter.get().saturating_sub(1)
+    }
+
+    /// Correlation id echoed on the reply currently being dispatched,
+    /// or `0` when the inbound is not a reply envelope.
+    pub fn reply_correlation(&self) -> u64 {
+        self.reply_correlation.get()
     }
 
     /// Dispatch mail. If the recipient is a sink, the handler runs inline
@@ -570,11 +582,27 @@ impl ComponentCtx {
         self.in_flight_root.set(root);
     }
 
+    /// Set the current dispatch's reply correlation. Only reply envelopes
+    /// expose their correlation; request mail from a component carries the
+    /// requester's id space and must not be surfaced to the recipient as its
+    /// own pending-key space.
+    pub(crate) fn set_reply_correlation(&self, source: Source) {
+        let correlation = if matches!(source.addr, SourceAddr::None)
+            && source.correlation_id != Source::NO_CORRELATION
+        {
+            source.correlation_id
+        } else {
+            Source::NO_CORRELATION
+        };
+        self.reply_correlation.set(correlation);
+    }
+
     /// Clear the in-flight context after the guest's `receive_p32`
     /// shim returns. Symmetric with [`Self::set_in_flight`].
     pub(crate) fn clear_in_flight(&self) {
         self.in_flight_mail_id.set(MailId::NONE);
         self.in_flight_root.set(MailId::NONE);
+        self.reply_correlation.set(Source::NO_CORRELATION);
     }
 }
 
@@ -1133,6 +1161,7 @@ impl Component {
         // call site that bypasses `deliver` (today: only test
         // fixtures) doesn't accidentally pick up stale lineage.
         self.store.data().set_in_flight(mail.mail_id, mail.root);
+        self.store.data().set_reply_correlation(mail.reply_to);
         // ADR-0114 decision #1: thread the routed recipient through to
         // the guest as a `receive_p32` frame slot so a guest handler (and
         // the inline-child membrane) can read which address the mail was
@@ -2198,6 +2227,26 @@ mod tests {
         )
     }
 
+    /// Issue 2791: fixture whose `receive_p32` reads the additive
+    /// `reply_correlation_p32` import and stores the low 32 bits at offset 500.
+    fn wat_stores_reply_correlation() -> String {
+        format!(
+            r#"
+        (module
+            (import "aether" "reply_correlation_p32"
+                (func $reply_correlation (result i64)))
+            (memory (export "memory") 1)
+            {WAT_REALLOC}
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64 i64) (result i32)
+                i32.const 500
+                call $reply_correlation
+                i32.wrap_i64
+                i32.store
+                i32.const 0))
+        "#
+        )
+    }
+
     /// Issue 2001 end-to-end through the dispatch unit path: `deliver`
     /// resolves the inbound `SourceAddr` and threads it as the trailing
     /// `receive_p32` slot. A peer-component origin yields that mailbox's
@@ -2249,6 +2298,32 @@ mod tests {
             component.read_u32(500),
             0,
             "a no-reply-target origin must thread 0 as the source param",
+        );
+    }
+
+    #[test]
+    fn reply_correlation_import_exposes_reply_envelope_only() {
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M, Source, SourceAddr};
+
+        let mut component = instantiate(&wat_stores_reply_correlation());
+
+        let reply = SubstrateMail::new(M(0), aether_data::KindId(0), vec![], 1)
+            .with_reply_to(Source::with_correlation(SourceAddr::None, 0x5151));
+        component.deliver(&reply).expect("deliver reply");
+        assert_eq!(
+            component.read_u32(500),
+            0x5151,
+            "reply envelope must expose its echoed correlation",
+        );
+
+        let request = SubstrateMail::new(M(0), aether_data::KindId(0), vec![], 1).with_reply_to(
+            Source::with_correlation(SourceAddr::Component(M(7)), 0x9999),
+        );
+        component.deliver(&request).expect("deliver request");
+        assert_eq!(
+            component.read_u32(500),
+            0,
+            "request envelope correlation is in the sender's id space and must not surface",
         );
     }
 

--- a/crates/aether-substrate/src/actor/wasm/host_fns.rs
+++ b/crates/aether-substrate/src/actor/wasm/host_fns.rs
@@ -508,6 +508,12 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
         |caller: Caller<'_, ComponentCtx>| -> u64 { caller.data().prev_correlation() },
     )?;
 
+    linker.func_wrap(
+        "aether",
+        "reply_correlation_p32",
+        |caller: Caller<'_, ComponentCtx>| -> u64 { caller.data().reply_correlation() },
+    )?;
+
     // HOST_FN_OK: ADR-0002 / issue 531. The ActorInitError plumbing
     // can't ride a mail sink because mail is not dispatched until
     // the component finishes booting — the `init` FFI call itself

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -98,7 +98,7 @@ pub use mail::outbound::{
     DroppingBackend, EgressBackend, EgressEvent, HubOutbound, RecordingBackend,
 };
 pub use mail::registry::{InboxHandler, InlineHandler, MailboxEntry, OwnedDispatch, Registry};
-pub use mail::{KindId, Mail, MailKind, MailRef, MailboxId, Source, SourceAddr};
+pub use mail::{KindId, Mail, MailKind, MailRef, MailboxId, RequestId, Source, SourceAddr};
 pub use runtime::panic_hook::init_panic_hook;
 
 /// Well-known mailbox name for substrate-level diagnostic events

--- a/crates/aether-substrate/src/mail/mod.rs
+++ b/crates/aether-substrate/src/mail/mod.rs
@@ -27,7 +27,7 @@ pub use registry::{InboxHandler, InlineHandler, MailboxEntry, OwnedDispatch, Reg
 /// ADR-0065 hoisted the canonical home into `aether_data` (per ADR-0069);
 /// this remains re-exported under the `aether_substrate::mail::MailboxId`
 /// path so existing call sites compile unchanged.
-pub use aether_data::{KindId, MailId, MailboxId};
+pub use aether_data::{KindId, MailId, MailboxId, RequestId};
 /// Reply-routing types. Canonical home is `aether-data` (ADR-0076) —
 /// `aether-actor`'s `Dispatch` trait references them in its signature
 /// without taking an `aether-actor`-internal dep, and the location

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/fs_demux.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/fs_demux.rs
@@ -1,0 +1,79 @@
+//! Issue 2791: end-to-end request-correlation fixture.
+//!
+//! The trigger fires two `aether.fs.read` requests for the same namespace/path
+//! and records the two returned request ids. The two `ReadResult` payloads are
+//! intentionally indistinguishable by echoed fields; the fixture only reports
+//! success after both replies match via `ctx.in_reply_to()`.
+
+use aether_actor::{
+    ActorInitError, MailSender, Manual, RequestId, WasmActor, WasmCtx, WasmInitCtx, actor,
+};
+use aether_capabilities::fs::{FsCapability, Read, ReadResult};
+use aether_test_fixtures_kinds::{FsDemuxReport, RunFsDemux, TEST_BENCH_OBSERVER_MAILBOX_NAME};
+
+#[derive(Default)]
+pub struct FsDemux {
+    first: Option<RequestId>,
+    second: Option<RequestId>,
+    first_matched: bool,
+    second_matched: bool,
+}
+
+#[actor]
+impl WasmActor for FsDemux {
+    const NAMESPACE: &'static str = "test.fs_demux";
+
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Self::default())
+    }
+
+    #[handler::single]
+    fn on_run(&mut self, ctx: &mut WasmCtx<'_>, msg: RunFsDemux) {
+        self.first = None;
+        self.second = None;
+        self.first_matched = false;
+        self.second_matched = false;
+
+        let fs = ctx.actor::<FsCapability>();
+        let read = Read {
+            namespace: msg.namespace,
+            path: msg.path,
+        };
+        self.first = Some(fs.send_tracked(&read));
+        self.second = Some(fs.send_tracked(&read));
+    }
+
+    #[handler::manual]
+    fn on_read_result(&mut self, ctx: &mut WasmCtx<'_, Manual>, _reply: ReadResult) {
+        let Some(request) = ctx.in_reply_to() else {
+            tracing::warn!(target: "test.fs_demux", "read_result carried no request id");
+            return;
+        };
+        if Some(request) == self.first {
+            self.first_matched = true;
+        } else if Some(request) == self.second {
+            self.second_matched = true;
+        } else {
+            tracing::warn!(
+                target: "test.fs_demux",
+                request_id = request.0,
+                "read_result request id did not match either pending read",
+            );
+            return;
+        }
+
+        if self.first_matched && self.second_matched {
+            tracing::info!(
+                target: "test.fs_demux",
+                "fs_demux first_matched=true second_matched=true",
+            );
+            ctx.send_to_named::<FsDemuxReport>(
+                TEST_BENCH_OBSERVER_MAILBOX_NAME,
+                &FsDemuxReport {
+                    first_matched: true,
+                    second_matched: true,
+                },
+            );
+        }
+    }
+}

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
@@ -15,6 +15,7 @@
 //! so each lives in its own satellite crate.
 
 mod cube;
+mod fs_demux;
 mod http_handler;
 mod inline_child;
 mod mat4_source;
@@ -26,6 +27,7 @@ mod stateful_replace;
 mod ui_widget;
 
 pub use cube::Cube;
+pub use fs_demux::FsDemux;
 pub use http_handler::{
     HttpHandler, RoutedHttpHandler, RoutedStreamingHttpHandler, StreamingHttpHandler,
     WebSocketHandler,
@@ -52,6 +54,7 @@ aether_actor::export!(
     RootManager,
     Panel,
     Cube,
+    FsDemux,
     MatSource,
     UiWidget,
     HttpHandler,

--- a/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
@@ -407,6 +407,42 @@ pub struct SourceReport {
     pub mailbox_id: u64,
 }
 
+/// Issue 2791: trigger for the request-correlation fixture. The fixture
+/// sends two `aether.fs.read` requests for this same namespace/path and
+/// demuxes the indistinguishable replies by `ctx.in_reply_to()`.
+#[derive(
+    aether_data::Kind,
+    aether_data::Schema,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    Default,
+)]
+#[kind(name = "aether.test_fixtures.run_fs_demux")]
+pub struct RunFsDemux {
+    pub namespace: String,
+    pub path: String,
+}
+
+/// Issue 2791: report emitted once both same-path fs replies were matched by
+/// request id rather than by echoed payload fields.
+#[derive(
+    aether_data::Kind,
+    aether_data::Schema,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+)]
+#[kind(name = "aether.test_fixtures.fs_demux_report")]
+pub struct FsDemuxReport {
+    pub first_matched: bool,
+    pub second_matched: bool,
+}
+
 /// Issue 1977 (ADR-0114 amendment) cluster-addressing matrix driver. Sent to
 /// the `matrix_sweep` fixture's parent over the wire to kick off the sweep:
 /// the parent drives every in-cluster addressing direction (parent → child,

--- a/docs/adr/0134-multi-reply-class-and-explicit-handler-classes.md
+++ b/docs/adr/0134-multi-reply-class-and-explicit-handler-classes.md
@@ -51,7 +51,7 @@ Bare `#[handler]` and `#[handler(mail)]` become pointed compile errors naming th
 ### Negative / limits
 
 - **A whole-tree migration** (~200 bare `#[handler]` sites plus the guide and CLAUDE.md examples) — mechanical, behavior-preserving, tracked separately from this ADR's implementation.
-- **Trace linkage from dispatch to emission is severed** — a detached root has no parent. Payload correlation is the domain-level linkage, as ADR-0133 accepted for HTTP.
+- **Trace linkage from dispatch to emission is severed** — a detached root has no parent. Payload correlation remains the domain-level linkage for multi emissions and other detached data phases, as ADR-0133 accepted for HTTP; one-shot request/reply paths use the envelope request id instead.
 - **A session-origin driver cannot sink emissions.** MCP `send_mail` dispatches carry no component source, so multi handlers are component-to-component surfaces — the same limit HTTP's data phase already has.
 - **One declared kind per multi handler.** Multi-kind conversations keep their other legs on `MailSender`, invisible to the reply contract. That is the price of a manifest that names one kind rather than reporting `Manual`-style opacity.
 

--- a/docs/guide/systems/concurrency.md
+++ b/docs/guide/systems/concurrency.md
@@ -62,9 +62,10 @@ shape: **return now, continue later.**
 The idiomatic shape is a small state machine spread across handler invocations:
 send the request, *return* from the handler (freeing the worker), and handle the
 reply when it arrives as a *separate* mail in a later handler call. Correlation
-survives across turns — a handler can stash the correlation id of its send
-(`prev_correlation`) and match it against the inbound reply's id, so multiple
-in-flight requests don't get confused (the surviving half of [ADR-0042](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0042-synchronous-mail-wait.md)). Every
+survives across turns through the envelope request id: a wasm handler calls
+`send_tracked(&request)`, stashes the returned `RequestId`, and later compares
+it with `ctx.in_reply_to()` in the reply handler, so duplicate in-flight
+requests don't get confused (the surviving half of [ADR-0042](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0042-synchronous-mail-wait.md)). Every
 request/reply in the engine works this way: `aether.fs.read` →
 `…read_result`, reply-to-sender, and the rest.
 

--- a/docs/guide/systems/mail-and-kinds.md
+++ b/docs/guide/systems/mail-and-kinds.md
@@ -114,6 +114,17 @@ reply. If a reply matters, that's a separate, explicit contract between the two
 kinds — never an implicit "every kind has a response." Don't write a caller
 that blocks waiting for a reply a handler never agreed to send.
 
+**When several requests are in flight, track the envelope id.** A wasm actor
+that sends a one-shot request and needs to match the later reply should call
+`send_tracked(&request)`, stash the returned `RequestId`, and compare it with
+`ctx.in_reply_to()` in the reply handler. `in_reply_to()` returns `None` for
+ordinary inbound requests, uncorrelated mail, and inline-cluster local dispatches
+that never crossed the host envelope boundary. Echoed payload fields such as
+`namespace` + `path` on `aether.fs.read_result` remain useful domain context,
+but exact duplicate-safe matching belongs to the envelope request id. Multi
+emissions and detached data phases still carry their own domain-level
+correlation in their payloads.
+
 **The ordering spine** ([ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md)) — **the single contract to hold in your head
 when writing handlers.** Get it wrong and you write code that passes in dev and
 breaks under load:


### PR DESCRIPTION
Closes #2791.

## Summary

- adds `RequestId`, wasm `send_tracked`, and wasm/native `in_reply_to()` APIs for exact request/reply matching
- exposes the current inbound reply correlation through the wasm host import and gates inline-cluster local dispatches away from stale host state
- adds a TestBench fs demux fixture plus docs clarifying envelope ids vs payload-level correlation

## Verification

- `cargo fmt -- --check`
- `cargo check -p aether-actor`
- `cargo check -p aether-substrate`
- `cargo check -p aether-test-fixtures-bundle`
- `cargo test -p aether-actor local_dispatch_ctx_never_reads_host_reply_correlation`
- `cargo test -p aether-actor send_tracked_local_route_returns_no_correlation_sentinel`
- `cargo test -p aether-substrate --lib reply_correlation_import_exposes_reply_envelope_only`
- `cargo test -p aether-substrate-bundle --test reply_correlation`
