### PR TITLE
feat(substrate): support format-aware render textures

### DIFF
--- a/crates/aether-capabilities/src/render/headless_runtime.rs
+++ b/crates/aether-capabilities/src/render/headless_runtime.rs
@@ -156,6 +156,7 @@ impl NativeActor for HeadlessRenderCapability {
 #[cfg(all(test, feature = "runtime"))]
 mod headless_tests {
     use super::*;
+    use crate::render::TextureFormat;
     use aether_data::{MailboxId, Source, SourceAddr};
     use aether_data::{SessionToken, Uuid};
     use aether_substrate::actor::native::NativeCtx;
@@ -189,6 +190,7 @@ mod headless_tests {
             CreateTexture {
                 width: 2,
                 height: 2,
+                format: TextureFormat::Rgba8,
                 pixels: vec![0u8; 16],
             },
         );

--- a/crates/aether-capabilities/src/render/kinds.rs
+++ b/crates/aether-capabilities/src/render/kinds.rs
@@ -71,28 +71,50 @@ pub struct Camera {
     pub view_proj: [f32; 16],
 }
 
-/// `aether.render.create_texture` — register an RGBA8 texture in the
-/// render cap's session-scoped texture registry. `pixels` is exactly
-/// `width * height * 4` bytes (RGBA8, row-major, top-down). The cap
-/// validates the dimensions, assigns the next `texture_id` past any
-/// previously created texture (the same id-assignment shape ADR-0103
-/// uses for instrument ids), stages the pixels CPU-side, and replies
-/// as soon as the id is assigned — the wgpu texture is realized lazily
-/// at the next frame record. Reply: `CreateTextureResult`. Desktop-
-/// only — the headless chassis replies `Err` (fail-fast, ADR-0105).
+/// Pixel storage format for a registered render texture.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TextureFormat {
+    /// Four bytes per pixel, row-major RGBA, top-down.
+    Rgba8,
+    /// One unsigned normalized byte per pixel. Sampling in WGSL yields
+    /// `vec4(r, 0.0, 0.0, 1.0)`.
+    R8,
+}
+
+impl TextureFormat {
+    #[must_use]
+    pub const fn bytes_per_pixel(self) -> usize {
+        match self {
+            Self::Rgba8 => 4,
+            Self::R8 => 1,
+        }
+    }
+}
+
+/// `aether.render.create_texture` — register a texture in the render
+/// cap's session-scoped texture registry. `pixels` is exactly
+/// `width * height * format.bytes_per_pixel()` bytes, row-major and
+/// top-down. The cap validates the dimensions, assigns the next
+/// `texture_id` past any previously created texture (the same
+/// id-assignment shape ADR-0103 uses for instrument ids), stages the
+/// pixels CPU-side, and replies as soon as the id is assigned — the
+/// wgpu texture is realized lazily at the next frame record. Reply:
+/// `CreateTextureResult`. Desktop-only — the headless chassis replies
+/// `Err` (fail-fast, ADR-0105).
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.render.create_texture")]
 pub struct CreateTexture {
     pub width: u32,
     pub height: u32,
+    pub format: TextureFormat,
     pub pixels: Vec<u8>,
 }
 
 /// Reply to `CreateTexture`. `Ok` carries the assigned `texture_id` —
 /// thread it into `DrawTexturedQuads.texture_id` and
 /// `UpdateTexture.texture_id`. `Err` carries a human-readable reason —
-/// a zero dimension, or a `pixels` length that doesn't match
-/// `width * height * 4`.
+/// a zero dimension, or a `pixels` length that doesn't match the
+/// texture format's byte count.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.render.create_texture_result")]
 pub enum CreateTextureResult {
@@ -103,10 +125,11 @@ pub enum CreateTextureResult {
 /// `aether.render.update_texture` — overwrite a sub-rectangle of a
 /// previously-created texture's pixels (atlas growth — e.g. the text
 /// cap rasterizing a new glyph into its atlas). `pixels` is exactly
-/// `width * height * 4` bytes covering the `(x, y, width, height)`
-/// sub-rect. Fire-and-forget; a bad `texture_id` or an out-of-bounds
-/// rect logs and drops. The staged pixels update immediately; the GPU
-/// texture re-uploads at the next frame record.
+/// `width * height * texture_format.bytes_per_pixel()` bytes covering
+/// the `(x, y, width, height)` sub-rect. Fire-and-forget; a bad
+/// `texture_id` or an out-of-bounds rect logs and drops. The staged
+/// pixels update immediately; the GPU texture re-uploads at the next
+/// frame record.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.render.update_texture")]
 pub struct UpdateTexture {

--- a/crates/aether-capabilities/src/render/mod.rs
+++ b/crates/aether-capabilities/src/render/mod.rs
@@ -254,15 +254,18 @@ mod tests {
         );
         assert_eq!(batches[0].quads[0].width, 30.0);
 
-        let tex_present = handles
+        let textures = handles
             .textures
             .lock()
-            .expect("textures mutex is not poisoned")
+            .expect("textures mutex is not poisoned");
+        let white = textures
             .entries
-            .contains_key(&WHITE_TEXTURE_ID);
-        assert!(
-            tex_present,
-            "white texture must be lazily inserted on first send"
+            .get(&WHITE_TEXTURE_ID)
+            .expect("white texture must be lazily inserted on first send");
+        assert_eq!(
+            white.format,
+            TextureFormat::Rgba8,
+            "white texture must remain RGBA8",
         );
 
         drop(chassis);

--- a/crates/aether-capabilities/src/render/runtime/mod.rs
+++ b/crates/aether-capabilities/src/render/runtime/mod.rs
@@ -62,7 +62,8 @@ use aether_substrate::chassis::error::BootError;
 
 use super::{
     Camera, CreateTexture, CreateTextureResult, DRAW_TRIANGLE_BYTES, DrawSolidQuads,
-    DrawTexturedQuads, DrawTriangle, RenderCapability, SolidQuad, TexturedQuad, UpdateTexture,
+    DrawTexturedQuads, DrawTriangle, RenderCapability, SolidQuad, TextureFormat, TexturedQuad,
+    UpdateTexture,
 };
 
 // These seam items are `pub` (visible in `render`) in their
@@ -383,15 +384,15 @@ impl NativeActor for RenderCapability {
     }
 
     /// `CreateTexture` handler (ADR-0105). Validates the dimensions
-    /// and pixel length, stages the RGBA8 pixels CPU-side under the
+    /// and pixel length, stages the pixels CPU-side under the
     /// next session-scoped `texture_id`, and replies immediately —
     /// the wgpu texture is realized lazily at the next frame record
     /// (the GPU bundle isn't installed until the chassis driver
     /// boots). A zero dimension or a `pixels` length that doesn't
-    /// match `width * height * 4` replies `Err` without registering.
+    /// match the texture format replies `Err` without registering.
     ///
     /// # Agent
-    /// Mail `aether.render.create_texture { width, height, pixels }`;
+    /// Mail `aether.render.create_texture { width, height, format, pixels }`;
     /// the reply `aether.render.create_texture_result` carries the
     /// `texture_id` to thread into `draw_textured_quads`.
     #[handler::single]
@@ -405,7 +406,7 @@ impl NativeActor for RenderCapability {
                 .expect("mutex poisoned; fail-fast per ADR-0063")
                 .push(<CreateTexture as Kind>::NAME.into());
         }
-        let expected = expected_pixel_bytes(mail.width, mail.height);
+        let expected = expected_pixel_bytes(mail.width, mail.height, mail.format);
         let Some(expected) = expected else {
             return CreateTextureResult::Err {
                 error: format!(
@@ -417,8 +418,11 @@ impl NativeActor for RenderCapability {
         if mail.pixels.len() != expected {
             return CreateTextureResult::Err {
                 error: format!(
-                    "pixels length {} does not match width*height*4 = {expected}",
-                    mail.pixels.len()
+                    "pixels length {} does not match {}x{} {:?} = {expected}",
+                    mail.pixels.len(),
+                    mail.width,
+                    mail.height,
+                    mail.format
                 ),
             };
         }
@@ -434,6 +438,7 @@ impl NativeActor for RenderCapability {
             StagedTexture {
                 width: mail.width,
                 height: mail.height,
+                format: mail.format,
                 pixels: mail.pixels,
                 realized: None,
                 dirty: true,
@@ -548,6 +553,7 @@ impl NativeActor for RenderCapability {
             .or_insert_with(|| StagedTexture {
                 width: 1,
                 height: 1,
+                format: TextureFormat::Rgba8,
                 pixels: vec![255, 255, 255, 255],
                 realized: None,
                 dirty: true,

--- a/crates/aether-capabilities/src/render/runtime/pipeline.rs
+++ b/crates/aether-capabilities/src/render/runtime/pipeline.rs
@@ -19,9 +19,10 @@ use std::sync::{Arc, Mutex, OnceLock};
 use aether_kinds::{QuadScale, QuadSpace};
 use aether_substrate::render::{
     CaptureMeta, OverlayDraw, Pipeline, QUAD_VERTEX_STRIDE, QUAD_VERTICES_PER_QUAD, QuadPipeline,
-    RenderError, Targets, build_main_pipeline, build_quad_pipeline, finish_capture,
-    map_capture_rgba, prepare_capture_copy, push_screen_quad_vertices, push_world_quad_vertices,
-    record_main_pass, record_quad_overlay_pass,
+    RenderError, Targets, TextureBindings, build_main_pipeline, build_quad_pipeline,
+    build_texture_bindings, finish_capture, map_capture_rgba, prepare_capture_copy,
+    push_screen_quad_vertices, push_world_quad_vertices, record_main_pass,
+    record_quad_overlay_pass,
 };
 
 use super::quad::QuadBatch;
@@ -285,7 +286,7 @@ impl RenderHandles {
         // mutably borrowing the registry.
         for batch in &batches {
             if let Some(entry) = registry.entries.get_mut(&batch.texture_id) {
-                entry.ensure_realized(&gpu.device, &gpu.queue, &gpu.quad_pipeline);
+                entry.ensure_realized(&gpu.device, &gpu.queue, &gpu.texture_bindings);
             } else {
                 tracing::warn!(
                     target: "aether_capabilities::render",
@@ -507,6 +508,10 @@ pub struct RenderGpu {
     pub device: Arc<wgpu::Device>,
     pub queue: Arc<wgpu::Queue>,
     pub pipeline: Pipeline,
+    /// Shared texture+sampler bindings used by every texture-sampling
+    /// pipeline. The quad overlay owns the first consumer; material
+    /// pipelines added by ADR-0140 use the same layout object.
+    pub texture_bindings: TextureBindings,
     /// Textured-quad overlay pipeline (ADR-0105). Built alongside the
     /// main pipeline so `record_overlay_pass` can draw the
     /// accumulated quads into the same offscreen target after the
@@ -543,12 +548,14 @@ impl RenderGpu {
             polygon_mode,
             vertex_buffer_bytes,
         );
-        let quad_pipeline = build_quad_pipeline(&device, color_format);
+        let texture_bindings = build_texture_bindings(&device);
+        let quad_pipeline = build_quad_pipeline(&device, color_format, &texture_bindings);
         let targets = Targets::new(&device, color_format, width, height);
         Self {
             device,
             queue,
             pipeline,
+            texture_bindings,
             quad_pipeline,
             targets: Mutex::new(targets),
             color_format,

--- a/crates/aether-capabilities/src/render/runtime/texture.rs
+++ b/crates/aether-capabilities/src/render/runtime/texture.rs
@@ -1,5 +1,5 @@
 //! Session-scoped texture registry for the `aether.render` cap
-//! (ADR-0105). Staged CPU RGBA8 pixels are the source of truth; the
+//! (ADR-0105). Staged CPU pixels are the source of truth; the
 //! wgpu texture + bind group are realized lazily at record time on the
 //! driver thread. `create_texture` / `update_texture` run on the cap
 //! dispatcher thread and only touch the staging side.
@@ -7,20 +7,23 @@
 use std::collections::HashMap;
 
 use aether_substrate::render::{
-    QuadPipeline, RealizedTexture, realize_texture, upload_texture_full,
+    RealizedTexture, TextureBindings, realize_texture, upload_texture_full,
 };
 
-/// A texture registered via `create_texture`: the staged RGBA8 pixels
-/// (the CPU source of truth), plus the lazily-realized GPU texture +
-/// bind group. `create_texture` / `update_texture` run on the cap
-/// dispatcher thread and only touch the staging side; the wgpu
-/// resources are realized at record time on the driver thread (the
-/// `RenderGpu` `OnceLock` isn't filled until the chassis driver boots
-/// the GPU). `dirty` flags staging that the GPU copy hasn't caught up
-/// to yet — the next record re-uploads the whole texture.
+use crate::render::TextureFormat;
+
+/// A texture registered via `create_texture`: the staged pixels (the CPU
+/// source of truth), plus the lazily-realized GPU texture + bind group.
+/// `create_texture` / `update_texture` run on the cap dispatcher thread
+/// and only touch the staging side; the wgpu resources are realized at
+/// record time on the driver thread (the `RenderGpu` `OnceLock` isn't
+/// filled until the chassis driver boots the GPU). `dirty` flags staging
+/// that the GPU copy hasn't caught up to yet — the next record re-uploads
+/// the whole texture.
 pub struct StagedTexture {
     pub width: u32,
     pub height: u32,
+    pub format: TextureFormat,
     pub pixels: Vec<u8>,
     pub realized: Option<RealizedTexture>,
     pub dirty: bool,
@@ -28,10 +31,11 @@ pub struct StagedTexture {
 
 impl StagedTexture {
     /// Overwrite the `(x, y, width, height)` sub-rect of the staged
-    /// pixels with `pixels` (RGBA8, row-major) and dirty the texture.
+    /// pixels with `pixels` (texture-format row-major) and dirty the texture.
     /// Returns `false` without touching the buffer if the rect is
     /// out of bounds, has a zero dimension, or `pixels` isn't exactly
-    /// `width * height * 4` bytes — the caller logs and drops.
+    /// `width * height * format.bytes_per_pixel()` bytes — the caller logs
+    /// and drops.
     pub fn apply_subrect(
         &mut self,
         x: u32,
@@ -40,7 +44,7 @@ impl StagedTexture {
         height: u32,
         pixels: &[u8],
     ) -> bool {
-        let Some(rect_bytes) = expected_pixel_bytes(width, height) else {
+        let Some(rect_bytes) = expected_pixel_bytes(width, height, self.format) else {
             return false;
         };
         let in_bounds = x
@@ -51,12 +55,13 @@ impl StagedTexture {
         if !in_bounds || pixels.len() != rect_bytes {
             return false;
         }
-        let row_bytes = width as usize * 4;
-        let dst_stride = self.width as usize * 4;
+        let bytes_per_pixel = self.format.bytes_per_pixel();
+        let row_bytes = width as usize * bytes_per_pixel;
+        let dst_stride = self.width as usize * bytes_per_pixel;
         for row in 0..height as usize {
             let src_start = row * row_bytes;
             let dst_row = y as usize + row;
-            let dst_start = dst_row * dst_stride + x as usize * 4;
+            let dst_start = dst_row * dst_stride + x as usize * bytes_per_pixel;
             self.pixels[dst_start..dst_start + row_bytes]
                 .copy_from_slice(&pixels[src_start..src_start + row_bytes]);
         }
@@ -72,7 +77,7 @@ impl StagedTexture {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        pipeline: &QuadPipeline,
+        texture_bindings: &TextureBindings,
     ) {
         if let Some(realized) = &self.realized {
             // Already on the GPU; re-upload only if `update_texture`
@@ -84,13 +89,21 @@ impl StagedTexture {
             self.realized = Some(realize_texture(
                 device,
                 queue,
-                pipeline,
+                texture_bindings,
                 self.width,
                 self.height,
+                wgpu_texture_format(self.format),
                 &self.pixels,
             ));
         }
         self.dirty = false;
+    }
+}
+
+fn wgpu_texture_format(format: TextureFormat) -> wgpu::TextureFormat {
+    match format {
+        TextureFormat::Rgba8 => wgpu::TextureFormat::Rgba8Unorm,
+        TextureFormat::R8 => wgpu::TextureFormat::R8Unorm,
     }
 }
 
@@ -119,32 +132,37 @@ impl TextureRegistry {
     }
 }
 
-/// RGBA8 byte count for a `width x height` texture, or `None` if the
-/// dimensions are zero or the product overflows `usize`. Shared by the
-/// `create_texture` validation and the `update_texture` sub-rect
+/// Byte count for a `width x height` texture in `format`, or `None` if
+/// the dimensions are zero or the product overflows `usize`. Shared by
+/// the `create_texture` validation and the `update_texture` sub-rect
 /// check.
-pub fn expected_pixel_bytes(width: u32, height: u32) -> Option<usize> {
+pub fn expected_pixel_bytes(width: u32, height: u32, format: TextureFormat) -> Option<usize> {
     if width == 0 || height == 0 {
         return None;
     }
     (width as usize)
         .checked_mul(height as usize)
-        .and_then(|pixels| pixels.checked_mul(4))
+        .and_then(|pixels| pixels.checked_mul(format.bytes_per_pixel()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// ADR-0105: `expected_pixel_bytes` is the single source of the
-    /// RGBA8 length rule. Zero dimensions and overflowing products
-    /// return `None`; a valid texture returns `width * height * 4`.
+    /// ADR-0105 + ADR-0140: `expected_pixel_bytes` is the single source
+    /// of the per-format length rule. Zero dimensions and overflowing
+    /// products return `None`; a valid texture returns
+    /// `width * height * bytes_per_pixel`.
     #[test]
     fn expected_pixel_bytes_validates_dimensions() {
-        assert_eq!(expected_pixel_bytes(2, 3), Some(24));
-        assert_eq!(expected_pixel_bytes(0, 4), None);
-        assert_eq!(expected_pixel_bytes(4, 0), None);
-        assert_eq!(expected_pixel_bytes(u32::MAX, u32::MAX), None);
+        assert_eq!(expected_pixel_bytes(2, 3, TextureFormat::Rgba8), Some(24));
+        assert_eq!(expected_pixel_bytes(2, 3, TextureFormat::R8), Some(6));
+        assert_eq!(expected_pixel_bytes(0, 4, TextureFormat::Rgba8), None);
+        assert_eq!(expected_pixel_bytes(4, 0, TextureFormat::R8), None);
+        assert_eq!(
+            expected_pixel_bytes(u32::MAX, u32::MAX, TextureFormat::Rgba8),
+            None
+        );
     }
 
     /// `apply_subrect` writes an in-bounds rect into the staged pixels
@@ -156,6 +174,7 @@ mod tests {
         let mut texture = StagedTexture {
             width: 2,
             height: 2,
+            format: TextureFormat::Rgba8,
             pixels: vec![0u8; 16],
             realized: None,
             dirty: false,
@@ -175,5 +194,25 @@ mod tests {
         assert!(!texture.apply_subrect(0, 0, 1, 1, &[1, 2, 3]));
         // Zero-sized rect.
         assert!(!texture.apply_subrect(0, 0, 0, 1, &[]));
+    }
+
+    #[test]
+    fn staged_texture_apply_subrect_uses_r8_stride() {
+        let mut texture = StagedTexture {
+            width: 4,
+            height: 2,
+            format: TextureFormat::R8,
+            pixels: vec![0u8; 8],
+            realized: None,
+            dirty: false,
+        };
+
+        assert!(texture.apply_subrect(1, 0, 2, 2, &[10, 20, 30, 40]));
+        assert_eq!(&texture.pixels, &[0, 10, 20, 0, 0, 30, 40, 0]);
+        assert!(texture.dirty);
+
+        texture.dirty = false;
+        assert!(!texture.apply_subrect(0, 0, 2, 1, &[1, 2, 3]));
+        assert!(!texture.dirty);
     }
 }

--- a/crates/aether-capabilities/src/text/runtime/mod.rs
+++ b/crates/aether-capabilities/src/text/runtime/mod.rs
@@ -21,7 +21,8 @@ pub use aether_substrate::chassis::error::BootError;
 
 pub use crate::fs::{FsCapability, Read, ReadResult};
 pub use crate::render::{
-    CreateTexture, CreateTextureResult, RenderCapability, TexturedQuad, UpdateTexture,
+    CreateTexture, CreateTextureResult, RenderCapability, TextureFormat, TexturedQuad,
+    UpdateTexture,
 };
 
 // ADR-0105 shelf-packed RGBA8 glyph atlas (`atlas`) and the pure layout /
@@ -187,6 +188,7 @@ impl TextCapabilityState {
         let create = CreateTexture {
             width: ATLAS_SIZE,
             height: ATLAS_SIZE,
+            format: TextureFormat::Rgba8,
             pixels: self.atlas.pixels().to_vec(),
         };
         // Address the render cap through the lineage-correct resolver

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -37,7 +37,7 @@ use aether_capabilities::fs::{
 };
 use aether_capabilities::render::{
     Camera, CreateTexture, CreateTextureResult, DrawSolidQuads, DrawTexturedQuads, SolidQuad,
-    TexturedQuad,
+    TextureFormat, TexturedQuad, UpdateTexture,
 };
 use aether_capabilities::text::{
     DrawText, FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontResult,
@@ -880,6 +880,7 @@ fn textured_quad_draws_screen_space_rect() {
                 &CreateTexture {
                     width: texture_width,
                     height: texture_height,
+                    format: TextureFormat::Rgba8,
                     pixels,
                 },
             ),
@@ -961,6 +962,110 @@ fn textured_quad_draws_screen_space_rect() {
         cleared_coverage < 0.01,
         "after the quad stopped being sent the frame should be uniform clear color, \
          but coverage was {cleared_coverage} (immediate-mode clear did not run)",
+    );
+}
+
+/// ADR-0140 texture-format half: an R8 texture stages one byte per
+/// pixel, accepts one-byte sub-rect updates, realizes as a sampleable
+/// `R8Unorm` texture, and renders through the existing textured-quad
+/// shader as red-channel-only (`vec4(r, 0, 0, 1)`).
+#[test]
+fn r8_texture_updates_and_draws_red_channel_only() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let (frame_width, frame_height) = (64u32, 48u32);
+    let mut bench = TestBench::start_with_size(frame_width, frame_height).expect("boot");
+
+    let texture_width = 8u32;
+    let texture_height = 4u32;
+    let mut pixels = vec![32u8; (texture_width * texture_height) as usize];
+    let created = bench
+        .execute(vec![(
+            "create",
+            BenchOp::send_and_await(
+                "aether.render",
+                &CreateTexture {
+                    width: texture_width,
+                    height: texture_height,
+                    format: TextureFormat::R8,
+                    pixels: pixels.clone(),
+                },
+            ),
+        )])
+        .expect("create r8 texture");
+    let texture_id = match created
+        .reply::<CreateTextureResult>("create")
+        .expect("decode CreateTextureResult")
+    {
+        CreateTextureResult::Ok { texture_id } => texture_id,
+        CreateTextureResult::Err { error } => panic!("create_texture failed: {error}"),
+    };
+
+    let update_width = texture_width / 2;
+    let update_height = texture_height;
+    pixels.clear();
+    pixels.resize((update_width * update_height) as usize, 224);
+
+    let pre = vec![
+        envelope(
+            "aether.render",
+            &UpdateTexture {
+                texture_id,
+                x: update_width,
+                y: 0,
+                width: update_width,
+                height: update_height,
+                pixels,
+            },
+        ),
+        envelope(
+            "aether.render",
+            &DrawTexturedQuads {
+                texture_id,
+                space: QuadSpace::Screen,
+                quads: vec![TexturedQuad {
+                    x: 16.0,
+                    y: 16.0,
+                    width: 32.0,
+                    height: 16.0,
+                    u0: 0.0,
+                    v0: 0.0,
+                    u1: 1.0,
+                    v1: 1.0,
+                    tint: [1.0, 1.0, 1.0, 1.0],
+                }],
+            },
+        ),
+    ];
+
+    let captured = bench
+        .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+        .expect("capture r8 texture");
+    let png = captured.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
+    assert_eq!((img.width, img.height), (frame_width, frame_height));
+
+    let sample = |x: u32, y: u32| -> [u8; 4] {
+        let start = ((y * img.width + x) * 4) as usize;
+        [
+            img.rgba[start],
+            img.rgba[start + 1],
+            img.rgba[start + 2],
+            img.rgba[start + 3],
+        ]
+    };
+    let left = sample(20, 24);
+    let right = sample(44, 24);
+
+    assert!(
+        right[0] > left[0].saturating_add(80),
+        "right-half R8 update should visibly raise only red; left={left:?} right={right:?}",
+    );
+    assert!(
+        left[1] <= 10 && left[2] <= 10 && right[1] <= 10 && right[2] <= 10,
+        "R8 texture sampled through quad shader should not contribute green/blue; \
+         left={left:?} right={right:?}",
     );
 }
 

--- a/crates/aether-substrate/src/render/mod.rs
+++ b/crates/aether-substrate/src/render/mod.rs
@@ -27,9 +27,9 @@ pub use capture::{
 pub use pipeline::{Pipeline, RenderError, build_main_pipeline, record_main_pass};
 pub use quad::{
     OverlayDraw, QUAD_UNIFORM_BYTES, QUAD_VERTEX_BUFFER_BYTES, QUAD_VERTEX_STRIDE,
-    QUAD_VERTICES_PER_QUAD, QuadPipeline, RealizedTexture, build_quad_pipeline,
-    push_screen_quad_vertices, push_world_quad_vertices, realize_texture, record_quad_overlay_pass,
-    upload_texture_full,
+    QUAD_VERTICES_PER_QUAD, QuadPipeline, RealizedTexture, TextureBindings, build_quad_pipeline,
+    build_texture_bindings, push_screen_quad_vertices, push_world_quad_vertices, realize_texture,
+    record_quad_overlay_pass, upload_texture_full,
 };
 pub use targets::Targets;
 

--- a/crates/aether-substrate/src/render/quad.rs
+++ b/crates/aether-substrate/src/render/quad.rs
@@ -10,11 +10,11 @@
 //! texture + sampler bind group, and alpha blending. So it is a sibling
 //! pass with its own vertex buffer ([`record_quad_overlay_pass`]).
 //!
-//! Texture realization is lazy: the render capability stages RGBA8
-//! pixels CPU-side at `create_texture` time and calls [`realize_texture`]
+//! Texture realization is lazy: the render capability stages pixels
+//! CPU-side at `create_texture` time and calls [`realize_texture`]
 //! / [`upload_texture_full`] at record time, when a device + queue are
 //! available. The realized [`RealizedTexture`] carries the wgpu texture
-//! plus the group-1 bind group built against this pipeline's layout.
+//! plus the group-1 bind group built against shared texture bindings.
 
 use super::targets::Targets;
 use std::slice;
@@ -42,27 +42,28 @@ pub const QUAD_UNIFORM_BYTES: u64 = 80;
 /// Source for the quad overlay shader.
 pub const QUAD_SHADER_WGSL: &str = include_str!("quad.wgsl");
 
+/// Shared GPU texture binding state for every pipeline that samples a
+/// registered render texture.
+pub struct TextureBindings {
+    /// Layout for texture view at binding 0 plus sampler at binding 1.
+    pub layout: wgpu::BindGroupLayout,
+    pub sampler: wgpu::Sampler,
+}
+
 /// Owned GPU state for the quad overlay pipeline: the render pipeline,
-/// the per-frame vertex buffer, the viewport uniform + its bind group
-/// (group 0), the shared sampler, and the group-1 (texture + sampler)
-/// bind group layout that [`realize_texture`] builds per-texture bind
-/// groups against. Built once at chassis boot via
-/// [`build_quad_pipeline`].
+/// the per-frame vertex buffer, and the viewport uniform + its bind
+/// group (group 0). Texture group-1 state is supplied by
+/// [`TextureBindings`].
 #[allow(clippy::struct_field_names)]
 pub struct QuadPipeline {
     pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
     viewport_buffer: wgpu::Buffer,
     viewport_bind_group: wgpu::BindGroup,
-    sampler: wgpu::Sampler,
-    /// Layout for group 1 (texture view at binding 0, sampler at
-    /// binding 1). Retained so the render cap can build a bind group per
-    /// realized texture without re-deriving the layout.
-    texture_bind_group_layout: wgpu::BindGroupLayout,
 }
 
 /// A texture realized on the GPU plus its group-1 bind group, built
-/// against a [`QuadPipeline`]'s `texture_bind_group_layout` + sampler.
+/// against shared [`TextureBindings`].
 /// The render cap caches one of these per registered texture and
 /// re-uploads its pixels via [`upload_texture_full`] when the staged
 /// CPU pixels change.
@@ -71,6 +72,7 @@ pub struct RealizedTexture {
     bind_group: wgpu::BindGroup,
     width: u32,
     height: u32,
+    format: wgpu::TextureFormat,
 }
 
 impl RealizedTexture {
@@ -91,6 +93,44 @@ pub struct OverlayDraw<'a> {
     pub vertex_count: u32,
 }
 
+/// Build the shared texture + sampler bindings used by texture-sampling
+/// pipelines.
+#[must_use]
+pub fn build_texture_bindings(device: &wgpu::Device) -> TextureBindings {
+    let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("shared texture bind group layout"),
+        entries: &[
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                count: None,
+            },
+        ],
+    });
+    let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        label: Some("shared texture sampler"),
+        address_mode_u: wgpu::AddressMode::ClampToEdge,
+        address_mode_v: wgpu::AddressMode::ClampToEdge,
+        address_mode_w: wgpu::AddressMode::ClampToEdge,
+        mag_filter: wgpu::FilterMode::Linear,
+        min_filter: wgpu::FilterMode::Linear,
+        mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+        ..Default::default()
+    });
+    TextureBindings { layout, sampler }
+}
+
 /// Build the quad overlay pipeline. `color_format` matches the
 /// [`Targets`] color target the overlay pass attaches to (the same
 /// format the main pipeline draws into).
@@ -102,6 +142,7 @@ pub struct OverlayDraw<'a> {
 pub fn build_quad_pipeline(
     device: &wgpu::Device,
     color_format: wgpu::TextureFormat,
+    texture_bindings: &TextureBindings,
 ) -> QuadPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("aether quad shader"),
@@ -123,29 +164,6 @@ pub fn build_quad_pipeline(
             }],
         });
 
-    let texture_bind_group_layout =
-        device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("quad texture bind group layout"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        multisampled: false,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                    count: None,
-                },
-            ],
-        });
-
     let viewport_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("quad viewport uniform"),
         size: QUAD_UNIFORM_BYTES,
@@ -162,22 +180,11 @@ pub fn build_quad_pipeline(
         }],
     });
 
-    let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-        label: Some("quad sampler"),
-        address_mode_u: wgpu::AddressMode::ClampToEdge,
-        address_mode_v: wgpu::AddressMode::ClampToEdge,
-        address_mode_w: wgpu::AddressMode::ClampToEdge,
-        mag_filter: wgpu::FilterMode::Linear,
-        min_filter: wgpu::FilterMode::Linear,
-        mipmap_filter: wgpu::MipmapFilterMode::Nearest,
-        ..Default::default()
-    });
-
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("aether quad pipeline layout"),
         bind_group_layouts: &[
             Some(&viewport_bind_group_layout),
-            Some(&texture_bind_group_layout),
+            Some(&texture_bindings.layout),
         ],
         immediate_size: 0,
     });
@@ -275,23 +282,23 @@ pub fn build_quad_pipeline(
         vertex_buffer,
         viewport_buffer,
         viewport_bind_group,
-        sampler,
-        texture_bind_group_layout,
     }
 }
 
-/// Create a GPU texture from staged RGBA8 `pixels` and build its group-1
-/// bind group against `pipeline`'s texture layout + sampler. `pixels`
-/// must be exactly `width * height * 4` bytes (the render cap validates
-/// this at `create_texture` time). Pair with [`upload_texture_full`] to
-/// refresh the pixels later without rebuilding the bind group.
+/// Create a GPU texture from staged `pixels` and build its group-1 bind
+/// group against shared texture bindings. `pixels` must be exactly
+/// `width * height * bytes_per_pixel(format)` bytes (the render cap
+/// validates this at `create_texture` time). Pair with
+/// [`upload_texture_full`] to refresh the pixels later without rebuilding
+/// the bind group.
 #[must_use]
 pub fn realize_texture(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
-    pipeline: &QuadPipeline,
+    texture_bindings: &TextureBindings,
     width: u32,
     height: u32,
+    format: wgpu::TextureFormat,
     pixels: &[u8],
 ) -> RealizedTexture {
     let texture = device.create_texture(&wgpu::TextureDescriptor {
@@ -304,14 +311,14 @@ pub fn realize_texture(
         mip_level_count: 1,
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::Rgba8Unorm,
+        format,
         usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
         view_formats: &[],
     });
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
     let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-        label: Some("aether quad texture bind group"),
-        layout: &pipeline.texture_bind_group_layout,
+        label: Some("aether texture bind group"),
+        layout: &texture_bindings.layout,
         entries: &[
             wgpu::BindGroupEntry {
                 binding: 0,
@@ -319,7 +326,7 @@ pub fn realize_texture(
             },
             wgpu::BindGroupEntry {
                 binding: 1,
-                resource: wgpu::BindingResource::Sampler(&pipeline.sampler),
+                resource: wgpu::BindingResource::Sampler(&texture_bindings.sampler),
             },
         ],
     });
@@ -328,6 +335,7 @@ pub fn realize_texture(
         bind_group,
         width,
         height,
+        format,
     };
     upload_texture_full(queue, &realized, pixels);
     realized
@@ -336,8 +344,8 @@ pub fn realize_texture(
 /// Re-upload the full staged `pixels` into an already-realized texture.
 /// Used when an `update_texture` mail changed the staged CPU pixels: the
 /// render cap re-uploads the whole texture at the next record rather
-/// than tracking dirty sub-rects on the GPU. `pixels` must be
-/// `width * height * 4` bytes.
+/// than tracking dirty sub-rects on the GPU. `pixels` must match the
+/// realized texture format's byte count.
 pub fn upload_texture_full(queue: &wgpu::Queue, realized: &RealizedTexture, pixels: &[u8]) {
     queue.write_texture(
         wgpu::TexelCopyTextureInfo {
@@ -349,7 +357,7 @@ pub fn upload_texture_full(queue: &wgpu::Queue, realized: &RealizedTexture, pixe
         pixels,
         wgpu::TexelCopyBufferLayout {
             offset: 0,
-            bytes_per_row: Some(realized.width.max(1) * 4),
+            bytes_per_row: Some(realized.width.max(1) * texture_bytes_per_pixel(realized.format)),
             rows_per_image: Some(realized.height.max(1)),
         },
         wgpu::Extent3d {
@@ -358,6 +366,14 @@ pub fn upload_texture_full(queue: &wgpu::Queue, realized: &RealizedTexture, pixe
             depth_or_array_layers: 1,
         },
     );
+}
+
+fn texture_bytes_per_pixel(format: wgpu::TextureFormat) -> u32 {
+    match format {
+        wgpu::TextureFormat::Rgba8Unorm => 4,
+        wgpu::TextureFormat::R8Unorm => 1,
+        _ => panic!("unsupported render texture format: {format:?}"),
+    }
 }
 
 /// Push the six vertices (two triangles) for one screen-space quad into

--- a/docs/guide/systems/rendering.md
+++ b/docs/guide/systems/rendering.md
@@ -49,7 +49,7 @@ the `RenderCapability` actor. It handles these payload kinds:
 |---|---|---|
 | `aether.draw_triangle` | `{ verts: [Vertex; 3] }`, cast-shaped | per-tick geometry; accumulates into the frame |
 | `aether.camera` | `{ view_proj: [f32; 16] }`, cast-shaped | the world→clip matrix; latest value wins |
-| `aether.render.create_texture` | `{ width, height, pixels }` → `create_texture_result` | register an RGBA8 texture; reply carries the `texture_id` |
+| `aether.render.create_texture` | `{ width, height, format, pixels }` → `create_texture_result` | register an `Rgba8` or `R8` texture; reply carries the `texture_id` |
 | `aether.render.update_texture` | `{ texture_id, x, y, width, height, pixels }` | overwrite a sub-rect of a texture (atlas growth) |
 | `aether.render.draw_textured_quads` | `{ texture_id, space, quads }` | per-tick textured alpha-blended quads; accumulates into the frame |
 | `aether.render.capture_frame` | `{ mails, after_mails }` | atomic "set state, read back a PNG, clean up" |
@@ -59,9 +59,12 @@ color. One `DrawTriangle` is three of them; a component batches many per envelop
 via `send_many` (each triangle is `DRAW_TRIANGLE_BYTES` on the wire).
 
 **Textured quads are the generic image surface** ([ADR-0105](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0105-text-rendering.md)).
-`create_texture` stages RGBA8 pixels under a session-scoped `texture_id` (the
-reply hands it back); `draw_textured_quads` then draws a batch of quads sampling
-that texture, each carrying a pixel-unit rect, a uv sub-rect, and an RGBA tint.
+`create_texture` stages `Rgba8` or `R8` pixels under a session-scoped
+`texture_id` (the reply hands it back); `draw_textured_quads` then draws a batch
+of quads sampling that texture, each carrying a pixel-unit rect, a uv sub-rect,
+and an RGBA tint. `R8` samples contribute their scalar value in the red channel
+(`vec4(r, 0, 0, 1)`), which is mainly a substrate for material passes; ordinary
+sprite/text atlas callers use `Rgba8`.
 Quads draw through a second alpha-blended pipeline in an overlay pass recorded
 after the world pass, so they always land on top. The accumulate-per-frame
 contract matches `draw_triangle`: resend the batch every frame it should appear.


### PR DESCRIPTION
Closes #2815.

## Summary

- adds `TextureFormat::{Rgba8,R8}` to `aether.render.create_texture` and threads per-format byte counts through staging and sub-rect updates
- extracts shared texture+sampler bindings from the quad pipeline so realized textures can be reused by future material pipelines
- migrates existing RGBA8 callers and adds a TestBench scenario proving R8 create/update/draw behavior

## Verification

- `cargo fmt -- --check`
- `cargo check -p aether-capabilities --features render-runtime,text-runtime`
- `cargo check -p aether-substrate --features render`
- `cargo test -p aether-capabilities --features render-runtime render::runtime::texture`
- `cargo test -p aether-substrate-bundle --test test_bench_scenario r8_texture_updates_and_draws_red_channel_only`
- `cargo test -p aether-substrate-bundle --test test_bench_scenario textured_quad_draws_screen_space_rect`
- `cargo clippy -p aether-capabilities --features render-runtime,text-runtime --all-targets -- -D warnings`
- `cargo clippy -p aether-substrate --features render,test-support --all-targets -- -D warnings`
- `cargo clippy -p aether-substrate-bundle --test test_bench_scenario -- -D warnings`
