### PR TITLE
feat(actor): add kind-typed request contexts

### DIFF
--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -54,6 +54,7 @@ pub mod local;
 pub mod log;
 pub mod mail;
 pub mod model;
+pub mod request_context;
 pub mod trace;
 pub mod wasm;
 
@@ -66,6 +67,9 @@ pub use model::{
     Actor, Addressable, EMBEDDED_SCOPE, Embedded, EmbeddedMany, HandlesKind, Instanced, Lifecycle,
     Many, NAMESPACE_SEGMENT_MAX_LEN, NamespaceError, One, Resolve, Singleton, Subname,
     validate_namespace_segment,
+};
+pub use request_context::{
+    REQUEST_CONTEXT_CAPACITY, RequestContextTable, compose_state_envelope, split_state_envelope,
 };
 // Issue 665: `Mailbox<K, T>` and `ActorMailbox<'_, R, T>` retired; the
 // surviving [`mail::mailbox::Mailbox<K>`] is a transport-free

--- a/crates/aether-actor/src/request_context.rs
+++ b/crates/aether-actor/src/request_context.rs
@@ -1,0 +1,402 @@
+//! Request-context table shared by wasm guests and native actors.
+//!
+//! The table is keyed by the reply correlation id minted for an outbound
+//! request. Context values are ordinary `Kind`s, so the stored bytes carry a
+//! schema-derived `KindId` and can be restored across guest replacement.
+
+use alloc::vec::Vec;
+
+use aether_data::{Kind, KindId, RequestId, Source};
+
+/// Default per-actor cap on remembered request contexts.
+pub const REQUEST_CONTEXT_CAPACITY: usize = 1024;
+
+const ENVELOPE_VERSION: u32 = 0xAEC0_0001;
+const ENVELOPE_MAGIC: &[u8; 8] = b"AECTX001";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RequestContextEntry {
+    request: RequestId,
+    kind: KindId,
+    bytes: Vec<u8>,
+    insert_seq: u64,
+}
+
+/// Per-actor request-context table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestContextTable {
+    entries: Vec<RequestContextEntry>,
+    next_seq: u64,
+    capacity: usize,
+}
+
+impl RequestContextTable {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            next_seq: 0,
+            capacity: REQUEST_CONTEXT_CAPACITY,
+        }
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Store a context under `request`, replacing any older entry for the same
+    /// correlation id. A no-correlation request is ignored because no reply can
+    /// recover it exactly.
+    pub fn insert<C: Kind>(&mut self, request: RequestId, context: &C) {
+        if request.0 == Source::NO_CORRELATION {
+            tracing::warn!(
+                kind = C::NAME,
+                "request context not stored: request has no correlation id",
+            );
+            return;
+        }
+
+        if let Some(existing) = self
+            .entries
+            .iter_mut()
+            .find(|entry| entry.request == request)
+        {
+            existing.kind = C::ID;
+            existing.bytes = context.encode_into_bytes();
+            existing.insert_seq = self.next_seq;
+            self.next_seq = self.next_seq.wrapping_add(1);
+            return;
+        }
+
+        if self.entries.len() >= self.capacity
+            && let Some((oldest, _)) = self
+                .entries
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, entry)| entry.insert_seq)
+        {
+            let dropped = self.entries.remove(oldest);
+            tracing::warn!(
+                request = dropped.request.0,
+                kind = dropped.kind.0,
+                age = self.next_seq.saturating_sub(dropped.insert_seq),
+                "request context table full; dropped oldest context",
+            );
+        }
+
+        self.entries.push(RequestContextEntry {
+            request,
+            kind: C::ID,
+            bytes: context.encode_into_bytes(),
+            insert_seq: self.next_seq,
+        });
+        self.next_seq = self.next_seq.wrapping_add(1);
+    }
+
+    /// Remove and decode the context associated with `request`.
+    ///
+    /// Wrong-kind and decode failures consume the stored entry. A reply is a
+    /// one-shot event, and retaining a malformed or wrong-type context would
+    /// make a later handler observe stale bookkeeping.
+    pub fn take<C: Kind>(&mut self, request: RequestId) -> Option<C> {
+        let index = self
+            .entries
+            .iter()
+            .position(|entry| entry.request == request)?;
+        let entry = self.entries.remove(index);
+        if entry.kind != C::ID {
+            tracing::warn!(
+                request = request.0,
+                expected_kind = C::ID.0,
+                actual_kind = entry.kind.0,
+                "request context kind mismatch",
+            );
+            return None;
+        }
+        let decoded = C::decode_from_bytes(&entry.bytes);
+        if decoded.is_none() {
+            tracing::warn!(
+                request = request.0,
+                kind = C::ID.0,
+                "request context decode failed",
+            );
+        }
+        decoded
+    }
+
+    #[must_use]
+    pub fn snapshot_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_u64(&mut out, self.next_seq);
+        push_len(&mut out, self.entries.len());
+        for entry in &self.entries {
+            push_u64(&mut out, entry.request.0);
+            push_u64(&mut out, entry.kind.0);
+            push_u64(&mut out, entry.insert_seq);
+            push_len(&mut out, entry.bytes.len());
+            out.extend_from_slice(&entry.bytes);
+        }
+        out
+    }
+
+    pub fn restore_snapshot_bytes(&mut self, bytes: &[u8]) -> bool {
+        let mut cursor = bytes;
+        let Some(next_seq) = take_u64(&mut cursor) else {
+            return false;
+        };
+        let Some(count) = take_u32(&mut cursor) else {
+            return false;
+        };
+        let mut entries = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            let (Some(request), Some(kind), Some(insert_seq), Some(len)) = (
+                take_u64(&mut cursor),
+                take_u64(&mut cursor),
+                take_u64(&mut cursor),
+                take_u32(&mut cursor),
+            ) else {
+                return false;
+            };
+            let len = len as usize;
+            if cursor.len() < len {
+                return false;
+            }
+            let (payload, rest) = cursor.split_at(len);
+            cursor = rest;
+            entries.push(RequestContextEntry {
+                request: RequestId(request),
+                kind: KindId(kind),
+                bytes: payload.to_vec(),
+                insert_seq,
+            });
+        }
+        if !cursor.is_empty() {
+            return false;
+        }
+        self.entries = entries;
+        self.next_seq = next_seq;
+        true
+    }
+}
+
+impl Default for RequestContextTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Compose the SDK request-context snapshot with the user/inline-child state
+/// bundle that already occupies the single `save_state` slot.
+#[must_use]
+pub fn compose_state_envelope(
+    table: &RequestContextTable,
+    user_state: Option<(u32, Vec<u8>)>,
+) -> Option<(u32, Vec<u8>)> {
+    if table.is_empty() {
+        return user_state;
+    }
+
+    let (user_version, user_bytes) = user_state.unwrap_or((0, Vec::new()));
+    let table_bytes = table.snapshot_bytes();
+    let mut out = Vec::new();
+    out.extend_from_slice(ENVELOPE_MAGIC);
+    push_len(&mut out, table_bytes.len());
+    out.extend_from_slice(&table_bytes);
+    push_u32(&mut out, user_version);
+    push_len(&mut out, user_bytes.len());
+    out.extend_from_slice(&user_bytes);
+    Some((ENVELOPE_VERSION, out))
+}
+
+/// Split a prior-state bundle into the restored request-context snapshot and
+/// the user/inline-child state to pass to existing rehydrate code. Old-format
+/// state is returned unchanged with an empty table.
+#[must_use]
+pub fn split_state_envelope(version: u32, bytes: &[u8]) -> (RequestContextTable, u32, Vec<u8>) {
+    if version != ENVELOPE_VERSION || !bytes.starts_with(ENVELOPE_MAGIC) {
+        return (RequestContextTable::new(), version, bytes.to_vec());
+    }
+
+    let mut cursor = &bytes[ENVELOPE_MAGIC.len()..];
+    let Some(table_len) = take_u32(&mut cursor) else {
+        tracing::warn!("request context state envelope truncated before table length");
+        return (RequestContextTable::new(), 0, Vec::new());
+    };
+    let table_len = table_len as usize;
+    if cursor.len() < table_len {
+        tracing::warn!("request context state envelope truncated in table payload");
+        return (RequestContextTable::new(), 0, Vec::new());
+    }
+    let (table_payload, rest) = cursor.split_at(table_len);
+    cursor = rest;
+    let Some(user_version) = take_u32(&mut cursor) else {
+        tracing::warn!("request context state envelope truncated before user version");
+        return (RequestContextTable::new(), 0, Vec::new());
+    };
+    let Some(user_len) = take_u32(&mut cursor) else {
+        tracing::warn!("request context state envelope truncated before user length");
+        return (RequestContextTable::new(), 0, Vec::new());
+    };
+    let user_len = user_len as usize;
+    if cursor.len() < user_len {
+        tracing::warn!("request context state envelope truncated in user payload");
+        return (RequestContextTable::new(), 0, Vec::new());
+    }
+    let (user_payload, rest) = cursor.split_at(user_len);
+    if !rest.is_empty() {
+        tracing::warn!("request context state envelope has trailing bytes");
+        return (RequestContextTable::new(), 0, Vec::new());
+    }
+
+    let mut table = RequestContextTable::new();
+    if !table.restore_snapshot_bytes(table_payload) {
+        tracing::warn!("request context snapshot failed to decode");
+        table = RequestContextTable::new();
+    }
+    (table, user_version, user_payload.to_vec())
+}
+
+fn push_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_len(out: &mut Vec<u8>, len: usize) {
+    let len = u32::try_from(len).expect("request context state length exceeds u32");
+    push_u32(out, len);
+}
+
+fn push_u64(out: &mut Vec<u8>, value: u64) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn take_u32(cursor: &mut &[u8]) -> Option<u32> {
+    if cursor.len() < 4 {
+        return None;
+    }
+    let (head, rest) = cursor.split_at(4);
+    *cursor = rest;
+    Some(u32::from_le_bytes(head.try_into().ok()?))
+}
+
+fn take_u64(cursor: &mut &[u8]) -> Option<u64> {
+    if cursor.len() < 8 {
+        return None;
+    }
+    let (head, rest) = cursor.split_at(8);
+    *cursor = rest;
+    Some(u64::from_le_bytes(head.try_into().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_data::{MailboxId, Source, SourceAddr};
+
+    #[derive(
+        aether_data::Kind,
+        aether_data::Schema,
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        Clone,
+        PartialEq,
+    )]
+    #[kind(name = "test.request_context")]
+    struct TestContext {
+        value: u32,
+    }
+
+    #[derive(
+        aether_data::Kind,
+        aether_data::Schema,
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        Clone,
+        PartialEq,
+    )]
+    #[kind(name = "test.other_request_context")]
+    struct OtherContext {
+        value: u32,
+    }
+
+    #[derive(
+        aether_data::Kind,
+        aether_data::Schema,
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        Clone,
+        PartialEq,
+    )]
+    #[kind(name = "test.source_request_context")]
+    struct SourceContext {
+        source: Source,
+    }
+
+    #[test]
+    fn take_removes_entry_once() {
+        let mut table = RequestContextTable::new();
+        table.insert(RequestId(7), &TestContext { value: 42 });
+        assert_eq!(
+            table.take::<TestContext>(RequestId(7)),
+            Some(TestContext { value: 42 })
+        );
+        assert_eq!(table.take::<TestContext>(RequestId(7)), None);
+    }
+
+    #[test]
+    fn wrong_kind_take_consumes_entry() {
+        let mut table = RequestContextTable::new();
+        table.insert(RequestId(7), &TestContext { value: 42 });
+        assert_eq!(table.take::<OtherContext>(RequestId(7)), None);
+        assert_eq!(table.take::<TestContext>(RequestId(7)), None);
+    }
+
+    #[test]
+    fn snapshot_round_trips_entries() {
+        let mut table = RequestContextTable::new();
+        table.insert(RequestId(7), &TestContext { value: 42 });
+        let bytes = table.snapshot_bytes();
+        let mut restored = RequestContextTable::new();
+        assert!(restored.restore_snapshot_bytes(&bytes));
+        assert_eq!(
+            restored.take::<TestContext>(RequestId(7)),
+            Some(TestContext { value: 42 })
+        );
+    }
+
+    #[test]
+    fn context_can_carry_source() {
+        let mut table = RequestContextTable::new();
+        let context = SourceContext {
+            source: Source::with_correlation(SourceAddr::Component(MailboxId(99)), 123),
+        };
+        table.insert(RequestId(10), &context);
+        assert_eq!(table.take::<SourceContext>(RequestId(10)), Some(context));
+    }
+
+    #[test]
+    fn envelope_preserves_user_state_and_table() {
+        let mut table = RequestContextTable::new();
+        table.insert(RequestId(9), &TestContext { value: 11 });
+        let (version, bytes) =
+            compose_state_envelope(&table, Some((3, alloc::vec![1, 2, 3]))).expect("envelope");
+        let (mut restored, user_version, user_bytes) = split_state_envelope(version, &bytes);
+        assert_eq!(user_version, 3);
+        assert_eq!(user_bytes, alloc::vec![1, 2, 3]);
+        assert_eq!(
+            restored.take::<TestContext>(RequestId(9)),
+            Some(TestContext { value: 11 })
+        );
+    }
+
+    #[test]
+    fn old_format_state_passes_through() {
+        let (table, version, bytes) = split_state_envelope(4, &[5, 6, 7]);
+        assert!(table.is_empty());
+        assert_eq!(version, 4);
+        assert_eq!(bytes, alloc::vec![5, 6, 7]);
+    }
+}

--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -28,7 +28,7 @@ use crate::model::{
     validate_namespace_segment,
 };
 use crate::wasm::bridge::{mail, persist};
-use crate::wasm::inline::{ChainMode, Registry};
+use crate::wasm::inline::{ChainMode, Registry, RouteDecision};
 use crate::wasm::mailbox::WasmActorMailbox;
 use crate::wasm::{ActorInitError, ErasedWasmActor, WasmActor};
 use alloc::boxed::Box;
@@ -409,6 +409,16 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
         (correlation != Source::NO_CORRELATION).then_some(RequestId(correlation))
     }
 
+    /// Recover and remove the typed context for the request this inbound reply
+    /// answers. Returns `None` for ordinary mail, unmatched replies, wrong
+    /// context kind, or decode failure.
+    pub fn take_context<C: Kind>(&mut self) -> Option<C> {
+        let request = self.in_reply_to()?;
+        // SAFETY: the macro-emitted registry is accessed only under the
+        // serialized wasm guest entrypoint.
+        unsafe { self.inline.request_contexts_mut().take(request) }
+    }
+
     /// The component's own mailbox id — the value the substrate uses to
     /// address `receive` calls to this instance. `wire`-stage explicit
     /// subscribes (sending `SubscribeInput` to the `InputCapability`)
@@ -744,6 +754,38 @@ impl<'a, M: ReplyMode> WasmCtx<'a, M> {
         );
     }
 
+    /// Send through a stored mailbox token and store a typed context for the
+    /// reply correlation id.
+    #[must_use]
+    pub fn send_with_context<K: Kind, C: Kind>(
+        &mut self,
+        mailbox: Mailbox<K>,
+        payload: &K,
+        context: &C,
+    ) -> RequestId {
+        match self.inline.route_decision(mailbox.mailbox()) {
+            RouteDecision::Local => {
+                tracing::warn!(
+                    kind = K::NAME,
+                    recipient = mailbox.mailbox(),
+                    "send_with_context on an inline-cluster local route has no host correlation",
+                );
+                self.send(mailbox, payload);
+                RequestId(Source::NO_CORRELATION)
+            }
+            RouteDecision::Remote => {
+                self.send(mailbox, payload);
+                let request = RequestId(mail::prev_correlation());
+                // SAFETY: the macro-emitted registry is accessed only under the
+                // serialized wasm guest entrypoint.
+                unsafe {
+                    self.inline.request_contexts_mut().insert(request, context);
+                }
+                request
+            }
+        }
+    }
+
     /// Issue 1987: send `payload` to a raw [`MailboxId`], threading this
     /// actor's own id as the send's `from`. The by-id escape hatch for a
     /// recipient address known only at runtime (the typed-token counterpart
@@ -755,6 +797,38 @@ impl<'a, M: ReplyMode> WasmCtx<'a, M> {
         let bytes = payload.encode_into_bytes();
         self.inline
             .route_or_enqueue(id.0, K::ID.0, &bytes, 1, ChainMode::Inherit, self.mailbox);
+    }
+
+    /// Send to a raw mailbox id and store a typed context for the reply
+    /// correlation id.
+    #[must_use]
+    pub fn send_to_with_context<K: Kind, C: Kind>(
+        &mut self,
+        id: MailboxId,
+        payload: &K,
+        context: &C,
+    ) -> RequestId {
+        match self.inline.route_decision(id.0) {
+            RouteDecision::Local => {
+                tracing::warn!(
+                    kind = K::NAME,
+                    recipient = id.0,
+                    "send_to_with_context on an inline-cluster local route has no host correlation",
+                );
+                self.send_to(id, payload);
+                RequestId(Source::NO_CORRELATION)
+            }
+            RouteDecision::Remote => {
+                self.send_to(id, payload);
+                let request = RequestId(mail::prev_correlation());
+                // SAFETY: the macro-emitted registry is accessed only under the
+                // serialized wasm guest entrypoint.
+                unsafe {
+                    self.inline.request_contexts_mut().insert(request, context);
+                }
+                request
+            }
+        }
     }
 }
 

--- a/crates/aether-actor/src/wasm/inline/mod.rs
+++ b/crates/aether-actor/src/wasm/inline/mod.rs
@@ -47,6 +47,7 @@ use core::cell::{Cell, UnsafeCell};
 use aether_data::MailboxId;
 
 use crate::mail::{Mail, NO_REPLY_HANDLE};
+use crate::request_context::RequestContextTable;
 use crate::wasm::ErasedWasmActor;
 use crate::wasm::bridge::mail;
 use crate::wasm::ctx::{ActorTypeTag, SpawnError, WasmCtx};
@@ -219,6 +220,10 @@ pub struct Registry {
     /// handled by the queue — a busy target is just a later queue item —
     /// not by nested dispatch.
     queue: UnsafeCell<VecDeque<QueuedMail>>,
+    /// SDK-owned request contexts keyed by host reply correlation id
+    /// (ADR-0139). Lives beside the inline registry because every wasm ctx and
+    /// mailbox already carries this macro-emitted per-component static.
+    request_contexts: UnsafeCell<RequestContextTable>,
     /// The `export!`-installed by-tag spawn resolver (issue 2692), or `None`
     /// on a raw registry never wired by `export!` (a host-unit registry).
     /// Set once from each init shim — the resolver enumerates the module's
@@ -249,7 +254,29 @@ impl Registry {
             inner: UnsafeCell::new(BTreeMap::new()),
             self_id: Cell::new(0),
             queue: UnsafeCell::new(VecDeque::new()),
+            request_contexts: UnsafeCell::new(RequestContextTable::new()),
             spawn_resolver: Cell::new(None),
+        }
+    }
+
+    /// Mutably borrow the per-component request-context table.
+    ///
+    /// # Safety
+    /// The caller must be running under the serialized wasm guest entrypoint,
+    /// the same invariant required by the rest of `Registry`'s interior
+    /// mutable state.
+    #[allow(clippy::mut_from_ref)]
+    pub(crate) unsafe fn request_contexts_mut(&self) -> &mut RequestContextTable {
+        // SAFETY: caller upholds the serialized-dispatch invariant.
+        unsafe { &mut *self.request_contexts.get() }
+    }
+
+    /// Replace the per-component request-context table during rehydrate.
+    #[allow(dead_code)]
+    pub(crate) fn restore_request_contexts(&self, table: RequestContextTable) {
+        // SAFETY: see [`Self::request_contexts_mut`].
+        unsafe {
+            *self.request_contexts.get() = table;
         }
     }
 

--- a/crates/aether-actor/src/wasm/inline/mod.rs
+++ b/crates/aether-actor/src/wasm/inline/mod.rs
@@ -265,15 +265,17 @@ impl Registry {
     /// The caller must be running under the serialized wasm guest entrypoint,
     /// the same invariant required by the rest of `Registry`'s interior
     /// mutable state.
+    #[doc(hidden)]
     #[allow(clippy::mut_from_ref)]
-    pub(crate) unsafe fn request_contexts_mut(&self) -> &mut RequestContextTable {
+    pub unsafe fn request_contexts_mut(&self) -> &mut RequestContextTable {
         // SAFETY: caller upholds the serialized-dispatch invariant.
         unsafe { &mut *self.request_contexts.get() }
     }
 
     /// Replace the per-component request-context table during rehydrate.
+    #[doc(hidden)]
     #[allow(dead_code)]
-    pub(crate) fn restore_request_contexts(&self, table: RequestContextTable) {
+    pub fn restore_request_contexts(&self, table: RequestContextTable) {
         // SAFETY: see [`Self::request_contexts_mut`].
         unsafe {
             *self.request_contexts.get() = table;

--- a/crates/aether-actor/src/wasm/mailbox.rs
+++ b/crates/aether-actor/src/wasm/mailbox.rs
@@ -185,6 +185,27 @@ impl<R: Addressable> WasmActorMailbox<'_, R> {
         }
     }
 
+    /// Send a request and store a typed context under the minted correlation
+    /// id for the eventual reply handler to recover with
+    /// [`WasmCtx::take_context`](crate::wasm::WasmCtx::take_context).
+    #[must_use]
+    pub fn send_with_context<K, C>(&self, payload: &K, context: &C) -> RequestId
+    where
+        R: HandlesKind<K>,
+        K: Kind,
+        C: Kind,
+    {
+        let request = self.send_tracked(payload);
+        if request.0 != Source::NO_CORRELATION {
+            // SAFETY: the macro-emitted registry is accessed only under the
+            // serialized wasm guest entrypoint.
+            unsafe {
+                self.inline.request_contexts_mut().insert(request, context);
+            }
+        }
+        request
+    }
+
     /// Send a slice of payloads as a contiguous batch. Cast-only —
     /// see [`crate::model::ctx::MailSender::send_many`] for the
     /// wire-shape rationale. Inherits the handler's causal chain like

--- a/crates/aether-actor/src/wasm/mod.rs
+++ b/crates/aether-actor/src/wasm/mod.rs
@@ -730,11 +730,19 @@ macro_rules! __export_internal {
             // composite is byte-identical to the parent's own blob, so a
             // childless component dehydrates exactly as before; a parent
             // that saves nothing and has no children skips the host save.
-            if let Some((version, bytes)) = $crate::wasm::inline::compose::dehydrate(
+            let __aether_user_state = $crate::wasm::inline::compose::dehydrate(
                 mailbox_id,
                 &__AETHER_INLINE,
                 |ctx| <$component as $crate::WasmActor>::on_dehydrate(instance, ctx),
-            ) {
+            );
+            let __aether_state = {
+                // SAFETY: `on_dehydrate` runs under the serialized wasm guest
+                // entrypoint, matching the registry's interior-mutability
+                // invariant.
+                let __aether_contexts = unsafe { __AETHER_INLINE.request_contexts_mut() };
+                $crate::compose_state_envelope(__aether_contexts, __aether_user_state)
+            };
+            if let Some((version, bytes)) = __aether_state {
                 let mut ctx: $crate::WasmDropCtx<'_> = $crate::WasmDropCtx::__new(mailbox_id);
                 ctx.save_state(version, &bytes);
             }
@@ -772,9 +780,12 @@ macro_rules! __export_internal {
                 // ABI); the slice is bounded by this call.
                 unsafe { ::core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) }
             };
+            let (__aether_contexts, __aether_user_version, __aether_user_bytes) =
+                $crate::split_state_envelope(version, prior_bytes);
+            __AETHER_INLINE.restore_request_contexts(__aether_contexts);
             $crate::wasm::inline::compose::reconstruct_inline_children(
-                version,
-                prior_bytes,
+                __aether_user_version,
+                &__aether_user_bytes,
                 &__AETHER_INLINE,
                 |parent_version, parent_bytes| {
                     let mut ctx = $crate::WasmCtx::__new(mailbox_id, &__AETHER_INLINE, $crate::wasm::NO_INBOUND_SOURCE);
@@ -1277,11 +1288,19 @@ macro_rules! __export_multi_internal {
             // composite, then `save_state` once (the boxed instance's
             // dehydrate routes through `erased_on_dehydrate`). Childless ⇒
             // byte-identical to the boxed parent's own blob.
-            if let Some((version, bytes)) = $crate::wasm::inline::compose::dehydrate(
+            let __aether_user_state = $crate::wasm::inline::compose::dehydrate(
                 mailbox_id,
                 &__AETHER_INLINE,
                 |ctx| instance.erased_on_dehydrate(ctx),
-            ) {
+            );
+            let __aether_state = {
+                // SAFETY: `on_dehydrate` runs under the serialized wasm guest
+                // entrypoint, matching the registry's interior-mutability
+                // invariant.
+                let __aether_contexts = unsafe { __AETHER_INLINE.request_contexts_mut() };
+                $crate::compose_state_envelope(__aether_contexts, __aether_user_state)
+            };
+            if let Some((version, bytes)) = __aether_state {
                 let mut ctx: $crate::WasmDropCtx<'_> = $crate::WasmDropCtx::__new(mailbox_id);
                 ctx.save_state(version, &bytes);
             }
@@ -1316,9 +1335,12 @@ macro_rules! __export_multi_internal {
                 // ABI); the slice is bounded by this call.
                 unsafe { ::core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) }
             };
+            let (__aether_contexts, __aether_user_version, __aether_user_bytes) =
+                $crate::split_state_envelope(version, prior_bytes);
+            __AETHER_INLINE.restore_request_contexts(__aether_contexts);
             $crate::wasm::inline::compose::reconstruct_inline_children(
-                version,
-                prior_bytes,
+                __aether_user_version,
+                &__aether_user_bytes,
                 &__AETHER_INLINE,
                 |parent_version, parent_bytes| {
                     // ADR-0112: the boxed `ErasedWasmActor` seam carries the

--- a/crates/aether-data/src/mail.rs
+++ b/crates/aether-data/src/mail.rs
@@ -13,7 +13,7 @@ use alloc::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
-use crate::schema::{LabelNode, NamedField, Primitive, SchemaType};
+use crate::schema::{EnumVariant, LabelNode, NamedField, Primitive, SchemaType};
 use crate::{EngineId, MailboxId, Schema, SessionToken};
 
 /// ADR-0080 §1: the unique identity of a mail. A 128-bit composite of
@@ -103,7 +103,7 @@ impl MailId {
 /// reply paths (ADR-0041's io capability is the motivating case) can
 /// route the `*Result` back to the component via the mailer rather
 /// than the hub.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SourceAddr {
     None,
     Session(SessionToken),
@@ -112,6 +112,43 @@ pub enum SourceAddr {
         mailbox_id: MailboxId,
     },
     Component(MailboxId),
+}
+
+impl Schema for SourceAddr {
+    const SCHEMA: SchemaType = SchemaType::Enum {
+        variants: Cow::Borrowed(&[
+            EnumVariant::Unit {
+                name: Cow::Borrowed("None"),
+                discriminant: 0,
+            },
+            EnumVariant::Tuple {
+                name: Cow::Borrowed("Session"),
+                discriminant: 1,
+                fields: Cow::Borrowed(&[SessionToken::SCHEMA]),
+            },
+            EnumVariant::Struct {
+                name: Cow::Borrowed("EngineMailbox"),
+                discriminant: 2,
+                fields: Cow::Borrowed(&[
+                    NamedField {
+                        name: Cow::Borrowed("engine_id"),
+                        ty: EngineId::SCHEMA,
+                    },
+                    NamedField {
+                        name: Cow::Borrowed("mailbox_id"),
+                        ty: SchemaType::TypeId(MailboxId::TYPE_ID),
+                    },
+                ]),
+            },
+            EnumVariant::Tuple {
+                name: Cow::Borrowed("Component"),
+                discriminant: 3,
+                fields: Cow::Borrowed(&[SchemaType::TypeId(MailboxId::TYPE_ID)]),
+            },
+        ]),
+    };
+    const LABEL: Option<&'static str> = Some("aether.source_addr");
+    const LABEL_NODE: LabelNode = LabelNode::Anonymous;
 }
 
 /// The immediate sender of a substrate-side `Mail` — the addressing
@@ -131,10 +168,28 @@ pub enum SourceAddr {
 /// the origin, and it does persist, in the tracing layer (`root` /
 /// `parent_mail`, ADR-0080), not here. Addressing is deliberately
 /// one-hop; the chain origin is observable, not addressable.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Source {
     pub addr: SourceAddr,
     pub correlation_id: u64,
+}
+
+impl Schema for Source {
+    const SCHEMA: SchemaType = SchemaType::Struct {
+        fields: Cow::Borrowed(&[
+            NamedField {
+                name: Cow::Borrowed("addr"),
+                ty: SourceAddr::SCHEMA,
+            },
+            NamedField {
+                name: Cow::Borrowed("correlation_id"),
+                ty: SchemaType::Scalar(Primitive::U64),
+            },
+        ]),
+        repr_c: false,
+    };
+    const LABEL: Option<&'static str> = Some("aether.source");
+    const LABEL_NODE: LabelNode = LabelNode::Anonymous;
 }
 
 impl Source {

--- a/crates/aether-data/src/wire_id.rs
+++ b/crates/aether-data/src/wire_id.rs
@@ -14,6 +14,10 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::Schema;
+use crate::schema::{LabelNode, NamedField, SchemaType};
+use alloc::borrow::Cow;
+
 pub use uuid::Uuid;
 
 /// Hub-assigned stable identity for an engine connection. Fresh per
@@ -22,6 +26,18 @@ pub use uuid::Uuid;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EngineId(pub Uuid);
 
+impl Schema for EngineId {
+    const SCHEMA: SchemaType = SchemaType::Struct {
+        fields: Cow::Borrowed(&[NamedField {
+            name: Cow::Borrowed("uuid"),
+            ty: SchemaType::Bytes,
+        }]),
+        repr_c: false,
+    };
+    const LABEL: Option<&'static str> = Some("aether.engine_id");
+    const LABEL_NODE: LabelNode = LabelNode::Anonymous;
+}
+
 /// Hub-minted routing handle for a Claude MCP session. The engine
 /// treats it as opaque bytes: it only echoes tokens the hub handed it
 /// on inbound mail back as the address on a reply. The hub validates
@@ -29,6 +45,18 @@ pub struct EngineId(pub Uuid);
 /// (per ADR-0008).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SessionToken(pub Uuid);
+
+impl Schema for SessionToken {
+    const SCHEMA: SchemaType = SchemaType::Struct {
+        fields: Cow::Borrowed(&[NamedField {
+            name: Cow::Borrowed("uuid"),
+            ty: SchemaType::Bytes,
+        }]),
+        repr_c: false,
+    };
+    const LABEL: Option<&'static str> = Some("aether.session_token");
+    const LABEL_NODE: LabelNode = LabelNode::Anonymous;
+}
 
 impl SessionToken {
     /// Placeholder used before session tracking lands at the hub.

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -51,6 +51,8 @@ use crate::mail::ring::{MailLoc, MailRing, RingFull};
 use crate::mail::{KindId, Mail, MailId, MailRef, MailboxId, Source, SourceAddr};
 use crate::runtime::lifecycle::{FatalAborter, PanicAborter};
 use crate::runtime::trace::SettlementHold;
+use aether_actor::RequestContextTable;
+use aether_data::{Kind, RequestId};
 
 /// Per-actor outbound ring capacity (ADR-0087). Sized to hold a typical
 /// handler's small-mail fan-out as one blob; a mail that doesn't fit (a
@@ -233,6 +235,8 @@ pub struct NativeBinding {
     /// mutability — the same single-logical-writer discipline as
     /// `outbound` / `blob_producer`.
     inflight: super::dispatch_blocking::InflightLedger,
+    /// ADR-0139: typed request contexts keyed by reply correlation id.
+    request_contexts: Mutex<RequestContextTable>,
 }
 
 impl NativeBinding {
@@ -271,6 +275,7 @@ impl NativeBinding {
             outbound: Mutex::new(OutboundBuffer::new()),
             blob_producer: Mutex::new(None),
             inflight: Mutex::new(super::dispatch_blocking::InflightTable::new()),
+            request_contexts: Mutex::new(RequestContextTable::new()),
         }
     }
 
@@ -482,12 +487,34 @@ impl NativeBinding {
         root: MailId,
         parent: Option<MailId>,
     ) where
-        K: aether_data::Kind,
+        K: Kind,
     {
         let correlation = self.reply_lineage.mint();
         let reply_id = MailId::new(self.self_mailbox, correlation);
         self.mailer
             .send_reply(sender, payload, reply_id, root, parent);
+    }
+
+    /// Store request context for a just-minted outbound request.
+    ///
+    /// # Panics
+    /// Panics if the request-context mutex is poisoned.
+    pub fn store_request_context<C: Kind>(&self, request: RequestId, context: &C) {
+        self.request_contexts
+            .lock()
+            .expect("request context table poisoned; fail-fast per ADR-0063")
+            .insert(request, context);
+    }
+
+    /// Remove and decode request context for an inbound reply.
+    ///
+    /// # Panics
+    /// Panics if the request-context mutex is poisoned.
+    pub fn take_request_context<C: Kind>(&self, request: RequestId) -> Option<C> {
+        self.request_contexts
+            .lock()
+            .expect("request context table poisoned; fail-fast per ADR-0063")
+            .take(request)
     }
 }
 

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -621,6 +621,14 @@ impl<M: ReplyMode> NativeCtx<'_, M> {
         }
     }
 
+    /// Recover and remove the typed context for the request this inbound reply
+    /// answers. Returns `None` for ordinary mail, unmatched replies, wrong
+    /// context kind, or decode failure.
+    pub fn take_context<C: Kind>(&mut self) -> Option<C> {
+        let request = self.in_reply_to()?;
+        self.binding.take_request_context(request)
+    }
+
     native_sender_methods!();
 
     /// Reply to an explicit [`Source`] under an explicit `(root, parent)`
@@ -1432,6 +1440,56 @@ mod tests {
     }
 
     impl HandlesKind<CastOnly> for StubActor {}
+
+    #[derive(
+        aether_data::Kind,
+        aether_data::Schema,
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        Clone,
+        PartialEq,
+    )]
+    #[kind(name = "test.native_request_context")]
+    struct NativeRequestContext {
+        value: u32,
+    }
+
+    #[test]
+    fn native_ctx_take_context_consumes_stored_reply_context() {
+        use crate::testing::bare_substrate;
+
+        let (_registry, mailer) = bare_substrate();
+        let binding = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0x00BE_EF10)));
+        binding.store_request_context(RequestId(77), &NativeRequestContext { value: 9 });
+
+        let reply_source = Source::with_correlation(SourceAddr::None, 77);
+        let mut ctx = NativeCtx::new(&binding, reply_source, MailId::NONE, MailId::NONE);
+
+        assert_eq!(
+            ctx.take_context::<NativeRequestContext>(),
+            Some(NativeRequestContext { value: 9 })
+        );
+        assert_eq!(ctx.take_context::<NativeRequestContext>(), None);
+    }
+
+    #[test]
+    fn native_actor_mailbox_send_with_context_stores_by_minted_correlation() {
+        use crate::testing::bare_substrate;
+
+        let (_registry, mailer) = bare_substrate();
+        let binding = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0x00BE_EF11)));
+        let mailbox =
+            NativeActorMailbox::<'_, StubActor>::__new_in_flight(0x00FE_ED01, &binding, None, None);
+
+        let mail_id =
+            mailbox.send_with_context(&CastOnly { code: 1 }, &NativeRequestContext { value: 13 });
+
+        assert_eq!(
+            binding.take_request_context::<NativeRequestContext>(RequestId(mail_id.correlation_id)),
+            Some(NativeRequestContext { value: 13 })
+        );
+    }
 
     /// ADR-0080 §7 (issue 1802): a handler's `ctx.actor::<R>().send()`
     /// inherits the in-flight causal chain — the recipient mail lands

--- a/crates/aether-substrate/src/actor/native/mailbox.rs
+++ b/crates/aether-substrate/src/actor/native/mailbox.rs
@@ -17,7 +17,7 @@
 use core::marker::PhantomData;
 
 use aether_actor::{Addressable, HandlesKind};
-use aether_data::{ActorId, Kind, MailId, Tag, fold_lineage, with_tag};
+use aether_data::{ActorId, Kind, MailId, RequestId, Tag, fold_lineage, with_tag};
 
 use crate::actor::native::binding::NativeBinding;
 
@@ -238,5 +238,21 @@ impl<R: Addressable> NativeActorMailbox<'_, R> {
             self.parent,
             self.root,
         )
+    }
+
+    /// Send a request and store a typed context under the minted correlation
+    /// id for the eventual reply handler to recover with
+    /// [`NativeCtx::take_context`](crate::actor::native::ctx::NativeCtx::take_context).
+    #[must_use]
+    pub fn send_with_context<K, C>(&self, payload: &K, context: &C) -> MailId
+    where
+        R: HandlesKind<K>,
+        K: Kind,
+        C: Kind,
+    {
+        let mail_id = self.send_tracked(payload);
+        self.binding
+            .store_request_context(RequestId(mail_id.correlation_id), context);
+        mail_id
     }
 }

--- a/docs/guide/systems/concurrency.md
+++ b/docs/guide/systems/concurrency.md
@@ -62,12 +62,14 @@ shape: **return now, continue later.**
 The idiomatic shape is a small state machine spread across handler invocations:
 send the request, *return* from the handler (freeing the worker), and handle the
 reply when it arrives as a *separate* mail in a later handler call. Correlation
-survives across turns through the envelope request id: a wasm handler calls
-`send_tracked(&request)`, stashes the returned `RequestId`, and later compares
-it with `ctx.in_reply_to()` in the reply handler, so duplicate in-flight
-requests don't get confused (the surviving half of [ADR-0042](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0042-synchronous-mail-wait.md)). Every
-request/reply in the engine works this way: `aether.fs.read` →
-`…read_result`, reply-to-sender, and the rest.
+survives across turns through a typed request context: call
+`send_with_context(&request, &context)` and later recover it with
+`ctx.take_context::<Context>()`, so duplicate in-flight requests don't get
+confused (the surviving half of [ADR-0042](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0042-synchronous-mail-wait.md)). The context should be small
+bookkeeping; bulky state belongs in actor fields. Every request/reply in the
+engine works this way: `aether.fs.read` → `…read_result`, reply-to-sender, and
+the rest. Use the lower-level `send_tracked` / `ctx.in_reply_to()` only when the
+raw request id is itself the domain key.
 
 **2. Blocking I/O or slow off-thread work → `dispatch_blocking` + `#[handler(task)]`.**
 When a (native) capability must make a genuinely blocking call — a multi-second

--- a/docs/guide/systems/mail-and-kinds.md
+++ b/docs/guide/systems/mail-and-kinds.md
@@ -114,16 +114,23 @@ reply. If a reply matters, that's a separate, explicit contract between the two
 kinds — never an implicit "every kind has a response." Don't write a caller
 that blocks waiting for a reply a handler never agreed to send.
 
-**When several requests are in flight, track the envelope id.** A wasm actor
-that sends a one-shot request and needs to match the later reply should call
-`send_tracked(&request)`, stash the returned `RequestId`, and compare it with
-`ctx.in_reply_to()` in the reply handler. `in_reply_to()` returns `None` for
-ordinary inbound requests, uncorrelated mail, and inline-cluster local dispatches
-that never crossed the host envelope boundary. Echoed payload fields such as
-`namespace` + `path` on `aether.fs.read_result` remain useful domain context,
-but exact duplicate-safe matching belongs to the envelope request id. Multi
-emissions and detached data phases still carry their own domain-level
-correlation in their payloads.
+**When several requests are in flight, carry a typed request context.** A
+one-shot request that needs to match a later reply should call
+`send_with_context(&request, &context)` and recover the bookkeeping in the
+reply handler with `ctx.take_context::<Context>()`. Contexts are `Kind`s, so the
+table stores schema-typed bytes, checks the `KindId` on take, and rides guest
+dehydrate/rehydrate automatically. Keep contexts small: stash routing
+bookkeeping such as the caller's reply handle, origin, or parse mode; keep bulky
+domain state in actor fields and put only an id in the context.
+
+The lower-level `send_tracked(&request)` / `ctx.in_reply_to()` pair is still
+available when the request id itself is the domain key. `in_reply_to()` returns
+`None` for ordinary inbound requests, uncorrelated mail, and inline-cluster local
+dispatches that never crossed the host envelope boundary. Echoed payload fields
+such as `namespace` + `path` on `aether.fs.read_result` remain useful domain
+context, but exact duplicate-safe matching belongs to the request context or
+envelope request id. Multi emissions and detached data phases still carry their
+own domain-level correlation in their payloads.
 
 **The ordering spine** ([ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md)) — **the single contract to hold in your head
 when writing handlers.** Get it wrong and you write code that passes in dev and


### PR DESCRIPTION
Closes #2792.

## Summary

Adds the SDK-owned request-context table keyed by reply correlation id, with Kind-typed context bytes, take-once recovery, kind mismatch handling, bounded oldest-entry eviction, and guest persistence envelope support so contexts survive replace_component without clobbering user/inline-child state.

Also adds the native parity surface on NativeBinding / NativeActorMailbox / NativeCtx, Schema/serde support for Source routing contexts, and updates the request/reply guide language to prefer send_with_context / take_context.

## Test plan

- cargo fmt -- --check
- cargo test -p aether-actor request_context
- cargo test -p aether-substrate --lib native_ctx_take_context_consumes_stored_reply_context
- cargo test -p aether-substrate --lib native_actor_mailbox_send_with_context_stores_by_minted_correlation
- cargo check -p aether-actor -p aether-data -p aether-substrate
- cargo clippy -p aether-actor -p aether-data --all-targets -- -D warnings
- cargo clippy -p aether-substrate --lib -- -D warnings

Note: `cargo test -p aether-substrate request_context` pulls the existing `native_actor_macro` integration test, which requires the `test-support` feature and fails without it; the new native request-context tests were run as library tests.

## Generated by

`/implement` — agent execution of [scoped issue #2792](https://github.com/iamacoffeepot/aether/issues/2792).
