### PR TITLE
refactor(kit): use request contexts for fs replies

### DIFF
--- a/crates/aether-kit/src/mesh/mod.rs
+++ b/crates/aether-kit/src/mesh/mod.rs
@@ -3,7 +3,7 @@
 //! cached list to the `"aether.render"` sink each frame on the `Render`
 //! lifecycle stage.
 //!
-//! Dispatches on the file extension echoed back on `aether.fs.read_result`:
+//! Dispatches on the file extension stashed in the fs request context:
 //!
 //! - `.dsl` → `aether-mesh`'s parser + mesher (ADR-0026 + ADR-0051).
 //!   Filled triangles use the DSL's `:color N` palette indices; the
@@ -38,13 +38,14 @@ pub use kinds::*;
 use aether_actor::{
     ActorInitError, Manual, OutboundReply, ReplyHandle, WasmActor, WasmCtx, WasmInitCtx, actor,
 };
-use aether_capabilities::fs::{FsMailboxExt, ReadResult};
+use aether_capabilities::fs::{Read, ReadResult};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::render::{DrawTriangle, Vertex};
 use aether_capabilities::{FsCapability, LifecycleCapability, RenderCapability};
 use aether_kinds::{MeshLoadResult, Render};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
+use serde::{Deserialize, Serialize};
 
 use core::str;
 
@@ -67,17 +68,14 @@ const OBJ_DEFAULT_COLOR: (f32, f32, f32) = PALETTE[0];
 
 pub struct MeshViewer {
     triangles: Vec<DrawTriangle>,
-    /// Reply target of the most recent `aether.kit.mesh.load` request, parked
-    /// across the async `aether.fs.read` round-trip (issue 964). `on_load`
-    /// runs in the requester's reply context; the actual parse + cache
-    /// replace happens later in `on_read_result`, whose reply context
-    /// points at `FsCapability`, not the original requester. Stashing the
-    /// handle here lets the load-result reply route back to whoever sent
-    /// the request (the parked-sender pattern; the handle stays valid for
-    /// the instance lifetime per the SDK `ReplyHandle` contract). `None`
-    /// when the load was fire-and-forget (no reply target) or when no load
-    /// is in flight.
-    pending_reply: Option<ReplyHandle>,
+}
+
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.mesh.load_context")]
+struct MeshLoadContext {
+    reply: Option<ReplyHandle>,
+    namespace: String,
+    path: String,
 }
 
 /// Mesh viewer component.
@@ -97,7 +95,6 @@ impl WasmActor for MeshViewer {
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(MeshViewer {
             triangles: Vec::new(),
-            pending_reply: None,
         })
     }
 
@@ -146,32 +143,37 @@ impl WasmActor for MeshViewer {
     /// succeeded (`ok`) and why it didn't (`error`).
     // `msg: LoadMesh` matches the dispatch ABI (ADR-0033 / ADR-0038);
     // the load body delegates straight to `FsCapability` via `ctx`.
-    #[allow(clippy::needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value, clippy::unused_self)]
     #[handler::single]
     fn on_load(&mut self, ctx: &mut WasmCtx<'_>, msg: LoadMesh) {
-        // Park the requester's reply target across the async read.
-        // `on_read_result` answers it with the structured outcome.
-        // Overwriting any prior pending handle is intentional —
-        // loads are serialized through one read round-trip, and a
-        // fresh load supersedes an unanswered prior one.
-        self.pending_reply = ctx.reply_target();
+        let read = Read {
+            namespace: msg.namespace.clone(),
+            path: msg.path.clone(),
+        };
+        let context = MeshLoadContext {
+            reply: ctx.reply_target(),
+            namespace: msg.namespace,
+            path: msg.path,
+        };
         tracing::info!(
             target: "aether_kit",
-            namespace = %msg.namespace,
-            path = %msg.path,
+            namespace = %read.namespace,
+            path = %read.path,
             "load requested; issuing read",
         );
-        ctx.actor::<FsCapability>().read(&msg.namespace, &msg.path);
+        let _ = ctx
+            .actor::<FsCapability>()
+            .send_with_context(&read, &context);
     }
 
-    /// Consumes the substrate's I/O reply. Dispatches on the echoed
-    /// `path`'s extension and replaces the cached triangle list on
+    /// Consumes the substrate's I/O reply. Dispatches on the request
+    /// context path's extension and replaces the cached triangle list on
     /// success. Any failure (read error, non-utf8, parse error,
     /// unknown extension) leaves the previous cache intact, with a
     /// warn log explaining the failure. Issue 964: after computing the
     /// outcome, replies `aether.mesh.load_result` to the originator of
-    /// the `aether.kit.mesh.load` request (parked in `on_load`), echoing
-    /// the request's `namespace` + `path` and carrying the structured
+    /// the `aether.kit.mesh.load` request (carried in the request context),
+    /// echoing the request's `namespace` + `path` and carrying the structured
     /// `ok` / `error` verdict so a scenario harness or MCP `send_mail`
     /// caller has a wire signal instead of having to scrape
     /// `engine_logs`.
@@ -180,32 +182,23 @@ impl WasmActor for MeshViewer {
     /// Substrate-driven; do not send manually.
     #[handler::manual]
     fn on_read_result(&mut self, ctx: &mut WasmCtx<'_, Manual>, r: ReadResult) {
-        let (namespace, path, outcome) = match r {
-            ReadResult::Ok {
-                namespace,
-                path,
-                bytes,
-            } => {
-                let outcome = self.load_bytes(&path, &bytes);
-                (namespace, path, outcome)
-            }
-            ReadResult::Err {
-                namespace,
-                path,
-                error,
-            } => {
+        let Some(context) = ctx.take_context::<MeshLoadContext>() else {
+            return;
+        };
+        let outcome = match r {
+            ReadResult::Ok { bytes, .. } => self.load_bytes(&context.path, &bytes),
+            ReadResult::Err { error, .. } => {
                 tracing::warn!(
                     target: "aether_kit",
-                    namespace = %namespace,
-                    path = %path,
+                    namespace = %context.namespace,
+                    path = %context.path,
                     error = ?error,
                     "read failed; keeping prior datum",
                 );
-                let outcome = LoadOutcome::failed(format!("read failed: {error:?}"));
-                (namespace, path, outcome)
+                LoadOutcome::failed(format!("read failed: {error:?}"))
             }
         };
-        self.reply_load_result(ctx, namespace, path, outcome);
+        self.reply_load_result(ctx, context.reply, context.namespace, context.path, outcome);
     }
 }
 
@@ -266,17 +259,18 @@ impl MeshViewer {
     }
 
     /// Build and dispatch the `aether.mesh.load_result` reply to the
-    /// parked requester. No-op when no reply target was parked (the
-    /// load was fire-and-forget). Clears the parked handle either way
-    /// so a stale target can't leak into a later load's reply.
+    /// requester carried in the fs request context. No-op when no reply
+    /// target was carried (the load was fire-and-forget).
+    #[allow(clippy::unused_self)]
     fn reply_load_result(
-        &mut self,
+        &self,
         ctx: &mut WasmCtx<'_, Manual>,
+        sender: Option<ReplyHandle>,
         namespace: String,
         path: String,
         outcome: LoadOutcome,
     ) {
-        let Some(sender) = self.pending_reply.take() else {
+        let Some(sender) = sender else {
             return;
         };
         let ok = outcome.error.is_none();

--- a/crates/aether-kit/src/world/mod.rs
+++ b/crates/aether-kit/src/world/mod.rs
@@ -57,11 +57,12 @@ pub mod mesher;
 use alloc::collections::BTreeMap;
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
-use aether_capabilities::fs::{FsMailboxExt, ReadResult};
+use aether_capabilities::fs::{Read, ReadResult};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::render::DrawTriangle;
 use aether_capabilities::{FsCapability, LifecycleCapability, RenderCapability};
 use aether_kinds::Render;
+use serde::{Deserialize, Serialize};
 
 use self::mesher::mesh_chunk;
 use self::mesher::style::StyleTable;
@@ -83,6 +84,13 @@ pub struct WorldView {
     meshes: BTreeMap<ChunkPos, Vec<DrawTriangle>>,
     mode: ViewMode,
     styles: StyleTable,
+}
+
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.world.load_context")]
+struct WorldLoadContext {
+    namespace: String,
+    path: String,
 }
 
 impl WorldView {
@@ -315,13 +323,23 @@ impl WasmActor for WorldView {
     #[allow(clippy::unused_self)]
     #[handler::single]
     fn on_load(&mut self, ctx: &mut WasmCtx<'_>, msg: WorldLoad) {
+        let read = Read {
+            namespace: msg.namespace.clone(),
+            path: msg.path.clone(),
+        };
+        let context = WorldLoadContext {
+            namespace: msg.namespace,
+            path: msg.path,
+        };
         tracing::info!(
             target: "aether_kit",
-            namespace = %msg.namespace,
-            path = %msg.path,
+            namespace = %read.namespace,
+            path = %read.path,
             "world load requested; issuing read",
         );
-        ctx.actor::<FsCapability>().read(&msg.namespace, &msg.path);
+        let _ = ctx
+            .actor::<FsCapability>()
+            .send_with_context(&read, &context);
     }
 
     /// Consume the `aether.fs` read reply. On `Ok`, decode the bytes with
@@ -332,40 +350,35 @@ impl WasmActor for WorldView {
     /// # Agent
     /// Substrate-driven; do not send manually.
     #[handler::single]
-    fn on_read_result(&mut self, _ctx: &mut WasmCtx<'_>, result: ReadResult) {
+    fn on_read_result(&mut self, ctx: &mut WasmCtx<'_>, result: ReadResult) {
+        let Some(context) = ctx.take_context::<WorldLoadContext>() else {
+            return;
+        };
         match result {
-            ReadResult::Ok {
-                namespace,
-                path,
-                bytes,
-            } => match World::from_bytes(&bytes) {
+            ReadResult::Ok { bytes, .. } => match World::from_bytes(&bytes) {
                 Ok(world) => {
                     self.world = world;
                     self.remesh_all();
                     tracing::info!(
                         target: "aether_kit",
-                        namespace = %namespace,
-                        path = %path,
+                        namespace = %context.namespace,
+                        path = %context.path,
                         chunks = self.meshes.len(),
                         "world load complete; cache replaced",
                     );
                 }
                 Err(error) => tracing::warn!(
                     target: "aether_kit",
-                    namespace = %namespace,
-                    path = %path,
+                    namespace = %context.namespace,
+                    path = %context.path,
                     error = ?error,
                     "world decode failed; keeping prior world",
                 ),
             },
-            ReadResult::Err {
-                namespace,
-                path,
-                error,
-            } => tracing::warn!(
+            ReadResult::Err { error, .. } => tracing::warn!(
                 target: "aether_kit",
-                namespace = %namespace,
-                path = %path,
+                namespace = %context.namespace,
+                path = %context.path,
                 error = ?error,
                 "world read failed; keeping prior world",
             ),

--- a/crates/aether-kit/tests/mesh_scenario.rs
+++ b/crates/aether-kit/tests/mesh_scenario.rs
@@ -38,6 +38,7 @@ use aether_substrate_bundle::visual::{decode_png, differs_from_background};
 use aether_kit as _;
 use std::fs;
 use std::path::Path;
+use std::time::Duration;
 
 /// User-facing component name passed to `LoadComponent`.
 const COMPONENT_NAME: &str = "mv";
@@ -355,4 +356,64 @@ fn bad_dsl_load_replies_err() {
     assert!(reply.error.is_some(), "bad load carries a failure reason");
     assert_eq!(reply.namespace, "save", "reply echoes request namespace");
     assert_eq!(reply.path, path, "reply echoes request path");
+}
+
+/// Issue 2796: overlapping mesh loads carry their requester and parse
+/// dispatch in request contexts rather than a single actor slot. A second
+/// load must not steal the first load's eventual `MeshLoadResult`.
+#[test]
+fn overlapping_loads_reply_to_their_own_requesters() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let sandbox = init_save_sandbox("kit-mesh");
+    let dsl_path = write_fixture("overlap_first.dsl", BOX_DSL);
+    let obj_path = write_fixture("overlap_second.obj", QUAD_OBJ);
+
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .settlement_cap(Some(Duration::from_secs(10)))
+        .build()
+        .expect("boot");
+    load_viewer(&mut bench, &wasm_path);
+
+    let first = bench
+        .send_deferred(
+            &component_address(),
+            &LoadMesh {
+                namespace: "save".to_owned(),
+                path: dsl_path.clone(),
+            },
+        )
+        .expect("enqueue first mesh load");
+    let second = bench
+        .send_deferred(
+            &component_address(),
+            &LoadMesh {
+                namespace: "save".to_owned(),
+                path: obj_path.clone(),
+            },
+        )
+        .expect("enqueue second mesh load");
+
+    let second_reply = bench
+        .await_deferred::<MeshLoadResult>(second)
+        .expect("second load replies");
+    let first_reply = bench
+        .await_deferred::<MeshLoadResult>(first)
+        .expect("first load replies");
+
+    assert!(
+        first_reply.ok,
+        "first DSL load should succeed: {:?}",
+        first_reply.error,
+    );
+    assert!(
+        second_reply.ok,
+        "second OBJ load should succeed: {:?}",
+        second_reply.error,
+    );
+    assert_eq!(first_reply.path, dsl_path, "first reply keeps its path");
+    assert_eq!(second_reply.path, obj_path, "second reply keeps its path");
 }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -14,8 +14,8 @@
 //!
 //! Reply correlation: every API call gets a fresh `correlation_id`.
 //! The substrate echoes it on the reply per ADR-0042, so multiple
-//! in-flight requests would be unambiguous — though `TestBench`'s
-//! synchronous shape means at most one is ever outstanding.
+//! in-flight requests are unambiguous. The common `execute` path stays
+//! synchronous, while focused tests can defer replies explicitly.
 
 // Test-only skip diagnostics emit `eprintln!` so `cargo test` runners
 // surface a visible "skipping: ..." line alongside `test ... ok`;
@@ -216,6 +216,14 @@ pub struct TestBench {
     /// stay alive; drops in reverse declaration order before
     /// `_boot`, so render+log shut down before the scheduler joins.
     passive: PassiveChassis<TestBenchChassis>,
+}
+
+/// A request enqueued through [`TestBench::send_deferred`] whose reply will
+/// be awaited later.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PendingBenchReply {
+    cid: u64,
+    expected: &'static str,
 }
 
 /// Fixed UUID used as the `SessionToken` for in-process replies.
@@ -820,6 +828,42 @@ impl TestBench {
         self.queue
             .push(Mail::new(mailbox, kind, payload, 1).with_reply_to(reply_to));
         self.pump_until_reply_bytes(cid, "<await-reply bytes>")
+    }
+
+    /// Enqueue a typed request with this bench's session as the reply target,
+    /// but do not pump the chassis or wait for the reply yet.
+    ///
+    /// This is the asynchronous counterpart to `send_and_await` for tests that
+    /// need several requests in flight at once to validate correlation.
+    pub fn send_deferred<K>(
+        &self,
+        recipient_name: &str,
+        mail: &K,
+    ) -> Result<PendingBenchReply, TestBenchError>
+    where
+        K: Kind,
+    {
+        let mailbox = self
+            .registry
+            .lookup(recipient_name)
+            .ok_or_else(|| TestBenchError::UnknownMailbox(recipient_name.to_owned()))?;
+        let cid = self.fresh_correlation_id();
+        let reply_to = Source::with_correlation(SourceAddr::Session(self.session), cid);
+        self.queue
+            .push(Mail::new(mailbox, K::ID, mail.encode_into_bytes(), 1).with_reply_to(reply_to));
+        Ok(PendingBenchReply {
+            cid,
+            expected: K::NAME,
+        })
+    }
+
+    /// Pump until the reply for a request returned by [`Self::send_deferred`]
+    /// arrives, stashing out-of-order replies for later awaits.
+    pub fn await_deferred<R>(&mut self, pending: PendingBenchReply) -> Result<R, TestBenchError>
+    where
+        R: Kind,
+    {
+        self.pump_until_reply(pending.cid, pending.expected)
     }
 
     /// Run `ticks` complete frames synchronously. Each frame


### PR DESCRIPTION
Closes #2796.

## Summary

Migrate the kit mesh and world filesystem reply correlation paths to request contexts. Mesh and world fs reads now carry typed context through the actor request context table instead of relying on echoed fs reply fields or pending local queues.

The change includes focused mesh scenario coverage and the TestBench helper support needed by the migration.

## Test plan

- `cargo fmt`
- `cargo check -p aether-kit --test mesh_scenario`
- `git diff --check`

## Generated by

`/implement` - agent execution of [scoped issue #2796](https://github.com/iamacoffeepot/aether/issues/2796).
