### PR TITLE
feat(substrate): add world-space material pass

### DIFF
--- a/crates/aether-capabilities/src/render/headless_runtime.rs
+++ b/crates/aether-capabilities/src/render/headless_runtime.rs
@@ -33,8 +33,9 @@ use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
 use aether_substrate::chassis::error::BootError;
 
 use super::{
-    CreateTexture, CreateTextureResult, DestroyTexture, DrawSolidQuads, DrawTexturedQuads,
-    DrawTriangle, HeadlessRenderCapability, UpdateTexture, ViewProjection,
+    CreateTexture, CreateTextureResult, DestroyTexture, DrawMaterialCoverage, DrawMaterialTextured,
+    DrawSolidQuads, DrawTexturedQuads, DrawTriangle, HeadlessRenderCapability, UpdateTexture,
+    ViewProjection,
 };
 
 /// `HeadlessRenderCapability` runtime state. Holds only the [`HubOutbound`]
@@ -160,6 +161,26 @@ impl NativeActor for HeadlessRenderCapability {
         _state: &mut Self::State,
         _ctx: &mut NativeCtx<'_>,
         _mail: DrawSolidQuads,
+    ) {
+    }
+
+    /// `DrawMaterialTextured` lands here as a no-op for the same
+    /// reason as `on_draw_textured_quads`.
+    #[handler::single]
+    fn on_draw_material_textured(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: DrawMaterialTextured,
+    ) {
+    }
+
+    /// `DrawMaterialCoverage` lands here as a no-op for the same
+    /// reason as `on_draw_textured_quads`.
+    #[handler::single]
+    fn on_draw_material_coverage(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: DrawMaterialCoverage,
     ) {
     }
 }

--- a/crates/aether-capabilities/src/render/kinds.rs
+++ b/crates/aether-capabilities/src/render/kinds.rs
@@ -218,6 +218,69 @@ pub struct DrawSolidQuads {
     pub quads: Vec<SolidQuad>,
 }
 
+/// Shared world-plane rect for material draws. `(x, y, width, height)`
+/// are world units and `z` is the depth-tested layer the material quad
+/// sits on. Not a kind on its own — embedded in the typed material
+/// draw payloads below.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct MaterialRect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub z: f32,
+}
+
+/// One textured material rect. The rect expands to a world-space quad;
+/// `(u0, v0)`–`(u1, v1)` selects the sampled texture region and `tint`
+/// multiplies the sampled RGBA texel.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct MaterialTexturedRect {
+    pub rect: MaterialRect,
+    pub u0: f32,
+    pub v0: f32,
+    pub u1: f32,
+    pub v1: f32,
+    pub tint: [f32; 4],
+}
+
+/// `aether.render.material.textured` — draw depth-tested, alpha-blended
+/// world-space image rects sampling one registered texture. This is the
+/// general substrate-authored image-in-world material for sprites,
+/// decals, and splats. `texture_id` comes from `CreateTexture`; an
+/// unknown texture warn-drops the batch at record time. Fire-and-forget,
+/// immediate-mode: resend every frame the material should be visible.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.render.material.textured")]
+pub struct DrawMaterialTextured {
+    pub texture_id: u32,
+    pub rects: Vec<MaterialTexturedRect>,
+}
+
+/// One coverage material rect. The shader samples an R8 texture,
+/// thresholds at the fixed iso value 127.5, antialiases the edge with
+/// `fwidth`, fills inside with `body_color`, and colors an inner band of
+/// `rim_width` coverage-fraction units with `rim_color`.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct MaterialCoverageRect {
+    pub rect: MaterialRect,
+    pub body_color: [f32; 4],
+    pub rim_color: [f32; 4],
+    pub rim_width: f32,
+}
+
+/// `aether.render.material.coverage` — draw depth-tested coverage bands
+/// from an R8 texture. The material is substrate-authored and closed:
+/// callers provide data (texture id + rect parameters), not WGSL. A
+/// non-R8 texture or unknown texture warn-drops the batch at record time.
+/// Fire-and-forget, immediate-mode.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.render.material.coverage")]
+pub struct DrawMaterialCoverage {
+    pub texture_id: u32,
+    pub rects: Vec<MaterialCoverageRect>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aether-capabilities/src/render/runtime/material.rs
+++ b/crates/aether-capabilities/src/render/runtime/material.rs
@@ -1,0 +1,34 @@
+//! Per-frame material accumulator for the `aether.render` cap
+//! (ADR-0140). Both typed material draw kinds push into one ordered
+//! stream so mixed textured/coverage submissions replay in the order
+//! the render capability received them.
+
+use super::super::kinds::{MaterialCoverageRect, MaterialTexturedRect, TextureFormat};
+
+#[derive(Clone)]
+pub enum MaterialBatch {
+    Textured {
+        texture_id: u32,
+        rects: Vec<MaterialTexturedRect>,
+    },
+    Coverage {
+        texture_id: u32,
+        rects: Vec<MaterialCoverageRect>,
+    },
+}
+
+#[must_use]
+pub fn accepts_coverage_texture(format: TextureFormat) -> bool {
+    matches!(format, TextureFormat::R8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coverage_material_accepts_only_r8_textures() {
+        assert!(accepts_coverage_texture(TextureFormat::R8));
+        assert!(!accepts_coverage_texture(TextureFormat::Rgba8));
+    }
+}

--- a/crates/aether-capabilities/src/render/runtime/mod.rs
+++ b/crates/aether-capabilities/src/render/runtime/mod.rs
@@ -29,10 +29,12 @@ pub use aether_substrate::render::IDENTITY_VIEW_PROJ;
 // The native impl seams, now nested under this `runtime` directory so the one
 // `mod runtime;` gate in the parent covers them (no per-sibling `#[cfg]`):
 // `pipeline` (GPU bundle + accumulator handles), `texture` (the texture
-// registry), `quad` (the quad-batch accumulator), `capture` (the cross-thread
-// readback machinery), and `config` (the per-instance `RenderConfig`).
+// registry), `quad` (the quad-batch accumulator), `material` (the
+// material-batch accumulator), `capture` (the cross-thread readback
+// machinery), and `config` (the per-instance `RenderConfig`).
 mod capture;
 mod config;
+mod material;
 mod pipeline;
 mod quad;
 mod texture;
@@ -61,9 +63,9 @@ use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
 use aether_substrate::chassis::error::BootError;
 
 use super::{
-    CreateTexture, CreateTextureResult, DRAW_TRIANGLE_BYTES, DestroyTexture, DrawSolidQuads,
-    DrawTexturedQuads, DrawTriangle, RenderCapability, SolidQuad, TextureFormat, TexturedQuad,
-    UpdateTexture, ViewProjection,
+    CreateTexture, CreateTextureResult, DRAW_TRIANGLE_BYTES, DestroyTexture, DrawMaterialCoverage,
+    DrawMaterialTextured, DrawSolidQuads, DrawTexturedQuads, DrawTriangle, RenderCapability,
+    SolidQuad, TextureFormat, TexturedQuad, UpdateTexture, ViewProjection,
 };
 
 // These seam items are `pub` (visible in `render`) in their
@@ -72,6 +74,7 @@ use super::{
 // `render`, the scope the co-located test module names them in. `pub use`
 // would try to widen them to `pub` and fail (E0364/E0365).
 pub use self::capture::resolve_reference;
+pub use self::material::MaterialBatch;
 pub use self::quad::QuadBatch;
 pub use self::texture::{StagedTexture, TextureRegistry, WHITE_TEXTURE_ID, expected_pixel_bytes};
 
@@ -139,6 +142,8 @@ impl NativeActor for RenderCapability {
             camera_state: Arc::new(Mutex::new(IDENTITY_VIEW_PROJ)),
             quad_frame: Arc::new(Mutex::new(Vec::new())),
             quad_last_submitted: Arc::new(Mutex::new(Vec::new())),
+            material_frame: Arc::new(Mutex::new(Vec::new())),
+            material_last_submitted: Arc::new(Mutex::new(Vec::new())),
             textures: Arc::new(Mutex::new(TextureRegistry::new())),
             gpu: Arc::new(OnceLock::new()),
             vertex_buffer_bytes: config.vertex_buffer_bytes,
@@ -629,6 +634,66 @@ impl NativeActor for RenderCapability {
                 texture_id: WHITE_TEXTURE_ID,
                 space: mail.space,
                 quads,
+            });
+    }
+
+    /// `DrawMaterialTextured` handler (ADR-0140). Accumulates a typed
+    /// textured material batch into the ordered material stream. Texture
+    /// existence is checked at record time so the handler stays a cheap
+    /// immediate-mode push.
+    ///
+    /// # Agent
+    /// Mail `aether.render.material.textured { texture_id, rects }`
+    /// every frame the world-space material rects should appear; no reply.
+    #[handler::single]
+    fn on_draw_material_textured(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: DrawMaterialTextured,
+    ) {
+        if let Some(obs) = &state.config.observed_kinds {
+            obs.lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063")
+                .push(<DrawMaterialTextured as Kind>::NAME.into());
+        }
+        state
+            .handles
+            .material_frame
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063")
+            .push(MaterialBatch::Textured {
+                texture_id: mail.texture_id,
+                rects: mail.rects,
+            });
+    }
+
+    /// `DrawMaterialCoverage` handler (ADR-0140). Accumulates a typed
+    /// coverage material batch into the ordered material stream. The R8
+    /// format requirement is checked at record time when the texture
+    /// registry is available to the encoder path.
+    ///
+    /// # Agent
+    /// Mail `aether.render.material.coverage { texture_id, rects }`
+    /// every frame the coverage material should appear; no reply.
+    #[handler::single]
+    fn on_draw_material_coverage(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: DrawMaterialCoverage,
+    ) {
+        if let Some(obs) = &state.config.observed_kinds {
+            obs.lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063")
+                .push(<DrawMaterialCoverage as Kind>::NAME.into());
+        }
+        state
+            .handles
+            .material_frame
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063")
+            .push(MaterialBatch::Coverage {
+                texture_id: mail.texture_id,
+                rects: mail.rects,
             });
     }
 }

--- a/crates/aether-capabilities/src/render/runtime/pipeline.rs
+++ b/crates/aether-capabilities/src/render/runtime/pipeline.rs
@@ -18,13 +18,17 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use aether_kinds::{QuadScale, QuadSpace};
 use aether_substrate::render::{
-    CaptureMeta, OverlayDraw, Pipeline, QUAD_VERTEX_STRIDE, QUAD_VERTICES_PER_QUAD, QuadPipeline,
-    RenderError, Targets, TextureBindings, build_main_pipeline, build_quad_pipeline,
+    CaptureMeta, MATERIAL_VERTEX_STRIDE, MATERIAL_VERTICES_PER_RECT, MaterialDraw,
+    MaterialPassDraw, MaterialPassRecord, MaterialPipelines, OverlayDraw, Pipeline,
+    QUAD_VERTEX_STRIDE, QUAD_VERTICES_PER_QUAD, QuadPipeline, RenderError, Targets,
+    TextureBindings, build_main_pipeline, build_material_pipelines, build_quad_pipeline,
     build_texture_bindings, finish_capture, map_capture_rgba, prepare_capture_copy,
-    push_screen_quad_vertices, push_world_quad_vertices, record_main_pass,
+    push_coverage_params, push_material_rect_vertices, push_screen_quad_vertices,
+    push_textured_params, push_world_quad_vertices, record_main_pass, record_material_pass,
     record_quad_overlay_pass,
 };
 
+use super::material::{MaterialBatch, accepts_coverage_texture};
 use super::quad::QuadBatch;
 use super::texture::TextureRegistry;
 
@@ -62,6 +66,12 @@ pub struct RenderHandles {
     /// idle `capture` (no producer this frame) replays them, matching
     /// `last_submitted`'s role for triangles.
     pub quad_last_submitted: Arc<Mutex<Vec<QuadBatch>>>,
+    /// Per-frame material accumulator (ADR-0140), holding both typed
+    /// material kinds in receive order so mixed material submissions
+    /// preserve painter's order among overlapping surfaces.
+    pub material_frame: Arc<Mutex<Vec<MaterialBatch>>>,
+    /// Most-recently-rendered material batches for idle capture replay.
+    pub material_last_submitted: Arc<Mutex<Vec<MaterialBatch>>>,
     /// Session-scoped texture registry: staged CPU pixels + lazily-
     /// realized GPU textures. Written by the cap dispatcher thread
     /// (`create_texture` / `update_texture`), realized + read by the
@@ -365,6 +375,178 @@ impl RenderHandles {
         );
     }
 
+    /// Record the depth-tested world-space material pass (ADR-0140)
+    /// between the main world pass and the screen overlay. Textures are
+    /// realized lazily from the shared registry. Coverage draws require
+    /// R8 textures and warn-drop otherwise.
+    ///
+    /// # Panics
+    /// Panics if `install_gpu` hasn't been called, or if any internal
+    /// mutex is poisoned — fail-fast per ADR-0063.
+    #[allow(clippy::too_many_lines)]
+    pub fn record_material_pass(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        replay_cache_when_idle: bool,
+    ) {
+        let gpu = self.expect_gpu();
+        commit_or_replay(
+            &self.material_frame,
+            &self.material_last_submitted,
+            replay_cache_when_idle,
+        );
+        let batches = self
+            .material_last_submitted
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063")
+            .clone();
+        if batches.is_empty() {
+            return;
+        }
+
+        let targets = gpu
+            .targets
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        let mut registry = self
+            .textures
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+
+        for batch in &batches {
+            let texture_id = match batch {
+                MaterialBatch::Textured { texture_id, .. }
+                | MaterialBatch::Coverage { texture_id, .. } => *texture_id,
+            };
+            if let Some(entry) = registry.entries.get_mut(&texture_id) {
+                entry.ensure_realized(&gpu.device, &gpu.queue, &gpu.texture_bindings);
+            } else {
+                tracing::warn!(
+                    target: "aether_capabilities::render",
+                    texture_id,
+                    "material draw for unknown texture id; dropping the batch",
+                );
+            }
+        }
+
+        let mut vertex_bytes = Vec::new();
+        let mut textured_params = Vec::new();
+        let mut coverage_params = Vec::new();
+        let mut draws = Vec::new();
+        let vertex_count =
+            u32::try_from(MATERIAL_VERTICES_PER_RECT).expect("material rect vertex count fits u32");
+        for batch in &batches {
+            match batch {
+                MaterialBatch::Textured { texture_id, rects } => {
+                    let Some(entry) = registry.entries.get(texture_id) else {
+                        continue;
+                    };
+                    let Some(realized) = entry.realized.as_ref() else {
+                        continue;
+                    };
+                    for rect in rects {
+                        let Some(params_offset) =
+                            push_textured_params(&mut textured_params, rect.tint)
+                        else {
+                            tracing::warn!(
+                                target: "aether_capabilities::render",
+                                texture_id,
+                                "textured material params overflow; dropping rect",
+                            );
+                            continue;
+                        };
+                        #[allow(clippy::cast_possible_truncation)]
+                        let first_vertex =
+                            (vertex_bytes.len() / MATERIAL_VERTEX_STRIDE as usize) as u32;
+                        push_material_rect_vertices(
+                            &mut vertex_bytes,
+                            [
+                                rect.rect.x,
+                                rect.rect.y,
+                                rect.rect.width,
+                                rect.rect.height,
+                                rect.rect.z,
+                            ],
+                            [rect.u0, rect.v0, rect.u1, rect.v1],
+                        );
+                        draws.push(MaterialPassDraw::Textured(MaterialDraw {
+                            bind_group: realized.bind_group(),
+                            first_vertex,
+                            vertex_count,
+                            params_offset,
+                        }));
+                    }
+                }
+                MaterialBatch::Coverage { texture_id, rects } => {
+                    let Some(entry) = registry.entries.get(texture_id) else {
+                        continue;
+                    };
+                    if !accepts_coverage_texture(entry.format) {
+                        tracing::warn!(
+                            target: "aether_capabilities::render",
+                            texture_id,
+                            ?entry.format,
+                            "coverage material requires an R8 texture; dropping the batch",
+                        );
+                        continue;
+                    }
+                    let Some(realized) = entry.realized.as_ref() else {
+                        continue;
+                    };
+                    for rect in rects {
+                        let Some(params_offset) = push_coverage_params(
+                            &mut coverage_params,
+                            rect.body_color,
+                            rect.rim_color,
+                            rect.rim_width,
+                        ) else {
+                            tracing::warn!(
+                                target: "aether_capabilities::render",
+                                texture_id,
+                                "coverage material params overflow; dropping rect",
+                            );
+                            continue;
+                        };
+                        #[allow(clippy::cast_possible_truncation)]
+                        let first_vertex =
+                            (vertex_bytes.len() / MATERIAL_VERTEX_STRIDE as usize) as u32;
+                        push_material_rect_vertices(
+                            &mut vertex_bytes,
+                            [
+                                rect.rect.x,
+                                rect.rect.y,
+                                rect.rect.width,
+                                rect.rect.height,
+                                rect.rect.z,
+                            ],
+                            [0.0, 0.0, 1.0, 1.0],
+                        );
+                        draws.push(MaterialPassDraw::Coverage(MaterialDraw {
+                            bind_group: realized.bind_group(),
+                            first_vertex,
+                            vertex_count,
+                            params_offset,
+                        }));
+                    }
+                }
+            }
+        }
+
+        record_material_pass(
+            encoder,
+            MaterialPassRecord {
+                queue: &gpu.queue,
+                pipeline: &gpu.material_pipelines,
+                main_pipeline: &gpu.pipeline,
+                targets: &targets,
+                vertex_bytes: &vertex_bytes,
+                draws: &draws,
+                textured_params: &textured_params,
+                coverage_params: &coverage_params,
+            },
+        );
+    }
+
     /// Encode a copy of the offscreen color target into a readback
     /// buffer. Pair with [`Self::finish_capture`] after submit. The
     /// readback buffer is reallocated on size mismatch with the
@@ -517,6 +699,9 @@ pub struct RenderGpu {
     /// accumulated quads into the same offscreen target after the
     /// world pass.
     pub quad_pipeline: QuadPipeline,
+    /// Depth-tested material pipelines (ADR-0140), recorded after the
+    /// main pass and before the quad overlay.
+    pub material_pipelines: MaterialPipelines,
     pub targets: Mutex<Targets>,
     pub color_format: wgpu::TextureFormat,
 }
@@ -550,6 +735,12 @@ impl RenderGpu {
         );
         let texture_bindings = build_texture_bindings(&device);
         let quad_pipeline = build_quad_pipeline(&device, color_format, &texture_bindings);
+        let material_pipelines = build_material_pipelines(
+            &device,
+            color_format,
+            &pipeline.camera_bind_group_layout,
+            &texture_bindings,
+        );
         let targets = Targets::new(&device, color_format, width, height);
         Self {
             device,
@@ -557,6 +748,7 @@ impl RenderGpu {
             pipeline,
             texture_bindings,
             quad_pipeline,
+            material_pipelines,
             targets: Mutex::new(targets),
             color_format,
         }

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -407,7 +407,12 @@ impl Gpu {
             Err(RenderError::VertexBufferOverflow { .. }) => return None,
         }
 
-        // ADR-0105 textured-quad overlay, recorded after the world pass —
+        // ADR-0140 material pass, recorded after the world pass and
+        // before the screen overlay.
+        self.render_handles
+            .record_material_pass(&mut encoder, false);
+
+        // ADR-0105 textured-quad overlay, recorded after world/material —
         // commit-current semantic to match `record_frame` above.
         self.render_handles.record_overlay_pass(&mut encoder, false);
 

--- a/crates/aether-substrate-bundle/src/test_bench/render.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/render.rs
@@ -119,7 +119,11 @@ impl Gpu {
             Ok(()) => {}
             Err(RenderError::VertexBufferOverflow { .. }) => return,
         }
-        // ADR-0105 textured-quad overlay, recorded after the world pass.
+        // ADR-0140 material pass, recorded after the world pass and
+        // before the screen overlay.
+        self.render_handles
+            .record_material_pass(&mut encoder, false);
+        // ADR-0105 textured-quad overlay, recorded after world/material.
         self.render_handles.record_overlay_pass(&mut encoder, false);
         queue.submit(iter::once(encoder.finish()));
     }
@@ -157,6 +161,9 @@ impl Gpu {
                 return Err("vertex buffer overflow — capture skipped".to_owned());
             }
         }
+        // ADR-0140 material pass, same replay-cache semantics so an idle
+        // capture replays the last committed material draws.
+        self.render_handles.record_material_pass(&mut encoder, true);
         // ADR-0105 textured-quad overlay, same replay-cache semantics so
         // an idle capture replays the last committed quads.
         self.render_handles.record_overlay_pass(&mut encoder, true);

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -36,8 +36,10 @@ use aether_capabilities::fs::{
     Delete, DeleteResult, FsError, List, ListResult, Read, ReadResult, Write, WriteResult,
 };
 use aether_capabilities::render::{
-    CreateTexture, CreateTextureResult, DestroyTexture, DrawSolidQuads, DrawTexturedQuads,
-    SolidQuad, TextureFormat, TexturedQuad, UpdateTexture, ViewProjection,
+    CreateTexture, CreateTextureResult, DestroyTexture, DrawMaterialCoverage, DrawMaterialTextured,
+    DrawSolidQuads, DrawTexturedQuads, DrawTriangle, MaterialCoverageRect, MaterialRect,
+    MaterialTexturedRect, SolidQuad, TextureFormat, TexturedQuad, UpdateTexture, Vertex,
+    ViewProjection,
 };
 use aether_capabilities::text::{
     DrawText, FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontResult,
@@ -55,7 +57,7 @@ use aether_substrate_bundle::test_bench::{
     test_helpers::{has_wgpu_adapter, init_save_sandbox, require_runtime, test_namespace_roots},
 };
 use aether_substrate_bundle::visual::{
-    background_top_left, bounding_box, centroid, coverage, decode_png,
+    Image, background_top_left, bounding_box, centroid, coverage, decode_png,
 };
 use aether_test_fixtures_kinds::{
     Bump, CountQuery, CountReport, DespawnChild, INLINE_WHO_CHILD, INLINE_WHO_PARENT, InlineEcho,
@@ -99,6 +101,16 @@ fn envelope<K: Kind>(recipient: &str, mail: &K) -> NamedMail {
         payload: mail.encode_into_bytes(),
         count: 1,
     }
+}
+
+fn rgba_at(img: &Image, x: u32, y: u32) -> [u8; 4] {
+    let start = ((y * img.width + x) * 4) as usize;
+    [
+        img.rgba[start],
+        img.rgba[start + 1],
+        img.rgba[start + 2],
+        img.rgba[start + 3],
+    ]
 }
 
 /// Load the probe into the bench via `execute`, blocking on the
@@ -1159,6 +1171,249 @@ fn r8_texture_updates_and_draws_red_channel_only() {
         left[1] <= 10 && left[2] <= 10 && right[1] <= 10 && right[2] <= 10,
         "R8 texture sampled through quad shader should not contribute green/blue; \
          left={left:?} right={right:?}",
+    );
+}
+
+/// ADR-0140 coverage material: an R8 plane renders in the world-space
+/// material pass between the main pass and overlay. A hand-authored
+/// horizontal coverage field produces outside/body/rim samples at known
+/// pixels.
+#[test]
+fn coverage_material_renders_body_rim_and_outside_bands() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let pixels = vec![
+        0, 0, 0, 0, 128, 128, 255, 255, //
+        0, 0, 0, 0, 128, 128, 255, 255, //
+        0, 0, 0, 0, 128, 128, 255, 255, //
+        0, 0, 0, 0, 128, 128, 255, 255,
+    ];
+    let created = bench
+        .execute(vec![(
+            "create",
+            BenchOp::send_and_await(
+                "aether.render",
+                &CreateTexture {
+                    width: 8,
+                    height: 4,
+                    format: TextureFormat::R8,
+                    pixels,
+                },
+            ),
+        )])
+        .expect("create coverage texture");
+    let texture_id = match created
+        .reply::<CreateTextureResult>("create")
+        .expect("decode CreateTextureResult")
+    {
+        CreateTextureResult::Ok { texture_id } => texture_id,
+        CreateTextureResult::Err { error } => panic!("create_texture failed: {error}"),
+    };
+
+    let pre = vec![envelope(
+        "aether.render",
+        &DrawMaterialCoverage {
+            texture_id,
+            rects: vec![MaterialCoverageRect {
+                rect: MaterialRect {
+                    x: -0.8,
+                    y: -0.6,
+                    width: 1.6,
+                    height: 1.2,
+                    z: 0.5,
+                },
+                body_color: [0.0, 0.9, 0.1, 1.0],
+                rim_color: [1.0, 0.9, 0.0, 1.0],
+                rim_width: 0.25,
+            }],
+        },
+    )];
+    let captured = bench
+        .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+        .expect("capture coverage material");
+    let img = decode_png(captured.captured("snap").expect("snap step ran"))
+        .expect("decode coverage material png");
+    let bg = background_top_left(&img);
+    let outside = rgba_at(&img, 12, 24);
+    let rim = rgba_at(&img, 38, 24);
+    let body = rgba_at(&img, 48, 24);
+
+    assert!(
+        outside[0].abs_diff(bg[0]) <= 8
+            && outside[1].abs_diff(bg[1]) <= 8
+            && outside[2].abs_diff(bg[2]) <= 8,
+        "outside coverage sample should stay background; bg={bg:?} outside={outside:?}",
+    );
+    assert!(
+        rim[0] > 150 && rim[1] > 120 && rim[2] < 80,
+        "coverage rim sample should be yellow; got {rim:?}",
+    );
+    assert!(
+        body[1] > body[0].saturating_add(80) && body[1] > body[2].saturating_add(60),
+        "coverage body sample should be green; got {body:?}",
+    );
+}
+
+/// ADR-0140 textured material: a world-space RGBA8 material rect samples
+/// a texture and depth-tests against the main pass. The left half is
+/// covered by a main-pass triangle at a nearer depth, while the right
+/// half remains visible.
+#[test]
+fn textured_material_depth_tests_against_main_geometry() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let pixels = vec![255u8, 255, 255, 255];
+    let created = bench
+        .execute(vec![(
+            "create",
+            BenchOp::send_and_await(
+                "aether.render",
+                &CreateTexture {
+                    width: 1,
+                    height: 1,
+                    format: TextureFormat::Rgba8,
+                    pixels,
+                },
+            ),
+        )])
+        .expect("create textured material texture");
+    let texture_id = match created
+        .reply::<CreateTextureResult>("create")
+        .expect("decode CreateTextureResult")
+    {
+        CreateTextureResult::Ok { texture_id } => texture_id,
+        CreateTextureResult::Err { error } => panic!("create_texture failed: {error}"),
+    };
+
+    let occluder = DrawTriangle {
+        verts: [
+            Vertex {
+                x: -0.9,
+                y: -0.8,
+                z: 0.0,
+                r: 0.9,
+                g: 0.0,
+                b: 0.0,
+            },
+            Vertex {
+                x: -0.9,
+                y: 0.8,
+                z: 0.0,
+                r: 0.9,
+                g: 0.0,
+                b: 0.0,
+            },
+            Vertex {
+                x: 0.0,
+                y: 0.8,
+                z: 0.0,
+                r: 0.9,
+                g: 0.0,
+                b: 0.0,
+            },
+        ],
+    };
+    let pre = vec![
+        envelope("aether.render", &occluder),
+        envelope(
+            "aether.render",
+            &DrawMaterialTextured {
+                texture_id,
+                rects: vec![MaterialTexturedRect {
+                    rect: MaterialRect {
+                        x: -0.8,
+                        y: -0.6,
+                        width: 1.6,
+                        height: 1.2,
+                        z: 0.5,
+                    },
+                    u0: 0.0,
+                    v0: 0.0,
+                    u1: 1.0,
+                    v1: 1.0,
+                    tint: [0.0, 0.1, 1.0, 1.0],
+                }],
+            },
+        ),
+    ];
+    let captured = bench
+        .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+        .expect("capture textured material");
+    let img = decode_png(captured.captured("snap").expect("snap step ran"))
+        .expect("decode textured material png");
+    let left = rgba_at(&img, 12, 20);
+    let right = rgba_at(&img, 48, 24);
+    assert!(
+        left[0] > left[2].saturating_add(80),
+        "left sample should show red main-pass occluder, not blue material; got {left:?}",
+    );
+    assert!(
+        right[2] > right[0].saturating_add(100),
+        "right sample should show blue textured material; got {right:?}",
+    );
+}
+
+/// ADR-0140 coverage material rejects non-R8 textures at encode time:
+/// the batch warn-drops, the frame still renders, and no material pixels
+/// appear.
+#[test]
+fn coverage_material_warn_drops_non_r8_texture() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let created = bench
+        .execute(vec![(
+            "create",
+            BenchOp::send_and_await(
+                "aether.render",
+                &CreateTexture {
+                    width: 2,
+                    height: 2,
+                    format: TextureFormat::Rgba8,
+                    pixels: vec![255u8; 16],
+                },
+            ),
+        )])
+        .expect("create rgba texture");
+    let texture_id = match created
+        .reply::<CreateTextureResult>("create")
+        .expect("decode CreateTextureResult")
+    {
+        CreateTextureResult::Ok { texture_id } => texture_id,
+        CreateTextureResult::Err { error } => panic!("create_texture failed: {error}"),
+    };
+    let pre = vec![envelope(
+        "aether.render",
+        &DrawMaterialCoverage {
+            texture_id,
+            rects: vec![MaterialCoverageRect {
+                rect: MaterialRect {
+                    x: -0.8,
+                    y: -0.6,
+                    width: 1.6,
+                    height: 1.2,
+                    z: 0.5,
+                },
+                body_color: [0.0, 1.0, 0.0, 1.0],
+                rim_color: [1.0, 1.0, 0.0, 1.0],
+                rim_width: 0.25,
+            }],
+        },
+    )];
+    let captured = bench
+        .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+        .expect("capture non-r8 coverage");
+    let img = decode_png(captured.captured("snap").expect("snap step ran"))
+        .expect("decode non-r8 coverage png");
+    let drawn = coverage(&img, background_top_left(&img), 5);
+    assert!(
+        drawn < 0.01,
+        "coverage draw against RGBA8 should be warn-dropped, but lit coverage was {drawn}",
     );
 }
 

--- a/crates/aether-substrate/src/render/material.rs
+++ b/crates/aether-substrate/src/render/material.rs
@@ -1,0 +1,458 @@
+//! Depth-tested world-space material pass (ADR-0140). A sibling pass
+//! between the main triangle pass and the screen overlay: it samples
+//! registered render textures, tests against the main pass depth buffer,
+//! leaves depth writes off, and alpha-blends into the shared offscreen
+//! color target.
+
+use super::targets::Targets;
+use super::{DEPTH_FORMAT, Pipeline};
+use crate::render::TextureBindings;
+use std::slice;
+
+pub const MATERIAL_VERTEX_STRIDE: u64 = 20;
+pub const MATERIAL_VERTICES_PER_RECT: usize = 6;
+pub const MATERIAL_VERTEX_BUFFER_BYTES: usize = 4 * 1024 * 1024;
+const MATERIAL_PARAMS_BUFFER_BYTES: u64 = 1024 * 1024;
+const PARAMS_ALIGN: usize = 256;
+const MATERIAL_PARAMS_BYTES: usize = 64;
+
+pub const MATERIAL_SHADER_WGSL: &str = include_str!("material.wgsl");
+
+#[allow(clippy::struct_field_names)]
+pub struct MaterialPipelines {
+    textured: wgpu::RenderPipeline,
+    coverage: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    textured_params_buffer: wgpu::Buffer,
+    textured_params_bind_group: wgpu::BindGroup,
+    coverage_params_buffer: wgpu::Buffer,
+    coverage_params_bind_group: wgpu::BindGroup,
+}
+
+pub struct MaterialDraw<'a> {
+    pub bind_group: &'a wgpu::BindGroup,
+    pub first_vertex: u32,
+    pub vertex_count: u32,
+    pub params_offset: u32,
+}
+
+pub enum MaterialPassDraw<'a> {
+    Textured(MaterialDraw<'a>),
+    Coverage(MaterialDraw<'a>),
+}
+
+#[must_use]
+pub fn build_material_pipelines(
+    device: &wgpu::Device,
+    color_format: wgpu::TextureFormat,
+    camera_layout: &wgpu::BindGroupLayout,
+    texture_bindings: &TextureBindings,
+) -> MaterialPipelines {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("aether material shader"),
+        source: wgpu::ShaderSource::Wgsl(MATERIAL_SHADER_WGSL.into()),
+    });
+
+    let textured_params_layout = material_params_layout(
+        device,
+        "material textured params bind group layout",
+        MATERIAL_PARAMS_BYTES as u64,
+    );
+    let coverage_params_layout = material_params_layout(
+        device,
+        "material coverage params bind group layout",
+        MATERIAL_PARAMS_BYTES as u64,
+    );
+
+    let vertex_layout = material_vertex_layout();
+    let textured_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("aether textured material pipeline layout"),
+        bind_group_layouts: &[
+            Some(camera_layout),
+            Some(&texture_bindings.layout),
+            Some(&textured_params_layout),
+        ],
+        immediate_size: 0,
+    });
+    let coverage_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("aether coverage material pipeline layout"),
+        bind_group_layouts: &[
+            Some(camera_layout),
+            Some(&texture_bindings.layout),
+            Some(&coverage_params_layout),
+        ],
+        immediate_size: 0,
+    });
+
+    let textured = material_pipeline(
+        device,
+        &shader,
+        &textured_layout,
+        "aether textured material pipeline",
+        color_format,
+        "fs_textured",
+        &vertex_layout,
+    );
+    let coverage = material_pipeline(
+        device,
+        &shader,
+        &coverage_layout,
+        "aether coverage material pipeline",
+        color_format,
+        "fs_coverage",
+        &vertex_layout,
+    );
+
+    let vertex_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("aether material vertex buffer"),
+        size: MATERIAL_VERTEX_BUFFER_BYTES as u64,
+        usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let textured_params_buffer = material_params_buffer(device, "aether textured params buffer");
+    let coverage_params_buffer = material_params_buffer(device, "aether coverage params buffer");
+    let textured_params_bind_group = material_params_bind_group(
+        device,
+        "aether textured params bind group",
+        &textured_params_layout,
+        &textured_params_buffer,
+        MATERIAL_PARAMS_BYTES as u64,
+    );
+    let coverage_params_bind_group = material_params_bind_group(
+        device,
+        "aether coverage params bind group",
+        &coverage_params_layout,
+        &coverage_params_buffer,
+        MATERIAL_PARAMS_BYTES as u64,
+    );
+
+    MaterialPipelines {
+        textured,
+        coverage,
+        vertex_buffer,
+        textured_params_buffer,
+        textured_params_bind_group,
+        coverage_params_buffer,
+        coverage_params_bind_group,
+    }
+}
+
+fn material_params_layout(
+    device: &wgpu::Device,
+    label: &'static str,
+    min_binding_size: u64,
+) -> wgpu::BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some(label),
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: true,
+                min_binding_size: wgpu::BufferSize::new(min_binding_size),
+            },
+            count: None,
+        }],
+    })
+}
+
+fn material_params_buffer(device: &wgpu::Device, label: &'static str) -> wgpu::Buffer {
+    device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        size: MATERIAL_PARAMS_BUFFER_BYTES,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    })
+}
+
+fn material_params_bind_group(
+    device: &wgpu::Device,
+    label: &'static str,
+    layout: &wgpu::BindGroupLayout,
+    buffer: &wgpu::Buffer,
+    size: u64,
+) -> wgpu::BindGroup {
+    device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some(label),
+        layout,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                buffer,
+                offset: 0,
+                size: wgpu::BufferSize::new(size),
+            }),
+        }],
+    })
+}
+
+fn material_vertex_layout() -> wgpu::VertexBufferLayout<'static> {
+    wgpu::VertexBufferLayout {
+        array_stride: MATERIAL_VERTEX_STRIDE,
+        step_mode: wgpu::VertexStepMode::Vertex,
+        attributes: &[
+            wgpu::VertexAttribute {
+                offset: 0,
+                shader_location: 0,
+                format: wgpu::VertexFormat::Float32x3,
+            },
+            wgpu::VertexAttribute {
+                offset: 12,
+                shader_location: 1,
+                format: wgpu::VertexFormat::Float32x2,
+            },
+        ],
+    }
+}
+
+fn material_pipeline(
+    device: &wgpu::Device,
+    shader: &wgpu::ShaderModule,
+    layout: &wgpu::PipelineLayout,
+    label: &'static str,
+    color_format: wgpu::TextureFormat,
+    fragment_entry: &'static str,
+    vertex_layout: &wgpu::VertexBufferLayout<'_>,
+) -> wgpu::RenderPipeline {
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some(label),
+        layout: Some(layout),
+        vertex: wgpu::VertexState {
+            module: shader,
+            entry_point: Some("vs_main"),
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+            buffers: slice::from_ref(vertex_layout),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: shader,
+            entry_point: Some(fragment_entry),
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+            targets: &[Some(wgpu::ColorTargetState {
+                format: color_format,
+                blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+        }),
+        primitive: wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            strip_index_format: None,
+            front_face: wgpu::FrontFace::Ccw,
+            cull_mode: None,
+            polygon_mode: wgpu::PolygonMode::Fill,
+            unclipped_depth: false,
+            conservative: false,
+        },
+        depth_stencil: Some(wgpu::DepthStencilState {
+            format: DEPTH_FORMAT,
+            depth_write_enabled: Some(false),
+            depth_compare: Some(wgpu::CompareFunction::LessEqual),
+            stencil: wgpu::StencilState::default(),
+            bias: wgpu::DepthBiasState::default(),
+        }),
+        multisample: wgpu::MultisampleState::default(),
+        multiview_mask: None,
+        cache: None,
+    })
+}
+
+pub fn material_params_offset(index: usize) -> Option<u32> {
+    index
+        .checked_mul(PARAMS_ALIGN)
+        .and_then(|offset| u32::try_from(offset).ok())
+}
+
+pub fn push_material_rect_vertices(out: &mut Vec<u8>, rect: [f32; 5], uv: [f32; 4]) {
+    let [x, y, width, height, z] = rect;
+    let [u0, v0, u1, v1] = uv;
+    let x0 = x;
+    let y0 = y;
+    let x1 = x + width;
+    let y1 = y + height;
+    let corners = [
+        (x0, y0, z, u0, v0),
+        (x0, y1, z, u0, v1),
+        (x1, y1, z, u1, v1),
+        (x0, y0, z, u0, v0),
+        (x1, y1, z, u1, v1),
+        (x1, y0, z, u1, v0),
+    ];
+    for (px, py, pz, u, v) in corners {
+        let floats: [f32; 5] = (px, py, pz, u, v).into();
+        out.extend_from_slice(bytemuck::cast_slice(&floats));
+    }
+}
+
+pub fn push_textured_params(out: &mut Vec<u8>, tint: [f32; 4]) -> Option<u32> {
+    let offset = material_params_offset(out.len() / PARAMS_ALIGN)?;
+    out.extend_from_slice(bytemuck::cast_slice(&tint));
+    out.extend_from_slice(bytemuck::cast_slice(&[0.0_f32; 12]));
+    pad_params(out);
+    Some(offset)
+}
+
+pub fn push_coverage_params(
+    out: &mut Vec<u8>,
+    body_color: [f32; 4],
+    rim_color: [f32; 4],
+    rim_width: f32,
+) -> Option<u32> {
+    let offset = material_params_offset(out.len() / PARAMS_ALIGN)?;
+    out.extend_from_slice(bytemuck::cast_slice(&body_color));
+    out.extend_from_slice(bytemuck::cast_slice(&rim_color));
+    out.extend_from_slice(bytemuck::cast_slice(&[
+        rim_width, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    ]));
+    pad_params(out);
+    Some(offset)
+}
+
+fn pad_params(out: &mut Vec<u8>) {
+    let padding = (PARAMS_ALIGN - (out.len() % PARAMS_ALIGN)) % PARAMS_ALIGN;
+    out.resize(out.len() + padding, 0);
+}
+
+#[derive(Clone, Copy)]
+pub struct MaterialPassRecord<'a> {
+    pub queue: &'a wgpu::Queue,
+    pub pipeline: &'a MaterialPipelines,
+    pub main_pipeline: &'a Pipeline,
+    pub targets: &'a Targets,
+    pub vertex_bytes: &'a [u8],
+    pub draws: &'a [MaterialPassDraw<'a>],
+    pub textured_params: &'a [u8],
+    pub coverage_params: &'a [u8],
+}
+
+pub fn record_material_pass(encoder: &mut wgpu::CommandEncoder, record: MaterialPassRecord<'_>) {
+    let MaterialPassRecord {
+        queue,
+        pipeline,
+        main_pipeline,
+        targets,
+        vertex_bytes,
+        draws,
+        textured_params,
+        coverage_params,
+    } = record;
+    if vertex_bytes.is_empty() || draws.is_empty() {
+        return;
+    }
+    if vertex_bytes.len() > MATERIAL_VERTEX_BUFFER_BYTES {
+        tracing::warn!(
+            target: "aether_substrate::render",
+            vertex_bytes = vertex_bytes.len(),
+            cap = MATERIAL_VERTEX_BUFFER_BYTES,
+            "dropping material pass: vertex bytes exceed fixed buffer",
+        );
+        return;
+    }
+    if textured_params.len() as u64 > MATERIAL_PARAMS_BUFFER_BYTES
+        || coverage_params.len() as u64 > MATERIAL_PARAMS_BUFFER_BYTES
+    {
+        tracing::warn!(
+            target: "aether_substrate::render",
+            textured_params_bytes = textured_params.len(),
+            coverage_params_bytes = coverage_params.len(),
+            cap = MATERIAL_PARAMS_BUFFER_BYTES,
+            "dropping material pass: parameter bytes exceed fixed buffers",
+        );
+        return;
+    }
+
+    queue.write_buffer(&pipeline.vertex_buffer, 0, vertex_bytes);
+    if !textured_params.is_empty() {
+        queue.write_buffer(&pipeline.textured_params_buffer, 0, textured_params);
+    }
+    if !coverage_params.is_empty() {
+        queue.write_buffer(&pipeline.coverage_params_buffer, 0, coverage_params);
+    }
+
+    let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("aether material pass"),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: targets.color_view(),
+            resolve_target: None,
+            depth_slice: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Load,
+                store: wgpu::StoreOp::Store,
+            },
+        })],
+        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+            view: &targets.depth.view,
+            depth_ops: Some(wgpu::Operations {
+                load: wgpu::LoadOp::Load,
+                store: wgpu::StoreOp::Store,
+            }),
+            stencil_ops: None,
+        }),
+        timestamp_writes: None,
+        occlusion_query_set: None,
+        multiview_mask: None,
+    });
+    pass.set_vertex_buffer(0, pipeline.vertex_buffer.slice(..vertex_bytes.len() as u64));
+    pass.set_bind_group(0, &main_pipeline.camera_bind_group, &[]);
+    for draw in draws {
+        match draw {
+            MaterialPassDraw::Textured(draw) => {
+                pass.set_pipeline(&pipeline.textured);
+                pass.set_bind_group(1, draw.bind_group, &[]);
+                pass.set_bind_group(
+                    2,
+                    &pipeline.textured_params_bind_group,
+                    &[draw.params_offset],
+                );
+                pass.draw(
+                    draw.first_vertex..draw.first_vertex + draw.vertex_count,
+                    0..1,
+                );
+            }
+            MaterialPassDraw::Coverage(draw) => {
+                pass.set_pipeline(&pipeline.coverage);
+                pass.set_bind_group(1, draw.bind_group, &[]);
+                pass.set_bind_group(
+                    2,
+                    &pipeline.coverage_params_bind_group,
+                    &[draw.params_offset],
+                );
+                pass.draw(
+                    draw.first_vertex..draw.first_vertex + draw.vertex_count,
+                    0..1,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn material_rect_vertices_have_expected_stride_and_corners() {
+        let mut bytes = Vec::new();
+        push_material_rect_vertices(&mut bytes, [1.0, 2.0, 3.0, 4.0, 0.5], [0.1, 0.2, 0.8, 0.9]);
+        let vertex_stride =
+            usize::try_from(MATERIAL_VERTEX_STRIDE).expect("material vertex stride fits usize");
+        assert_eq!(bytes.len(), MATERIAL_VERTICES_PER_RECT * vertex_stride);
+        let floats: &[f32] = bytemuck::cast_slice(&bytes);
+        assert_eq!(&floats[0..5], &[1.0, 2.0, 0.5, 0.1, 0.2]);
+        assert_eq!(&floats[5..10], &[1.0, 6.0, 0.5, 0.1, 0.9]);
+        assert_eq!(&floats[10..15], &[4.0, 6.0, 0.5, 0.8, 0.9]);
+        assert_eq!(&floats[25..30], &[4.0, 2.0, 0.5, 0.8, 0.2]);
+    }
+
+    #[test]
+    fn material_params_are_aligned_for_dynamic_uniform_offsets() {
+        let mut bytes = Vec::new();
+        let first = push_textured_params(&mut bytes, [1.0, 0.0, 0.0, 1.0])
+            .expect("first textured params offset");
+        let second = push_textured_params(&mut bytes, [0.0, 1.0, 0.0, 1.0])
+            .expect("second textured params offset");
+        let params_align = u32::try_from(PARAMS_ALIGN).expect("material params alignment fits u32");
+        assert_eq!(first, 0);
+        assert_eq!(second, params_align);
+        assert_eq!(bytes.len(), PARAMS_ALIGN * 2);
+    }
+}

--- a/crates/aether-substrate/src/render/material.wgsl
+++ b/crates/aether-substrate/src/render/material.wgsl
@@ -1,0 +1,57 @@
+struct Camera {
+    view_proj: mat4x4<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> camera: Camera;
+
+@group(1) @binding(0)
+var material_texture: texture_2d<f32>;
+@group(1) @binding(1)
+var material_sampler: sampler;
+
+struct MaterialParams {
+    color0: vec4<f32>,
+    rim_color: vec4<f32>,
+    rim_width: f32,
+    _pad0: vec3<f32>,
+}
+
+@group(2) @binding(0)
+var<uniform> params: MaterialParams;
+
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) uv: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.clip_pos = camera.view_proj * vec4<f32>(in.position, 1.0);
+    out.uv = in.uv;
+    return out;
+}
+
+@fragment
+fn fs_textured(in: VertexOutput) -> @location(0) vec4<f32> {
+    let texel = textureSample(material_texture, material_sampler, in.uv);
+    return texel * params.color0;
+}
+
+@fragment
+fn fs_coverage(in: VertexOutput) -> @location(0) vec4<f32> {
+    let coverage = textureSample(material_texture, material_sampler, in.uv).r;
+    let iso = 127.5 / 255.0;
+    let width = max(fwidth(coverage), 0.001);
+    let inside = smoothstep(iso - width, iso + width, coverage);
+    let distance_inside = max(coverage - iso, 0.0);
+    let rim_t = 1.0 - smoothstep(0.0, max(params.rim_width, width), distance_inside);
+    let color = mix(params.color0, params.rim_color, rim_t);
+    return vec4<f32>(color.rgb, color.a * inside);
+}

--- a/crates/aether-substrate/src/render/mod.rs
+++ b/crates/aether-substrate/src/render/mod.rs
@@ -17,12 +17,18 @@
 //! hub don't enable the feature so wgpu stays out of their build.
 
 mod capture;
+mod material;
 mod pipeline;
 mod quad;
 mod targets;
 
 pub use capture::{
     CaptureMeta, encode_png, finish_capture, map_capture_rgba, prepare_capture_copy,
+};
+pub use material::{
+    MATERIAL_VERTEX_BUFFER_BYTES, MATERIAL_VERTEX_STRIDE, MATERIAL_VERTICES_PER_RECT, MaterialDraw,
+    MaterialPassDraw, MaterialPassRecord, MaterialPipelines, build_material_pipelines,
+    push_coverage_params, push_material_rect_vertices, push_textured_params, record_material_pass,
 };
 pub use pipeline::{Pipeline, RenderError, build_main_pipeline, record_main_pass};
 pub use quad::{

--- a/crates/aether-substrate/src/render/pipeline.rs
+++ b/crates/aether-substrate/src/render/pipeline.rs
@@ -241,7 +241,7 @@ pub fn record_main_pass(
             view: &targets.depth.view,
             depth_ops: Some(wgpu::Operations {
                 load: wgpu::LoadOp::Clear(1.0),
-                store: wgpu::StoreOp::Discard,
+                store: wgpu::StoreOp::Store,
             }),
             stencil_ops: None,
         }),

--- a/docs/guide/systems/rendering.md
+++ b/docs/guide/systems/rendering.md
@@ -53,6 +53,8 @@ the `RenderCapability` actor. It handles these payload kinds:
 | `aether.render.update_texture` | `{ texture_id, x, y, width, height, pixels }` | overwrite a sub-rect of a texture (atlas growth) |
 | `aether.render.destroy_texture` | `{ texture_id }` | release a registered texture; fire-and-forget |
 | `aether.render.draw_textured_quads` | `{ texture_id, space, quads }` | per-tick textured alpha-blended quads; accumulates into the frame |
+| `aether.render.material.textured` | `{ texture_id, rects }` | per-tick depth-tested world-space textured rects |
+| `aether.render.material.coverage` | `{ texture_id, rects }` | per-tick depth-tested world-space coverage bands from an R8 texture |
 | `aether.render.capture_frame` | `{ mails, after_mails }` | atomic "set state, read back a PNG, clean up" |
 
 A `Vertex` is `{ x, y, z, r, g, b }` — a world-space position plus a per-vertex
@@ -78,6 +80,15 @@ the scene through the camera's `view_proj`. `Screen`-space quads draw today; the
 path. Sprites, HUD images, and the `aether.text` capability all compose this
 surface.
 
+**World-space materials are textured and depth-tested** ([ADR-0140](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0140-render-material-pass.md)).
+The material pass records after the triangle pass and before the screen overlay,
+loading the main pass depth buffer with writes disabled. Components send typed
+material draw kinds rather than shader source. `aether.render.material.textured`
+draws sampled rects in the world plane with a tint. `aether.render.material.coverage`
+requires an R8 texture, thresholds at iso 127.5, and renders a body/rim band
+from the rect parameters. Both are immediate-mode: resend the batch every frame
+or it disappears on the next commit-current frame.
+
 **The `view_proj` uniform, latest wins.** The substrate holds one column-major
 4×4 matrix and uploads it verbatim to the shader each frame (column-major matches
 wgpu's uniform layout, so the 64 bytes upload with no transpose). Each
@@ -100,10 +111,11 @@ last live frame drew.
 
 **Headless absorbs draw and camera mail.** The headless and hub chassis have no
 GPU, so they compose `HeadlessRenderCapability` on the same `aether.render`
-mailbox: `DrawTriangle`, `aether.view_projection`, `update_texture`, and
-`destroy_texture`, and `draw_textured_quads` no-op (a desktop-built component
-mailing them every frame doesn't warn-storm), and `aether.render.capture_frame`
-and `create_texture` reply `Err` so an MCP call fails fast instead of hanging.
+mailbox: `DrawTriangle`, `aether.view_projection`, `update_texture`,
+`destroy_texture`, `draw_textured_quads`, and `aether.render.material.*` no-op
+(a desktop-built component mailing them every frame doesn't warn-storm), and
+`aether.render.capture_frame` and `create_texture` reply `Err` so an MCP call
+fails fast instead of hanging.
 
 ## How to use it
 


### PR DESCRIPTION
Closes #2816.

## Summary

Add the depth-tested world-space material pass and typed material draw kinds for the ADR-0140 render path. The substrate/runtime pipeline now has material-pass support, WGSL material shading, runtime handlers, headless absorption, and TestBench coverage for the new pass.

The docs describe the new rendering material surface.

## Test plan

- `cargo fmt`
- `cargo check -p aether-substrate-bundle --tests`
- `git diff --check`

## Generated by

`/implement` - agent execution of [scoped issue #2816](https://github.com/iamacoffeepot/aether/issues/2816).
