### PR TITLE
ci(kit): widen kit scenario nextest timeouts

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,6 +6,14 @@ final-status-level = "slow"
 fail-fast = false
 slow-timeout = { period = "60s", terminate-after = 1 }
 
+# The kit scenario integration binaries cold-load and compile
+# `aether_kit.wasm` in each test. CI measurements in #2805 put the
+# camera scenario around 56.5s and mesh around 52-53s against the default
+# 60s cap, so give only these known wasm-heavy binaries extra headroom.
+[[profile.ci.overrides]]
+filter = "package(=aether-kit) & (binary(camera_scenario) | binary(mesh_scenario))"
+slow-timeout = { period = "120s", terminate-after = 1 }
+
 # The `aether-substrate-bundle` integration tests (FleetBench + the engines /
 # routing fleet suites) fork real debug `aether-substrate` processes and wait
 # for them to bind. Run concurrently they make timely progress but stretch
@@ -17,6 +25,13 @@ slow-timeout = { period = "60s", terminate-after = 1 }
 [[profile.ci.overrides]]
 filter = "package(=aether-substrate-bundle) & kind(test)"
 slow-timeout = { period = "180s", terminate-after = 1 }
+
+# The fleetbench replace binary also cold-loads `aether_kit.wasm` and was
+# measured in #2805 around 156.8s against the 180s bundle cap. Keep the
+# package-wide cap intact and widen only this known slow binary.
+[[profile.ci.overrides]]
+filter = "package(=aether-substrate-bundle) & binary(fleetbench_replace)"
+slow-timeout = { period = "300s", terminate-after = 1 }
 
 # Trybuild fixtures spawn a nested `cargo` build per `.rs` fixture.
 # iamacoffeepot/aether#1275 feature-gated wasmtime out of the


### PR DESCRIPTION
Closes #2805.

## Summary

Adds targeted nextest timeout headroom for the kit wasm scenario tests that were running close to their budgets.

## Test plan

- `git diff --check`
- `cargo nextest list -p aether-kit`
- `cargo nextest list -p aether-kit --features wasm`
- `cargo nextest list -p aether-kit --no-default-features`

## Generated by

`/implement` - agent execution of scoped issue #2805.
