### PR TITLE
feat(substrate): render overlay coverage planes

### DIFF
--- a/crates/aether-kit/src/world/mesher/mod.rs
+++ b/crates/aether-kit/src/world/mesher/mod.rs
@@ -44,23 +44,23 @@
 //! Material boundaries smooth identically whether the materials differ by
 //! explicit paint or by region default.
 //!
-//! # Overlay pass — corner-minimized contours
+//! # Overlay reference — corner-minimized contours
 //!
 //! Per distinct overlay material present, the material's binary subcell
-//! field runs through [`minimize_corners`] (upsample, one analytic
-//! 45-degree chamfer, angle-gated cellular passes) and then
-//! [`march_grid`] into crisp contour polygons plus greedy-merged
-//! interior. Smoothing params are spatial: each subcell reads its owning
-//! cell's smoothing-field override ([`World::smoothing_override`]) with
-//! the material's style row as the fallback, so where an edge reads soft
-//! versus crisp is authored on the map. The pooled rim is a second marched
-//! layer over an eroded mask: the smoothed shape draws in a darkened rim
-//! color, and the body draws one octimeter above it inset by the rim
-//! width. Every overlay material contours identically — water is underlay
-//! ground fabric (below), so an overlay-painted water body draws as a
-//! generic marched surface with no special treatment. Overlay geometry
-//! lifts a hair above the underlay surface so the coplanar passes never
-//! z-fight, and it carries its own vertices so the seam stays hard.
+//! field runs through [`prepare_material_mask_plane`], which applies
+//! [`minimize_corners`] (upsample, one analytic 45-degree chamfer,
+//! angle-gated cellular passes) to produce the smoothed scalar plane the
+//! runtime uploads as R8. The retained CPU oracle then feeds that plane to
+//! [`march_grid`] into crisp contour polygons plus greedy-merged interior
+//! for host tests. Smoothing params are spatial: each subcell reads its
+//! owning cell's smoothing-field override ([`World::smoothing_override`])
+//! with the material's style row as the fallback, so where an edge reads
+//! soft versus crisp is authored on the map. The pooled rim oracle is a
+//! second marched layer over an eroded mask: the smoothed shape draws in a
+//! darkened rim color, and the body draws one octimeter above it inset by
+//! the rim width. Runtime painted overlays no longer add these triangles
+//! to [`mesh_chunk`]; [`super::WorldView`] draws the prepared plane through
+//! `aether.render.material.coverage` instead.
 //!
 //! # Water — a flat underlay plane
 //!
@@ -204,10 +204,12 @@ const WALL_VOID_SKIRT_OCTIMETERS: i32 = 512;
 /// The overlay rim layer lift — two octimeters over the underlay, one
 /// above the encroachment flap so an overlay contour always draws over a
 /// material margin that grew across the same seam.
+#[allow(dead_code)]
 const OVERLAY_RIM_LIFT: f32 = 2.0 / OCTIMETERS_PER_METER;
 
 /// The overlay body layer lift — one octimeter over the rim, so the body
 /// sits on top of the rim it insets from.
+#[allow(dead_code)]
 const OVERLAY_BODY_LIFT: f32 = 3.0 / OCTIMETERS_PER_METER;
 
 /// The encroachment flap layer lift — one octimeter over the underlay.
@@ -272,11 +274,26 @@ pub fn mesh_chunk(
         }
         ViewMode::Painted => {
             let partition = mesh_underlay(world, at, styles, &mut tris);
-            mesh_overlay(world, at, styles, &mut tris);
             emit_walls(world, at, mode, styles, partition.as_ref(), &mut tris);
         }
     }
     tris
+}
+
+/// Smoothed material mask plane for one chunk/material overlay.
+///
+/// The plane includes the fixed smoothing apron. Runtime rendering uploads
+/// `samples` as an R8 texture and draws it as a coverage material rect;
+/// the CPU march consumes the same structure as the reference oracle.
+#[derive(Clone)]
+pub struct MaterialMaskPlane {
+    pub material: Material,
+    pub samples: Vec<u8>,
+    pub width: usize,
+    pub height: usize,
+    pub placement: GridPlacement,
+    pub apron_samples: i32,
+    pub step_octimeters: i32,
 }
 
 /// The repartitioned material grid the underlay pass marches its caps from,
@@ -397,6 +414,7 @@ impl SubPatch {
 /// lift through, continuous wherever no cliff intervenes. Where the cell
 /// carries authored relief the point patch resolves the subcell height;
 /// otherwise the whole-cell patch is the fast path.
+#[allow(dead_code)]
 fn point_lift(world: &World, wx: f32, wz: f32) -> (f32, f32) {
     let cell = CellPos {
         x: floor_to_i32(wx),
@@ -1972,9 +1990,19 @@ fn subcell_coverage(world: &World, at: ChunkPos, six: i32, siz: i32, material: M
 
 /// Emit the overlay pass: for each distinct overlay material present in
 /// the chunk, contour its subcell field.
+#[allow(dead_code)]
 fn mesh_overlay(world: &World, at: ChunkPos, styles: &StyleTable, tris: &mut Vec<DrawTriangle>) {
+    for material in overlay_materials(world, at) {
+        mesh_overlay_material(world, at, material, styles, tris);
+    }
+}
+
+/// Distinct non-void overlay materials present in the chunk, in stable
+/// material-id order.
+#[must_use]
+pub fn overlay_materials(world: &World, at: ChunkPos) -> Vec<Material> {
     let Some(chunk) = world.chunk(at) else {
-        return;
+        return Vec::new();
     };
     let mut present = [false; 6];
     for material in &chunk.overlay {
@@ -1982,11 +2010,12 @@ fn mesh_overlay(world: &World, at: ChunkPos, styles: &StyleTable, tris: &mut Vec
             present[*material as usize] = true;
         }
     }
-    for (id, seen) in present.iter().enumerate() {
-        if *seen {
-            mesh_overlay_material(world, at, Material::from_u8_or_void(id as u8), styles, tris);
-        }
-    }
+    present
+        .iter()
+        .enumerate()
+        .filter(|(_, seen)| **seen)
+        .map(|(id, _)| Material::from_u8_or_void(id.try_into().unwrap_or(0)))
+        .collect()
 }
 
 /// Sample one overlay material's subcell coverage field (plus its
@@ -2047,6 +2076,7 @@ fn sample_params(
 /// generic marched surface with no special treatment. The apron is fixed at
 /// the maximum a profile can demand ([`MAX_APRON_SUBCELLS`]), so field
 /// content never changes a chunk's read reach.
+#[allow(dead_code)]
 fn mesh_overlay_material(
     world: &World,
     at: ChunkPos,
@@ -2055,6 +2085,42 @@ fn mesh_overlay_material(
     tris: &mut Vec<DrawTriangle>,
 ) {
     let s = styles.get(material);
+    let plane = prepare_material_mask_plane(world, at, material, styles);
+    let rim_color = hsl_to_linear_rgb(s.base_hue, s.base_sat, s.base_light * (1.0 - s.rim_darken));
+    let rim_vertex = surface_vertex(world, OVERLAY_RIM_LIFT, rim_color);
+    march_grid(
+        &plane.samples,
+        plane.width,
+        plane.height,
+        &plane.placement,
+        &rim_vertex,
+        tris,
+    );
+    let rim_width = (s.rim_inset_octimeters / plane.step_octimeters).max(1);
+    let eroded = erode(&plane.samples, plane.width, plane.height, rim_width);
+
+    let body_color = hsl_to_linear_rgb(s.base_hue, s.base_sat, s.base_light);
+    let body_vertex = surface_vertex(world, OVERLAY_BODY_LIFT, body_color);
+    march_grid(
+        &eroded,
+        plane.width,
+        plane.height,
+        &plane.placement,
+        &body_vertex,
+        tris,
+    );
+}
+
+/// Prepare one overlay material's scalar material mask plane using the same
+/// sample-domain field, smoothing params, and corner minimization as the
+/// CPU marching oracle.
+#[must_use]
+pub fn prepare_material_mask_plane(
+    world: &World,
+    at: ChunkPos,
+    material: Material,
+    styles: &StyleTable,
+) -> MaterialMaskPlane {
     let apron = MAX_APRON_SUBCELLS;
     let (field, n) = sample_field(world, at, material, apron);
     let params = sample_params(world, at, material, apron, n, styles);
@@ -2064,31 +2130,31 @@ fn mesh_overlay_material(
     ];
 
     let upsample = CONTOUR_UPSAMPLE;
-    let (smoothed, gw, gh) = minimize_corners(&field, n, n, upsample, &params);
-    let step_oct = OCTIMETERS_PER_SUBCELL / upsample as i32;
+    let (samples, width, height) = minimize_corners(&field, n, n, upsample, &params);
+    let step_octimeters = OCTIMETERS_PER_SUBCELL / upsample as i32;
     let origin_oct = [
-        base_oct[0] - apron * OCTIMETERS_PER_SUBCELL + step_oct / 2,
-        base_oct[1] - apron * OCTIMETERS_PER_SUBCELL + step_oct / 2,
+        base_oct[0] - apron * OCTIMETERS_PER_SUBCELL + step_octimeters / 2,
+        base_oct[1] - apron * OCTIMETERS_PER_SUBCELL + step_octimeters / 2,
     ];
-    let rim_color = hsl_to_linear_rgb(s.base_hue, s.base_sat, s.base_light * (1.0 - s.rim_darken));
-    let place = GridPlacement {
-        origin_oct,
-        step_oct,
-    };
-    let rim_vertex = surface_vertex(world, OVERLAY_RIM_LIFT, rim_color);
-    march_grid(&smoothed, gw, gh, &place, &rim_vertex, tris);
-    let rim_width = (s.rim_inset_octimeters / step_oct).max(1);
-    let eroded = erode(&smoothed, gw, gh, rim_width);
-
-    let body_color = hsl_to_linear_rgb(s.base_hue, s.base_sat, s.base_light);
-    let body_vertex = surface_vertex(world, OVERLAY_BODY_LIFT, body_color);
-    march_grid(&eroded, gw, gh, &place, &body_vertex, tris);
+    MaterialMaskPlane {
+        material,
+        samples,
+        width,
+        height,
+        placement: GridPlacement {
+            origin_oct,
+            step_oct: step_octimeters,
+        },
+        apron_samples: apron * upsample as i32,
+        step_octimeters,
+    }
 }
 
 /// A vertex builder for overlay geometry: one flat color, lifted `lift`
 /// above the surface at the vertex's own (floor) cell — overlay contours
 /// drape the terrain; a contour crossing a cliff line stretches down the
 /// face rather than floating.
+#[allow(dead_code)]
 fn surface_vertex(world: &World, lift: f32, color: [f32; 3]) -> impl Fn(f32, f32) -> Vertex + '_ {
     move |wx: f32, wz: f32| Vertex {
         x: wx,
@@ -3186,18 +3252,11 @@ mod tests {
             }
             world.insert_chunk(ChunkPos { x: cx, z: 0 }, chunk);
         }
-        let mesh0 = mesh_chunk(
-            &world,
-            ChunkPos { x: 0, z: 0 },
-            ViewMode::Painted,
-            &StyleTable::default(),
-        );
-        let mesh1 = mesh_chunk(
-            &world,
-            ChunkPos { x: 1, z: 0 },
-            ViewMode::Painted,
-            &StyleTable::default(),
-        );
+        let styles = StyleTable::default();
+        let mut mesh0 = Vec::new();
+        mesh_overlay(&world, ChunkPos { x: 0, z: 0 }, &styles, &mut mesh0);
+        let mut mesh1 = Vec::new();
+        mesh_overlay(&world, ChunkPos { x: 1, z: 0 }, &styles, &mut mesh1);
         let max_x = |mesh: &[DrawTriangle]| {
             mesh.iter()
                 .flat_map(|t| t.verts.iter())
@@ -3265,11 +3324,12 @@ mod tests {
             .into_chunk(),
         );
 
-        let mesh = mesh_chunk(
+        let mut mesh = Vec::new();
+        mesh_overlay(
             &world,
             ChunkPos { x: 0, z: 0 },
-            ViewMode::Painted,
             &StyleTable::default(),
+            &mut mesh,
         );
         let overlay_covers = |px: f32, pz: f32| {
             mesh.iter()
@@ -3682,7 +3742,8 @@ mod tests {
             }
         }
         world.insert_chunk(at, chunk);
-        let mesh = mesh_chunk(&world, at, ViewMode::Painted, &StyleTable::default());
+        let mut mesh = Vec::new();
+        mesh_overlay(&world, at, &StyleTable::default(), &mut mesh);
         let mut overlay_verts = 0;
         for v in mesh.iter().flat_map(|t| t.verts.iter()) {
             let lift = v.y - world.surface_height(v.x, v.z);

--- a/crates/aether-kit/src/world/mod.rs
+++ b/crates/aether-kit/src/world/mod.rs
@@ -3,18 +3,19 @@
 #![allow(clippy::needless_pass_by_value)]
 
 //! World-view runtime. Meshes the chunked plane stack
-//! ([`crate::world`]) into ground geometry and replays the cached
-//! per-chunk mesh to `"aether.render"` each frame on the `Render`
-//! lifecycle stage.
+//! ([`crate::world`]) into ground geometry, uploads painted overlay
+//! material mask planes as render textures, and replays both cached surfaces
+//! to `"aether.render"` each frame on the `Render` lifecycle stage.
 //!
-//! The mesher lives in [`mesher`] as a pure function
-//! ([`mesh_chunk`]); this actor keeps the per-chunk mesh cache, the active
-//! view mode, and the cache invalidation. Each chunk becomes keyed-quilt
-//! underlay cells (flat world-anchored color with pooled rims and a wash
-//! gradient) and corner-minimized overlay contours over the subcell masks,
-//! in world-space meters (`1 cell = 1 m`) with the existing `aether.view_projection`
-//! `view_proj` handling projection. A chunk's rims and contours read a
-//! bounded apron into its neighbors, so a write invalidates its own mesh
+//! The mesher lives in [`mesher`] as pure functions ([`mesh_chunk`] for
+//! terrain triangles and [`mesher::prepare_material_mask_plane`] for overlay
+//! sample fields); this actor keeps the per-chunk mesh cache, the
+//! per-(chunk, material) R8 material-mask texture cache, the active view mode,
+//! and the cache invalidation. Each chunk becomes keyed-quilt underlay
+//! cells (flat world-anchored color with pooled rims and a wash gradient),
+//! while painted overlays render as depth-tested coverage material rects
+//! sampling the prepared plane. A chunk's rims and material mask planes read a
+//! bounded apron into its neighbors, so a write invalidates its own cache
 //! and its eight cached neighbors.
 //!
 //! # Mail surface
@@ -56,16 +57,19 @@ pub mod mesher;
 
 use alloc::collections::BTreeMap;
 
-use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, RequestId, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::fs::{Read, ReadResult};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
-use aether_capabilities::render::DrawTriangle;
+use aether_capabilities::render::{
+    CreateTexture, CreateTextureResult, DrawMaterialCoverage, DrawTriangle, MaterialCoverageRect,
+    MaterialRect, TextureFormat, UpdateTexture,
+};
 use aether_capabilities::{FsCapability, LifecycleCapability, RenderCapability};
 use aether_kinds::Render;
 use serde::{Deserialize, Serialize};
 
-use self::mesher::mesh_chunk;
-use self::mesher::style::StyleTable;
+use self::mesher::style::{StyleTable, hsl_to_linear_rgb};
+use self::mesher::{MaterialMaskPlane, mesh_chunk, overlay_materials, prepare_material_mask_plane};
 
 /// World-view component: holds the world plane stack and a per-chunk
 /// mesh cache, and replays the cache to the render sink each frame.
@@ -82,6 +86,7 @@ use self::mesher::style::StyleTable;
 pub struct WorldView {
     world: World,
     meshes: BTreeMap<ChunkPos, Vec<DrawTriangle>>,
+    material_mask_planes: BTreeMap<MaterialMaskPlaneKey, MaterialMaskPlaneEntry>,
     mode: ViewMode,
     styles: StyleTable,
 }
@@ -93,17 +98,50 @@ struct WorldLoadContext {
     path: String,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct MaterialMaskPlaneKey {
+    chunk: ChunkPos,
+    material: u8,
+}
+
+#[derive(Clone)]
+struct MaterialMaskPlaneEntry {
+    plane: MaterialMaskPlane,
+    texture: MaterialMaskTextureState,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum MaterialMaskTextureState {
+    Pending(RequestId),
+    Ready(u32),
+    Failed,
+}
+
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.world.material_mask_texture_context")]
+struct MaterialMaskTextureContext {
+    chunk_x: i32,
+    chunk_z: i32,
+    material: u8,
+}
+
+/// Convert the CPU rim inset into the coverage shader's normalized
+/// coverage-distance band. The texture is an R8 normalized field; a
+/// nominal one-sample coverage ramp spans 1.0 coverage fraction.
+const MATERIAL_MASK_RIM_FRACTION_PER_SAMPLE: f32 = 1.0;
+
 impl WorldView {
     /// Rebuild every chunk's cached mesh from the current world — used
     /// after a whole-world change (region default, world load, view mode,
     /// material style) that can alter any chunk's mesh.
-    fn remesh_all(&mut self) {
+    fn remesh_all(&mut self, ctx: &mut WasmCtx<'_>) {
         self.meshes.clear();
         let positions: Vec<ChunkPos> = self.world.chunks().map(|(pos, _)| pos).collect();
         for pos in positions {
             self.meshes
                 .insert(pos, mesh_chunk(&self.world, pos, self.mode, &self.styles));
         }
+        self.sync_material_mask_planes(ctx);
     }
 
     /// Remesh `pos` and its eight cached neighbors after a write inside
@@ -112,7 +150,7 @@ impl WorldView {
     /// neighbor as well as `pos`'s own mesh. Neighbors with no cached mesh
     /// are not rendered, so they need no remesh; an empty neighbor's border
     /// geometry is already covered by this chunk's own apron windows.
-    fn remesh_around(&mut self, pos: ChunkPos) {
+    fn remesh_around(&mut self, ctx: &mut WasmCtx<'_>, pos: ChunkPos) {
         for dz in -1..=1 {
             for dx in -1..=1 {
                 let neighbor = ChunkPos {
@@ -127,7 +165,180 @@ impl WorldView {
                 }
             }
         }
+        self.sync_material_mask_planes(ctx);
     }
+
+    fn sync_material_mask_planes(&mut self, ctx: &mut WasmCtx<'_>) {
+        if self.mode != ViewMode::Painted {
+            self.material_mask_planes.clear();
+            return;
+        }
+
+        let mut expected = Vec::new();
+        let positions: Vec<ChunkPos> = self.meshes.keys().copied().collect();
+        for chunk in positions {
+            for material in overlay_materials(&self.world, chunk) {
+                let key = MaterialMaskPlaneKey {
+                    chunk,
+                    material: material as u8,
+                };
+                expected.push(key);
+                let plane = prepare_material_mask_plane(&self.world, chunk, material, &self.styles);
+                self.sync_material_mask_plane(ctx, key, plane);
+            }
+        }
+        self.material_mask_planes
+            .retain(|key, _| expected.iter().any(|expected| expected == key));
+    }
+
+    fn sync_material_mask_plane(
+        &mut self,
+        ctx: &mut WasmCtx<'_>,
+        key: MaterialMaskPlaneKey,
+        plane: MaterialMaskPlane,
+    ) {
+        let Some(entry) = self.material_mask_planes.get_mut(&key) else {
+            let request = send_create_material_mask_texture(ctx, key, &plane);
+            self.material_mask_planes.insert(
+                key,
+                MaterialMaskPlaneEntry {
+                    plane,
+                    texture: MaterialMaskTextureState::Pending(request),
+                },
+            );
+            return;
+        };
+
+        let changed = entry.plane.samples != plane.samples
+            || entry.plane.width != plane.width
+            || entry.plane.height != plane.height;
+        entry.plane = plane;
+        if changed && let MaterialMaskTextureState::Ready(texture_id) = entry.texture {
+            send_update_material_mask_texture(ctx, texture_id, &entry.plane);
+        }
+    }
+
+    fn coverage_rect(
+        &self,
+        key: MaterialMaskPlaneKey,
+        entry: &MaterialMaskPlaneEntry,
+    ) -> Option<MaterialCoverageRect> {
+        let MaterialMaskTextureState::Ready(_) = entry.texture else {
+            return None;
+        };
+        let material = entry.plane.material;
+        let style = self.styles.get(material);
+        let body = hsl_to_linear_rgb(style.base_hue, style.base_sat, style.base_light);
+        let rim = hsl_to_linear_rgb(
+            style.base_hue,
+            style.base_sat,
+            style.base_light * (1.0 - style.rim_darken),
+        );
+        let origin_x = octimeters_to_meters(
+            entry.plane.placement.origin_oct[0] - entry.plane.step_octimeters / 2,
+        );
+        let origin_z = octimeters_to_meters(
+            entry.plane.placement.origin_oct[1] - entry.plane.step_octimeters / 2,
+        );
+        let width = material_mask_extent_meters(entry.plane.width, entry.plane.step_octimeters);
+        let height = material_mask_extent_meters(entry.plane.height, entry.plane.step_octimeters);
+        let layer = chunk_high_plane(&self.world, key.chunk) + 3.0 / 256.0;
+        let rim_width =
+            material_mask_rim_width(style.rim_inset_octimeters, entry.plane.step_octimeters);
+
+        Some(MaterialCoverageRect {
+            rect: MaterialRect {
+                x: origin_x,
+                y: origin_z,
+                width,
+                height,
+                z: layer,
+            },
+            body_color: [body[0], body[1], body[2], 1.0],
+            rim_color: [rim[0], rim[1], rim[2], 1.0],
+            rim_width,
+        })
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn octimeters_to_meters(octimeters: i32) -> f32 {
+    octimeters as f32 / 256.0
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn material_mask_extent_meters(samples: usize, step_octimeters: i32) -> f32 {
+    samples as f32 * step_octimeters as f32 / 256.0
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn material_mask_rim_width(rim_inset_octimeters: i32, step_octimeters: i32) -> f32 {
+    (rim_inset_octimeters as f32 / step_octimeters as f32) * MATERIAL_MASK_RIM_FRACTION_PER_SAMPLE
+}
+
+fn send_create_material_mask_texture(
+    ctx: &mut WasmCtx<'_>,
+    key: MaterialMaskPlaneKey,
+    plane: &MaterialMaskPlane,
+) -> RequestId {
+    let create = CreateTexture {
+        width: plane
+            .width
+            .try_into()
+            .expect("material mask plane width fits u32"),
+        height: plane
+            .height
+            .try_into()
+            .expect("material mask plane height fits u32"),
+        format: TextureFormat::R8,
+        pixels: plane.samples.clone(),
+    };
+    let context = MaterialMaskTextureContext {
+        chunk_x: key.chunk.x,
+        chunk_z: key.chunk.z,
+        material: key.material,
+    };
+    ctx.actor::<RenderCapability>()
+        .send_with_context(&create, &context)
+}
+
+fn send_update_material_mask_texture(
+    ctx: &mut WasmCtx<'_>,
+    texture_id: u32,
+    plane: &MaterialMaskPlane,
+) {
+    ctx.actor::<RenderCapability>().send(&UpdateTexture {
+        texture_id,
+        x: 0,
+        y: 0,
+        width: plane
+            .width
+            .try_into()
+            .expect("material mask plane width fits u32"),
+        height: plane
+            .height
+            .try_into()
+            .expect("material mask plane height fits u32"),
+        pixels: plane.samples.clone(),
+    });
+}
+
+fn chunk_high_plane(world: &World, chunk: ChunkPos) -> f32 {
+    let base_x = chunk.x * CELLS_PER_CHUNK;
+    let base_z = chunk.z * CELLS_PER_CHUNK;
+    let mut highest = 0.0_f32;
+    for z in 0..CELLS_PER_CHUNK {
+        for x in 0..CELLS_PER_CHUNK {
+            let cell = CellPos {
+                x: base_x + x,
+                z: base_z + z,
+            };
+            for corner in world.cell_corner_heights(cell) {
+                highest = highest.max(corner);
+            }
+        }
+    }
+    highest
 }
 
 #[actor]
@@ -138,6 +349,7 @@ impl WasmActor for WorldView {
         Ok(WorldView {
             world: World::new(),
             meshes: BTreeMap::new(),
+            material_mask_planes: BTreeMap::new(),
             mode: ViewMode::default(),
             styles: StyleTable::default(),
         })
@@ -168,6 +380,20 @@ impl WasmActor for WorldView {
                 ctx.actor::<RenderCapability>().send_many(mesh);
             }
         }
+        if self.mode == ViewMode::Painted {
+            for (key, entry) in &self.material_mask_planes {
+                let MaterialMaskTextureState::Ready(texture_id) = entry.texture else {
+                    continue;
+                };
+                let Some(rect) = self.coverage_rect(*key, entry) else {
+                    continue;
+                };
+                ctx.actor::<RenderCapability>().send(&DrawMaterialCoverage {
+                    texture_id,
+                    rects: vec![rect],
+                });
+            }
+        }
     }
 
     /// Write one chunk's planes into the world, then remesh that chunk and
@@ -178,10 +404,10 @@ impl WasmActor for WorldView {
     /// rendered, so they need no remesh; an empty neighbor's border
     /// geometry is already covered by this chunk's own apron windows.
     #[handler::single]
-    fn on_set_chunk(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetChunk) {
+    fn on_set_chunk(&mut self, ctx: &mut WasmCtx<'_>, msg: SetChunk) {
         let pos = msg.chunk_pos();
         self.world.insert_chunk(pos, msg.into_chunk());
-        self.remesh_around(pos);
+        self.remesh_around(ctx, pos);
     }
 
     /// Stamp one cell's underlay material points into the world, then remesh
@@ -197,10 +423,10 @@ impl WasmActor for WorldView {
     /// remaining points inheriting. `capture_frame` to verify the marched
     /// silhouette.
     #[handler::single]
-    fn on_set_cell_points(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetCellPoints) {
+    fn on_set_cell_points(&mut self, ctx: &mut WasmCtx<'_>, msg: SetCellPoints) {
         let cell = msg.cell();
         self.world.set_cell_points(cell, &msg.points);
-        self.remesh_around(cell.chunk());
+        self.remesh_around(ctx, cell.chunk());
     }
 
     /// Stamp one cell's height deltas into the world, then remesh that cell's
@@ -215,10 +441,10 @@ impl WasmActor for WorldView {
     /// (`0` = no relief). A short vector leaves the cell's remaining points
     /// flat. `capture_frame` to verify the authored relief.
     #[handler::single]
-    fn on_set_cell_heights(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetCellHeights) {
+    fn on_set_cell_heights(&mut self, ctx: &mut WasmCtx<'_>, msg: SetCellHeights) {
         let cell = msg.cell();
         self.world.set_cell_heights(cell, &msg.deltas);
-        self.remesh_around(cell.chunk());
+        self.remesh_around(ctx, cell.chunk());
     }
 
     /// Switch the view between the painted gouache grammar and the raw
@@ -230,9 +456,9 @@ impl WasmActor for WorldView {
     /// painted look or `mode = 1` for the raw hue-noise field, used to
     /// calibrate the material table by eye. `capture_frame` to compare.
     #[handler::single]
-    fn on_set_view_mode(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetViewMode) {
+    fn on_set_view_mode(&mut self, ctx: &mut WasmCtx<'_>, msg: SetViewMode) {
         self.mode = msg.view_mode();
-        self.remesh_all();
+        self.remesh_all(ctx);
     }
 
     /// Register a region in the world's table so the underlay cascade has
@@ -240,10 +466,10 @@ impl WasmActor for WorldView {
     /// default can change the resolved underlay of any cell pointing at
     /// that region.
     #[handler::single]
-    fn on_set_region(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetRegion) {
+    fn on_set_region(&mut self, ctx: &mut WasmCtx<'_>, msg: SetRegion) {
         let id = msg.region_id;
         self.world.insert_region(id, msg.into_region());
-        self.remesh_all();
+        self.remesh_all(ctx);
     }
 
     /// Register a contour-smoothing profile in the world's table, then
@@ -257,10 +483,10 @@ impl WasmActor for WorldView {
     /// through the `smoothing` plane of `aether.kit.world.set_chunk`
     /// (byte = profile id, `0` = the material default).
     #[handler::single]
-    fn on_set_smoothing_profile(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetSmoothingProfile) {
+    fn on_set_smoothing_profile(&mut self, ctx: &mut WasmCtx<'_>, msg: SetSmoothingProfile) {
         self.world
             .insert_smoothing_profile(msg.profile_id, msg.profile());
-        self.remesh_all();
+        self.remesh_all(ctx);
     }
 
     /// Register a water plane in the world's table, then remesh every cached
@@ -274,9 +500,9 @@ impl WasmActor for WorldView {
     /// `0` = the datum-0 level). One write retunes a whole lake live; use
     /// `capture_frame` to verify.
     #[handler::single]
-    fn on_set_water_plane(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetWaterPlane) {
+    fn on_set_water_plane(&mut self, ctx: &mut WasmCtx<'_>, msg: SetWaterPlane) {
         self.world.insert_water_plane(msg.plane_id, msg.plane());
-        self.remesh_all();
+        self.remesh_all(ctx);
     }
 
     /// Write a material's complete live style row, then remesh every
@@ -294,7 +520,7 @@ impl WasmActor for WorldView {
     /// judged row back into `mesher::style`'s const table as the new
     /// default once satisfied.
     #[handler::single]
-    fn on_set_material_style(&mut self, _ctx: &mut WasmCtx<'_>, msg: SetMaterialStyle) {
+    fn on_set_material_style(&mut self, ctx: &mut WasmCtx<'_>, msg: SetMaterialStyle) {
         match Material::try_from(msg.material) {
             Ok(Material::Void) | Err(_) => {
                 tracing::warn!(
@@ -305,7 +531,64 @@ impl WasmActor for WorldView {
             }
             Ok(_) => {
                 self.styles.apply(&msg);
-                self.remesh_all();
+                self.remesh_all(ctx);
+            }
+        }
+    }
+
+    /// Resolve an R8 material-mask texture create request. A successful reply
+    /// makes the prepared plane drawable on the next `Render` stage; an
+    /// error leaves the entry textureless so headless and failed texture
+    /// creation never submit a coverage material draw.
+    #[handler::single]
+    fn on_create_texture_result(&mut self, ctx: &mut WasmCtx<'_>, result: CreateTextureResult) {
+        let Some(context) = ctx.take_context::<MaterialMaskTextureContext>() else {
+            return;
+        };
+        let key = MaterialMaskPlaneKey {
+            chunk: ChunkPos {
+                x: context.chunk_x,
+                z: context.chunk_z,
+            },
+            material: context.material,
+        };
+        let Some(entry) = self.material_mask_planes.get_mut(&key) else {
+            tracing::warn!(
+                target: "aether_kit",
+                chunk_x = context.chunk_x,
+                chunk_z = context.chunk_z,
+                material = context.material,
+                "material mask texture reply had no pending plane entry",
+            );
+            return;
+        };
+        let pending = match entry.texture {
+            MaterialMaskTextureState::Pending(request) => Some(request),
+            MaterialMaskTextureState::Ready(_) | MaterialMaskTextureState::Failed => None,
+        };
+        match result {
+            CreateTextureResult::Ok { texture_id } => {
+                entry.texture = MaterialMaskTextureState::Ready(texture_id);
+                if let Some(request) = pending {
+                    tracing::debug!(
+                        target: "aether_kit",
+                        request_id = request.0,
+                        texture_id,
+                        "material mask texture ready",
+                    );
+                }
+            }
+            CreateTextureResult::Err { error } => {
+                entry.texture = MaterialMaskTextureState::Failed;
+                tracing::warn!(
+                    target: "aether_kit",
+                    chunk_x = context.chunk_x,
+                    chunk_z = context.chunk_z,
+                    material = context.material,
+                    request_id = pending.map_or(0, |request| request.0),
+                    error = %error,
+                    "material mask texture creation failed; overlay plane left textureless",
+                );
             }
         }
     }
@@ -358,7 +641,7 @@ impl WasmActor for WorldView {
             ReadResult::Ok { bytes, .. } => match World::from_bytes(&bytes) {
                 Ok(world) => {
                     self.world = world;
-                    self.remesh_all();
+                    self.remesh_all(ctx);
                     tracing::info!(
                         target: "aether_kit",
                         namespace = %context.namespace,

--- a/crates/aether-substrate-bundle/tests/mover_walks_painted_world.rs
+++ b/crates/aether-substrate-bundle/tests/mover_walks_painted_world.rs
@@ -24,6 +24,7 @@
 use std::fs;
 
 use aether_actor::Addressable;
+use aether_capabilities::render::{CreateTexture, DrawMaterialCoverage, UpdateTexture};
 use aether_data::Kind;
 use aether_kinds::keycode::KEY_W;
 use aether_kinds::{Key, LoadComponent, LoadResult, NamedMail, Render, WindowSize};
@@ -42,6 +43,9 @@ const WINDOW_HEIGHT: u32 = 96;
 /// Chunk edge in cells (`CELLS_PER_CHUNK`), mirrored here so the split-paint
 /// plane below is the right length.
 const CHUNK_EDGE: usize = 16;
+const SUBCELL_EDGE: usize = 16;
+const SUBCELLS_PER_CELL: usize = SUBCELL_EDGE * SUBCELL_EDGE;
+const OVERLAY_MASK_BYTES: usize = CHUNK_EDGE * CHUNK_EDGE * SUBCELLS_PER_CELL;
 
 /// The full trampoline address a loaded component registers at (ADR-0099 §4):
 /// the component host `/`-joined to the trampoline node under `name`.
@@ -98,6 +102,8 @@ fn load_kit_export(bench: &mut TestBench, wasm: &[u8], export: &str, name: &str)
 /// scrolls over as the body walks, guaranteeing the two captures differ.
 fn split_chunk() -> SetChunk {
     let mut underlay = vec![0u8; CHUNK_EDGE * CHUNK_EDGE];
+    let mut overlay = vec![0u8; CHUNK_EDGE * CHUNK_EDGE];
+    let mut overlay_mask = vec![0u8; OVERLAY_MASK_BYTES];
     for z in 0..CHUNK_EDGE {
         for x in 0..CHUNK_EDGE {
             let material = if x < CHUNK_EDGE / 2 {
@@ -106,6 +112,11 @@ fn split_chunk() -> SetChunk {
                 Material::Stone
             };
             underlay[z * CHUNK_EDGE + x] = material.to_u8();
+            if (5..11).contains(&x) && (4..12).contains(&z) {
+                overlay[z * CHUNK_EDGE + x] = Material::Sand.to_u8();
+                let base = (z * CHUNK_EDGE + x) * SUBCELLS_PER_CELL;
+                overlay_mask[base..base + SUBCELLS_PER_CELL].fill(u8::MAX);
+            }
         }
     }
     SetChunk {
@@ -114,8 +125,8 @@ fn split_chunk() -> SetChunk {
         underlay,
         underlay_points: Vec::new(),
         height_points: Vec::new(),
-        overlay: Vec::new(),
-        overlay_mask: Vec::new(),
+        overlay,
+        overlay_mask,
         height: Vec::new(),
         region: Vec::new(),
         water_plane: Vec::new(),
@@ -187,6 +198,17 @@ fn held_key_walks_the_body_across_the_painted_world() {
         .expect("paint + place + settle");
 
     let before = capture_scene(&mut bench, &mover, &world, "before");
+    assert!(
+        bench.count_observed(CreateTexture::NAME) > 0,
+        "painted overlay should upload an R8 coverage texture; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+    assert!(
+        bench.count_observed(DrawMaterialCoverage::NAME) > 0,
+        "painted overlay should render through a coverage material, not overlay triangles; \
+         observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
 
     // Hold W (no release) and advance four cells' worth of travel: at 8
     // octimeters/tick a 256-octimeter cell takes 32 ticks, so 128 ticks walks
@@ -229,5 +251,52 @@ fn held_key_walks_the_body_across_the_painted_world() {
         "walking the body should scroll the painted world under the camera; the frame \
          mean-absolute-error was {mae:.3} (expected 0.02..0.9) — the body did not move \
          across the painted ground",
+    );
+}
+
+#[test]
+fn painted_overlay_repaint_updates_the_coverage_texture() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = TestBench::start_with_size(WINDOW_WIDTH, WINDOW_HEIGHT).expect("boot");
+
+    let world = component_address("world");
+    load_kit_export(&mut bench, &wasm, "aether.kit.world", "world");
+
+    let mut repainted = split_chunk();
+    let cell = 7 * CHUNK_EDGE + 7;
+    repainted.overlay[cell] = Material::Void.to_u8();
+    let base = cell * SUBCELLS_PER_CELL;
+    repainted.overlay_mask[base..base + SUBCELLS_PER_CELL].fill(0);
+
+    bench
+        .execute(vec![
+            ("paint", BenchOp::send_mail(world.as_str(), &split_chunk())),
+            ("settle_create", BenchOp::advance(2)),
+            ("repaint", BenchOp::send_mail(world.as_str(), &repainted)),
+            ("settle_update", BenchOp::advance(1)),
+            (
+                "draw",
+                BenchOp::capture_with_mails(vec![envelope(&world, &Render)], Vec::new()),
+            ),
+        ])
+        .expect("paint + repaint + capture");
+
+    assert!(
+        bench.count_observed(CreateTexture::NAME) > 0,
+        "initial overlay paint should create an R8 texture; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+    assert!(
+        bench.count_observed(UpdateTexture::NAME) > 0,
+        "overlay repaint should update the existing coverage texture; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+    assert!(
+        bench.count_observed(DrawMaterialCoverage::NAME) > 0,
+        "updated overlay should still draw through coverage material; observed kinds: {:?}",
+        bench.observed_kinds(),
     );
 }

--- a/docs/guide/systems/rendering.md
+++ b/docs/guide/systems/rendering.md
@@ -89,6 +89,14 @@ requires an R8 texture, thresholds at iso 127.5, and renders a body/rim band
 from the rect parameters. Both are immediate-mode: resend the batch every frame
 or it disappears on the next commit-current frame.
 
+`aether.kit.world` uses the coverage material for painted overlay surfaces. It
+prepares the same smoothed scalar material mask plane the CPU contour oracle
+marches, uploads that plane as an R8 texture per chunk/material, and redraws a
+depth-tested coverage material rect for each ready plane on `Render`. Repainting
+the overlay plane updates the existing texture instead of sending replacement
+overlay triangles; terrain underlay, relief, walls, and raw calibration geometry
+remain ordinary `DrawTriangle` meshes.
+
 **The `view_proj` uniform, latest wins.** The substrate holds one column-major
 4×4 matrix and uploads it verbatim to the shader each frame (column-major matches
 wgpu's uniform layout, so the 64 bytes upload with no transpose). Each


### PR DESCRIPTION
Closes #2781.

## Summary

Switch painted world overlays from CPU-emitted overlay triangles to an R8 coverage-material render path. The kit now prepares the same smoothed scalar coverage plane used by the CPU contour oracle, uploads it per chunk/material, updates it on repaint, and draws it with `aether.render.material.coverage`.

The CPU overlay march remains compiled as the reference oracle for tests, while runtime painted mode sends terrain triangles plus coverage material draws.

## Test plan

- `cargo fmt`
- `git diff --check`
- `cargo check -p aether-kit`
- `cargo test -p aether-kit world::mesher`
- `cargo test -p aether-substrate-bundle --test mover_walks_painted_world`

## Generated by

`/implement` - agent execution of [scoped issue #2781](https://github.com/iamacoffeepot/aether/issues/2781).
