### PR TITLE
feat(substrate-bundle): add chassis config file source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "wasmtime",
  "wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ proc-macro2 = "1"
 quote = "1"
 serde = { version = "1", default-features = false }
 serde_json = "1"
+toml = "0.9"
 # Content-addressed hashing for the hub binary store (ADR-0115, issue
 # 1953): sha256 over a binary's raw bytes keys each entry. Native-only
 # consumer (`aether-capabilities` under `native`); pinned here so any

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -123,6 +123,7 @@ serde_json = { workspace = true }
 # thiserror consumer.
 thiserror = "2"
 tracing = { workspace = true, features = ["std", "attributes"] }
+toml = { workspace = true }
 wgpu = { workspace = true }
 winit = "0.30.13"
 

--- a/crates/aether-substrate-bundle/src/autoload.rs
+++ b/crates/aether-substrate-bundle/src/autoload.rs
@@ -235,6 +235,7 @@ mod tests {
         // no-op that loads nothing.
         match expand_replicas(packed(Some(0))) {
             Err(ConfigError::UnparseableKnown { .. }) => {}
+            Err(e) => panic!("0 replicas returned the wrong config error: {e}"),
             Ok(_) => panic!("0 replicas must be an error, not a silent no-op"),
         }
     }

--- a/crates/aether-substrate-bundle/src/bin/desktop.rs
+++ b/crates/aether-substrate-bundle/src/bin/desktop.rs
@@ -5,7 +5,7 @@
 //! each per-cap overlay shadows its `AETHER_*` env var, unset flags
 //! fall through to env-only resolution.
 
-// `--config` prints the discovery dump to stdout before boot
+// `--print-config` prints the discovery dump to stdout before boot
 // (ADR-0090 §4 / e2).
 #![allow(clippy::print_stdout)]
 
@@ -17,7 +17,7 @@ use clap::Parser as _;
 
 fn main() -> anyhow::Result<()> {
     let cli = DesktopCli::parse();
-    if cli.config {
+    if cli.print_config {
         print!("{}", chassis_config_dump());
         return Ok(());
     }

--- a/crates/aether-substrate-bundle/src/bin/headless.rs
+++ b/crates/aether-substrate-bundle/src/bin/headless.rs
@@ -4,7 +4,7 @@
 //! each per-cap overlay shadows its `AETHER_*` env var, unset flags
 //! fall through to env-only resolution.
 
-// `--config` prints the discovery dump to stdout before tracing is up
+// `--print-config` prints the discovery dump to stdout before tracing is up
 // (ADR-0090 §4 / e2).
 #![allow(clippy::print_stdout)]
 
@@ -16,7 +16,7 @@ use clap::Parser as _;
 
 fn main() -> anyhow::Result<()> {
     let cli = HeadlessCli::parse();
-    if cli.config {
+    if cli.print_config {
         print!("{}", chassis_config_dump());
         return Ok(());
     }

--- a/crates/aether-substrate-bundle/src/bin/hub.rs
+++ b/crates/aether-substrate-bundle/src/bin/hub.rs
@@ -5,7 +5,7 @@
 //! `--rpc-port` shadows `AETHER_RPC_PORT`.
 
 // CLI diagnostic before tracing subscriber is installed (issue 891).
-// `--config` prints the discovery dump to stdout before boot
+// `--print-config` prints the discovery dump to stdout before boot
 // (ADR-0090 §4 / e2).
 #![allow(clippy::print_stderr)]
 #![allow(clippy::print_stdout)]
@@ -17,7 +17,7 @@ use clap::Parser as _;
 
 fn main() -> anyhow::Result<()> {
     let cli = HubCli::parse();
-    if cli.config {
+    if cli.print_config {
         print!("{}", hub_config_dump());
         return Ok(());
     }

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -11,7 +11,11 @@
 //! minimal RPC-only chassis, test-bench drives a loopback), so the
 //! helper module stays scoped to the two full-stack chassis.
 
+use std::env;
+use std::fs;
+use std::io;
 use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -41,7 +45,8 @@ use aether_kinds::{BinaryManifest, Present, Render, Shutdown, Tick};
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::Builder;
 use aether_substrate::config::{
-    KnobKind, KnobRecord, KnownKeys, RingCapacities, SchedulerTuning, dump_config, known_keys,
+    ConfigError, FromArgvThenEnv, KnobKind, KnobRecord, KnownKeys, RingCapacities, SchedulerTuning,
+    dump_config, known_keys,
 };
 use aether_substrate::runtime::RUNTIME_KNOBS;
 use aether_substrate::runtime::lifecycle::FatalAborter;
@@ -51,18 +56,29 @@ use confique::meta::Meta;
 use crate::desktop::driver::WindowConfigLayer;
 use crate::headless::driver::TickConfigLayer;
 
+/// Env fallback for the chassis config-file path. The path is
+/// meta-config: it selects the file source and does not change the file
+/// layer's lower precedence relative to ordinary `AETHER_*` env knobs.
+pub const CONFIG_FILE_ENV: &str = "AETHER_CONFIG_FILE";
+
 /// Chassis-direct env knobs that aren't `#[derive(Config)]` fields —
 /// the hand-registered knobs the chassis bins read inline
 /// (`AETHER_RPC_PORT`) plus the one orphaned codec knob that can't
 /// live substrate-side (`AETHER_MAX_FRAME_SIZE` — `aether-codec`
 /// cannot depend on `aether-substrate`, where `KnobRecord`/`KnobKind`
 /// live). Registered as [`KnobRecord`]s so e1's unknown-`AETHER_*`
-/// sweep doesn't flag them and e2's `--config` dump lists them.
+/// sweep doesn't flag them and e2's `--print-config` dump lists them.
 /// ADR-0090 §1/§4. The runtime (log / panic-hook) knobs are registered
 /// by `aether_substrate::runtime::RUNTIME_KNOBS`; the scheduler
 /// hot-path, chassis boot, window, and tick knobs are covered by the
 /// derive-emitted `*Layer::META`s in [`chassis_registry`].
 pub const CHASSIS_KNOBS: &[KnobRecord] = &[
+    KnobRecord {
+        env_key: CONFIG_FILE_ENV,
+        doc: "Path to a sectioned TOML chassis config file; overridden by --config <PATH>.",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
     KnobRecord {
         env_key: "AETHER_RPC_PORT",
         doc: "aether.rpc.server bind port; desktop/headless skip the server when unset, hub always \
@@ -79,6 +95,112 @@ pub const CHASSIS_KNOBS: &[KnobRecord] = &[
         kind: KnobKind::HandRegistered,
     },
 ];
+
+/// Resolve the optional chassis config-file path from argv first, then
+/// `AETHER_CONFIG_FILE`. Empty values are treated as absent.
+#[must_use]
+pub fn chassis_config_path(argv: Option<String>) -> Option<PathBuf> {
+    argv.filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            // This is the central meta-config read for selecting the config
+            // file source, not a subsystem reading its own knob.
+            #[allow(clippy::disallowed_methods)]
+            env::var_os(CONFIG_FILE_ENV)
+                .filter(|path| !path.as_os_str().is_empty())
+                .map(PathBuf::from)
+        })
+}
+
+/// Read and parse an explicitly supplied sectioned TOML chassis config
+/// file. Missing or malformed files are hard boot errors because the
+/// operator asked for this source.
+///
+/// # Errors
+///
+/// Returns [`ConfigError`] when the file cannot be read or parsed as TOML.
+pub fn load_config_file(path: &Path) -> Result<toml::Table, ConfigError> {
+    let text = fs::read_to_string(path).map_err(|source| ConfigError::config_file(path, source))?;
+    text.parse::<toml::Table>()
+        .map_err(|source| ConfigError::config_file(path, source))
+}
+
+/// Load the chassis config file selected by argv or
+/// `AETHER_CONFIG_FILE`, returning `None` when neither is set.
+///
+/// # Errors
+///
+/// Returns [`ConfigError`] when an explicitly supplied file cannot be
+/// read or parsed.
+pub fn load_chassis_config(argv: Option<String>) -> Result<Option<toml::Table>, ConfigError> {
+    chassis_config_path(argv)
+        .map(|path| load_config_file(&path))
+        .transpose()
+}
+
+/// Extract one `[section]` from the parsed chassis config file and
+/// deserialize it into the target config's partial confique layer. An
+/// absent section is `None`; a present but malformed section is a hard
+/// boot error.
+///
+/// # Errors
+///
+/// Returns [`ConfigError`] when a present section is not a table or
+/// cannot deserialize into the target layer.
+pub fn file_section<C: FromArgvThenEnv>(
+    table: &toml::Table,
+    section: &str,
+) -> Result<Option<<C::Layer as confique::Config>::Layer>, ConfigError> {
+    let Some(value) = table.get(section) else {
+        return Ok(None);
+    };
+    if !matches!(value, toml::Value::Table(_)) {
+        let source = io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("expected [{section}] to be a TOML table"),
+        );
+        return Err(ConfigError::config_section(section, source));
+    }
+    value
+        .clone()
+        .try_into()
+        .map(Some)
+        .map_err(|source| ConfigError::config_section(section, source))
+}
+
+/// Resolve a config from argv/env plus the optional file section named
+/// by `section`, preserving source priority argv > env > file > defaults.
+///
+/// # Errors
+///
+/// Returns [`ConfigError`] from section deserialization or config
+/// resolution.
+pub fn resolve_with_file<C: FromArgvThenEnv>(
+    argv: <C::Layer as confique::Config>::Layer,
+    file: Option<&toml::Table>,
+    section: &str,
+) -> Result<C, ConfigError> {
+    let file = file
+        .map(|table| file_section::<C>(table, section))
+        .transpose()?
+        .flatten();
+    C::try_resolve(argv, file)
+}
+
+/// Resolve a config with no argv overlay, but with the optional file
+/// section below env.
+///
+/// # Errors
+///
+/// Returns [`ConfigError`] from section deserialization or config
+/// resolution.
+pub fn resolve_env_with_file<C: FromArgvThenEnv>(
+    file: Option<&toml::Table>,
+    section: &str,
+) -> Result<C, ConfigError> {
+    let argv = <<C::Layer as confique::Config>::Layer as confique::Layer>::empty();
+    resolve_with_file::<C>(argv, file, section)
+}
 
 /// Per-actor ring-capacity knob (issue 1990, ADR-0081 / ADR-0086). The
 /// `#[derive(aether_substrate::Config)]` emits the env-shaped
@@ -313,6 +435,17 @@ pub fn resolve_teardown_cap() -> Duration {
     SettlementConfig::from_env().to_cap()
 }
 
+/// Resolve the teardown cap from argv/env plus the optional
+/// `[settlement]` config-file section.
+///
+/// # Errors
+///
+/// Returns [`ConfigError`] when the file section or env value is
+/// malformed.
+pub fn resolve_teardown_cap_with_file(file: Option<&toml::Table>) -> Result<Duration, ConfigError> {
+    Ok(resolve_env_with_file::<SettlementConfig>(file, "settlement")?.to_cap())
+}
+
 /// Default lifecycle advance timeout in milliseconds. The literal
 /// `default = 1000` on [`ChassisBootConfig`] must equal this;
 /// `chassis_boot_config_defaults_match` guards the pair.
@@ -397,7 +530,7 @@ impl ChassisBootConfig {
 /// and the orphaned frame-size knob) and the runtime log-filter /
 /// panic-hook knobs (`aether_substrate::runtime::RUNTIME_KNOBS`). e1's
 /// [`validate_env`](aether_substrate::config::validate_env) sweeps the
-/// process env against this; e2's `--config` dump walks the same
+/// process env against this; e2's `--print-config` dump walks the same
 /// metas + records.
 ///
 /// Lives bundle-side rather than in `aether-substrate::config` because
@@ -415,7 +548,7 @@ pub fn chassis_known_keys() -> KnownKeys {
 /// plus the hand-registered knob records (`CHASSIS_KNOBS` +
 /// `aether_substrate::runtime::RUNTIME_KNOBS`). Shared by
 /// [`chassis_known_keys`] (e1's sweep) and [`chassis_config_dump`] (e2's
-/// `--config`) so both read one source of truth.
+/// `--print-config`) so both read one source of truth.
 fn chassis_registry() -> (&'static [&'static Meta], Vec<KnobRecord>) {
     const METAS: &[&Meta] = &[
         &HttpConfigLayer::META,
@@ -438,10 +571,10 @@ fn chassis_registry() -> (&'static [&'static Meta], Vec<KnobRecord>) {
     (METAS, records)
 }
 
-/// Render the `--config` discovery dump for the full-stack chassis
+/// Render the `--print-config` discovery dump for the full-stack chassis
 /// (ADR-0090 §4): every cap layer knob + hand-registered knob with its
 /// live source-resolved value, default, and doc. The chassis bins call
-/// this when `--config` is passed and exit before boot.
+/// this when `--print-config` is passed and exit before boot.
 #[must_use]
 pub fn chassis_config_dump() -> String {
     let (metas, records) = chassis_registry();
@@ -457,7 +590,7 @@ pub fn chassis_config_dump() -> String {
 /// inherits the hub's process environment, so fleet-wide cap knobs
 /// legitimately sit in the hub's env destined for the spawned engine.
 /// Shared by [`hub_known_keys`] (e1's sweep) and [`hub_config_dump`]
-/// (e2's `--config`) so both read one source of truth (ADR-0090 §4).
+/// (e2's `--print-config`) so both read one source of truth (ADR-0090 §4).
 fn hub_chassis_registry() -> (Vec<&'static Meta>, Vec<KnobRecord>) {
     let (metas, mut records) = chassis_registry();
     let mut metas: Vec<&'static Meta> = metas.to_vec();
@@ -482,7 +615,7 @@ pub fn hub_known_keys() -> KnownKeys {
     known_keys(&metas, &records)
 }
 
-/// Render the `--config` discovery dump for the hub chassis
+/// Render the `--print-config` discovery dump for the hub chassis
 /// (ADR-0090 §4): the full fleet registry plus the hub-only engine
 /// knobs, so an operator sees every knob that will take effect on the
 /// hub and the substrates it spawns.
@@ -739,18 +872,30 @@ mod tests {
     use super::SchedulerTuningConfigLayer;
     use super::SettlementConfig;
     use super::chassis_known_keys;
+    use super::file_section;
     use aether_actor::log::DEFAULT_RING_CAP;
     use aether_actor::trace::{DEFAULT_TRACE_RING_CAP, DEFAULT_TRACE_RING_MAX_CAP};
     use aether_capabilities::LifecycleConfig;
     use aether_substrate::SchedulerTuning;
+    use aether_substrate::config::ConfigError;
     use std::env;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process;
     use std::sync::Mutex;
     use std::sync::PoisonError;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     /// Process-wide guard around the `AETHER_ACTOR_*` ring env mutation,
     /// so ring tests serialise their set/remove pairs.
     static RING_ENV_LOCK: Mutex<()> = Mutex::new(());
+    static CONFIG_FILE_TEST_ID: AtomicUsize = AtomicUsize::new(0);
+
+    fn config_test_path(stem: &str) -> PathBuf {
+        let id = CONFIG_FILE_TEST_ID.fetch_add(1, Ordering::Relaxed);
+        env::temp_dir().join(format!("aether-{stem}-{}-{id}.toml", process::id()))
+    }
 
     #[test]
     fn actor_ring_config_defaults_match() {
@@ -860,7 +1005,7 @@ mod tests {
         // The nine scheduler hot-path env keys join the chassis known-key
         // set via `SchedulerTuningConfigLayer::META` (they rode
         // `SCHEDULER_KNOBS` before issue 2485), so the unknown-AETHER_*
-        // sweep (e1) doesn't flag them and the `--config` dump lists them.
+        // sweep (e1) doesn't flag them and the `--print-config` dump lists them.
         let known = chassis_known_keys();
         for key in [
             "AETHER_SPIN_WINDOW_USEC",
@@ -1074,7 +1219,7 @@ mod tests {
 
     #[test]
     fn hub_config_dump_lists_an_engine_knob() {
-        // e2's hub `--config` walks the same registry as e1's sweep, so
+        // e2's hub `--print-config` walks the same registry as e1's sweep, so
         // the hub-only engine knobs render in the dump.
         let dump = super::hub_config_dump();
         assert!(dump.contains("AETHER_HUB_HEARTBEAT_INTERVAL_SECS"));
@@ -1136,7 +1281,7 @@ mod tests {
 
     #[test]
     fn chassis_config_dump_lists_a_knob_from_each_cap_plus_scheduler() {
-        // ADR-0090 §4 `--config`: the dump walks the same registry as
+        // ADR-0090 §4 `--print-config`: the dump walks the same registry as
         // the sweep, so it lists a representative knob from each cap, a
         // chassis-boot knob, and a scheduler hot-path knob — with a
         // header row.
@@ -1152,6 +1297,48 @@ mod tests {
         assert!(dump.contains("AETHER_WORKERS")); // chassis-boot derive-Config knob
         assert!(dump.contains("AETHER_LOCAL_STICKY_MAX")); // scheduler knob
         assert!(dump.contains("AETHER_LOG_FILTER")); // runtime knob
+    }
+
+    #[test]
+    fn load_config_file_errors_on_missing_or_malformed_file() {
+        let missing = config_test_path("missing-config");
+        assert!(
+            matches!(
+                super::load_config_file(&missing),
+                Err(ConfigError::ConfigFile { .. })
+            ),
+            "explicit missing config file must hard-error",
+        );
+
+        let malformed = config_test_path("malformed-config");
+        fs::write(&malformed, "[http\n").expect("write malformed config");
+        let result = super::load_config_file(&malformed);
+        let _ = fs::remove_file(&malformed);
+        assert!(
+            matches!(result, Err(ConfigError::ConfigFile { .. })),
+            "malformed config file must hard-error",
+        );
+    }
+
+    #[test]
+    fn file_section_absent_is_none_and_present_section_deserializes() {
+        let table = "[http]\ndisabled = true\n"
+            .parse::<toml::Table>()
+            .expect("parse table");
+        assert!(
+            file_section::<ActorRingConfig>(&table, "actor")
+                .expect("absent section ok")
+                .is_none(),
+            "absent sections fall through to env/defaults",
+        );
+
+        let table = "[actor]\nlog_ring_capacity = 2048\n"
+            .parse::<toml::Table>()
+            .expect("parse table");
+        let section = file_section::<ActorRingConfig>(&table, "actor")
+            .expect("present section decodes")
+            .expect("actor section present");
+        assert_eq!(section.log_ring_capacity, Some(2048));
     }
 
     /// Regression guard for the enable / disable convention (#1791): a

--- a/crates/aether-substrate-bundle/src/cli.rs
+++ b/crates/aether-substrate-bundle/src/cli.rs
@@ -98,10 +98,15 @@ pub struct DesktopCli {
     #[command(flatten)]
     pub window: WindowOverlay,
 
+    /// Sectioned TOML chassis config file. Values from this file sit
+    /// below env and argv in the source stack.
+    #[arg(long = "config", value_name = "PATH")]
+    pub config: Option<String>,
+
     /// Print every config knob (source-resolved value, default, doc)
     /// and exit before boot (ADR-0090 §4 discovery dump).
-    #[arg(long = "config")]
-    pub config: bool,
+    #[arg(long = "print-config")]
+    pub print_config: bool,
 
     /// Print this binary's `BinaryManifest` (chassis kind, linked caps,
     /// build provenance) as JSON and exit before boot (ADR-0115, issue
@@ -124,10 +129,15 @@ pub struct HeadlessCli {
     #[command(flatten)]
     pub tick: TickOverlay,
 
+    /// Sectioned TOML chassis config file. Values from this file sit
+    /// below env and argv in the source stack.
+    #[arg(long = "config", value_name = "PATH")]
+    pub config: Option<String>,
+
     /// Print every config knob (source-resolved value, default, doc)
     /// and exit before boot (ADR-0090 §4 discovery dump).
-    #[arg(long = "config")]
-    pub config: bool,
+    #[arg(long = "print-config")]
+    pub print_config: bool,
 
     /// Print this binary's `BinaryManifest` (chassis kind, linked caps,
     /// build provenance) as JSON and exit before boot (ADR-0115, issue
@@ -155,10 +165,15 @@ pub struct HubCli {
     #[command(flatten)]
     pub engine: EngineOverlay,
 
+    /// Sectioned TOML chassis config file. Values from this file sit
+    /// below env and argv in the source stack.
+    #[arg(long = "config", value_name = "PATH")]
+    pub config: Option<String>,
+
     /// Print every config knob (source-resolved value, default, doc)
     /// and exit before boot (ADR-0090 §4 discovery dump).
-    #[arg(long = "config")]
-    pub config: bool,
+    #[arg(long = "print-config")]
+    pub print_config: bool,
 
     /// Print this binary's `BinaryManifest` (chassis kind, linked caps,
     /// build provenance) as JSON and exit before boot (ADR-0115, issue

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -17,6 +17,7 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use aether_actor::Addressable;
 use aether_capabilities::LifecycleCapability;
@@ -39,8 +40,8 @@ use super::driver::{DesktopDriverCapability, WindowConfig};
 use crate::autoload::{AutoloadComponent, autoload_mail, boot_manifest_autoload};
 use crate::chassis_common::{
     ActorRingConfig, ChassisBootConfig, CommonBoot, SchedulerTuningConfig, chassis_known_keys,
-    frame_lifecycle_config, maybe_with_http_server, maybe_with_rpc_server, resolve_teardown_cap,
-    with_common_caps,
+    frame_lifecycle_config, load_chassis_config, maybe_with_http_server, maybe_with_rpc_server,
+    resolve_env_with_file, resolve_teardown_cap_with_file, resolve_with_file, with_common_caps,
 };
 use crate::cli::{CommonOverlay, DesktopCli};
 use crate::hub;
@@ -214,6 +215,10 @@ pub struct DesktopEnv {
     /// `AETHER_LOCAL_STICKY_MAX` / …). Default is
     /// [`SchedulerTuning::default`] (the built-in scheduler literals).
     pub scheduler_tuning: SchedulerTuning,
+    /// Issue #2509: cumulative patience for the instanced-actor teardown
+    /// close-done gate, resolved from `AETHER_SETTLEMENT_CAP_SECS` /
+    /// `[settlement]`.
+    pub teardown_cap: Duration,
     /// Issue 2706: render boot knobs resolved from the
     /// `RenderTuningConfig` knob (`AETHER_RENDER_VERTEX_BUFFER_BYTES`).
     /// Threaded into the render cap's `RenderConfig` in `build_inner`.
@@ -266,11 +271,14 @@ impl DesktopEnv {
             common,
             audio: audio_overlay,
             window: window_overlay,
-            // The bin handles `--config` / `--describe` (print + exit)
-            // before this resolver runs; ignore them here.
-            config: _,
+            // The bin handles `--print-config` / `--describe` (print + exit)
+            // before this resolver runs.
+            config,
+            print_config: _,
             describe: _,
         } = cli;
+        let config_file = load_chassis_config(config)?;
+        let config_file = config_file.as_ref();
         let CommonOverlay {
             http,
             http_server: http_server_overlay,
@@ -282,9 +290,13 @@ impl DesktopEnv {
             rpc_port: cli_rpc_port,
         } = common;
 
-        let chassis_boot =
-            ChassisBootConfig::try_from_argv_then_env(chassis_boot_overlay.into_layer())?;
-        let window_config = WindowConfig::from_argv_then_env(window_overlay.into_layer());
+        let chassis_boot = resolve_with_file::<ChassisBootConfig>(
+            chassis_boot_overlay.into_layer(),
+            config_file,
+            "chassis",
+        )?;
+        let window_config =
+            resolve_with_file::<WindowConfig>(window_overlay.into_layer(), config_file, "window")?;
 
         // Boot manifest: argv wins over `AETHER_BOOT_MANIFEST` (resolved
         // through `ChassisBootConfig`). When set, the listed components'
@@ -300,18 +312,28 @@ impl DesktopEnv {
         event_loop.set_control_flow(ControlFlow::Poll);
         let capture_queue = CaptureQueue::new();
 
-        let http = HttpConf::try_from_argv_then_env(http.into_layer())?;
-        let anthropic = AnthropicConfig::try_from_argv_then_env(anthropic.into_layer())?;
-        let gemini = GeminiConfig::try_from_argv_then_env(gemini.into_layer())?;
-        let contentgen = ContentGenConfig::try_from_argv_then_env(contentgen.into_layer())?;
-        let namespace_roots = NamespaceRoots::from_argv_then_env(fs.into_layer());
+        let http = resolve_with_file::<HttpConf>(http.into_layer(), config_file, "http")?;
+        let anthropic =
+            resolve_with_file::<AnthropicConfig>(anthropic.into_layer(), config_file, "anthropic")?;
+        let gemini = resolve_with_file::<GeminiConfig>(gemini.into_layer(), config_file, "gemini")?;
+        let contentgen = resolve_with_file::<ContentGenConfig>(
+            contentgen.into_layer(),
+            config_file,
+            "contentgen",
+        )?;
+        let namespace_roots =
+            resolve_with_file::<NamespaceRoots>(fs.into_layer(), config_file, "fs")?;
         // The HTTP server is opt-in: resolve its config and boot the cap
         // only when `enabled` is set (ADR-0108 / issue 1761). Default-off,
         // so an unconfigured chassis binds no HTTP port.
-        let http_server_config =
-            HttpServerConfig::try_from_argv_then_env(http_server_overlay.into_layer())?;
+        let http_server_config = resolve_with_file::<HttpServerConfig>(
+            http_server_overlay.into_layer(),
+            config_file,
+            "http-server",
+        )?;
         let http_server = http_server_config.enabled.then_some(http_server_config);
-        let audio = AudioConf::try_from_argv_then_env(audio_overlay.into_layer())?;
+        let audio =
+            resolve_with_file::<AudioConf>(audio_overlay.into_layer(), config_file, "audio")?;
 
         // Window mode and title: resolved through `WindowConfig` (argv > env >
         // default). `to_boot_mode` delegates to `parse_window_mode_env` and
@@ -333,16 +355,20 @@ impl DesktopEnv {
         // Issue 1990: resolve the per-actor ring capacities from
         // `AETHER_ACTOR_{LOG,TRACE}_RING_SIZE` (ADR-0090 §4 hard-error on
         // an unparseable known value, surfaced as `DesktopBootError::Config`).
-        let ring_caps = ActorRingConfig::try_from_env()?.to_ring_capacities();
+        let ring_caps =
+            resolve_env_with_file::<ActorRingConfig>(config_file, "actor")?.to_ring_capacities();
         // Issue 2485: resolve the scheduler hot-path tuning from
         // `AETHER_SPIN_WINDOW_USEC` / `AETHER_LOCAL_*` / `AETHER_BLOB_*` /
         // `AETHER_*_COST_*` (ADR-0090 §4 hard-error on an unparseable
         // known value, surfaced as `DesktopBootError::Config`).
-        let scheduler_tuning = SchedulerTuningConfig::try_from_env()?.to_scheduler_tuning();
+        let scheduler_tuning =
+            resolve_env_with_file::<SchedulerTuningConfig>(config_file, "scheduler")?
+                .to_scheduler_tuning();
+        let teardown_cap = resolve_teardown_cap_with_file(config_file)?;
         // Issue 2706: resolve the render boot knobs
         // (`AETHER_RENDER_VERTEX_BUFFER_BYTES`; ADR-0090 §4 hard-error
         // on an unparseable known value).
-        let render_tuning = RenderTuningConfig::try_from_env()?;
+        let render_tuning = resolve_env_with_file::<RenderTuningConfig>(config_file, "render")?;
 
         Ok(Self {
             event_loop,
@@ -362,6 +388,7 @@ impl DesktopEnv {
             workers,
             ring_caps,
             scheduler_tuning,
+            teardown_cap,
             render_tuning,
             lifecycle_advance_timeout_millis,
             autoload,
@@ -397,6 +424,7 @@ impl DesktopChassis {
             workers,
             ring_caps,
             scheduler_tuning,
+            teardown_cap,
             render_tuning,
             lifecycle_advance_timeout_millis,
             autoload,
@@ -477,7 +505,7 @@ impl DesktopChassis {
             // Issue #2509: the instanced-actor teardown gate honors the
             // same `AETHER_SETTLEMENT_CAP_SECS` knob (including its
             // `0 → wait forever` sentinel) as the settlement gates.
-            teardown_cap: resolve_teardown_cap(),
+            teardown_cap,
             input_config,
             component_host_config,
             namespace_roots,

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -37,8 +37,9 @@ use super::driver::{HeadlessTimerDriverCapability, TickConfig};
 use crate::autoload::{AutoloadComponent, autoload_mail, boot_manifest_autoload};
 use crate::chassis_common::{
     ActorRingConfig, ChassisBootConfig, CommonBoot, SchedulerTuningConfig, chassis_known_keys,
-    maybe_with_http_server, maybe_with_rpc_server, resolve_teardown_cap,
-    tick_only_lifecycle_config, with_common_caps,
+    load_chassis_config, maybe_with_http_server, maybe_with_rpc_server, resolve_env_with_file,
+    resolve_teardown_cap_with_file, resolve_with_file, tick_only_lifecycle_config,
+    with_common_caps,
 };
 use crate::cli::{CommonOverlay, HeadlessCli};
 use crate::hub;
@@ -126,6 +127,10 @@ pub struct HeadlessEnv {
     /// `AETHER_LOCAL_STICKY_MAX` / …). Default is
     /// [`SchedulerTuning::default`] (the built-in scheduler literals).
     pub scheduler_tuning: SchedulerTuning,
+    /// Issue #2509: cumulative patience for the instanced-actor teardown
+    /// close-done gate, resolved from `AETHER_SETTLEMENT_CAP_SECS` /
+    /// `[settlement]`.
+    pub teardown_cap: Duration,
     /// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS` — timeout for one lifecycle
     /// advance step (Tick) before the scheduler logs a slow-frame warning.
     /// Resolved through `ChassisBootConfig`; default is 1000 ms.
@@ -169,11 +174,14 @@ impl HeadlessEnv {
         let HeadlessCli {
             common,
             tick: tick_overlay,
-            // The bin handles `--config` / `--describe` (print + exit)
-            // before this resolver runs; ignore them here.
-            config: _,
+            // The bin handles `--print-config` / `--describe` (print + exit)
+            // before this resolver runs.
+            config,
+            print_config: _,
             describe: _,
         } = cli;
+        let config_file = load_chassis_config(config)?;
+        let config_file = config_file.as_ref();
         let CommonOverlay {
             http,
             http_server: http_server_overlay,
@@ -185,9 +193,13 @@ impl HeadlessEnv {
             rpc_port: cli_rpc_port,
         } = common;
 
-        let chassis_boot =
-            ChassisBootConfig::try_from_argv_then_env(chassis_boot_overlay.into_layer())?;
-        let tick_config = TickConfig::try_from_argv_then_env(tick_overlay.into_layer())?;
+        let chassis_boot = resolve_with_file::<ChassisBootConfig>(
+            chassis_boot_overlay.into_layer(),
+            config_file,
+            "chassis",
+        )?;
+        let tick_config =
+            resolve_with_file::<TickConfig>(tick_overlay.into_layer(), config_file, "tick")?;
 
         // Boot manifest: argv wins over `AETHER_BOOT_MANIFEST` (resolved
         // through `ChassisBootConfig`). When set, the listed components'
@@ -198,16 +210,25 @@ impl HeadlessEnv {
             Some(path) => boot_manifest_autoload(Path::new(&path))?,
             None => Vec::new(),
         };
-        let http = HttpConf::try_from_argv_then_env(http.into_layer())?;
-        let anthropic = AnthropicConfig::try_from_argv_then_env(anthropic.into_layer())?;
-        let gemini = GeminiConfig::try_from_argv_then_env(gemini.into_layer())?;
-        let contentgen = ContentGenConfig::try_from_argv_then_env(contentgen.into_layer())?;
-        let namespace_roots = NamespaceRoots::from_argv_then_env(fs.into_layer());
+        let http = resolve_with_file::<HttpConf>(http.into_layer(), config_file, "http")?;
+        let anthropic =
+            resolve_with_file::<AnthropicConfig>(anthropic.into_layer(), config_file, "anthropic")?;
+        let gemini = resolve_with_file::<GeminiConfig>(gemini.into_layer(), config_file, "gemini")?;
+        let contentgen = resolve_with_file::<ContentGenConfig>(
+            contentgen.into_layer(),
+            config_file,
+            "contentgen",
+        )?;
+        let namespace_roots =
+            resolve_with_file::<NamespaceRoots>(fs.into_layer(), config_file, "fs")?;
         // The HTTP server is opt-in: resolve its config and boot the cap
         // only when `enabled` is set (ADR-0108 / issue 1761). Default-off,
         // so an unconfigured chassis binds no HTTP port.
-        let http_server_config =
-            HttpServerConfig::try_from_argv_then_env(http_server_overlay.into_layer())?;
+        let http_server_config = resolve_with_file::<HttpServerConfig>(
+            http_server_overlay.into_layer(),
+            config_file,
+            "http-server",
+        )?;
         let http_server = http_server_config.enabled.then_some(http_server_config);
         // Tick cadence: resolved through `TickConfig` (argv > env > default).
         // `nonzero` maps 0 to the default (60 Hz); a garbage value hard-errors.
@@ -220,11 +241,15 @@ impl HeadlessEnv {
         // Issue 1990: resolve the per-actor ring capacities from
         // `AETHER_ACTOR_{LOG,TRACE}_RING_SIZE` (ADR-0090 §4 hard-error on
         // an unparseable known value, surfaced as `ConfigError`).
-        let ring_caps = ActorRingConfig::try_from_env()?.to_ring_capacities();
+        let ring_caps =
+            resolve_env_with_file::<ActorRingConfig>(config_file, "actor")?.to_ring_capacities();
         // Issue 2485: resolve the scheduler hot-path tuning (ADR-0090 §4
         // hard-error on an unparseable known value, surfaced as
         // `ConfigError`).
-        let scheduler_tuning = SchedulerTuningConfig::try_from_env()?.to_scheduler_tuning();
+        let scheduler_tuning =
+            resolve_env_with_file::<SchedulerTuningConfig>(config_file, "scheduler")?
+                .to_scheduler_tuning();
+        let teardown_cap = resolve_teardown_cap_with_file(config_file)?;
         Ok(Self {
             namespace_roots,
             http,
@@ -237,6 +262,7 @@ impl HeadlessEnv {
             workers,
             ring_caps,
             scheduler_tuning,
+            teardown_cap,
             lifecycle_advance_timeout_millis,
             autoload,
         })
@@ -264,6 +290,7 @@ impl HeadlessChassis {
             workers,
             ring_caps,
             scheduler_tuning,
+            teardown_cap,
             lifecycle_advance_timeout_millis,
             autoload,
         } = env;
@@ -349,7 +376,7 @@ impl HeadlessChassis {
             // Issue #2509: the instanced-actor teardown gate honors the
             // same `AETHER_SETTLEMENT_CAP_SECS` knob (including its
             // `0 → wait forever` sentinel) as the settlement gates.
-            teardown_cap: resolve_teardown_cap(),
+            teardown_cap,
             input_config,
             component_host_config,
             namespace_roots,

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -13,6 +13,7 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use aether_actor::Addressable;
 use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
@@ -22,11 +23,12 @@ use aether_substrate::chassis::builder::{
     Builder, BuiltChassis, DriverCapability, DriverCtx, DriverRunning, RunError,
 };
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::config::{ConfigError, validate_env};
+use aether_substrate::config::{ConfigError, RingCapacities, SchedulerTuning, validate_env};
 use aether_substrate::{Chassis, SubstrateBoot};
 
 use crate::chassis_common::{
-    ActorRingConfig, SchedulerTuningConfig, hub_known_keys, resolve_teardown_cap,
+    ActorRingConfig, SchedulerTuningConfig, hub_known_keys, load_chassis_config,
+    resolve_env_with_file, resolve_teardown_cap_with_file, resolve_with_file,
 };
 use crate::cli::HubCli;
 use crate::hub::DEFAULT_RPC_PORT;
@@ -75,6 +77,9 @@ impl HubChassis {
 pub struct HubEnv {
     pub rpc_addr: SocketAddr,
     pub engine: EngineConfig,
+    pub ring_caps: RingCapacities,
+    pub scheduler_tuning: SchedulerTuning,
+    pub teardown_cap: Duration,
 }
 
 impl HubEnv {
@@ -98,7 +103,7 @@ impl HubEnv {
     /// derive-emitted `from_argv_then_env` (argv beats
     /// `AETHER_HUB_HEARTBEAT_*` env beats the literal default). Takes
     /// `&HubCli`, cloning the overlay rather than consuming `cli` so the
-    /// bin keeps it for the `--config` dump.
+    /// bin keeps it for the `--print-config` dump.
     ///
     /// # Errors
     ///
@@ -111,40 +116,45 @@ impl HubEnv {
         // ADR-0090 §4 (e1): warn on any unknown AETHER_ env var before
         // resolving — a typo / stale export is loud but non-fatal.
         validate_env(&hub_known_keys())?;
+        let config_file = load_chassis_config(cli.config.clone())?;
+        let config_file = config_file.as_ref();
         let rpc_port = cli
             .rpc_port
             .or_else(super::rpc_port_from_env)
             .unwrap_or(DEFAULT_RPC_PORT);
         Ok(Self {
             rpc_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_port),
-            engine: EngineConfig::from_argv_then_env(cli.engine.clone().into_layer()),
+            engine: resolve_with_file::<EngineConfig>(
+                cli.engine.clone().into_layer(),
+                config_file,
+                "engine",
+            )?,
+            ring_caps: resolve_env_with_file::<ActorRingConfig>(config_file, "actor")?
+                .to_ring_capacities(),
+            scheduler_tuning: resolve_env_with_file::<SchedulerTuningConfig>(
+                config_file,
+                "scheduler",
+            )?
+            .to_scheduler_tuning(),
+            teardown_cap: resolve_teardown_cap_with_file(config_file)?,
         })
     }
 }
 
 impl HubChassis {
     fn build_inner(env: HubEnv) -> Result<BuiltChassis<Self>, BootError> {
-        let HubEnv { rpc_addr, engine } = env;
+        let HubEnv {
+            rpc_addr,
+            engine,
+            ring_caps,
+            scheduler_tuning,
+            teardown_cap,
+        } = env;
         let boot = SubstrateBoot::builder("aether-hub", env!("CARGO_PKG_VERSION")).build()?;
         let registry = Arc::clone(&boot.registry);
         let mailer = Arc::clone(&boot.queue);
 
         let driver = HubServerDriverCapability { boot };
-
-        // Issue 1990: resolve the per-actor ring capacities so the hub
-        // chassis honours `AETHER_ACTOR_{LOG,TRACE}_RING_SIZE` like the
-        // full-stack chassis (which thread it via `with_common_caps`).
-        let ring_caps = ActorRingConfig::try_from_env()?.to_ring_capacities();
-        // Issue 2485: resolve the scheduler hot-path tuning so the hub
-        // chassis honours `AETHER_SPIN_WINDOW_USEC` / `AETHER_LOCAL_*` /
-        // etc. like the full-stack chassis (which thread it via
-        // `with_common_caps`).
-        let scheduler_tuning = SchedulerTuningConfig::try_from_env()?.to_scheduler_tuning();
-        // Issue #2509: the instanced-actor teardown gate honors the same
-        // `AETHER_SETTLEMENT_CAP_SECS` knob (including its `0 → wait
-        // forever` sentinel) as the settlement gates, like the full-stack
-        // chassis (which thread it via `with_common_caps`).
-        let teardown_cap = resolve_teardown_cap();
 
         Builder::<Self>::new(registry, mailer)
             .with_ring_caps(ring_caps)

--- a/crates/aether-substrate-bundle/tests/headless_autoload.rs
+++ b/crates/aether-substrate-bundle/tests/headless_autoload.rs
@@ -88,6 +88,7 @@ mod tests {
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
             scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
+            teardown_cap: Duration::from_millis(100),
             lifecycle_advance_timeout_millis: 1_000,
             autoload: decoded
                 .components
@@ -165,6 +166,7 @@ mod tests {
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
             scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
+            teardown_cap: Duration::from_millis(100),
             lifecycle_advance_timeout_millis: 1_000,
             autoload,
         };

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -287,6 +287,7 @@ mod tests {
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
             scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
+            teardown_cap: Duration::from_millis(100),
             lifecycle_advance_timeout_millis: 1_000,
             autoload: vec![AutoloadComponent {
                 wasm,
@@ -409,6 +410,7 @@ mod tests {
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
             scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
+            teardown_cap: Duration::from_millis(100),
             lifecycle_advance_timeout_millis: 1_000,
             autoload: vec![AutoloadComponent {
                 wasm,
@@ -533,6 +535,7 @@ mod tests {
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
             scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
+            teardown_cap: Duration::from_millis(100),
             lifecycle_advance_timeout_millis: 1_000,
             autoload: vec![AutoloadComponent {
                 wasm,
@@ -653,6 +656,7 @@ mod tests {
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
             scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
+            teardown_cap: Duration::from_millis(100),
             lifecycle_advance_timeout_millis: 1_000,
             autoload: vec![AutoloadComponent {
                 wasm,
@@ -947,6 +951,7 @@ mod tests {
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
             scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
+            teardown_cap: Duration::from_millis(100),
             lifecycle_advance_timeout_millis: 1_000,
             autoload: vec![
                 AutoloadComponent {

--- a/crates/aether-substrate/src/config.rs
+++ b/crates/aether-substrate/src/config.rs
@@ -79,6 +79,7 @@ use std::env;
 use std::error::Error as StdError;
 use std::fmt;
 use std::fmt::Write as _;
+use std::path::PathBuf;
 
 use aether_actor::log::DEFAULT_RING_CAP;
 use aether_actor::trace::{DEFAULT_TRACE_RING_CAP, DEFAULT_TRACE_RING_MAX_CAP};
@@ -215,7 +216,8 @@ impl Default for SchedulerTuning {
 }
 
 /// Build a cap config by overlaying an argv-derived partial confique
-/// layer on top of the env layer (ADR-0090 unit d).
+/// layer on top of the env layer (ADR-0090 unit d) and, optionally, a
+/// lower-priority config-file layer (ADR-0090 step 3).
 ///
 /// The cap declares its env-shaped layer via [`Layer`] (a
 /// `#[derive(confique::Config)]` struct) and its per-cap mapping via
@@ -272,11 +274,28 @@ pub trait FromArgvThenEnv: Sized {
     fn try_from_argv_then_env(
         argv: <Self::Layer as confique::Config>::Layer,
     ) -> Result<Self, ConfigError> {
-        let layer = <Self::Layer as confique::Config>::builder()
+        Self::try_resolve(argv, None)
+    }
+
+    /// Resolve with a lower-priority config-file layer. Source order is
+    /// argv > env > file > typed defaults; `None` preserves the old
+    /// argv > env > defaults path byte-for-byte.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::UnparseableKnown`] when a known env key or
+    /// preloaded layer value fails the layer's parser.
+    fn try_resolve(
+        argv: <Self::Layer as confique::Config>::Layer,
+        file: Option<<Self::Layer as confique::Config>::Layer>,
+    ) -> Result<Self, ConfigError> {
+        let mut builder = <Self::Layer as confique::Config>::builder()
             .preloaded(argv)
-            .env()
-            .load()
-            .map_err(ConfigError::from_confique)?;
+            .env();
+        if let Some(file) = file {
+            builder = builder.preloaded(file);
+        }
+        let layer = builder.load().map_err(ConfigError::from_confique)?;
         Ok(Self::from_layer(layer))
     }
 }
@@ -551,6 +570,23 @@ pub enum ConfigError {
         /// The underlying parse error.
         source: Box<dyn StdError + Send + Sync + 'static>,
     },
+    /// An explicitly supplied chassis config file could not be read or
+    /// parsed. Missing files are hard errors because the operator asked
+    /// for this source.
+    ConfigFile {
+        /// File path supplied by `--config` or `AETHER_CONFIG_FILE`.
+        path: PathBuf,
+        /// The underlying read or TOML parse error.
+        source: Box<dyn StdError + Send + Sync + 'static>,
+    },
+    /// A section inside the chassis config file was present but could
+    /// not be decoded into the target config layer.
+    ConfigSection {
+        /// TOML section name, e.g. `http` or `scheduler`.
+        section: String,
+        /// The underlying TOML decode error.
+        source: Box<dyn StdError + Send + Sync + 'static>,
+    },
 }
 
 impl ConfigError {
@@ -581,6 +617,30 @@ impl ConfigError {
             source: Box::new(source),
         }
     }
+
+    /// Build a hard error for an explicitly supplied config file.
+    #[must_use]
+    pub fn config_file(
+        path: impl Into<PathBuf>,
+        source: impl StdError + Send + Sync + 'static,
+    ) -> Self {
+        Self::ConfigFile {
+            path: path.into(),
+            source: Box::new(source),
+        }
+    }
+
+    /// Build a hard error for a malformed section in a config file.
+    #[must_use]
+    pub fn config_section(
+        section: impl Into<String>,
+        source: impl StdError + Send + Sync + 'static,
+    ) -> Self {
+        Self::ConfigSection {
+            section: section.into(),
+            source: Box::new(source),
+        }
+    }
 }
 
 impl fmt::Display for ConfigError {
@@ -601,6 +661,16 @@ impl fmt::Display for ConfigError {
                     )
                 }
             }
+            Self::ConfigFile { path, source } => {
+                let path = path.display();
+                write!(f, "failed to load chassis config file {path}: {source}")
+            }
+            Self::ConfigSection { section, source } => {
+                write!(
+                    f,
+                    "failed to parse chassis config section [{section}]: {source}"
+                )
+            }
         }
     }
 }
@@ -608,7 +678,9 @@ impl fmt::Display for ConfigError {
 impl StdError for ConfigError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Self::UnparseableKnown { source, .. } => Some(&**source),
+            Self::UnparseableKnown { source, .. }
+            | Self::ConfigFile { source, .. }
+            | Self::ConfigSection { source, .. } => Some(&**source),
         }
     }
 }
@@ -669,6 +741,28 @@ mod tests {
         count: u32,
         #[config(env = "AETHER_TEST_FLAG", default = false)]
         enabled: bool,
+    }
+
+    #[derive(Clone, Debug, confique::Config)]
+    #[allow(dead_code)]
+    struct PrecedenceConfig {
+        #[config(env = "AETHER_PRECEDENCE_COUNT", default = 7)]
+        count: u32,
+    }
+
+    impl FromArgvThenEnv for PrecedenceConfig {
+        type Layer = Self;
+
+        fn from_layer(layer: Self::Layer) -> Self {
+            layer
+        }
+    }
+
+    fn precedence_file_layer(value: u32) -> <PrecedenceConfig as confique::Config>::Layer {
+        use confique::Layer as _;
+        let mut file = <PrecedenceConfig as confique::Config>::Layer::empty();
+        file.count = Some(value);
+        file
     }
 
     fn parse_count(raw: &str) -> Result<u32, ParseIntError> {
@@ -798,5 +892,36 @@ mod tests {
         unsafe { env::remove_var("AETHER_TEST_COUNT") };
         let result = loaded.map_err(ConfigError::from_confique);
         assert!(matches!(result, Err(ConfigError::UnparseableKnown { .. })));
+    }
+
+    #[test]
+    fn try_resolve_orders_argv_over_env_over_file() {
+        use confique::Layer as _;
+
+        // Tripwire: file layer must sit below env below argv.
+        let mut argv = <PrecedenceConfig as confique::Config>::Layer::empty();
+        argv.count = Some(33);
+
+        // SAFETY: unique key set then removed in this test scope.
+        unsafe { env::set_var("AETHER_PRECEDENCE_COUNT", "22") };
+        let resolved = PrecedenceConfig::try_resolve(argv, Some(precedence_file_layer(11)))
+            .expect("argv/env/file resolve");
+        assert_eq!(resolved.count, 33, "argv wins over env and file");
+
+        let env_wins = PrecedenceConfig::try_resolve(
+            <PrecedenceConfig as confique::Config>::Layer::empty(),
+            Some(precedence_file_layer(11)),
+        )
+        .expect("env/file resolve");
+        assert_eq!(env_wins.count, 22, "env wins over file");
+
+        // SAFETY: same scope.
+        unsafe { env::remove_var("AETHER_PRECEDENCE_COUNT") };
+        let file_wins = PrecedenceConfig::try_resolve(
+            <PrecedenceConfig as confique::Config>::Layer::empty(),
+            Some(precedence_file_layer(11)),
+        )
+        .expect("file/default resolve");
+        assert_eq!(file_wins.count, 11, "file wins over default");
     }
 }

--- a/docs/guide/recipes/adding-a-config-knob.md
+++ b/docs/guide/recipes/adding-a-config-knob.md
@@ -10,8 +10,8 @@
 A knob is a field on a subsystem's resolved-config struct, declared once with a
 `#[config(...)]` hint that supplies its default and its env/CLI names. That
 single declaration generates the env layer, the `clap` argument
-overlay, the layered resolver, and the `--config` discovery entry — so you never
-write an `env::var(...).parse()` read. This recipe adds a knob end to end, with
+overlay, the layered resolver, and the `--print-config` discovery entry — so you
+never write an `env::var(...).parse()` read. This recipe adds a knob end to end, with
 the two gotchas (the `native` feature gate, the `*_defaults_match` test) inline at
 the step where each bites.
 
@@ -26,7 +26,7 @@ it alongside this recipe and mirror the field you're closest to.
 
 The steps below add a field to an **existing** config struct (`HttpConfig`),
 which is the common case — the struct's layer is already registered for
-discovery, so a new field joins the `--config` dump for free. Adding a
+discovery, so a new field joins the `--print-config` dump for free. Adding a
 **brand-new** config struct takes two extra steps, called out at the end.
 
 ## Enable / disable flags
@@ -166,14 +166,14 @@ lowercase, hyphenate — `AETHER_HTTP_REQUIRE_HTTPS` becomes `--http-require-htt
 A bool flag accepts zero or one value (`--http-disable` ⇒ `true`,
 `--http-disable=false` ⇒ `false`, absent ⇒ `None`).
 
-### 4. Confirm the knob in the `--config` dump
+### 4. Confirm the knob in the `--print-config` dump
 
-Build and run any full-stack chassis with `--config` — it walks the same
+Build and run any full-stack chassis with `--print-config` — it walks the same
 declarations and prints every knob's env key, resolved value, source, default,
 and doc, then exits before boot:
 
 ```sh
-cargo run -p aether-substrate-bundle --bin aether-substrate-headless -- --config
+cargo run -p aether-substrate-bundle --bin aether-substrate-headless -- --print-config
 ```
 
 Your new field appears with its default. The dump is rendered by
@@ -200,7 +200,7 @@ If the knob doesn't belong on any existing struct, you're declaring a new
 
 - **Register its layer META for discovery.** Add `&YourConfigLayer::META` to the
   `METAS` slice in `chassis_registry()`
-  (`crates/aether-substrate-bundle/src/chassis_common.rs`) so the `--config` dump
+  (`crates/aether-substrate-bundle/src/chassis_common.rs`) so the `--print-config` dump
   and the unknown-key sweep (`chassis_known_keys`) both see its knobs.
 - **Flatten its overlay into a chassis CLI.** Re-export `YourOverlay` in
   `crates/aether-substrate-bundle/src/cli.rs` and `#[command(flatten)]` it into

--- a/docs/guide/systems/configuration.md
+++ b/docs/guide/systems/configuration.md
@@ -3,10 +3,9 @@
 > **Governing ADR:** [ADR-0090](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0090-application-configuration.md)
 > (application configuration). The **model** — the layered source-stack, one
 > typed struct per subsystem, validation, and discovery — is **stable** and
-> mostly shipped; the rollout is still **settling** at the edges (a config-*file*
-> layer is planned but not yet in, and a handful of chassis-wide knobs are still
-> read inline). This page documents the contract and defers the rollout's
-> internals to the ADR.
+> mostly shipped; the rollout is still **settling** at the edges (a handful of
+> chassis-wide knobs are still read inline). This page documents the contract
+> and defers the rollout's internals to the ADR.
 
 Configuration is how a knob's value gets decided before the engine runs — the
 worker-pool size, an HTTP allowlist, a provider's API key, the tick rate. Values
@@ -52,10 +51,9 @@ typed defaults   <   config file   <   environment   <   argv
 ```
 
 Argv overrides the environment, the environment overrides a file, a file
-overrides the declared default. (The file layer is the one piece still to land —
-today the live stack is `defaults < environment < argv`, and a missing argument
-simply falls through to env-then-default, so an engine launched with no arguments
-boots exactly as the environment alone dictates.)
+overrides the declared default. The file is a sectioned TOML source supplied with
+`--config <PATH>` or the `AETHER_CONFIG_FILE` fallback; if neither is set, an
+engine boots exactly as env-then-argv configuration dictates.
 
 Each subsystem owns its own config struct, in its own crate, declaring its own
 knobs — there is no central registry that every subsystem has to register into.
@@ -75,7 +73,7 @@ that's set but fails to parse, rather than falling through to the default. A bad
 value stops the boot with the key named, instead of a subsystem quietly running
 on a default you didn't ask for.
 
-Discovery is the `--config` flag on any chassis binary: it walks the same
+Discovery is the `--print-config` flag on any chassis binary: it walks the same
 declarations and prints every knob — its environment key, the value it resolves
 to and which source that value came from, its default, and its doc — then exits
 without booting. That listing is generated from the field annotations, so it
@@ -91,6 +89,13 @@ Over MCP there are three ways to set configuration, from coarsest to finest:
   `AETHER_ACTOR_TRACE_RING_SIZE`, and the rest). It's fleet-wide and fixed at
   launch: set it before bringing the tunnel up, and every engine the hub forks
   inherits it.
+- **A chassis config file** is the persistent per-deployment layer. Pass
+  `--config path/to/chassis.toml` on the chassis command line, or set
+  `AETHER_CONFIG_FILE` as a fallback for the file path. The file is sectioned by
+  subsystem, for example `[http]`, `[http-server]`, `[fs]`, `[anthropic]`,
+  `[gemini]`, `[contentgen]`, `[actor]`, `[scheduler]`, `[settlement]`,
+  `[chassis]`, plus chassis-specific sections such as `[window]`, `[tick]`, and
+  hub `[engine]`. Environment variables still override file values.
 - **Per-spawn arguments** are the per-engine override. `spawn_substrate` forwards
   its `args` to the substrate as command-line arguments, layered *above* the
   inherited environment — so you can spawn one engine with `--gemini-api-key …`


### PR DESCRIPTION
Closes #2231.

## Summary

Add a dedicated chassis config-file source below env and argv. The bundle parses a sectioned TOML file from `--config <PATH>` or `AETHER_CONFIG_FILE`, threads per-section partial layers through the existing Config derive path, and renames the discovery dump to `--print-config`.

The fileless boot path continues to delegate through the existing env/argv resolution, while malformed or explicitly missing config files are hard boot errors.

## Test plan

- `cargo fmt`
- `cargo fmt -- --check`
- `git diff --check`
- `cargo test -p aether-substrate --lib try_resolve_orders_argv_over_env_over_file`
- `cargo test -p aether-substrate-bundle --lib load_config_file_errors_on_missing_or_malformed_file`
- `cargo test -p aether-substrate-bundle --lib file_section_absent_is_none_and_present_section_deserializes`
- `cargo check -p aether-substrate-bundle --bins`

## Generated by

`/implement` - agent execution of [scoped issue #2231](https://github.com/iamacoffeepot/aether/issues/2231).
