### PR TITLE
flake(aether-kit): drop tight settlement cap on overlapping-loads test

### DIFF
--- a/crates/aether-kit/tests/mesh_scenario.rs
+++ b/crates/aether-kit/tests/mesh_scenario.rs
@@ -38,7 +38,6 @@ use aether_substrate_bundle::visual::{decode_png, differs_from_background};
 use aether_kit as _;
 use std::fs;
 use std::path::Path;
-use std::time::Duration;
 
 /// User-facing component name passed to `LoadComponent`.
 const COMPONENT_NAME: &str = "mv";
@@ -373,7 +372,6 @@ fn overlapping_loads_reply_to_their_own_requesters() {
     let mut bench = TestBench::builder()
         .size(64, 48)
         .namespace_roots(test_namespace_roots(sandbox))
-        .settlement_cap(Some(Duration::from_secs(10)))
         .build()
         .expect("boot");
     load_viewer(&mut bench, &wasm_path);


### PR DESCRIPTION
## What

`overlapping_loads_reply_to_their_own_requesters` overrode the test-bench settlement cap to 10s. That cap is the pump's *no-progress backstop*, fixed at boot and applied to every await in the test — including `load_viewer`'s wasm component load.

Loading the kit wasm triggers a wasmtime compile routed through the component-host thread (issue 603). Under parallel-test CPU pressure that compile runs longer than 10s of quiet, so the load timed out at `mesh_scenario.rs:93` before the test's own overlapping-load assertions ran. The four sibling tests pass because they use the default 5-minute cap, which exists precisely to ride out that compile.

## Change

Drop the `.settlement_cap(Some(Duration::from_secs(10)))` override so the test matches its siblings, and remove the now-unused `Duration` import.

The cap can only be set at boot (no per-operation cap), so it can't be loose for the load and tight for the awaits. A genuine reply-stealing regression now surfaces as a 5-minute hang rather than a 10-second one — the same tradeoff every other test in the file already accepts.