### PR TITLE
feat(aether-kinds): add backquote keycode mapping

### DIFF
--- a/crates/aether-kinds/src/keycode.rs
+++ b/crates/aether-kinds/src/keycode.rs
@@ -57,6 +57,9 @@ pub const KEY_7: u32 = b'7' as u32;
 pub const KEY_8: u32 = b'8' as u32;
 pub const KEY_9: u32 = b'9' as u32;
 
+/// Printable punctuation — ASCII codepoint.
+pub const KEY_BACKQUOTE: u32 = b'`' as u32;
+
 /// Control keys — above the ASCII range so printable codepoints stay
 /// free. Values are arbitrary-but-stable; additions go at the end.
 pub const KEY_SPACE: u32 = 0x0100;

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -278,6 +278,7 @@ fn map_winit_keycode(k: KeyCode) -> Option<u32> {
         KeyCode::Digit7 => keycode::KEY_7,
         KeyCode::Digit8 => keycode::KEY_8,
         KeyCode::Digit9 => keycode::KEY_9,
+        KeyCode::Backquote => keycode::KEY_BACKQUOTE,
         KeyCode::Space => keycode::KEY_SPACE,
         KeyCode::Escape => keycode::KEY_ESCAPE,
         KeyCode::Enter => keycode::KEY_ENTER,
@@ -1941,6 +1942,14 @@ mod tests {
     #[test]
     fn map_mouse_button_other_produces_no_mail() {
         assert_eq!(map_mouse_button(WinitMouseButton::Other(9)), None);
+    }
+
+    #[test]
+    fn map_winit_keycode_covers_backquote() {
+        assert_eq!(
+            map_winit_keycode(KeyCode::Backquote),
+            Some(keycode::KEY_BACKQUOTE)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #2850.

## Summary

Adds a stable `KEY_BACKQUOTE` code to the engine key vocabulary and maps desktop `KeyCode::Backquote` to it. This gives kit actors a physical activation key for the console without relying on layout-resolved text input.

## Test plan

- `cargo fmt`
- `cargo test -p aether-substrate-bundle map_winit_keycode_covers_backquote`

## Generated by

`/implement` — agent execution of [scoped issue #2850](https://github.com/iamacoffeepot/aether/issues/2850).
