### PR TITLE
feat(aether-kit): add primitive-rendered console overlay

### DIFF
--- a/crates/aether-kit/src/console/kinds.rs
+++ b/crates/aether-kit/src/console/kinds.rs
@@ -1,0 +1,134 @@
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_data::MailboxId;
+use serde::{Deserialize, Serialize};
+
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct ConsoleTheme {
+    pub background_color: [f32; 4],
+    pub separator_color: [f32; 4],
+    pub prompt_color: [f32; 4],
+    pub input_color: [f32; 4],
+    pub output_color: [f32; 4],
+    pub error_color: [f32; 4],
+    pub cursor_color: [f32; 4],
+}
+
+impl Default for ConsoleTheme {
+    fn default() -> Self {
+        Self {
+            background_color: [0.02, 0.025, 0.03, 0.88],
+            separator_color: [0.36, 0.40, 0.46, 0.90],
+            prompt_color: [0.65, 0.92, 0.72, 1.0],
+            input_color: [0.92, 0.95, 0.98, 1.0],
+            output_color: [0.78, 0.82, 0.88, 1.0],
+            error_color: [1.0, 0.45, 0.42, 1.0],
+            cursor_color: [1.0, 1.0, 1.0, 1.0],
+        }
+    }
+}
+
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.console.config")]
+pub struct ConsoleConfig {
+    pub panel_height: f32,
+    pub activation_key_code: u32,
+    pub font_namespace: String,
+    pub font_path: String,
+    pub font_size: f32,
+    pub scrollback_limit: u32,
+    pub prompt: String,
+    pub theme: ConsoleTheme,
+}
+
+impl Default for ConsoleConfig {
+    fn default() -> Self {
+        Self {
+            panel_height: 280.0,
+            activation_key_code: b'`' as u32,
+            font_namespace: String::from("assets"),
+            font_path: String::from("fonts/RobotoMono.ttf"),
+            font_size: 16.0,
+            scrollback_limit: 256,
+            prompt: String::from("> "),
+            theme: ConsoleTheme::default(),
+        }
+    }
+}
+
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "aether.kit.console.register_command")]
+pub struct RegisterConsoleCommand {
+    pub name: String,
+    pub description: String,
+    pub mailbox: MailboxId,
+}
+
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "aether.kit.console.unregister_command")]
+pub struct UnregisterConsoleCommand {
+    pub name: String,
+}
+
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "aether.kit.console.command_invoked")]
+pub struct ConsoleCommandInvoked {
+    pub name: String,
+    pub args: Vec<String>,
+    pub input: String,
+}
+
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "aether.kit.console.command_output")]
+pub struct ConsoleCommandOutput {
+    pub command: String,
+    pub lines: Vec<String>,
+    pub error: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_data::Kind;
+
+    #[test]
+    fn command_output_round_trips() {
+        let output = ConsoleCommandOutput {
+            command: String::from("diagnostics"),
+            lines: Vec::from([String::from("ok")]),
+            error: false,
+        };
+
+        let decoded = ConsoleCommandOutput::decode_from_bytes(&output.encode_into_bytes())
+            .expect("output decodes");
+
+        assert_eq!(decoded, output);
+    }
+
+    #[test]
+    fn registration_schema_has_stable_kind_name() {
+        assert_eq!(
+            <RegisterConsoleCommand as Kind>::NAME,
+            "aether.kit.console.register_command"
+        );
+        let registration = RegisterConsoleCommand {
+            name: String::from("profile"),
+            description: String::from("show profiling data"),
+            mailbox: MailboxId(0x4000_0000_0000_0001),
+        };
+
+        let decoded = RegisterConsoleCommand::decode_from_bytes(&registration.encode_into_bytes())
+            .expect("registration decodes");
+
+        assert_eq!(decoded, registration);
+    }
+}

--- a/crates/aether-kit/src/console/kinds.rs
+++ b/crates/aether-kit/src/console/kinds.rs
@@ -46,7 +46,7 @@ impl Default for ConsoleConfig {
     fn default() -> Self {
         Self {
             panel_height: 280.0,
-            activation_key_code: b'`' as u32,
+            activation_key_code: u32::from(b'`'),
             font_namespace: String::from("assets"),
             font_path: String::from("fonts/RobotoMono.ttf"),
             font_size: 16.0,

--- a/crates/aether-kit/src/console/kinds.rs
+++ b/crates/aether-kit/src/console/kinds.rs
@@ -49,7 +49,7 @@ impl Default for ConsoleConfig {
             activation_key_code: u32::from(b'`'),
             font_namespace: String::from("assets"),
             font_path: String::from("fonts/RobotoMono.ttf"),
-            font_size: 16.0,
+            font_size: 18.0,
             scrollback_limit: 256,
             prompt: String::from("> "),
             theme: ConsoleTheme::default(),

--- a/crates/aether-kit/src/console/mod.rs
+++ b/crates/aether-kit/src/console/mod.rs
@@ -1,0 +1,386 @@
+// `#[handler]` methods take decoded mail by value per the actor ABI.
+#![allow(clippy::needless_pass_by_value)]
+
+mod kinds;
+mod state;
+
+pub use kinds::*;
+pub use state::*;
+
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, Manual, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::input::{InputCapability, InputMailboxExt};
+use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::render::{DrawSolidQuads, SolidQuad};
+use aether_capabilities::text::{
+    DrawText, FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontResult,
+};
+use aether_capabilities::{LifecycleCapability, RenderCapability, TextCapability};
+use aether_data::MailboxId;
+use aether_kinds::keycode::{KEY_BACKSPACE, KEY_DOWN, KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_UP};
+use aether_kinds::{
+    CachedFontMetrics, Key, MouseWheel, QuadSpace, Quit, TextInput, Tick, WindowSize,
+};
+
+const HORIZONTAL_PADDING: f32 = 12.0;
+const TOP_PADDING: f32 = 10.0;
+const BOTTOM_PADDING: f32 = 10.0;
+const SEPARATOR_HEIGHT: f32 = 1.0;
+const CURSOR_WIDTH: f32 = 8.0;
+
+pub struct ConsoleOverlay {
+    config: ConsoleConfig,
+    state: ConsoleState,
+    window_size: [u32; 2],
+    font_id: Option<u32>,
+    metrics: Option<CachedFontMetrics>,
+}
+
+impl ConsoleOverlay {
+    fn visible_rows(&self) -> usize {
+        let available =
+            (self.config.panel_height - self.input_band_height() - TOP_PADDING).max(0.0);
+        (available / self.row_height()).floor().max(0.0) as usize
+    }
+
+    fn row_height(&self) -> f32 {
+        (self.config.font_size * 1.25).max(1.0)
+    }
+
+    fn input_band_height(&self) -> f32 {
+        self.row_height() + BOTTOM_PADDING
+    }
+
+    fn render(&mut self, ctx: &mut WasmCtx<'_, Manual>) {
+        if !self.state.open {
+            return;
+        }
+
+        let width = self.window_size[0] as f32;
+        if width <= 0.0 || self.config.panel_height <= 0.0 {
+            return;
+        }
+
+        let visible_rows = self.visible_rows();
+        self.state.clamp_scroll(visible_rows);
+        let panel_height = self.config.panel_height.min(self.window_size[1] as f32);
+        let mut quads = vec![
+            SolidQuad {
+                x: 0.0,
+                y: 0.0,
+                width,
+                height: panel_height,
+                color: self.config.theme.background_color,
+            },
+            SolidQuad {
+                x: 0.0,
+                y: panel_height - SEPARATOR_HEIGHT,
+                width,
+                height: SEPARATOR_HEIGHT,
+                color: self.config.theme.separator_color,
+            },
+        ];
+
+        let input_y = (panel_height - BOTTOM_PADDING - self.config.font_size).max(TOP_PADDING);
+        if self.state.cursor_visible {
+            let prompt_width = self.measure(&self.config.prompt);
+            let caret_text_width = self.measure_prefix(&self.state.input, self.state.caret);
+            quads.push(SolidQuad {
+                x: HORIZONTAL_PADDING + prompt_width + caret_text_width,
+                y: input_y,
+                width: self.cursor_width(),
+                height: self.config.font_size,
+                color: self.config.theme.cursor_color,
+            });
+        }
+
+        ctx.actor::<RenderCapability>().send(&DrawSolidQuads {
+            space: QuadSpace::Screen,
+            quads,
+        });
+
+        let Some(font_id) = self.font_id else {
+            return;
+        };
+
+        let mut y = TOP_PADDING + self.config.font_size;
+        for line in self.state.visible_history(visible_rows) {
+            ctx.actor::<TextCapability>().send(&DrawText {
+                font_id,
+                text: line.text,
+                size_pixels: self.config.font_size,
+                color: ConsoleState::theme_color(&self.config.theme, line.style),
+                origin: [HORIZONTAL_PADDING, y],
+                space: QuadSpace::Screen,
+            });
+            y += self.row_height();
+        }
+
+        ctx.actor::<TextCapability>().send(&DrawText {
+            font_id,
+            text: self.config.prompt.clone(),
+            size_pixels: self.config.font_size,
+            color: self.config.theme.prompt_color,
+            origin: [HORIZONTAL_PADDING, input_y],
+            space: QuadSpace::Screen,
+        });
+        ctx.actor::<TextCapability>().send(&DrawText {
+            font_id,
+            text: self.state.input.clone(),
+            size_pixels: self.config.font_size,
+            color: self.config.theme.input_color,
+            origin: [
+                HORIZONTAL_PADDING + self.measure(&self.config.prompt),
+                input_y,
+            ],
+            space: QuadSpace::Screen,
+        });
+    }
+
+    fn measure(&self, text: &str) -> f32 {
+        self.metrics.as_ref().map_or_else(
+            || text.chars().count() as f32 * self.cursor_width(),
+            |metrics| metrics.measure(text, self.config.font_size),
+        )
+    }
+
+    fn measure_prefix(&self, text: &str, caret: usize) -> f32 {
+        self.metrics.as_ref().map_or_else(
+            || caret as f32 * self.cursor_width(),
+            |metrics| metrics.caret_x(text, caret, self.config.font_size),
+        )
+    }
+
+    fn cursor_width(&self) -> f32 {
+        self.metrics
+            .as_ref()
+            .map_or(CURSOR_WIDTH, |metrics| {
+                metrics.measure("M", self.config.font_size)
+            })
+            .max(2.0)
+    }
+
+    fn is_activation_text(&self, text: &str) -> bool {
+        let mut chars = text.chars();
+        let Some(ch) = chars.next() else {
+            return false;
+        };
+        chars.next().is_none() && ch as u32 == self.config.activation_key_code
+    }
+
+    fn dispatch_actions(&mut self, ctx: &mut WasmCtx<'_, Manual>, actions: Vec<ConsoleAction>) {
+        for action in actions {
+            match action {
+                ConsoleAction::InvokeExternal { mailbox, payload } => {
+                    ctx.send_to(mailbox, &payload);
+                }
+                ConsoleAction::Quit => {
+                    ctx.actor::<LifecycleCapability>().send(&Quit);
+                }
+            }
+        }
+    }
+
+    fn register_command(&mut self, ctx: &mut WasmCtx<'_, Manual>, mail: RegisterConsoleCommand) {
+        let mailbox = if mail.mailbox == MailboxId::NONE {
+            ctx.source_mailbox().unwrap_or(MailboxId::NONE)
+        } else {
+            mail.mailbox
+        };
+        if mailbox == MailboxId::NONE {
+            self.state.push_error(format!(
+                "cannot register command without mailbox: {}",
+                mail.name
+            ));
+            return;
+        }
+        self.state
+            .register_external(mail.name, mail.description, mailbox);
+    }
+}
+
+#[actor(instanced)]
+impl WasmActor for ConsoleOverlay {
+    type Config = ConsoleConfig;
+    const NAMESPACE: &'static str = "aether.kit.console";
+
+    fn init(config: ConsoleConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Self {
+            state: ConsoleState::new(&config),
+            config,
+            window_size: [1280, 720],
+            font_id: None,
+            metrics: None,
+        })
+    }
+
+    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+        ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
+        let input = ctx.actor::<InputCapability>();
+        input.subscribe::<Key>();
+        input.subscribe::<TextInput>();
+        input.subscribe::<MouseWheel>();
+        input.subscribe::<WindowSize>();
+
+        let font = FontRef::Path {
+            namespace: self.config.font_namespace.clone(),
+            path: self.config.font_path.clone(),
+        };
+        ctx.actor::<TextCapability>().send(&LoadFont {
+            namespace: self.config.font_namespace.clone(),
+            path: self.config.font_path.clone(),
+        });
+        ctx.actor::<TextCapability>()
+            .send(&FontMetricsRequest { font });
+    }
+
+    #[handler::manual]
+    fn on_tick(&mut self, ctx: &mut WasmCtx<'_, Manual>, _tick: Tick) {
+        self.state.tick_cursor();
+        self.render(ctx);
+    }
+
+    #[handler::manual]
+    fn on_key(&mut self, ctx: &mut WasmCtx<'_, Manual>, key: Key) {
+        if key.code == self.config.activation_key_code {
+            self.state.open = !self.state.open;
+            self.state.cursor_visible = true;
+            return;
+        }
+        if !self.state.open {
+            return;
+        }
+
+        match key.code {
+            KEY_ENTER => {
+                let actions = self.state.submit(&self.config.prompt);
+                self.dispatch_actions(ctx, actions);
+            }
+            KEY_BACKSPACE => self.state.backspace(),
+            KEY_LEFT => self.state.move_left(),
+            KEY_RIGHT => self.state.move_right(),
+            KEY_UP => self.state.history_prev(),
+            KEY_DOWN => self.state.history_next(),
+            _ => {}
+        }
+    }
+
+    #[handler::manual]
+    fn on_text_input(&mut self, _ctx: &mut WasmCtx<'_, Manual>, input: TextInput) {
+        if self.state.open {
+            if self.is_activation_text(&input.text) {
+                return;
+            }
+            self.state.insert_text(&input.text);
+        }
+    }
+
+    #[handler::manual]
+    fn on_mouse_wheel(&mut self, _ctx: &mut WasmCtx<'_, Manual>, wheel: MouseWheel) {
+        if !self.state.open {
+            return;
+        }
+        let rows = if wheel.delta_y > 0.0 {
+            3
+        } else if wheel.delta_y < 0.0 {
+            -3
+        } else {
+            0
+        };
+        self.state.scroll_by(rows, self.visible_rows());
+    }
+
+    #[handler::manual]
+    fn on_window_size(&mut self, _ctx: &mut WasmCtx<'_, Manual>, size: WindowSize) {
+        self.window_size = [size.width, size.height];
+    }
+
+    #[handler::manual]
+    fn on_load_font_result(&mut self, _ctx: &mut WasmCtx<'_, Manual>, result: LoadFontResult) {
+        match result {
+            LoadFontResult::Ok { font_id, .. } => self.font_id = Some(font_id),
+            LoadFontResult::Err { error, .. } => {
+                self.state.push_error(format!("font load failed: {error}"));
+            }
+        }
+    }
+
+    #[handler::manual]
+    fn on_font_metrics_result(
+        &mut self,
+        _ctx: &mut WasmCtx<'_, Manual>,
+        result: FontMetricsResult,
+    ) {
+        match result {
+            FontMetricsResult::Ok { metrics } => {
+                self.metrics = Some(CachedFontMetrics::new(&metrics));
+            }
+            FontMetricsResult::Err { error } => {
+                self.state
+                    .push_error(format!("font metrics failed: {error}"));
+            }
+        }
+    }
+
+    #[handler::manual]
+    fn on_register_command(&mut self, ctx: &mut WasmCtx<'_, Manual>, mail: RegisterConsoleCommand) {
+        self.register_command(ctx, mail);
+    }
+
+    #[handler::manual]
+    fn on_unregister_command(
+        &mut self,
+        _ctx: &mut WasmCtx<'_, Manual>,
+        mail: UnregisterConsoleCommand,
+    ) {
+        self.state.unregister_external(&mail.name);
+    }
+
+    #[handler::manual]
+    fn on_command_output(&mut self, _ctx: &mut WasmCtx<'_, Manual>, output: ConsoleCommandOutput) {
+        self.state.append_command_output(output.lines, output.error);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visible_rows_reserve_input_band() {
+        let overlay = ConsoleOverlay {
+            config: ConsoleConfig {
+                panel_height: 100.0,
+                font_size: 10.0,
+                ..ConsoleConfig::default()
+            },
+            state: ConsoleState::new(&ConsoleConfig::default()),
+            window_size: [100, 100],
+            font_id: None,
+            metrics: None,
+        };
+
+        assert_eq!(overlay.visible_rows(), 5);
+    }
+
+    #[test]
+    fn default_activation_key_is_backquote_codepoint() {
+        assert_eq!(ConsoleConfig::default().activation_key_code, b'`' as u32);
+    }
+
+    #[test]
+    fn activation_text_matches_single_activation_character_only() {
+        let overlay = ConsoleOverlay {
+            config: ConsoleConfig::default(),
+            state: ConsoleState::new(&ConsoleConfig::default()),
+            window_size: [100, 100],
+            font_id: None,
+            metrics: None,
+        };
+
+        assert!(overlay.is_activation_text("`"));
+        assert!(!overlay.is_activation_text("``"));
+        assert!(!overlay.is_activation_text("a"));
+    }
+}

--- a/crates/aether-kit/src/console/mod.rs
+++ b/crates/aether-kit/src/console/mod.rs
@@ -20,14 +20,17 @@ use aether_capabilities::{LifecycleCapability, RenderCapability, TextCapability}
 use aether_data::MailboxId;
 use aether_kinds::keycode::{KEY_BACKSPACE, KEY_DOWN, KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_UP};
 use aether_kinds::{
-    CachedFontMetrics, Key, MouseWheel, QuadSpace, Quit, TextInput, Tick, WindowSize,
+    CachedFontMetrics, Key, KeyRelease, MouseWheel, QuadSpace, Quit, TextInput, Tick, WindowSize,
 };
 
 const HORIZONTAL_PADDING: f32 = 12.0;
 const TOP_PADDING: f32 = 10.0;
 const BOTTOM_PADDING: f32 = 10.0;
+const HISTORY_INPUT_GAP: f32 = 8.0;
 const SEPARATOR_HEIGHT: f32 = 1.0;
 const CURSOR_WIDTH: f32 = 8.0;
+const BACKSPACE_INITIAL_DELAY_TICKS: u32 = 18;
+const BACKSPACE_REPEAT_INTERVAL_TICKS: u32 = 3;
 
 pub struct ConsoleOverlay {
     config: ConsoleConfig,
@@ -35,21 +38,32 @@ pub struct ConsoleOverlay {
     window_size: [u32; 2],
     font_id: Option<u32>,
     metrics: Option<CachedFontMetrics>,
+    backspace_held: bool,
+    backspace_ticks: u32,
 }
 
 impl ConsoleOverlay {
     fn visible_rows(&self) -> usize {
         let available =
-            (self.config.panel_height - self.input_band_height() - TOP_PADDING).max(0.0);
-        f32_floor_to_usize(available / self.row_height())
+            (self.input_y() - HISTORY_INPUT_GAP - self.history_top_y() - self.config.font_size)
+                .max(0.0);
+        f32_floor_to_usize(available / self.row_height()) + usize::from(available > 0.0)
     }
 
     fn row_height(&self) -> f32 {
         (self.config.font_size * 1.25).max(1.0)
     }
 
-    fn input_band_height(&self) -> f32 {
-        self.row_height() + BOTTOM_PADDING
+    fn history_top_y(&self) -> f32 {
+        TOP_PADDING + self.config.font_size
+    }
+
+    fn input_y(&self) -> f32 {
+        let panel_height = self
+            .config
+            .panel_height
+            .min(bounded_u32_to_f32(self.window_size[1]));
+        (panel_height - BOTTOM_PADDING - self.config.font_size).max(TOP_PADDING)
     }
 
     fn render(&mut self, ctx: &mut WasmCtx<'_, Manual>) {
@@ -85,7 +99,7 @@ impl ConsoleOverlay {
             },
         ];
 
-        let input_y = (panel_height - BOTTOM_PADDING - self.config.font_size).max(TOP_PADDING);
+        let input_y = self.input_y();
         if self.state.cursor_visible {
             let prompt_width = self.measure(&self.config.prompt);
             let caret_text_width = self.measure_prefix(&self.state.input, self.state.caret);
@@ -107,8 +121,11 @@ impl ConsoleOverlay {
             return;
         };
 
-        let mut y = TOP_PADDING + self.config.font_size;
+        let mut y = self.history_top_y();
         for line in self.state.visible_history(visible_rows) {
+            if y + self.config.font_size > input_y - HISTORY_INPUT_GAP {
+                break;
+            }
             ctx.actor::<TextCapability>().send(&DrawText {
                 font_id,
                 text: line.text,
@@ -201,6 +218,33 @@ impl ConsoleOverlay {
         self.state
             .register_external(mail.name, mail.description, mailbox);
     }
+
+    fn press_backspace(&mut self) {
+        self.state.backspace();
+        self.backspace_held = true;
+        self.backspace_ticks = 0;
+    }
+
+    fn release_backspace(&mut self) {
+        self.backspace_held = false;
+        self.backspace_ticks = 0;
+    }
+
+    fn tick_backspace_repeat(&mut self) {
+        if !self.state.open || !self.backspace_held {
+            return;
+        }
+
+        self.backspace_ticks = self.backspace_ticks.saturating_add(1);
+        if self.backspace_ticks < BACKSPACE_INITIAL_DELAY_TICKS {
+            return;
+        }
+        if (self.backspace_ticks - BACKSPACE_INITIAL_DELAY_TICKS)
+            .is_multiple_of(BACKSPACE_REPEAT_INTERVAL_TICKS)
+        {
+            self.state.backspace();
+        }
+    }
 }
 
 #[actor(instanced)]
@@ -215,6 +259,8 @@ impl WasmActor for ConsoleOverlay {
             window_size: [1280, 720],
             font_id: None,
             metrics: None,
+            backspace_held: false,
+            backspace_ticks: 0,
         })
     }
 
@@ -222,6 +268,7 @@ impl WasmActor for ConsoleOverlay {
         ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
         let input = ctx.actor::<InputCapability>();
         input.subscribe::<Key>();
+        input.subscribe::<KeyRelease>();
         input.subscribe::<TextInput>();
         input.subscribe::<MouseWheel>();
         input.subscribe::<WindowSize>();
@@ -241,6 +288,7 @@ impl WasmActor for ConsoleOverlay {
     #[handler::manual]
     fn on_tick(&mut self, ctx: &mut WasmCtx<'_, Manual>, _tick: Tick) {
         self.state.tick_cursor();
+        self.tick_backspace_repeat();
         self.render(ctx);
     }
 
@@ -249,6 +297,9 @@ impl WasmActor for ConsoleOverlay {
         if key.code == self.config.activation_key_code {
             self.state.open = !self.state.open;
             self.state.cursor_visible = true;
+            if !self.state.open {
+                self.release_backspace();
+            }
             return;
         }
         if !self.state.open {
@@ -260,12 +311,19 @@ impl WasmActor for ConsoleOverlay {
                 let actions = self.state.submit(&self.config.prompt);
                 Self::dispatch_actions(ctx, actions);
             }
-            KEY_BACKSPACE => self.state.backspace(),
+            KEY_BACKSPACE => self.press_backspace(),
             KEY_LEFT => self.state.move_left(),
             KEY_RIGHT => self.state.move_right(),
             KEY_UP => self.state.history_prev(),
             KEY_DOWN => self.state.history_next(),
             _ => {}
+        }
+    }
+
+    #[handler::manual]
+    fn on_key_release(&mut self, _ctx: &mut WasmCtx<'_, Manual>, key: KeyRelease) {
+        if key.code == KEY_BACKSPACE {
+            self.release_backspace();
         }
     }
 
@@ -382,9 +440,16 @@ mod tests {
             window_size: [100, 100],
             font_id: None,
             metrics: None,
+            backspace_held: false,
+            backspace_ticks: 0,
         };
 
-        assert_eq!(overlay.visible_rows(), 5);
+        assert_eq!(overlay.visible_rows(), 4);
+    }
+
+    #[test]
+    fn default_font_size_is_larger_than_initial_sketch() {
+        assert_eq!(ConsoleConfig::default().font_size, 18.0);
     }
 
     #[test]
@@ -403,6 +468,8 @@ mod tests {
             window_size: [100, 100],
             font_id: None,
             metrics: None,
+            backspace_held: false,
+            backspace_ticks: 0,
         };
 
         assert!(ConsoleOverlay::is_activation_text(
@@ -417,5 +484,32 @@ mod tests {
             "a",
             overlay.config.activation_key_code
         ));
+    }
+
+    #[test]
+    fn held_backspace_repeats_after_initial_delay() {
+        let mut overlay = ConsoleOverlay {
+            config: ConsoleConfig::default(),
+            state: ConsoleState::new(&ConsoleConfig::default()),
+            window_size: [100, 100],
+            font_id: None,
+            metrics: None,
+            backspace_held: false,
+            backspace_ticks: 0,
+        };
+        overlay.state.open = true;
+        overlay.state.insert_text("abcd");
+
+        overlay.press_backspace();
+        for _ in 0..BACKSPACE_INITIAL_DELAY_TICKS {
+            overlay.tick_backspace_repeat();
+        }
+
+        assert_eq!(overlay.state.input, "ab");
+        overlay.release_backspace();
+        for _ in 0..BACKSPACE_REPEAT_INTERVAL_TICKS {
+            overlay.tick_backspace_repeat();
+        }
+        assert_eq!(overlay.state.input, "ab");
     }
 }

--- a/crates/aether-kit/src/console/mod.rs
+++ b/crates/aether-kit/src/console/mod.rs
@@ -41,7 +41,7 @@ impl ConsoleOverlay {
     fn visible_rows(&self) -> usize {
         let available =
             (self.config.panel_height - self.input_band_height() - TOP_PADDING).max(0.0);
-        (available / self.row_height()).floor().max(0.0) as usize
+        f32_floor_to_usize(available / self.row_height())
     }
 
     fn row_height(&self) -> f32 {
@@ -57,14 +57,17 @@ impl ConsoleOverlay {
             return;
         }
 
-        let width = self.window_size[0] as f32;
+        let width = bounded_u32_to_f32(self.window_size[0]);
         if width <= 0.0 || self.config.panel_height <= 0.0 {
             return;
         }
 
         let visible_rows = self.visible_rows();
         self.state.clamp_scroll(visible_rows);
-        let panel_height = self.config.panel_height.min(self.window_size[1] as f32);
+        let panel_height = self
+            .config
+            .panel_height
+            .min(bounded_u32_to_f32(self.window_size[1]));
         let mut quads = vec![
             SolidQuad {
                 x: 0.0,
@@ -140,14 +143,14 @@ impl ConsoleOverlay {
 
     fn measure(&self, text: &str) -> f32 {
         self.metrics.as_ref().map_or_else(
-            || text.chars().count() as f32 * self.cursor_width(),
+            || bounded_usize_to_f32(text.chars().count()) * self.cursor_width(),
             |metrics| metrics.measure(text, self.config.font_size),
         )
     }
 
     fn measure_prefix(&self, text: &str, caret: usize) -> f32 {
         self.metrics.as_ref().map_or_else(
-            || caret as f32 * self.cursor_width(),
+            || bounded_usize_to_f32(caret) * self.cursor_width(),
             |metrics| metrics.caret_x(text, caret, self.config.font_size),
         )
     }
@@ -161,15 +164,15 @@ impl ConsoleOverlay {
             .max(2.0)
     }
 
-    fn is_activation_text(&self, text: &str) -> bool {
+    fn is_activation_text(text: &str, activation_key_code: u32) -> bool {
         let mut chars = text.chars();
         let Some(ch) = chars.next() else {
             return false;
         };
-        chars.next().is_none() && ch as u32 == self.config.activation_key_code
+        chars.next().is_none() && u32::from(ch) == activation_key_code
     }
 
-    fn dispatch_actions(&mut self, ctx: &mut WasmCtx<'_, Manual>, actions: Vec<ConsoleAction>) {
+    fn dispatch_actions(ctx: &mut WasmCtx<'_, Manual>, actions: Vec<ConsoleAction>) {
         for action in actions {
             match action {
                 ConsoleAction::InvokeExternal { mailbox, payload } => {
@@ -255,7 +258,7 @@ impl WasmActor for ConsoleOverlay {
         match key.code {
             KEY_ENTER => {
                 let actions = self.state.submit(&self.config.prompt);
-                self.dispatch_actions(ctx, actions);
+                Self::dispatch_actions(ctx, actions);
             }
             KEY_BACKSPACE => self.state.backspace(),
             KEY_LEFT => self.state.move_left(),
@@ -269,7 +272,7 @@ impl WasmActor for ConsoleOverlay {
     #[handler::manual]
     fn on_text_input(&mut self, _ctx: &mut WasmCtx<'_, Manual>, input: TextInput) {
         if self.state.open {
-            if self.is_activation_text(&input.text) {
+            if Self::is_activation_text(&input.text, self.config.activation_key_code) {
                 return;
             }
             self.state.insert_text(&input.text);
@@ -343,6 +346,26 @@ impl WasmActor for ConsoleOverlay {
     }
 }
 
+fn bounded_u32_to_f32(value: u32) -> f32 {
+    let bounded = u16::try_from(value).unwrap_or(u16::MAX);
+    f32::from(bounded)
+}
+
+fn bounded_usize_to_f32(value: usize) -> f32 {
+    let bounded = u16::try_from(value).unwrap_or(u16::MAX);
+    f32::from(bounded)
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn f32_floor_to_usize(value: f32) -> usize {
+    if !value.is_finite() || value <= 0.0 {
+        return 0;
+    }
+
+    // Row counts come from bounded panel pixel geometry and are small in practice.
+    value.floor() as usize
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -366,7 +389,10 @@ mod tests {
 
     #[test]
     fn default_activation_key_is_backquote_codepoint() {
-        assert_eq!(ConsoleConfig::default().activation_key_code, b'`' as u32);
+        assert_eq!(
+            ConsoleConfig::default().activation_key_code,
+            u32::from(b'`')
+        );
     }
 
     #[test]
@@ -379,8 +405,17 @@ mod tests {
             metrics: None,
         };
 
-        assert!(overlay.is_activation_text("`"));
-        assert!(!overlay.is_activation_text("``"));
-        assert!(!overlay.is_activation_text("a"));
+        assert!(ConsoleOverlay::is_activation_text(
+            "`",
+            overlay.config.activation_key_code
+        ));
+        assert!(!ConsoleOverlay::is_activation_text(
+            "``",
+            overlay.config.activation_key_code
+        ));
+        assert!(!ConsoleOverlay::is_activation_text(
+            "a",
+            overlay.config.activation_key_code
+        ));
     }
 }

--- a/crates/aether-kit/src/console/state.rs
+++ b/crates/aether-kit/src/console/state.rs
@@ -71,6 +71,7 @@ pub struct ConsoleState {
 }
 
 impl ConsoleState {
+    #[must_use]
     pub fn new(config: &ConsoleConfig) -> Self {
         let mut state = Self {
             open: false,
@@ -79,7 +80,7 @@ impl ConsoleState {
             scroll_offset: 0,
             cursor_visible: true,
             blink_ticks: 0,
-            scrollback_limit: config.scrollback_limit.max(1) as usize,
+            scrollback_limit: usize::try_from(config.scrollback_limit.max(1)).unwrap_or(usize::MAX),
             history_cursor: None,
             submitted: Vec::new(),
             lines: VecDeque::new(),
@@ -89,6 +90,7 @@ impl ConsoleState {
         state
     }
 
+    #[must_use]
     pub fn theme_color(theme: &ConsoleTheme, style: LineStyle) -> [f32; 4] {
         match style {
             LineStyle::Input => theme.input_color,
@@ -97,10 +99,12 @@ impl ConsoleState {
         }
     }
 
+    #[must_use]
     pub fn lines(&self) -> &VecDeque<ConsoleLine> {
         &self.lines
     }
 
+    #[must_use]
     pub fn commands(&self) -> &BTreeMap<String, CommandEntry> {
         &self.commands
     }
@@ -159,7 +163,7 @@ impl ConsoleState {
         if rows < 0 {
             self.scroll_offset = self.scroll_offset.saturating_sub(rows.unsigned_abs());
         } else {
-            self.scroll_offset = self.scroll_offset.saturating_add(rows as usize);
+            self.scroll_offset = self.scroll_offset.saturating_add(rows.unsigned_abs());
         }
         self.clamp_scroll(visible_rows);
     }
@@ -168,10 +172,12 @@ impl ConsoleState {
         self.scroll_offset = self.max_scroll_offset(visible_rows).min(self.scroll_offset);
     }
 
+    #[must_use]
     pub fn max_scroll_offset(&self, visible_rows: usize) -> usize {
         self.lines.len().saturating_sub(visible_rows)
     }
 
+    #[must_use]
     pub fn visible_history(&self, visible_rows: usize) -> Vec<ConsoleLine> {
         if visible_rows == 0 {
             return Vec::new();
@@ -385,6 +391,7 @@ impl ConsoleState {
     }
 }
 
+#[must_use]
 pub fn parse_command(input: &str) -> Option<ParsedCommand> {
     let mut parts = input.split_whitespace();
     let name = normalize_command_name(parts.next()?)?;

--- a/crates/aether-kit/src/console/state.rs
+++ b/crates/aether-kit/src/console/state.rs
@@ -1,0 +1,532 @@
+use alloc::collections::{BTreeMap, VecDeque};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use aether_data::MailboxId;
+
+use super::{ConsoleCommandInvoked, ConsoleConfig, ConsoleTheme};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedCommand {
+    pub name: String,
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConsoleAction {
+    InvokeExternal {
+        mailbox: MailboxId,
+        payload: ConsoleCommandInvoked,
+    },
+    Quit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineStyle {
+    Input,
+    Output,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsoleLine {
+    pub text: String,
+    pub style: LineStyle,
+}
+
+#[derive(Debug, Clone)]
+pub struct CommandEntry {
+    pub description: String,
+    pub target: CommandTarget,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandTarget {
+    BuiltIn(BuiltInCommand),
+    External(MailboxId),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuiltInCommand {
+    Help,
+    Clear,
+    Echo,
+    Version,
+    Diagnostics,
+    Quit,
+}
+
+pub struct ConsoleState {
+    pub open: bool,
+    pub input: String,
+    pub caret: usize,
+    pub scroll_offset: usize,
+    pub cursor_visible: bool,
+    blink_ticks: u32,
+    scrollback_limit: usize,
+    history_cursor: Option<usize>,
+    submitted: Vec<String>,
+    lines: VecDeque<ConsoleLine>,
+    commands: BTreeMap<String, CommandEntry>,
+}
+
+impl ConsoleState {
+    pub fn new(config: &ConsoleConfig) -> Self {
+        let mut state = Self {
+            open: false,
+            input: String::new(),
+            caret: 0,
+            scroll_offset: 0,
+            cursor_visible: true,
+            blink_ticks: 0,
+            scrollback_limit: config.scrollback_limit.max(1) as usize,
+            history_cursor: None,
+            submitted: Vec::new(),
+            lines: VecDeque::new(),
+            commands: BTreeMap::new(),
+        };
+        state.register_builtins();
+        state
+    }
+
+    pub fn theme_color(theme: &ConsoleTheme, style: LineStyle) -> [f32; 4] {
+        match style {
+            LineStyle::Input => theme.input_color,
+            LineStyle::Output => theme.output_color,
+            LineStyle::Error => theme.error_color,
+        }
+    }
+
+    pub fn lines(&self) -> &VecDeque<ConsoleLine> {
+        &self.lines
+    }
+
+    pub fn commands(&self) -> &BTreeMap<String, CommandEntry> {
+        &self.commands
+    }
+
+    pub fn register_external(&mut self, name: String, description: String, mailbox: MailboxId) {
+        if let Some(name) = normalize_command_name(&name) {
+            self.commands.insert(
+                name,
+                CommandEntry {
+                    description,
+                    target: CommandTarget::External(mailbox),
+                },
+            );
+        }
+    }
+
+    pub fn unregister_external(&mut self, name: &str) -> bool {
+        let Some(name) = normalize_command_name(name) else {
+            return false;
+        };
+        if matches!(
+            self.commands.get(&name).map(|entry| entry.target),
+            Some(CommandTarget::BuiltIn(_))
+        ) {
+            return false;
+        }
+        self.commands.remove(&name).is_some()
+    }
+
+    pub fn push_output(&mut self, text: impl Into<String>) {
+        self.push_line(ConsoleLine {
+            text: text.into(),
+            style: LineStyle::Output,
+        });
+    }
+
+    pub fn push_error(&mut self, text: impl Into<String>) {
+        self.push_line(ConsoleLine {
+            text: text.into(),
+            style: LineStyle::Error,
+        });
+    }
+
+    pub fn append_command_output(&mut self, lines: Vec<String>, error: bool) {
+        let style = if error {
+            LineStyle::Error
+        } else {
+            LineStyle::Output
+        };
+        for text in lines {
+            self.push_line(ConsoleLine { text, style });
+        }
+    }
+
+    pub fn scroll_by(&mut self, rows: isize, visible_rows: usize) {
+        if rows < 0 {
+            self.scroll_offset = self.scroll_offset.saturating_sub(rows.unsigned_abs());
+        } else {
+            self.scroll_offset = self.scroll_offset.saturating_add(rows as usize);
+        }
+        self.clamp_scroll(visible_rows);
+    }
+
+    pub fn clamp_scroll(&mut self, visible_rows: usize) {
+        self.scroll_offset = self.max_scroll_offset(visible_rows).min(self.scroll_offset);
+    }
+
+    pub fn max_scroll_offset(&self, visible_rows: usize) -> usize {
+        self.lines.len().saturating_sub(visible_rows)
+    }
+
+    pub fn visible_history(&self, visible_rows: usize) -> Vec<ConsoleLine> {
+        if visible_rows == 0 {
+            return Vec::new();
+        }
+        let max_offset = self.max_scroll_offset(visible_rows);
+        let offset = self.scroll_offset.min(max_offset);
+        let end = self.lines.len().saturating_sub(offset);
+        let start = end.saturating_sub(visible_rows);
+        self.lines
+            .iter()
+            .skip(start)
+            .take(end.saturating_sub(start))
+            .cloned()
+            .collect()
+    }
+
+    pub fn insert_text(&mut self, text: &str) {
+        for ch in text.chars().filter(|ch| !ch.is_control()) {
+            let byte = byte_index_for_char(&self.input, self.caret);
+            self.input.insert(byte, ch);
+            self.caret += 1;
+        }
+        self.reset_blink();
+    }
+
+    pub fn backspace(&mut self) {
+        if self.caret == 0 {
+            return;
+        }
+        let start = byte_index_for_char(&self.input, self.caret - 1);
+        let end = byte_index_for_char(&self.input, self.caret);
+        self.input.replace_range(start..end, "");
+        self.caret -= 1;
+        self.reset_blink();
+    }
+
+    pub fn move_left(&mut self) {
+        self.caret = self.caret.saturating_sub(1);
+        self.reset_blink();
+    }
+
+    pub fn move_right(&mut self) {
+        self.caret = (self.caret + 1).min(char_count(&self.input));
+        self.reset_blink();
+    }
+
+    pub fn history_prev(&mut self) {
+        if self.submitted.is_empty() {
+            return;
+        }
+        let next = self
+            .history_cursor
+            .map_or(self.submitted.len() - 1, |cursor| cursor.saturating_sub(1));
+        self.apply_history(next);
+    }
+
+    pub fn history_next(&mut self) {
+        let Some(cursor) = self.history_cursor else {
+            return;
+        };
+        if cursor + 1 >= self.submitted.len() {
+            self.history_cursor = None;
+            self.input.clear();
+            self.caret = 0;
+        } else {
+            self.apply_history(cursor + 1);
+        }
+        self.reset_blink();
+    }
+
+    pub fn tick_cursor(&mut self) {
+        self.blink_ticks = self.blink_ticks.wrapping_add(1);
+        if self.blink_ticks >= 30 {
+            self.blink_ticks = 0;
+            self.cursor_visible = !self.cursor_visible;
+        }
+    }
+
+    pub fn submit(&mut self, prompt: &str) -> Vec<ConsoleAction> {
+        let input = self.input.trim().to_string();
+        let echoed = format!("{prompt}{}", self.input);
+        self.push_line(ConsoleLine {
+            text: echoed,
+            style: LineStyle::Input,
+        });
+        self.input.clear();
+        self.caret = 0;
+        self.history_cursor = None;
+        self.scroll_offset = 0;
+        self.reset_blink();
+
+        if input.is_empty() {
+            return Vec::new();
+        }
+        self.submitted.push(input.clone());
+        let Some(parsed) = parse_command(&input) else {
+            return Vec::new();
+        };
+        self.execute(parsed, input)
+    }
+
+    fn execute(&mut self, parsed: ParsedCommand, input: String) -> Vec<ConsoleAction> {
+        let Some(entry) = self.commands.get(&parsed.name).cloned() else {
+            self.push_error(format!("unknown command: {}", parsed.name));
+            return Vec::new();
+        };
+
+        match entry.target {
+            CommandTarget::BuiltIn(command) => self.execute_builtin(command, parsed.args),
+            CommandTarget::External(mailbox) => {
+                vec![ConsoleAction::InvokeExternal {
+                    mailbox,
+                    payload: ConsoleCommandInvoked {
+                        name: parsed.name,
+                        args: parsed.args,
+                        input,
+                    },
+                }]
+            }
+        }
+    }
+
+    fn execute_builtin(
+        &mut self,
+        command: BuiltInCommand,
+        args: Vec<String>,
+    ) -> Vec<ConsoleAction> {
+        match command {
+            BuiltInCommand::Help => {
+                let lines: Vec<_> = self
+                    .commands
+                    .iter()
+                    .map(|(name, entry)| format!("{name} - {}", entry.description))
+                    .collect();
+                for line in lines {
+                    self.push_output(line);
+                }
+                Vec::new()
+            }
+            BuiltInCommand::Clear => {
+                self.lines.clear();
+                self.scroll_offset = 0;
+                Vec::new()
+            }
+            BuiltInCommand::Echo => {
+                self.push_output(args.join(" "));
+                Vec::new()
+            }
+            BuiltInCommand::Version => {
+                self.push_output(format!("aether-kit {}", env!("CARGO_PKG_VERSION")));
+                Vec::new()
+            }
+            BuiltInCommand::Diagnostics => {
+                self.push_output(format!("lines: {}", self.lines.len()));
+                self.push_output(format!("commands: {}", self.commands.len()));
+                self.push_output(format!("scroll offset: {}", self.scroll_offset));
+                Vec::new()
+            }
+            BuiltInCommand::Quit => vec![ConsoleAction::Quit],
+        }
+    }
+
+    fn register_builtins(&mut self) {
+        self.register_builtin("help", "list commands", BuiltInCommand::Help);
+        self.register_builtin("clear", "clear scrollback", BuiltInCommand::Clear);
+        self.register_builtin(
+            "echo",
+            "write arguments to the console",
+            BuiltInCommand::Echo,
+        );
+        self.register_builtin(
+            "version",
+            "show aether-kit version",
+            BuiltInCommand::Version,
+        );
+        self.register_builtin(
+            "diagnostics",
+            "show console diagnostics",
+            BuiltInCommand::Diagnostics,
+        );
+        self.register_builtin("quit", "request engine shutdown", BuiltInCommand::Quit);
+    }
+
+    fn register_builtin(&mut self, name: &str, description: &str, command: BuiltInCommand) {
+        self.commands.insert(
+            String::from(name),
+            CommandEntry {
+                description: String::from(description),
+                target: CommandTarget::BuiltIn(command),
+            },
+        );
+    }
+
+    fn apply_history(&mut self, cursor: usize) {
+        self.history_cursor = Some(cursor);
+        self.input = self.submitted[cursor].clone();
+        self.caret = char_count(&self.input);
+        self.reset_blink();
+    }
+
+    fn push_line(&mut self, line: ConsoleLine) {
+        self.lines.push_back(line);
+        while self.lines.len() > self.scrollback_limit {
+            self.lines.pop_front();
+        }
+    }
+
+    fn reset_blink(&mut self) {
+        self.blink_ticks = 0;
+        self.cursor_visible = true;
+    }
+}
+
+pub fn parse_command(input: &str) -> Option<ParsedCommand> {
+    let mut parts = input.split_whitespace();
+    let name = normalize_command_name(parts.next()?)?;
+    let args = parts.map(ToString::to_string).collect();
+    Some(ParsedCommand { name, args })
+}
+
+fn normalize_command_name(name: &str) -> Option<String> {
+    let normalized = name.trim().to_ascii_lowercase();
+    (!normalized.is_empty()
+        && normalized
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-'))
+    .then_some(normalized)
+}
+
+fn byte_index_for_char(text: &str, char_index: usize) -> usize {
+    text.char_indices()
+        .nth(char_index)
+        .map_or(text.len(), |(index, _)| index)
+}
+
+fn char_count(text: &str) -> usize {
+    text.chars().count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::console::ConsoleConfig;
+
+    fn state() -> ConsoleState {
+        ConsoleState::new(&ConsoleConfig {
+            scrollback_limit: 32,
+            ..ConsoleConfig::default()
+        })
+    }
+
+    #[test]
+    fn parsing_splits_name_and_args() {
+        let parsed = parse_command("  ECHO hello  world ").expect("parsed");
+
+        assert_eq!(parsed.name, "echo");
+        assert_eq!(parsed.args, ["hello", "world"]);
+    }
+
+    #[test]
+    fn help_output_is_alphabetical() {
+        let mut state = state();
+        state.register_external(
+            String::from("aaa"),
+            String::from("first external"),
+            MailboxId(0x4000_0000_0000_0002),
+        );
+
+        state.insert_text("help");
+        state.submit("> ");
+        let lines: Vec<_> = state
+            .lines()
+            .iter()
+            .map(|line| line.text.as_str())
+            .filter(|line| line.contains(" - "))
+            .collect();
+
+        assert_eq!(lines.first(), Some(&"aaa - first external"));
+        assert_eq!(lines.last(), Some(&"version - show aether-kit version"));
+    }
+
+    #[test]
+    fn scroll_clamps_to_available_lines() {
+        let mut state = state();
+        for line in ["one", "two", "three"] {
+            state.push_output(line);
+        }
+
+        state.scroll_by(99, 2);
+
+        assert_eq!(state.scroll_offset, 1);
+    }
+
+    #[test]
+    fn enter_submit_echoes_and_clears_input() {
+        let mut state = state();
+        state.insert_text("echo hello");
+
+        state.submit("> ");
+
+        assert_eq!(state.input, "");
+        assert_eq!(state.caret, 0);
+        assert_eq!(state.lines()[0].text, "> echo hello");
+        assert_eq!(state.lines()[1].text, "hello");
+    }
+
+    #[test]
+    fn clear_removes_scrollback() {
+        let mut state = state();
+        state.push_output("old");
+
+        state.insert_text("clear");
+        state.submit("> ");
+
+        assert!(state.lines().is_empty());
+    }
+
+    #[test]
+    fn unknown_command_outputs_error() {
+        let mut state = state();
+
+        state.insert_text("wat");
+        state.submit("> ");
+
+        assert_eq!(
+            state.lines().back(),
+            Some(&ConsoleLine {
+                text: String::from("unknown command: wat"),
+                style: LineStyle::Error
+            })
+        );
+    }
+
+    #[test]
+    fn external_registration_replaces_and_removes() {
+        let mut state = state();
+        let first = MailboxId(0x4000_0000_0000_0003);
+        let second = MailboxId(0x4000_0000_0000_0004);
+
+        state.register_external(String::from("profile"), String::from("old"), first);
+        state.register_external(String::from("profile"), String::from("new"), second);
+
+        assert!(matches!(
+            state.commands()["profile"].target,
+            CommandTarget::External(id) if id == second
+        ));
+        assert!(state.unregister_external("profile"));
+        assert!(!state.commands().contains_key("profile"));
+    }
+
+    #[test]
+    fn builtin_registration_cannot_be_removed_by_extension() {
+        let mut state = state();
+
+        assert!(!state.unregister_external("help"));
+        assert!(state.commands().contains_key("help"));
+    }
+}

--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -14,6 +14,9 @@
 //!   `aether_kit@aether.kit.camera_controller` export. Its
 //!   `aether.kit.camera_controller.config` init-config lives in
 //!   [`camera_controller`].
+//! - [`console::ConsoleOverlay`] — a primitive-rendered developer console
+//!   overlay, selected by the `aether_kit@aether.kit.console` export. Its
+//!   config and extension command vocabulary live in [`console`].
 //! - [`mesh::MeshViewer`] — loads a `.dsl` / `.obj` mesh file and replays it
 //!   to the render sink, selected by the `aether_kit@aether.kit.mesh`
 //!   export. Its `aether.kit.mesh.load` kind lives in [`mesh`].
@@ -53,11 +56,16 @@ extern crate alloc;
 
 pub mod camera;
 pub mod camera_controller;
+pub mod console;
 pub mod mesh;
 pub mod mover;
 pub mod widget;
 pub mod world;
 
+pub use console::{
+    ConsoleCommandInvoked, ConsoleCommandOutput, ConsoleConfig, ConsoleTheme,
+    RegisterConsoleCommand, UnregisterConsoleCommand,
+};
 pub use mover::MoverTeleport;
 pub use widget::theme::{SetTheme, Theme, WidgetState};
 pub use widget::{
@@ -97,6 +105,7 @@ pub const TILE_BITS: u32 = 8;
 aether_actor::export!(
     camera::CameraComponent,
     camera_controller::CameraController,
+    console::ConsoleOverlay,
     mesh::MeshViewer,
     world::WorldView,
     mover::WorldMover,
@@ -113,6 +122,7 @@ aether_actor::export!(
 aether_actor::export!(
     camera::CameraComponent,
     camera_controller::CameraController,
+    console::ConsoleOverlay,
     mesh::MeshViewer,
     world::WorldView,
     mover::WorldMover,

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -1916,6 +1916,14 @@ mod tests {
     }
 
     #[test]
+    fn map_winit_keycode_covers_console_activation_key() {
+        assert_eq!(
+            map_winit_keycode(KeyCode::Backquote),
+            Some(keycode::KEY_BACKQUOTE)
+        );
+    }
+
+    #[test]
     fn map_mouse_button_covers_named_buttons() {
         assert_eq!(
             map_mouse_button(WinitMouseButton::Left),

--- a/crates/aether-substrate-bundle/tests/console_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/console_render_interaction.rs
@@ -1,0 +1,195 @@
+//! Console render + activation acceptance tests.
+//!
+//! These tests load the real `aether.kit.console` actor into a `TestBench`,
+//! drive its typed input path, and assert rendered output through frame
+//! reductions. The desktop driver has a unit tripwire for the physical
+//! `Backquote` mapping; this suite proves the engine key code actually opens
+//! the console overlay and reaches the render sink.
+//!
+//! Skipped when no wgpu adapter is available or the `aether_kit` wasm has not
+//! been pre-built. CI sets `AETHER_REQUIRE_RUNTIME=1` to make either skip a
+//! hard failure.
+
+// Integration-test skip diagnostic: emit via stderr so `cargo test` surfaces
+// "skipping: ..." alongside `test ... ok`.
+#![allow(clippy::print_stderr)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use aether_actor::Addressable;
+use aether_capabilities::RenderCapability;
+use aether_capabilities::fs::NamespaceRoots;
+use aether_data::Kind;
+use aether_kinds::keycode::KEY_BACKQUOTE;
+use aether_kinds::{
+    CaptureFrame, CaptureFrameResult, FrameCheck, FrameCheckResult, FrameRect, FrameReduction, Key,
+    LoadComponent, LoadResult, NamedMail, Tick, WindowSize,
+};
+use aether_kit::ConsoleConfig;
+use aether_substrate_bundle::test_bench::{
+    BenchOp, TestBench,
+    test_helpers::{init_save_sandbox, require_runtime},
+};
+
+const WINDOW_WIDTH: u32 = 320;
+const WINDOW_HEIGHT: u32 = 200;
+const CLEAR_SRGB: [u8; 3] = [63, 75, 97];
+const PARTITION_TOLERANCE: u8 = 8;
+
+fn console_address() -> String {
+    format!(
+        "aether.component/{}:console",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    )
+}
+
+fn assets_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("assets")
+}
+
+fn build_bench() -> TestBench {
+    let sandbox = init_save_sandbox("console-render-interaction");
+    let roots = NamespaceRoots {
+        save: sandbox.to_path_buf(),
+        assets: assets_dir(),
+        config: sandbox.to_path_buf(),
+    };
+    TestBench::builder()
+        .size(WINDOW_WIDTH, WINDOW_HEIGHT)
+        .namespace_roots(roots)
+        .build()
+        .expect("boot")
+}
+
+fn envelope<K: Kind>(recipient: &str, mail: &K) -> NamedMail {
+    NamedMail {
+        recipient_name: recipient.to_owned(),
+        kind_name: K::NAME.to_owned(),
+        payload: mail.encode_into_bytes(),
+        count: 1,
+    }
+}
+
+fn load_console(bench: &mut TestBench, wasm: &[u8]) {
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: wasm.to_vec(),
+                    name: Some("console".to_owned()),
+                    config: ConsoleConfig::default().encode_into_bytes(),
+                    export: Some("aether.kit.console".to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { name, .. } => assert!(
+            name.ends_with(":console"),
+            "console should register under :console; got {name}",
+        ),
+        LoadResult::Err { error } => panic!("load console: {error}"),
+    }
+}
+
+fn top_band() -> FrameRect {
+    FrameRect {
+        min_x: 0,
+        min_y: 0,
+        max_x: WINDOW_WIDTH - 1,
+        max_y: 96,
+    }
+}
+
+fn top_band_coverage(bench: &mut TestBench, label: &'static str) -> f32 {
+    let captured = bench
+        .execute(vec![(
+            label,
+            BenchOp::send_and_await(
+                RenderCapability::NAMESPACE,
+                &CaptureFrame {
+                    mails: vec![envelope(&console_address(), &Tick)],
+                    after_mails: Vec::new(),
+                    checks: vec![FrameCheck {
+                        reduction: FrameReduction::Coverage,
+                        tolerance: PARTITION_TOLERANCE,
+                        background: Some(CLEAR_SRGB),
+                        region: Some(top_band()),
+                    }],
+                    similarity: None,
+                },
+            ),
+        )])
+        .expect("capture sequence");
+    let result = match captured
+        .reply::<CaptureFrameResult>(label)
+        .expect("decode CaptureFrameResult")
+    {
+        CaptureFrameResult::Ok { verdict, .. } => {
+            let verdict = verdict.expect("checks requested");
+            verdict
+                .results
+                .into_iter()
+                .next()
+                .expect("one check result")
+        }
+        CaptureFrameResult::Err { error } => panic!("capture failed: {error}"),
+    };
+    match result {
+        FrameCheckResult::Coverage { fraction, .. } => fraction,
+        other => panic!("expected Coverage result; got {other:?}"),
+    }
+}
+
+#[test]
+fn backquote_key_opens_console_overlay() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = build_bench();
+    load_console(&mut bench, &wasm);
+
+    bench
+        .execute(vec![(
+            "size",
+            BenchOp::send_mail(
+                &console_address(),
+                &WindowSize {
+                    width: WINDOW_WIDTH,
+                    height: WINDOW_HEIGHT,
+                },
+            ),
+        )])
+        .expect("window size");
+
+    let closed = top_band_coverage(&mut bench, "closed");
+    assert!(
+        closed < 0.01,
+        "closed console should leave the top band at clear color; coverage={closed:.3}",
+    );
+
+    bench
+        .execute(vec![(
+            "toggle",
+            BenchOp::send_mail(
+                &console_address(),
+                &Key {
+                    code: KEY_BACKQUOTE,
+                },
+            ),
+        )])
+        .expect("toggle key");
+
+    let open = top_band_coverage(&mut bench, "open");
+    assert!(
+        open > 0.90,
+        "backquote should open the console and cover the top band; coverage={open:.3}",
+    );
+}

--- a/crates/aether-substrate-bundle/tests/console_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/console_render_interaction.rs
@@ -160,7 +160,7 @@ fn backquote_key_opens_console_overlay() {
         .execute(vec![(
             "size",
             BenchOp::send_mail(
-                &console_address(),
+                console_address(),
                 &WindowSize {
                     width: WINDOW_WIDTH,
                     height: WINDOW_HEIGHT,
@@ -179,7 +179,7 @@ fn backquote_key_opens_console_overlay() {
         .execute(vec![(
             "toggle",
             BenchOp::send_mail(
-                &console_address(),
+                console_address(),
                 &Key {
                     code: KEY_BACKQUOTE,
                 },


### PR DESCRIPTION
Closes #2848.

## Summary

Adds a primitive-rendered `aether-kit` console overlay with configurable activation, Roboto Mono font loading, scrollback, command input, built-in commands, extension command registration, and primitive rendering through solid quads plus text. The console uses a top-anchored panel, pinned input row, mouse-wheel history scrolling, and a blinking square cursor.

## Test plan

- `cargo test -p aether-kit`
- `cargo fmt`
- `cargo test -p aether-kit --lib`
- `git diff --check`

## Generated by

`/implement` — agent execution of [scoped issue #2848](https://github.com/iamacoffeepot/aether/issues/2848).
