### PR TITLE
docs(adr): flip 0139 and 0140 to accepted

### DIFF
--- a/docs/adr/0139-guest-reply-correlation-and-request-contexts.md
+++ b/docs/adr/0139-guest-reply-correlation-and-request-contexts.md
@@ -1,6 +1,6 @@
 # ADR-0139: Guest Reply Correlation and Request Contexts
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — kind-typed request contexts + reply correlation ids in aether-actor; consumers migrated across fs/audio/text/behavior/kit)
 - **Date:** 2026-07-08
 
 Amends **ADR-0134** (multi reply class): one-shot request/reply flows correlate on the envelope, not the payload; `multi`-class emissions keep the payload-level keying ADR-0133 established. Builds on the correlation machinery **ADR-0042** left in place at its retirement, the `MailId` / causal-chain model of **ADR-0080**, the reply classes of **ADR-0109** / **ADR-0112**, and the inline-cluster addressing of **ADR-0114**.

--- a/docs/adr/0140-render-material-pass.md
+++ b/docs/adr/0140-render-material-pass.md
@@ -1,6 +1,6 @@
 # ADR-0140: Render material pass
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — world-space material pass; crates/aether-substrate/src/render/material.rs)
 - **Date:** 2026-07-08
 
 ## Context


### PR DESCRIPTION
ADR-0139 (guest reply correlation and request contexts) and ADR-0140 (render material pass) both read Proposed, but their implementation arcs have fully landed on main.

ADR-0139: kind-typed request contexts plus reply correlation ids shipped in aether-actor, with consumers migrated across fs, audio, text, behavior, and kit.

ADR-0140: the world-space material pass shipped in aether-substrate (crates/aether-substrate/src/render/material.rs) with capabilities render runtime, test bench, and desktop wiring.

Surfaced by /sweep adrs. Status-only amendment; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)