### PR TITLE
feat(aether-kit): add console markdown formatting

### DIFF
--- a/crates/aether-kit/src/console/kinds.rs
+++ b/crates/aether-kit/src/console/kinds.rs
@@ -13,20 +13,111 @@ pub struct ConsoleTheme {
     pub output_color: [f32; 4],
     pub error_color: [f32; 4],
     pub cursor_color: [f32; 4],
+    #[serde(default)]
+    pub markdown: ConsoleMarkdownTheme,
+}
+
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct ConsoleMarkdownTheme {
+    pub heading_color: [f32; 4],
+    pub emphasis_color: [f32; 4],
+    pub strong_color: [f32; 4],
+    pub inline_code_color: [f32; 4],
+    pub inline_code_background_color: [f32; 4],
+    pub fenced_code_color: [f32; 4],
+    pub fenced_code_background_color: [f32; 4],
+    pub link_color: [f32; 4],
+    pub image_color: [f32; 4],
+    pub quote_marker_color: [f32; 4],
+    pub quote_text_color: [f32; 4],
+    pub list_marker_color: [f32; 4],
+    pub task_marker_color: [f32; 4],
+    pub table_border_color: [f32; 4],
+    pub table_header_color: [f32; 4],
+    pub table_text_color: [f32; 4],
+    pub thematic_break_color: [f32; 4],
+    pub muted_marker_color: [f32; 4],
+    pub escaped_marker_color: [f32; 4],
+    pub code_padding_pixels: f32,
+    pub strong_offset_pixels: f32,
+}
+
+impl ConsoleMarkdownTheme {
+    #[must_use]
+    pub fn from_palette(
+        separator_color: [f32; 4],
+        prompt_color: [f32; 4],
+        input_color: [f32; 4],
+        output_color: [f32; 4],
+    ) -> Self {
+        Self {
+            heading_color: prompt_color,
+            emphasis_color: input_color,
+            strong_color: prompt_color,
+            inline_code_color: input_color,
+            inline_code_background_color: scaled_color(separator_color, 0.35, 0.45),
+            fenced_code_color: input_color,
+            fenced_code_background_color: scaled_color(separator_color, 0.25, 0.38),
+            link_color: [0.45, 0.74, 1.0, 1.0],
+            image_color: [0.68, 0.82, 1.0, 1.0],
+            quote_marker_color: separator_color,
+            quote_text_color: output_color,
+            list_marker_color: separator_color,
+            task_marker_color: prompt_color,
+            table_border_color: separator_color,
+            table_header_color: prompt_color,
+            table_text_color: output_color,
+            thematic_break_color: separator_color,
+            muted_marker_color: separator_color,
+            escaped_marker_color: input_color,
+            code_padding_pixels: 4.0,
+            strong_offset_pixels: 1.0,
+        }
+    }
+}
+
+impl Default for ConsoleMarkdownTheme {
+    fn default() -> Self {
+        Self::from_palette(
+            [0.36, 0.40, 0.46, 0.90],
+            [0.65, 0.92, 0.72, 1.0],
+            [0.92, 0.95, 0.98, 1.0],
+            [0.78, 0.82, 0.88, 1.0],
+        )
+    }
 }
 
 impl Default for ConsoleTheme {
     fn default() -> Self {
+        let separator_color = [0.36, 0.40, 0.46, 0.90];
+        let prompt_color = [0.65, 0.92, 0.72, 1.0];
+        let input_color = [0.92, 0.95, 0.98, 1.0];
+        let output_color = [0.78, 0.82, 0.88, 1.0];
         Self {
             background_color: [0.02, 0.025, 0.03, 0.88],
-            separator_color: [0.36, 0.40, 0.46, 0.90],
-            prompt_color: [0.65, 0.92, 0.72, 1.0],
-            input_color: [0.92, 0.95, 0.98, 1.0],
-            output_color: [0.78, 0.82, 0.88, 1.0],
+            separator_color,
+            prompt_color,
+            input_color,
+            output_color,
             error_color: [1.0, 0.45, 0.42, 1.0],
             cursor_color: [1.0, 1.0, 1.0, 1.0],
+            markdown: ConsoleMarkdownTheme::from_palette(
+                separator_color,
+                prompt_color,
+                input_color,
+                output_color,
+            ),
         }
     }
+}
+
+fn scaled_color(color: [f32; 4], rgb_scale: f32, alpha: f32) -> [f32; 4] {
+    [
+        color[0] * rgb_scale,
+        color[1] * rgb_scale,
+        color[2] * rgb_scale,
+        alpha,
+    ]
 }
 
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
@@ -112,6 +203,17 @@ mod tests {
             .expect("output decodes");
 
         assert_eq!(decoded, output);
+    }
+
+    #[test]
+    fn default_theme_carries_explicit_markdown_styles() {
+        let theme = ConsoleTheme::default();
+
+        assert_eq!(theme.markdown.heading_color, theme.prompt_color);
+        assert_eq!(theme.markdown.emphasis_color, theme.input_color);
+        assert_eq!(theme.markdown.table_border_color, theme.separator_color);
+        assert!(theme.markdown.code_padding_pixels > 0.0);
+        assert!(theme.markdown.strong_offset_pixels > 0.0);
     }
 
     #[test]

--- a/crates/aether-kit/src/console/markdown.rs
+++ b/crates/aether-kit/src/console/markdown.rs
@@ -1,0 +1,705 @@
+use alloc::collections::VecDeque;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use super::{ConsoleLine, LineStyle};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownLine {
+    pub style: LineStyle,
+    pub code_block: bool,
+    pub thematic_break: bool,
+    pub runs: Vec<MarkdownRun>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownRun {
+    pub text: String,
+    pub tone: MarkdownTone,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkdownTone {
+    Text,
+    Heading,
+    Emphasis,
+    Strong,
+    InlineCode,
+    FencedCode,
+    Link,
+    Image,
+    QuoteMarker,
+    QuoteText,
+    ListMarker,
+    TaskMarker,
+    TableBorder,
+    TableHeader,
+    TableText,
+    ThematicBreak,
+    MutedMarker,
+    EscapedMarker,
+}
+
+#[derive(Debug, Clone, Default)]
+struct MarkdownBlockState {
+    in_fenced_code: bool,
+}
+
+pub fn format_visible_history(
+    lines: &VecDeque<ConsoleLine>,
+    start: usize,
+    end: usize,
+) -> Vec<MarkdownLine> {
+    let mut state = MarkdownBlockState::default();
+    let bounded_end = end.min(lines.len());
+    let mut formatted = Vec::new();
+    for index in 0..bounded_end {
+        let Some(line) = lines.get(index) else {
+            continue;
+        };
+        let next = lines.get(index + 1).map(|line| line.text.as_str());
+        let markdown = state.format_line(line, next);
+        if index >= start {
+            formatted.push(markdown);
+        }
+    }
+    formatted
+}
+
+impl MarkdownBlockState {
+    fn format_line(&mut self, line: &ConsoleLine, next: Option<&str>) -> MarkdownLine {
+        if line.style == LineStyle::Input {
+            return literal_line(line);
+        }
+
+        let text = line.text.as_str();
+        if fenced_code_marker(text).is_some() {
+            let was_open = self.in_fenced_code;
+            self.in_fenced_code = !self.in_fenced_code;
+            return MarkdownLine {
+                style: line.style,
+                code_block: true,
+                thematic_break: false,
+                runs: vec![MarkdownRun {
+                    text: if was_open {
+                        String::from("```")
+                    } else {
+                        text.trim().to_string()
+                    },
+                    tone: MarkdownTone::MutedMarker,
+                }],
+            };
+        }
+
+        if self.in_fenced_code {
+            return MarkdownLine {
+                style: line.style,
+                code_block: true,
+                thematic_break: false,
+                runs: vec![MarkdownRun {
+                    text: sanitize_text(text),
+                    tone: MarkdownTone::FencedCode,
+                }],
+            };
+        }
+
+        if let Some(code) = text.strip_prefix("    ") {
+            return MarkdownLine {
+                style: line.style,
+                code_block: true,
+                thematic_break: false,
+                runs: vec![MarkdownRun {
+                    text: sanitize_text(code),
+                    tone: MarkdownTone::FencedCode,
+                }],
+            };
+        }
+
+        if thematic_break(text) {
+            return MarkdownLine {
+                style: line.style,
+                code_block: false,
+                thematic_break: true,
+                runs: vec![MarkdownRun {
+                    text: String::new(),
+                    tone: MarkdownTone::ThematicBreak,
+                }],
+            };
+        }
+
+        if table_separator(text) {
+            return MarkdownLine {
+                style: line.style,
+                code_block: false,
+                thematic_break: false,
+                runs: vec![MarkdownRun {
+                    text: sanitize_text(text.trim()),
+                    tone: MarkdownTone::TableBorder,
+                }],
+            };
+        }
+
+        if table_row(text) {
+            return MarkdownLine {
+                style: line.style,
+                code_block: false,
+                thematic_break: false,
+                runs: table_runs(text, next.is_some_and(table_separator)),
+            };
+        }
+
+        format_block_line(text, line.style)
+    }
+}
+
+fn literal_line(line: &ConsoleLine) -> MarkdownLine {
+    MarkdownLine {
+        style: line.style,
+        code_block: false,
+        thematic_break: false,
+        runs: vec![MarkdownRun {
+            text: sanitize_text(&line.text),
+            tone: MarkdownTone::Text,
+        }],
+    }
+}
+
+fn format_block_line(text: &str, style: LineStyle) -> MarkdownLine {
+    let trimmed = text.trim_start();
+    if let Some(body) = heading_body(trimmed) {
+        return MarkdownLine {
+            style,
+            code_block: false,
+            thematic_break: false,
+            runs: vec![MarkdownRun {
+                text: sanitize_text(body),
+                tone: MarkdownTone::Heading,
+            }],
+        };
+    }
+
+    if let Some(body) = trimmed.strip_prefix("> ") {
+        let mut runs = vec![MarkdownRun {
+            text: String::from("> "),
+            tone: MarkdownTone::QuoteMarker,
+        }];
+        runs.extend(inline_runs(body, MarkdownTone::QuoteText));
+        return MarkdownLine {
+            style,
+            code_block: false,
+            thematic_break: false,
+            runs,
+        };
+    }
+
+    if trimmed == ">" {
+        return MarkdownLine {
+            style,
+            code_block: false,
+            thematic_break: false,
+            runs: vec![MarkdownRun {
+                text: String::from(">"),
+                tone: MarkdownTone::QuoteMarker,
+            }],
+        };
+    }
+
+    if let Some((marker, task, body)) = unordered_list(trimmed) {
+        let mut runs = vec![MarkdownRun {
+            text: marker,
+            tone: MarkdownTone::ListMarker,
+        }];
+        if let Some(task) = task {
+            runs.push(MarkdownRun {
+                text: task,
+                tone: MarkdownTone::TaskMarker,
+            });
+        }
+        runs.extend(inline_runs(body, MarkdownTone::Text));
+        return MarkdownLine {
+            style,
+            code_block: false,
+            thematic_break: false,
+            runs,
+        };
+    }
+
+    if let Some((marker, body)) = ordered_list(trimmed) {
+        let mut runs = vec![MarkdownRun {
+            text: marker,
+            tone: MarkdownTone::ListMarker,
+        }];
+        runs.extend(inline_runs(body, MarkdownTone::Text));
+        return MarkdownLine {
+            style,
+            code_block: false,
+            thematic_break: false,
+            runs,
+        };
+    }
+
+    MarkdownLine {
+        style,
+        code_block: false,
+        thematic_break: false,
+        runs: inline_runs(text, MarkdownTone::Text),
+    }
+}
+
+fn fenced_code_marker(text: &str) -> Option<&str> {
+    let trimmed = text.trim_start();
+    if trimmed.starts_with("```") {
+        Some("```")
+    } else if trimmed.starts_with("~~~") {
+        Some("~~~")
+    } else {
+        None
+    }
+}
+
+fn thematic_break(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.len() < 3 {
+        return false;
+    }
+    let mut count = 0usize;
+    let mut marker = None;
+    for ch in trimmed.chars() {
+        if ch.is_whitespace() {
+            continue;
+        }
+        if ch != '-' && ch != '*' && ch != '_' {
+            return false;
+        }
+        if marker.is_some_and(|marker| marker != ch) {
+            return false;
+        }
+        marker = Some(ch);
+        count += 1;
+    }
+    count >= 3
+}
+
+fn heading_body(text: &str) -> Option<&str> {
+    let mut marker_len = 0usize;
+    for ch in text.chars().take(6) {
+        if ch == '#' {
+            marker_len += 1;
+        } else {
+            break;
+        }
+    }
+    if marker_len == 0 {
+        return None;
+    }
+    let body = text.get(marker_len..)?;
+    let first = body.chars().next()?;
+    if !first.is_whitespace() {
+        return None;
+    }
+    Some(body.trim().trim_end_matches('#').trim_end())
+}
+
+fn unordered_list(text: &str) -> Option<(String, Option<String>, &str)> {
+    let mut chars = text.chars();
+    let marker = chars.next()?;
+    if marker != '-' && marker != '*' && marker != '+' {
+        return None;
+    }
+    let rest = chars.as_str();
+    if !rest.chars().next().is_some_and(char::is_whitespace) {
+        return None;
+    }
+    let body = rest.trim_start();
+    let (task, body) = task_marker(body).unwrap_or((None, body));
+    Some((String::from("- "), task, body))
+}
+
+fn task_marker(text: &str) -> Option<(Option<String>, &str)> {
+    text.strip_prefix("[ ] ")
+        .map(|body| (Some(String::from("[ ] ")), body))
+        .or_else(|| {
+            text.strip_prefix("[x] ")
+                .map(|body| (Some(String::from("[x] ")), body))
+        })
+        .or_else(|| {
+            text.strip_prefix("[X] ")
+                .map(|body| (Some(String::from("[x] ")), body))
+        })
+}
+
+fn ordered_list(text: &str) -> Option<(String, &str)> {
+    let mut digits = 0usize;
+    for ch in text.chars() {
+        if ch.is_ascii_digit() {
+            digits += 1;
+        } else {
+            break;
+        }
+    }
+    if digits == 0 || digits > 9 {
+        return None;
+    }
+    let rest = text.get(digits..)?;
+    if !(rest.starts_with(". ") || rest.starts_with(") ")) {
+        return None;
+    }
+    Some((
+        text.get(..digits + 2)?.to_string(),
+        text.get(digits + 2..)?.trim_start(),
+    ))
+}
+
+fn table_row(text: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed.contains('|') && !trimmed.is_empty()
+}
+
+fn table_separator(text: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed.contains('|')
+        && trimmed
+            .chars()
+            .all(|ch| ch == '|' || ch == '-' || ch == ':' || ch.is_whitespace())
+        && trimmed.chars().filter(|ch| *ch == '-').count() >= 3
+}
+
+fn table_runs(text: &str, header: bool) -> Vec<MarkdownRun> {
+    let cell_tone = if header {
+        MarkdownTone::TableHeader
+    } else {
+        MarkdownTone::TableText
+    };
+    let mut runs = Vec::new();
+    let mut cell = String::new();
+    for ch in text.chars() {
+        if ch == '|' {
+            push_run(&mut runs, &cell, cell_tone);
+            cell.clear();
+            push_run(&mut runs, "|", MarkdownTone::TableBorder);
+        } else {
+            cell.push(ch);
+        }
+    }
+    push_run(&mut runs, &cell, cell_tone);
+    runs
+}
+
+fn inline_runs(text: &str, default_tone: MarkdownTone) -> Vec<MarkdownRun> {
+    let mut runs = Vec::new();
+    let mut plain = String::new();
+    let mut index = 0usize;
+    while index < text.len() {
+        let rest = &text[index..];
+        if let Some((consumed, escaped)) = escaped_at(rest) {
+            push_owned_run(&mut runs, &mut plain, default_tone);
+            push_run(&mut runs, escaped, MarkdownTone::EscapedMarker);
+            index += consumed;
+        } else if let Some((consumed, rendered, tone)) = image_at(rest) {
+            push_owned_run(&mut runs, &mut plain, default_tone);
+            push_run(&mut runs, &rendered, tone);
+            index += consumed;
+        } else if let Some((consumed, rendered, tone)) = link_at(rest) {
+            push_owned_run(&mut runs, &mut plain, default_tone);
+            push_run(&mut runs, &rendered, tone);
+            index += consumed;
+        } else if let Some((consumed, body, tone)) = delimited_at(rest) {
+            push_owned_run(&mut runs, &mut plain, default_tone);
+            push_run(&mut runs, body, tone);
+            index += consumed;
+        } else {
+            let Some(ch) = rest.chars().next() else {
+                break;
+            };
+            push_sanitized_char(&mut plain, ch);
+            index += ch.len_utf8();
+        }
+    }
+    push_owned_run(&mut runs, &mut plain, default_tone);
+    if runs.is_empty() {
+        runs.push(MarkdownRun {
+            text: String::new(),
+            tone: default_tone,
+        });
+    }
+    runs
+}
+
+fn escaped_at(text: &str) -> Option<(usize, &str)> {
+    let rest = text.strip_prefix('\\')?;
+    let ch = rest.chars().next()?;
+    is_markdown_punctuation(ch).then_some((1 + ch.len_utf8(), &rest[..ch.len_utf8()]))
+}
+
+fn is_markdown_punctuation(ch: char) -> bool {
+    matches!(
+        ch,
+        '\\' | '`'
+            | '*'
+            | '_'
+            | '{'
+            | '}'
+            | '['
+            | ']'
+            | '('
+            | ')'
+            | '#'
+            | '+'
+            | '-'
+            | '.'
+            | '!'
+            | '|'
+            | '>'
+    )
+}
+
+fn image_at(text: &str) -> Option<(usize, String, MarkdownTone)> {
+    let body = text.strip_prefix("![")?;
+    let alt_end = body.find("](")?;
+    let target_start = alt_end + 2;
+    let target_end = body.get(target_start..)?.find(')')? + target_start;
+    let alt = sanitize_text(&body[..alt_end]);
+    let target = sanitize_text(&body[target_start..target_end]);
+    let rendered = if target.is_empty() {
+        format!("[image: {alt}]")
+    } else {
+        format!("[image: {alt}] ({target})")
+    };
+    Some((2 + target_end + 1, rendered, MarkdownTone::Image))
+}
+
+fn link_at(text: &str) -> Option<(usize, String, MarkdownTone)> {
+    let body = text.strip_prefix('[')?;
+    let label_end = body.find("](")?;
+    let target_start = label_end + 2;
+    let target_end = body.get(target_start..)?.find(')')? + target_start;
+    let label = sanitize_text(&body[..label_end]);
+    if label.is_empty() {
+        return None;
+    }
+    let target = sanitize_text(&body[target_start..target_end]);
+    let rendered = if target.is_empty() {
+        label
+    } else {
+        format!("{label} ({target})")
+    };
+    Some((1 + target_end + 1, rendered, MarkdownTone::Link))
+}
+
+fn delimited_at(text: &str) -> Option<(usize, &str, MarkdownTone)> {
+    for (open, close, tone) in [
+        ("`", "`", MarkdownTone::InlineCode),
+        ("**", "**", MarkdownTone::Strong),
+        ("__", "__", MarkdownTone::Strong),
+        ("*", "*", MarkdownTone::Emphasis),
+        ("_", "_", MarkdownTone::Emphasis),
+    ] {
+        let Some(rest) = text.strip_prefix(open) else {
+            continue;
+        };
+        let close_index = rest.find(close)?;
+        if close_index == 0 {
+            continue;
+        }
+        return Some((
+            open.len() + close_index + close.len(),
+            &rest[..close_index],
+            tone,
+        ));
+    }
+    None
+}
+
+fn push_owned_run(runs: &mut Vec<MarkdownRun>, text: &mut String, tone: MarkdownTone) {
+    if text.is_empty() {
+        return;
+    }
+    push_run(runs, text, tone);
+    text.clear();
+}
+
+fn push_run(runs: &mut Vec<MarkdownRun>, text: &str, tone: MarkdownTone) {
+    let sanitized = sanitize_text(text);
+    if sanitized.is_empty() {
+        return;
+    }
+    if let Some(last) = runs.last_mut()
+        && last.tone == tone
+    {
+        last.text.push_str(&sanitized);
+        return;
+    }
+    runs.push(MarkdownRun {
+        text: sanitized,
+        tone,
+    });
+}
+
+fn sanitize_text(text: &str) -> String {
+    let mut sanitized = String::new();
+    for ch in text.chars() {
+        push_sanitized_char(&mut sanitized, ch);
+    }
+    sanitized
+}
+
+fn push_sanitized_char(text: &mut String, ch: char) {
+    if ch.is_control() && ch != '\t' {
+        text.push('?');
+    } else {
+        text.push(ch);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::collections::VecDeque;
+
+    fn line(text: &str) -> ConsoleLine {
+        ConsoleLine {
+            text: text.to_string(),
+            style: LineStyle::Output,
+        }
+    }
+
+    fn tones(markdown: &MarkdownLine) -> Vec<(&str, MarkdownTone)> {
+        markdown
+            .runs
+            .iter()
+            .map(|run| (run.text.as_str(), run.tone))
+            .collect()
+    }
+
+    #[test]
+    fn inline_markdown_formats_common_spans() {
+        let runs = inline_runs(
+            "plain *em* **strong** `code` [site](https://example.test) ![alt](img.png)",
+            MarkdownTone::Text,
+        );
+
+        assert_eq!(
+            runs.iter()
+                .map(|run| (run.text.as_str(), run.tone))
+                .collect::<Vec<_>>(),
+            vec![
+                ("plain ", MarkdownTone::Text),
+                ("em", MarkdownTone::Emphasis),
+                (" ", MarkdownTone::Text),
+                ("strong", MarkdownTone::Strong),
+                (" ", MarkdownTone::Text),
+                ("code", MarkdownTone::InlineCode),
+                (" ", MarkdownTone::Text),
+                ("site (https://example.test)", MarkdownTone::Link),
+                (" ", MarkdownTone::Text),
+                ("[image: alt] (img.png)", MarkdownTone::Image),
+            ]
+        );
+    }
+
+    #[test]
+    fn block_markdown_formats_heading_quote_lists_and_tasks() {
+        let mut state = MarkdownBlockState::default();
+
+        assert_eq!(
+            tones(&state.format_line(&line("## Heading ##"), None)),
+            vec![("Heading", MarkdownTone::Heading)]
+        );
+        assert_eq!(
+            tones(&state.format_line(&line("> quoted"), None)),
+            vec![
+                ("> ", MarkdownTone::QuoteMarker),
+                ("quoted", MarkdownTone::QuoteText),
+            ]
+        );
+        assert_eq!(
+            tones(&state.format_line(&line("- [x] done"), None)),
+            vec![
+                ("- ", MarkdownTone::ListMarker),
+                ("[x] ", MarkdownTone::TaskMarker),
+                ("done", MarkdownTone::Text),
+            ]
+        );
+        assert_eq!(
+            tones(&state.format_line(&line("1. first"), None)),
+            vec![
+                ("1. ", MarkdownTone::ListMarker),
+                ("first", MarkdownTone::Text),
+            ]
+        );
+    }
+
+    #[test]
+    fn fenced_code_state_survives_visible_window_slicing() {
+        let lines = VecDeque::from([
+            line("```rust"),
+            line("let value = **literal**;"),
+            line("```"),
+            line("**strong**"),
+        ]);
+
+        let visible = format_visible_history(&lines, 1, 3);
+
+        assert_eq!(visible.len(), 2);
+        assert!(visible[0].code_block);
+        assert_eq!(
+            tones(&visible[0]),
+            vec![("let value = **literal**;", MarkdownTone::FencedCode)]
+        );
+        assert!(visible[1].code_block);
+    }
+
+    #[test]
+    fn table_rows_and_separator_use_table_tones() {
+        let mut state = MarkdownBlockState::default();
+
+        assert_eq!(
+            tones(&state.format_line(&line("| Name | Value |"), Some("| --- | --- |"))),
+            vec![
+                ("|", MarkdownTone::TableBorder),
+                (" Name ", MarkdownTone::TableHeader),
+                ("|", MarkdownTone::TableBorder),
+                (" Value ", MarkdownTone::TableHeader),
+                ("|", MarkdownTone::TableBorder),
+            ]
+        );
+        assert_eq!(
+            tones(&state.format_line(&line("| --- | --- |"), None)),
+            vec![("| --- | --- |", MarkdownTone::TableBorder)]
+        );
+    }
+
+    #[test]
+    fn escaped_markers_and_controls_are_visible() {
+        let runs = inline_runs("\\*not emphasized\\* \\| bad\u{0007}", MarkdownTone::Text);
+
+        assert_eq!(
+            runs.iter()
+                .map(|run| (run.text.as_str(), run.tone))
+                .collect::<Vec<_>>(),
+            vec![
+                ("*", MarkdownTone::EscapedMarker),
+                ("not emphasized", MarkdownTone::Text),
+                ("*", MarkdownTone::EscapedMarker),
+                (" ", MarkdownTone::Text),
+                ("|", MarkdownTone::EscapedMarker),
+                (" bad?", MarkdownTone::Text),
+            ]
+        );
+    }
+
+    #[test]
+    fn input_echoes_are_not_markdown_formatted() {
+        let mut state = MarkdownBlockState::default();
+        let input = ConsoleLine {
+            text: String::from("> **literal**"),
+            style: LineStyle::Input,
+        };
+
+        assert_eq!(
+            tones(&state.format_line(&input, None)),
+            vec![("> **literal**", MarkdownTone::Text)]
+        );
+    }
+}

--- a/crates/aether-kit/src/console/mod.rs
+++ b/crates/aether-kit/src/console/mod.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::needless_pass_by_value)]
 
 mod kinds;
+mod markdown;
 mod state;
 
 pub use kinds::*;
@@ -22,6 +23,8 @@ use aether_kinds::keycode::{KEY_BACKSPACE, KEY_DOWN, KEY_ENTER, KEY_LEFT, KEY_RI
 use aether_kinds::{
     CachedFontMetrics, Key, KeyRelease, MouseWheel, QuadSpace, Quit, TextInput, Tick, WindowSize,
 };
+
+use self::markdown::{MarkdownLine, MarkdownTone};
 
 const HORIZONTAL_PADDING: f32 = 12.0;
 const TOP_PADDING: f32 = 10.0;
@@ -82,6 +85,7 @@ impl ConsoleOverlay {
             .config
             .panel_height
             .min(bounded_u32_to_f32(self.window_size[1]));
+        let history = self.state.visible_markdown_history(visible_rows);
         let mut quads = vec![
             SolidQuad {
                 x: 0.0,
@@ -112,6 +116,15 @@ impl ConsoleOverlay {
             });
         }
 
+        let mut y = self.history_top_y();
+        for line in &history {
+            if y + self.config.font_size > input_y - HISTORY_INPUT_GAP {
+                break;
+            }
+            self.push_markdown_quads(&mut quads, line, y, width);
+            y += self.row_height();
+        }
+
         ctx.actor::<RenderCapability>().send(&DrawSolidQuads {
             space: QuadSpace::Screen,
             quads,
@@ -122,18 +135,11 @@ impl ConsoleOverlay {
         };
 
         let mut y = self.history_top_y();
-        for line in self.state.visible_history(visible_rows) {
+        for line in &history {
             if y + self.config.font_size > input_y - HISTORY_INPUT_GAP {
                 break;
             }
-            ctx.actor::<TextCapability>().send(&DrawText {
-                font_id,
-                text: line.text,
-                size_pixels: self.config.font_size,
-                color: ConsoleState::theme_color(&self.config.theme, line.style),
-                origin: [HORIZONTAL_PADDING, y],
-                space: QuadSpace::Screen,
-            });
+            self.draw_markdown_line(ctx, font_id, line, y);
             y += self.row_height();
         }
 
@@ -156,6 +162,132 @@ impl ConsoleOverlay {
             ],
             space: QuadSpace::Screen,
         });
+    }
+
+    fn push_markdown_quads(
+        &self,
+        quads: &mut Vec<SolidQuad>,
+        line: &MarkdownLine,
+        y: f32,
+        width: f32,
+    ) {
+        let padding = self.config.theme.markdown.code_padding_pixels.max(0.0);
+        if line.thematic_break {
+            quads.push(SolidQuad {
+                x: HORIZONTAL_PADDING,
+                y: y + (self.config.font_size * 0.55),
+                width: (width - (HORIZONTAL_PADDING * 2.0)).max(0.0),
+                height: 1.0,
+                color: self.config.theme.markdown.thematic_break_color,
+            });
+            return;
+        }
+        if line.code_block {
+            quads.push(SolidQuad {
+                x: HORIZONTAL_PADDING - padding,
+                y: y - padding,
+                width: (width - (HORIZONTAL_PADDING * 2.0)) + (padding * 2.0),
+                height: self.config.font_size + (padding * 2.0),
+                color: self.config.theme.markdown.fenced_code_background_color,
+            });
+            return;
+        }
+
+        let mut x = HORIZONTAL_PADDING;
+        for run in &line.runs {
+            let run_width = self.measure(&run.text);
+            if run.tone == MarkdownTone::InlineCode {
+                quads.push(SolidQuad {
+                    x: x - padding,
+                    y: y - padding,
+                    width: run_width + (padding * 2.0),
+                    height: self.config.font_size + (padding * 2.0),
+                    color: self.config.theme.markdown.inline_code_background_color,
+                });
+            }
+            x += run_width;
+        }
+    }
+
+    fn draw_markdown_line(
+        &self,
+        ctx: &mut WasmCtx<'_, Manual>,
+        font_id: u32,
+        line: &MarkdownLine,
+        y: f32,
+    ) {
+        let mut x = HORIZONTAL_PADDING;
+        for run in &line.runs {
+            if run.text.is_empty() || run.tone == MarkdownTone::ThematicBreak {
+                continue;
+            }
+            let color = self.markdown_color(line.style, run.tone);
+            ctx.actor::<TextCapability>().send(&DrawText {
+                font_id,
+                text: run.text.clone(),
+                size_pixels: self.config.font_size,
+                color,
+                origin: [x, y],
+                space: QuadSpace::Screen,
+            });
+            if run.tone == MarkdownTone::Strong {
+                ctx.actor::<TextCapability>().send(&DrawText {
+                    font_id,
+                    text: run.text.clone(),
+                    size_pixels: self.config.font_size,
+                    color,
+                    origin: [
+                        x + self.config.theme.markdown.strong_offset_pixels.max(0.0),
+                        y,
+                    ],
+                    space: QuadSpace::Screen,
+                });
+            }
+            x += self.measure(&run.text);
+        }
+    }
+
+    fn markdown_color(&self, style: LineStyle, tone: MarkdownTone) -> [f32; 4] {
+        if style == LineStyle::Error
+            && matches!(
+                tone,
+                MarkdownTone::Text
+                    | MarkdownTone::Heading
+                    | MarkdownTone::Emphasis
+                    | MarkdownTone::Strong
+                    | MarkdownTone::InlineCode
+                    | MarkdownTone::FencedCode
+                    | MarkdownTone::Link
+                    | MarkdownTone::Image
+                    | MarkdownTone::QuoteText
+                    | MarkdownTone::TableHeader
+                    | MarkdownTone::TableText
+            )
+        {
+            return self.config.theme.error_color;
+        }
+
+        let markdown = &self.config.theme.markdown;
+        match tone {
+            MarkdownTone::Text => ConsoleState::theme_color(&self.config.theme, style),
+            MarkdownTone::Heading => markdown.heading_color,
+            MarkdownTone::Emphasis => markdown.emphasis_color,
+            MarkdownTone::Strong => markdown.strong_color,
+            MarkdownTone::InlineCode => markdown.inline_code_color,
+            MarkdownTone::FencedCode => markdown.fenced_code_color,
+            MarkdownTone::Link => markdown.link_color,
+            MarkdownTone::Image => markdown.image_color,
+            MarkdownTone::QuoteMarker => markdown.quote_marker_color,
+            MarkdownTone::QuoteText => markdown.quote_text_color,
+            MarkdownTone::ListMarker => markdown.list_marker_color,
+            MarkdownTone::TaskMarker => markdown.task_marker_color,
+            MarkdownTone::TableBorder => markdown.table_border_color,
+            MarkdownTone::TableHeader => markdown.table_header_color,
+            MarkdownTone::TableText => markdown.table_text_color,
+            MarkdownTone::ThematicBreak => markdown.thematic_break_color,
+            MarkdownTone::MutedMarker => markdown.muted_marker_color,
+            MarkdownTone::EscapedMarker => markdown.escaped_marker_color,
+        }
     }
 
     fn measure(&self, text: &str) -> f32 {
@@ -511,5 +643,88 @@ mod tests {
             overlay.tick_backspace_repeat();
         }
         assert_eq!(overlay.state.input, "ab");
+    }
+
+    #[test]
+    fn markdown_tones_map_to_explicit_theme_fields() {
+        let overlay = ConsoleOverlay {
+            config: ConsoleConfig::default(),
+            state: ConsoleState::new(&ConsoleConfig::default()),
+            window_size: [100, 100],
+            font_id: None,
+            metrics: None,
+            backspace_held: false,
+            backspace_ticks: 0,
+        };
+        let markdown = overlay.config.theme.markdown;
+
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::Heading),
+            markdown.heading_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::Emphasis),
+            markdown.emphasis_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::Strong),
+            markdown.strong_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::InlineCode),
+            markdown.inline_code_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::FencedCode),
+            markdown.fenced_code_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::Link),
+            markdown.link_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::Image),
+            markdown.image_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::QuoteMarker),
+            markdown.quote_marker_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::QuoteText),
+            markdown.quote_text_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::ListMarker),
+            markdown.list_marker_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::TaskMarker),
+            markdown.task_marker_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::TableBorder),
+            markdown.table_border_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::TableHeader),
+            markdown.table_header_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::TableText),
+            markdown.table_text_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::ThematicBreak),
+            markdown.thematic_break_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::MutedMarker),
+            markdown.muted_marker_color
+        );
+        assert_eq!(
+            overlay.markdown_color(LineStyle::Output, MarkdownTone::EscapedMarker),
+            markdown.escaped_marker_color
+        );
     }
 }

--- a/crates/aether-kit/src/console/mod.rs
+++ b/crates/aether-kit/src/console/mod.rs
@@ -175,8 +175,8 @@ impl ConsoleOverlay {
         if line.thematic_break {
             quads.push(SolidQuad {
                 x: HORIZONTAL_PADDING,
-                y: y + (self.config.font_size * 0.55),
-                width: (width - (HORIZONTAL_PADDING * 2.0)).max(0.0),
+                y: self.config.font_size.mul_add(0.55, y),
+                width: HORIZONTAL_PADDING.mul_add(-2.0, width).max(0.0),
                 height: 1.0,
                 color: self.config.theme.markdown.thematic_break_color,
             });
@@ -186,7 +186,7 @@ impl ConsoleOverlay {
             quads.push(SolidQuad {
                 x: HORIZONTAL_PADDING - padding,
                 y: y - padding,
-                width: (width - (HORIZONTAL_PADDING * 2.0)) + (padding * 2.0),
+                width: padding.mul_add(2.0, HORIZONTAL_PADDING.mul_add(-2.0, width)),
                 height: self.config.font_size + (padding * 2.0),
                 color: self.config.theme.markdown.fenced_code_background_color,
             });

--- a/crates/aether-kit/src/console/state.rs
+++ b/crates/aether-kit/src/console/state.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 
 use aether_data::MailboxId;
 
+use super::markdown::{MarkdownLine, format_visible_history};
 use super::{ConsoleCommandInvoked, ConsoleConfig, ConsoleTheme};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -192,6 +193,18 @@ impl ConsoleState {
             .take(end.saturating_sub(start))
             .cloned()
             .collect()
+    }
+
+    #[must_use]
+    pub fn visible_markdown_history(&self, visible_rows: usize) -> Vec<MarkdownLine> {
+        if visible_rows == 0 {
+            return Vec::new();
+        }
+        let max_offset = self.max_scroll_offset(visible_rows);
+        let offset = self.scroll_offset.min(max_offset);
+        let end = self.lines.len().saturating_sub(offset);
+        let start = end.saturating_sub(visible_rows);
+        format_visible_history(&self.lines, start, end)
     }
 
     pub fn insert_text(&mut self, text: &str) {
@@ -535,5 +548,28 @@ mod tests {
 
         assert!(!state.unregister_external("help"));
         assert!(state.commands().contains_key("help"));
+    }
+
+    #[test]
+    fn markdown_history_replays_fenced_code_before_visible_window() {
+        let mut state = state();
+        state.push_output("```rust");
+        state.push_output("let value = **literal**;");
+        state.push_output("```");
+
+        let visible = state.visible_markdown_history(2);
+
+        assert!(visible[0].code_block);
+        assert_eq!(visible[0].runs[0].text, "let value = **literal**;");
+    }
+
+    #[test]
+    fn markdown_history_keeps_raw_lines_unchanged() {
+        let mut state = state();
+        state.push_output("**strong**");
+
+        let _ = state.visible_markdown_history(1);
+
+        assert_eq!(state.lines()[0].text, "**strong**");
     }
 }

--- a/crates/aether-substrate-bundle/tests/console_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/console_render_interaction.rs
@@ -26,7 +26,7 @@ use aether_kinds::{
     CaptureFrame, CaptureFrameResult, FrameCheck, FrameCheckResult, FrameRect, FrameReduction, Key,
     LoadComponent, LoadResult, NamedMail, Tick, WindowSize,
 };
-use aether_kit::ConsoleConfig;
+use aether_kit::{ConsoleCommandOutput, ConsoleConfig};
 use aether_substrate_bundle::test_bench::{
     BenchOp, TestBench,
     test_helpers::{init_save_sandbox, require_runtime},
@@ -108,6 +108,24 @@ fn top_band() -> FrameRect {
 }
 
 fn top_band_coverage(bench: &mut TestBench, label: &'static str) -> f32 {
+    coverage_in_region(bench, label, top_band(), CLEAR_SRGB)
+}
+
+fn history_text_band() -> FrameRect {
+    FrameRect {
+        min_x: 8,
+        min_y: 20,
+        max_x: WINDOW_WIDTH - 8,
+        max_y: 72,
+    }
+}
+
+fn coverage_in_region(
+    bench: &mut TestBench,
+    label: &'static str,
+    region: FrameRect,
+    background: [u8; 3],
+) -> f32 {
     let captured = bench
         .execute(vec![(
             label,
@@ -119,8 +137,8 @@ fn top_band_coverage(bench: &mut TestBench, label: &'static str) -> f32 {
                     checks: vec![FrameCheck {
                         reduction: FrameReduction::Coverage,
                         tolerance: PARTITION_TOLERANCE,
-                        background: Some(CLEAR_SRGB),
-                        region: Some(top_band()),
+                        background: Some(background),
+                        region: Some(region),
                     }],
                     similarity: None,
                 },
@@ -144,6 +162,46 @@ fn top_band_coverage(bench: &mut TestBench, label: &'static str) -> f32 {
     match result {
         FrameCheckResult::Coverage { fraction, .. } => fraction,
         other => panic!("expected Coverage result; got {other:?}"),
+    }
+}
+
+fn history_text_differs_from_panel(bench: &mut TestBench, label: &'static str) -> bool {
+    let captured = bench
+        .execute(vec![(
+            label,
+            BenchOp::send_and_await(
+                RenderCapability::NAMESPACE,
+                &CaptureFrame {
+                    mails: vec![envelope(&console_address(), &Tick)],
+                    after_mails: Vec::new(),
+                    checks: vec![FrameCheck {
+                        reduction: FrameReduction::DiffersFromBackground,
+                        tolerance: PARTITION_TOLERANCE,
+                        background: None,
+                        region: Some(history_text_band()),
+                    }],
+                    similarity: None,
+                },
+            ),
+        )])
+        .expect("capture sequence");
+    let result = match captured
+        .reply::<CaptureFrameResult>(label)
+        .expect("decode CaptureFrameResult")
+    {
+        CaptureFrameResult::Ok { verdict, .. } => {
+            let verdict = verdict.expect("checks requested");
+            verdict
+                .results
+                .into_iter()
+                .next()
+                .expect("one check result")
+        }
+        CaptureFrameResult::Err { error } => panic!("capture failed: {error}"),
+    };
+    match result {
+        FrameCheckResult::DiffersFromBackground { passed, .. } => passed,
+        other => panic!("expected DiffersFromBackground result; got {other:?}"),
     }
 }
 
@@ -191,5 +249,69 @@ fn backquote_key_opens_console_overlay() {
     assert!(
         open > 0.90,
         "backquote should open the console and cover the top band; coverage={open:.3}",
+    );
+}
+
+#[test]
+fn markdown_command_output_renders_into_history_band() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = build_bench();
+    load_console(&mut bench, &wasm);
+
+    bench
+        .execute(vec![
+            (
+                "size",
+                BenchOp::send_mail(
+                    console_address(),
+                    &WindowSize {
+                        width: WINDOW_WIDTH,
+                        height: WINDOW_HEIGHT,
+                    },
+                ),
+            ),
+            ("settle", BenchOp::advance(3)),
+            (
+                "toggle",
+                BenchOp::send_mail(
+                    console_address(),
+                    &Key {
+                        code: KEY_BACKQUOTE,
+                    },
+                ),
+            ),
+        ])
+        .expect("open console");
+
+    let empty = history_text_differs_from_panel(&mut bench, "empty-history");
+    assert!(
+        !empty,
+        "empty history band should match the panel background"
+    );
+
+    bench
+        .execute(vec![(
+            "markdown-output",
+            BenchOp::send_mail(
+                console_address(),
+                &ConsoleCommandOutput {
+                    command: String::from("diagnostics"),
+                    lines: vec![
+                        String::from("## Heading"),
+                        String::from("- [x] `code` [link](target)"),
+                    ],
+                    error: false,
+                },
+            ),
+        )])
+        .expect("send markdown output");
+
+    let rendered = history_text_differs_from_panel(&mut bench, "rendered-history");
+    assert!(
+        rendered,
+        "markdown output should add visible text/background pixels to the history band",
     );
 }


### PR DESCRIPTION
Closes #2860.

## Summary

Adds no-std/alloc markdown formatting for the `aether-kit` console output path while preserving raw scrollback and the existing `ConsoleCommandOutput { lines, error }` wire shape.

The console now has explicit markdown theme configuration, formats visible history into styled runs, and renders markdown text/background/table/separator adornments through the existing `aether.text` and `aether.render` draw surfaces.

## Test plan

- `cargo fmt`
- `cargo test -p aether-kit console`
- `cargo test -p aether-substrate-bundle --test console_render_interaction --no-run`

## Generated by

`/implement` — agent execution of [scoped issue #2860](https://github.com/iamacoffeepot/aether/issues/2860).
