### PR TITLE
chore(workflow): require local pre-pr checks

### DIFF
--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -19,5 +19,5 @@ Use this Codex skill for the repository's issue-to-draft-PR workflow.
 3. Create a dedicated Codex worktree under `.agents/worktrees/issue-<N>` from `origin/main`; do not edit the primary `main` checkout.
 4. Move the issue to `phase:executing` before implementation work starts.
 5. Follow the issue's `## Implementation plan` literally. Deviations are bounces, not freelancing.
-6. Commit the work, run `cargo fmt`, assert a clean worktree, push, and open a draft PR over REST.
+6. Commit the work, then run the cheap deterministic pre-PR tier before any push that opens or updates a draft PR: `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings`. If either check fails, fix it locally and amend or recommit before pushing; do not push a known fmt, compile, or clippy red. Assert a clean worktree, push, and open a draft PR over REST.
 7. Use `scripts/wave-status.sh --wait <pr>` for CI monitoring. Leave successful work at `phase:refine` with the PR still draft.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Read relevant guide pages and ADRs before changing a subsystem. Prefer current c
 - Format check: `cargo fmt -- --check`
 - Check only: `cargo check`
 
-For implementation PRs, this repo uses GitHub Actions as the full build engine. Locally run `cargo fmt` before pushing; let CI run the expensive checks unless the issue explicitly asks for local verification. If a user explicitly asks for full local build, test, or dist verification, report the result and then note that `target/` and generated `dist/` artifacts can be large, so clean them up when they are no longer needed or ask before preserving them.
+For implementation PRs, this repo uses GitHub Actions as the full build engine. Before pushing an implement branch, locally run the cheap deterministic tier: `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings`; fix any red locally before opening or updating a draft PR. Let CI run the expensive checks unless the issue explicitly asks for local verification. If a user explicitly asks for full local build, test, or dist verification, report the result and then note that `target/` and generated `dist/` artifacts can be large, so clean them up when they are no longer needed or ask before preserving them.
 
 ## Codex Hooks
 


### PR DESCRIPTION
Closes #2875.

## Summary

Require Codex implement runs to pass the cheap deterministic local gate before opening or updating a draft PR, so formatting, compile, and clippy failures are fixed locally instead of waiting for GitHub Actions.

The implement skill now names `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` as mandatory pre-push checks, and AGENTS.md carries the same requirement while preserving CI as the full expensive build engine.

## Test plan

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`

## Generated by

`/implement` — agent execution of [scoped issue #2875](https://github.com/iamacoffeepot/aether/issues/2875).
