### PR TITLE
feat(aether-capabilities): add primitive draw clipping

### DIFF
--- a/crates/aether-capabilities/src/render/kinds.rs
+++ b/crates/aether-capabilities/src/render/kinds.rs
@@ -12,7 +12,7 @@
 //! `aether.text.draw` kind in `aether-kinds` consumes them — so the quad
 //! draw kinds below import them from there.
 
-use aether_kinds::QuadSpace;
+use aether_kinds::{ClipRect, QuadSpace};
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
 
@@ -186,6 +186,9 @@ pub struct TexturedQuad {
 pub struct DrawTexturedQuads {
     pub texture_id: u32,
     pub space: QuadSpace,
+    /// Optional framebuffer-pixel scissor applied to this batch. `None`
+    /// leaves the draw unclipped.
+    pub clip: Option<ClipRect>,
     pub quads: Vec<TexturedQuad>,
 }
 
@@ -215,6 +218,9 @@ pub struct SolidQuad {
 #[kind(name = "aether.render.draw_solid_quads")]
 pub struct DrawSolidQuads {
     pub space: QuadSpace,
+    /// Optional framebuffer-pixel scissor applied to this batch. `None`
+    /// leaves the draw unclipped.
+    pub clip: Option<ClipRect>,
     pub quads: Vec<SolidQuad>,
 }
 

--- a/crates/aether-capabilities/src/render/mod.rs
+++ b/crates/aether-capabilities/src/render/mod.rs
@@ -327,6 +327,7 @@ mod tests {
 
         let mail = DrawSolidQuads {
             space: QuadSpace::Screen,
+            clip: None,
             quads: vec![SolidQuad {
                 x: 10.0,
                 y: 20.0,

--- a/crates/aether-capabilities/src/render/runtime/mod.rs
+++ b/crates/aether-capabilities/src/render/runtime/mod.rs
@@ -559,6 +559,7 @@ impl NativeActor for RenderCapability {
             .push(QuadBatch {
                 texture_id: mail.texture_id,
                 space: mail.space,
+                clip: mail.clip,
                 quads: mail.quads,
             });
     }
@@ -633,6 +634,7 @@ impl NativeActor for RenderCapability {
             .push(QuadBatch {
                 texture_id: WHITE_TEXTURE_ID,
                 space: mail.space,
+                clip: mail.clip,
                 quads,
             });
     }

--- a/crates/aether-capabilities/src/render/runtime/pipeline.rs
+++ b/crates/aether-capabilities/src/render/runtime/pipeline.rs
@@ -360,6 +360,10 @@ impl RenderHandles {
                 bind_group: realized.bind_group(),
                 first_vertex,
                 vertex_count,
+                clip: batch
+                    .clip
+                    .as_ref()
+                    .map(|clip| [clip.x, clip.y, clip.width, clip.height]),
             });
         }
 

--- a/crates/aether-capabilities/src/render/runtime/quad.rs
+++ b/crates/aether-capabilities/src/render/runtime/quad.rs
@@ -3,7 +3,7 @@
 //! push a [`QuadBatch`] into the accumulator; the driver's
 //! `record_overlay_pass` consumes them at record time.
 
-use aether_kinds::QuadSpace;
+use aether_kinds::{ClipRect, QuadSpace};
 
 use super::super::kinds::TexturedQuad;
 
@@ -16,5 +16,6 @@ use super::super::kinds::TexturedQuad;
 pub struct QuadBatch {
     pub texture_id: u32,
     pub space: QuadSpace,
+    pub clip: Option<ClipRect>,
     pub quads: Vec<TexturedQuad>,
 }

--- a/crates/aether-capabilities/src/text/kinds.rs
+++ b/crates/aether-capabilities/src/text/kinds.rs
@@ -13,7 +13,7 @@
 //! kinds reference them via `use aether_kinds::{FontMetrics, QuadSpace}` —
 //! the existing `capabilities → kinds` direction.
 
-use aether_kinds::{FontMetrics, QuadSpace};
+use aether_kinds::{ClipRect, FontMetrics, QuadSpace};
 use serde::{Deserialize, Serialize};
 
 /// Synthetic namespace used when a font is loaded directly from mail-carried
@@ -90,6 +90,9 @@ pub struct DrawText {
     /// `World` mode — the `anchor` positions there.
     pub origin: [f32; 2],
     pub space: QuadSpace,
+    /// Optional framebuffer-pixel scissor applied to the emitted glyph
+    /// quad batch. `None` leaves the text unclipped.
+    pub clip: Option<ClipRect>,
 }
 
 /// Names the font a `FontMetricsRequest` measures: by the

--- a/crates/aether-capabilities/src/text/runtime/layout.rs
+++ b/crates/aether-capabilities/src/text/runtime/layout.rs
@@ -6,7 +6,7 @@
 
 use std::path::Path;
 
-use aether_kinds::{FontMetrics, GlyphAdvance, QuadSpace};
+use aether_kinds::{ClipRect, FontMetrics, GlyphAdvance, QuadSpace};
 use aether_substrate::actor::native::NativeCtx;
 
 use crate::render::{DrawTexturedQuads, RenderCapability, TexturedQuad};
@@ -18,11 +18,13 @@ pub fn emit_draw(
     ctx: &mut NativeCtx<'_>,
     texture_id: u32,
     space: QuadSpace,
+    clip: Option<ClipRect>,
     quads: Vec<TexturedQuad>,
 ) {
     let draw = DrawTexturedQuads {
         texture_id,
         space,
+        clip,
         quads,
     };
     ctx.actor::<RenderCapability>().send(&draw);

--- a/crates/aether-capabilities/src/text/runtime/mod.rs
+++ b/crates/aether-capabilities/src/text/runtime/mod.rs
@@ -638,7 +638,7 @@ impl NativeActor for TextCapability {
                     q.y += oy;
                 }
             }
-            emit_draw(ctx, texture_id, mail.space, quads);
+            emit_draw(ctx, texture_id, mail.space, mail.clip, quads);
         }
     }
 }
@@ -755,6 +755,7 @@ mod tests {
                 color: [1.0, 1.0, 1.0, 1.0],
                 origin,
                 space: QuadSpace::Screen,
+                clip: None,
             },
         );
     }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1721,6 +1721,19 @@ mod control_plane {
     // moving them would close a cycle — they're sibling-kind-consumed and
     // therefore pinned here.
 
+    /// Screen/framebuffer-pixel clip rectangle applied after projection.
+    ///
+    /// Render and text draw calls use this as a per-call scissor. The
+    /// coordinates are framebuffer pixels regardless of whether the draw's
+    /// projection space is screen or world.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+    pub struct ClipRect {
+        pub x: f32,
+        pub y: f32,
+        pub width: f32,
+        pub height: f32,
+    }
+
     /// How a `QuadSpace::World` quad's clip-space scale factor `k`
     /// relates on-screen size to distance (ADR-0105).
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/aether-kit/src/console/mod.rs
+++ b/crates/aether-kit/src/console/mod.rs
@@ -145,6 +145,7 @@ impl ConsoleOverlay {
 
         ctx.actor::<RenderCapability>().send(&DrawSolidQuads {
             space: QuadSpace::Screen,
+            clip: None,
             quads,
         });
 
@@ -168,6 +169,7 @@ impl ConsoleOverlay {
             color: self.config.theme.prompt_color,
             origin: [HORIZONTAL_PADDING, input_y],
             space: QuadSpace::Screen,
+            clip: None,
         });
         ctx.actor::<TextCapability>().send(&DrawText {
             font_id,
@@ -179,6 +181,7 @@ impl ConsoleOverlay {
                 input_y,
             ],
             space: QuadSpace::Screen,
+            clip: None,
         });
     }
 
@@ -247,6 +250,7 @@ impl ConsoleOverlay {
                 color,
                 origin: [x, y],
                 space: QuadSpace::Screen,
+                clip: None,
             });
             if run.tone == MarkdownTone::Strong {
                 ctx.actor::<TextCapability>().send(&DrawText {
@@ -259,6 +263,7 @@ impl ConsoleOverlay {
                         y,
                     ],
                     space: QuadSpace::Screen,
+                    clip: None,
                 });
             }
             x += self.measure(&run.text);

--- a/crates/aether-kit/src/widget/mod.rs
+++ b/crates/aether-kit/src/widget/mod.rs
@@ -197,6 +197,7 @@ pub(crate) fn emit(ctx: &mut WasmCtx<'_, Manual>, list: &WidgetDrawList) {
     if !quads.is_empty() {
         ctx.actor::<RenderCapability>().send(&DrawSolidQuads {
             space: QuadSpace::Screen,
+            clip: None,
             quads,
         });
     }
@@ -217,6 +218,7 @@ pub(crate) fn emit(ctx: &mut WasmCtx<'_, Manual>, list: &WidgetDrawList) {
                 color: *color,
                 origin: [*x, *y],
                 space: QuadSpace::Screen,
+                clip: None,
             });
         }
     }

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -46,8 +46,8 @@ use aether_capabilities::text::{
 };
 use aether_data::{Kind, MailboxId};
 use aether_kinds::{
-    CachedFontMetrics, CaptureFrame, CaptureFrameResult, DropComponent, DropResult, FrameCheck,
-    FrameCheckResult, FrameRect, FrameReduction, ListComponents, ListComponentsResult,
+    CachedFontMetrics, CaptureFrame, CaptureFrameResult, ClipRect, DropComponent, DropResult,
+    FrameCheck, FrameCheckResult, FrameRect, FrameReduction, ListComponents, ListComponentsResult,
     LoadComponent, LoadResult, NamedMail, Ping, QuadScale, QuadSpace, ReplaceComponent,
     ReplaceResult,
 };
@@ -111,6 +111,40 @@ fn rgba_at(img: &Image, x: u32, y: u32) -> [u8; 4] {
         img.rgba[start + 2],
         img.rgba[start + 3],
     ]
+}
+
+fn rgb_close(actual: [u8; 4], expected: [u8; 3], tolerance: u8) -> bool {
+    actual[..3]
+        .iter()
+        .zip(expected)
+        .all(|(actual, expected)| actual.abs_diff(expected) <= tolerance)
+}
+
+fn pixel_is_lit(img: &Image, x: u32, y: u32, bg: [u8; 3], tolerance: u8) -> bool {
+    !rgb_close(rgba_at(img, x, y), bg, tolerance)
+}
+
+fn lit_fraction_in_rect(
+    img: &Image,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+    bg: [u8; 3],
+    tolerance: u8,
+) -> f32 {
+    let mut lit = 0u32;
+    for py in y..y + height {
+        for px in x..x + width {
+            if pixel_is_lit(img, px, py, bg, tolerance) {
+                lit += 1;
+            }
+        }
+    }
+    #[allow(clippy::cast_precision_loss)]
+    {
+        lit as f32 / (width * height) as f32
+    }
 }
 
 /// Load the probe into the bench via `execute`, blocking on the
@@ -915,6 +949,7 @@ fn textured_quad_draws_screen_space_rect() {
         &DrawTexturedQuads {
             texture_id,
             space: QuadSpace::Screen,
+            clip: None,
             quads: vec![TexturedQuad {
                 x: quad_x,
                 y: quad_y,
@@ -1020,6 +1055,7 @@ fn destroyed_texture_draw_drops_from_frame() {
             &DrawTexturedQuads {
                 texture_id,
                 space: QuadSpace::Screen,
+                clip: None,
                 quads: vec![TexturedQuad {
                     x: 16.0,
                     y: 12.0,
@@ -1129,6 +1165,7 @@ fn r8_texture_updates_and_draws_red_channel_only() {
             &DrawTexturedQuads {
                 texture_id,
                 space: QuadSpace::Screen,
+                clip: None,
                 quads: vec![TexturedQuad {
                     x: 16.0,
                     y: 16.0,
@@ -1439,6 +1476,7 @@ fn solid_quad_draws_screen_space_rect() {
         "aether.render",
         &DrawSolidQuads {
             space: QuadSpace::Screen,
+            clip: None,
             quads: vec![SolidQuad {
                 x: quad_x,
                 y: quad_y,
@@ -1494,6 +1532,148 @@ fn solid_quad_draws_screen_space_rect() {
     );
 }
 
+/// Issue #2855: a per-batch clip rect becomes a GPU scissor. A clipped
+/// solid batch can only light pixels inside the clip, and the following
+/// unclipped batch resets to the full framebuffer instead of inheriting
+/// the prior scissor.
+#[test]
+fn solid_quad_clip_bounds_pixels_and_does_not_leak() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let clipped = envelope(
+        "aether.render",
+        &DrawSolidQuads {
+            space: QuadSpace::Screen,
+            clip: Some(ClipRect {
+                x: 20.0,
+                y: 12.0,
+                width: 12.0,
+                height: 10.0,
+            }),
+            quads: vec![SolidQuad {
+                x: 10.0,
+                y: 8.0,
+                width: 44.0,
+                height: 30.0,
+                color: [1.0, 0.0, 0.0, 1.0],
+            }],
+        },
+    );
+    let unclipped = envelope(
+        "aether.render",
+        &DrawSolidQuads {
+            space: QuadSpace::Screen,
+            clip: None,
+            quads: vec![SolidQuad {
+                x: 44.0,
+                y: 30.0,
+                width: 8.0,
+                height: 8.0,
+                color: [0.0, 1.0, 0.0, 1.0],
+            }],
+        },
+    );
+
+    let captured = bench
+        .execute(vec![(
+            "snap",
+            BenchOp::capture_with_mails(vec![clipped, unclipped], vec![]),
+        )])
+        .expect("capture clipped solid quads");
+    let img = decode_png(captured.captured("snap").expect("snap step ran"))
+        .expect("decode clipped solid png");
+    let bg = background_top_left(&img);
+    let tolerance = 5;
+    assert!(
+        pixel_is_lit(&img, 24, 16, bg, tolerance),
+        "pixel inside the solid clip rect should be painted",
+    );
+    assert!(
+        !pixel_is_lit(&img, 16, 16, bg, tolerance),
+        "pixel inside the solid quad but outside the clip rect should remain clear",
+    );
+    assert!(
+        pixel_is_lit(&img, 48, 34, bg, tolerance),
+        "following unclipped batch should paint outside the previous clip rect",
+    );
+}
+
+/// Issue #2855: user-textured quad batches carry the same per-call
+/// framebuffer clip as solid batches.
+#[test]
+fn textured_quad_clip_bounds_pixels() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let created = bench
+        .execute(vec![(
+            "create",
+            BenchOp::send_and_await(
+                "aether.render",
+                &CreateTexture {
+                    width: 1,
+                    height: 1,
+                    format: TextureFormat::Rgba8,
+                    pixels: vec![255, 255, 255, 255],
+                },
+            ),
+        )])
+        .expect("create white texture");
+    let texture_id = match created
+        .reply::<CreateTextureResult>("create")
+        .expect("decode CreateTextureResult")
+    {
+        CreateTextureResult::Ok { texture_id } => texture_id,
+        CreateTextureResult::Err { error } => panic!("create_texture failed: {error}"),
+    };
+    let draw = envelope(
+        "aether.render",
+        &DrawTexturedQuads {
+            texture_id,
+            space: QuadSpace::Screen,
+            clip: Some(ClipRect {
+                x: 18.0,
+                y: 14.0,
+                width: 14.0,
+                height: 12.0,
+            }),
+            quads: vec![TexturedQuad {
+                x: 8.0,
+                y: 8.0,
+                width: 40.0,
+                height: 30.0,
+                u0: 0.0,
+                v0: 0.0,
+                u1: 1.0,
+                v1: 1.0,
+                tint: [1.0, 1.0, 1.0, 1.0],
+            }],
+        },
+    );
+
+    let captured = bench
+        .execute(vec![(
+            "snap",
+            BenchOp::capture_with_mails(vec![draw], vec![]),
+        )])
+        .expect("capture clipped textured quad");
+    let img = decode_png(captured.captured("snap").expect("snap step ran"))
+        .expect("decode clipped textured png");
+    let bg = background_top_left(&img);
+    let tolerance = 5;
+    assert!(
+        pixel_is_lit(&img, 24, 20, bg, tolerance),
+        "pixel inside the textured clip rect should be painted",
+    );
+    assert!(
+        !pixel_is_lit(&img, 12, 20, bg, tolerance),
+        "pixel inside the textured quad but outside the clip rect should remain clear",
+    );
+}
+
 /// iamacoffeepot/aether#1777: a `capture_frame` carrying a `checks`
 /// request returns a substrate-side verdict scored on the exact RGBA
 /// the PNG is built from — no caller-side PNG decode. Draws a known
@@ -1520,6 +1700,7 @@ fn capture_frame_checks_return_substrate_verdict() {
         "aether.render",
         &DrawSolidQuads {
             space: QuadSpace::Screen,
+            clip: None,
             quads: vec![SolidQuad {
                 x: quad_x,
                 y: quad_y,
@@ -1647,6 +1828,7 @@ fn capture_frame_region_scopes_reduction_to_one_widget_rect() {
         "aether.render",
         &DrawSolidQuads {
             space: QuadSpace::Screen,
+            clip: None,
             quads: vec![
                 SolidQuad {
                     x: first_x,
@@ -2454,6 +2636,7 @@ fn text_draws_a_screen_space_string() {
         color: [1.0, 1.0, 1.0, 1.0],
         origin: [0.0, 0.0],
         space: QuadSpace::Screen,
+        clip: None,
     };
 
     // First draw: lazily creates the atlas texture (fire-and-forget — a
@@ -2508,6 +2691,126 @@ fn text_draws_a_screen_space_string() {
         silhouette.min_x < frame_width / 2 && silhouette.max_y < frame_height,
         "text silhouette {silhouette:?} should bound the upper-left of the \
          {frame_width}x{frame_height} frame",
+    );
+}
+
+/// Issue #2855: `aether.text.draw` forwards its framebuffer clip to the
+/// textured glyph quad batch it emits, so glyph pixels outside the clip
+/// are discarded by the same overlay-pass scissor as primitive quads.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn text_draw_clip_bounds_glyph_pixels() {
+    const TTF: &[u8] = include_bytes!("../assets/fonts/RobotoMono.ttf");
+    if !require_wgpu_only() {
+        return;
+    }
+    let sandbox = init_save_sandbox("test-bench-text-clip");
+    fs::write(sandbox.join("font.ttf"), TTF).expect("stage font asset");
+
+    let mut bench = TestBench::builder()
+        .size(128, 64)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.text",
+                &LoadFont {
+                    namespace: "assets".to_owned(),
+                    path: "font.ttf".to_owned(),
+                },
+            ),
+        )])
+        .expect("load_font sequence");
+    let font_id = match loaded
+        .reply::<LoadFontResult>("load")
+        .expect("decode LoadFontResult")
+    {
+        LoadFontResult::Ok { font_id, .. } => font_id,
+        LoadFontResult::Err { error, .. } => panic!("load_font failed: {error}"),
+    };
+
+    let unclipped = DrawText {
+        font_id,
+        text: "MMMMMMMM".to_owned(),
+        size_pixels: 32.0,
+        color: [1.0, 1.0, 1.0, 1.0],
+        origin: [8.0, 8.0],
+        space: QuadSpace::Screen,
+        clip: None,
+    };
+    bench
+        .execute(vec![
+            (
+                "prime",
+                BenchOp::send_mail::<DrawText>("aether.text", &unclipped),
+            ),
+            ("settle", BenchOp::advance(2)),
+        ])
+        .expect("prime draw");
+
+    let outside_region = (58, 18, 18, 18);
+    let baseline = bench
+        .execute(vec![(
+            "baseline",
+            BenchOp::capture_with_mails(vec![envelope("aether.text", &unclipped)], vec![]),
+        )])
+        .expect("capture unclipped text");
+    let baseline_img = decode_png(baseline.captured("baseline").expect("baseline ran"))
+        .expect("decode unclipped text png");
+    let baseline_bg = background_top_left(&baseline_img);
+    let tolerance = 5;
+    let baseline_outside = lit_fraction_in_rect(
+        &baseline_img,
+        outside_region.0,
+        outside_region.1,
+        outside_region.2,
+        outside_region.3,
+        baseline_bg,
+        tolerance,
+    );
+    assert!(
+        baseline_outside > 0.05,
+        "unclipped text should light the sampled outside region; coverage={baseline_outside}",
+    );
+
+    let clipped = DrawText {
+        clip: Some(ClipRect {
+            x: 18.0,
+            y: 12.0,
+            width: 22.0,
+            height: 24.0,
+        }),
+        ..unclipped
+    };
+    let captured = bench
+        .execute(vec![(
+            "clipped",
+            BenchOp::capture_with_mails(vec![envelope("aether.text", &clipped)], vec![]),
+        )])
+        .expect("capture clipped text");
+    let img =
+        decode_png(captured.captured("clipped").expect("clipped ran")).expect("decode text png");
+    let bg = background_top_left(&img);
+    let inside = lit_fraction_in_rect(&img, 20, 18, 14, 14, bg, tolerance);
+    let outside = lit_fraction_in_rect(
+        &img,
+        outside_region.0,
+        outside_region.1,
+        outside_region.2,
+        outside_region.3,
+        bg,
+        tolerance,
+    );
+    assert!(
+        inside > 0.05,
+        "clipped text should still light pixels inside the clip; coverage={inside}",
+    );
+    assert_eq!(
+        outside, 0.0,
+        "glyph pixels outside the text clip should remain background",
     );
 }
 
@@ -2637,6 +2940,7 @@ fn text_screen_origin_shifts_centroid() {
         color: [1.0, 1.0, 1.0, 1.0],
         origin: [0.0, 0.0],
         space: QuadSpace::Screen,
+        clip: None,
     };
 
     // Prime pass: lazily creates the atlas texture; nothing draws yet.
@@ -2784,6 +3088,7 @@ fn text_draws_world_space_label() {
                 reference_distance: 10.0,
             },
         },
+        clip: None,
     };
     let draw_px = DrawText {
         font_id,
@@ -2795,6 +3100,7 @@ fn text_draws_world_space_label() {
             anchor,
             scale: QuadScale::Pixels,
         },
+        clip: None,
     };
 
     // Prime: the first draw lazily creates the atlas texture and draws

--- a/crates/aether-substrate/src/render/quad.rs
+++ b/crates/aether-substrate/src/render/quad.rs
@@ -91,6 +91,8 @@ pub struct OverlayDraw<'a> {
     pub bind_group: &'a wgpu::BindGroup,
     pub first_vertex: u32,
     pub vertex_count: u32,
+    /// Optional framebuffer-pixel scissor: `[x, y, width, height]`.
+    pub clip: Option<[f32; 4]>,
 }
 
 /// Build the shared texture + sampler bindings used by texture-sampling
@@ -529,10 +531,42 @@ pub fn record_quad_overlay_pass(
         if draw.vertex_count == 0 {
             continue;
         }
+        let Some(scissor) = clamped_scissor(draw.clip, targets.width(), targets.height()) else {
+            continue;
+        };
+        pass.set_scissor_rect(scissor[0], scissor[1], scissor[2], scissor[3]);
         pass.set_bind_group(1, draw.bind_group, &[]);
         pass.draw(
             draw.first_vertex..draw.first_vertex + draw.vertex_count,
             0..1,
         );
     }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn clamped_scissor(
+    clip: Option<[f32; 4]>,
+    target_width: u32,
+    target_height: u32,
+) -> Option<[u32; 4]> {
+    let Some([x, y, width, height]) = clip else {
+        return Some([0, 0, target_width, target_height]);
+    };
+    if !x.is_finite() || !y.is_finite() || !width.is_finite() || !height.is_finite() {
+        return None;
+    }
+    let min_x = x.max(0.0).min(target_width as f32).floor();
+    let min_y = y.max(0.0).min(target_height as f32).floor();
+    let max_x = (x + width).max(0.0).min(target_width as f32).ceil();
+    let max_y = (y + height).max(0.0).min(target_height as f32).ceil();
+    if max_x <= min_x || max_y <= min_y {
+        return None;
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    Some([
+        min_x as u32,
+        min_y as u32,
+        (max_x - min_x) as u32,
+        (max_y - min_y) as u32,
+    ])
 }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/ui_widget.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/ui_widget.rs
@@ -73,6 +73,7 @@ impl WasmActor for UiWidget {
         }
         ctx.actor::<RenderCapability>().send(&DrawSolidQuads {
             space: QuadSpace::Screen,
+            clip: None,
             quads,
         });
     }


### PR DESCRIPTION
Closes #2855.

## Summary

Adds optional per-draw clip rectangles to primitive render and text draw calls, threads them through the capabilities runtime, and applies them as framebuffer-space scissors in the substrate overlay pass.

Text draw clipping is forwarded into the generated glyph quad batches, existing unclipped calls remain unchanged, and TestBench scenarios cover solid, textured, and text clipping behavior.

## Test plan

- `cargo test -p aether-substrate-bundle --test test_bench_scenario clip -- --nocapture`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`

## Generated by

`/implement` — agent execution of [scoped issue #2855](https://github.com/iamacoffeepot/aether/issues/2855).
