### PR TITLE
fix(ci): widen behavior derive trybuild timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -38,9 +38,9 @@ slow-timeout = { period = "300s", terminate-after = 1 }
 # `aether-derive` fixture dep graph (local wall-clock 240s → 18s on
 # our dev boxes); CI's 2-core runners still push it past 60s under
 # parallel contention with `aether-data-derive`'s ui binary, so all
-# three derive crates (`aether-data-derive`, `aether-derive`,
-# `aether-actor-derive`) keep the wider cap. The bigger speedup for
-# all three is its own follow-up.
+# four derive crates (`aether-data-derive`, `aether-derive`,
+# `aether-actor-derive`, `aether-behavior-derive`) keep the wider cap.
+# The bigger speedup for all four is its own follow-up.
 [[profile.ci.overrides]]
-filter = "package(=aether-data-derive) | package(=aether-derive) | package(=aether-actor-derive)"
+filter = "package(=aether-data-derive) | package(=aether-derive) | package(=aether-actor-derive) | package(=aether-behavior-derive)"
 slow-timeout = { period = "300s", terminate-after = 1 }


### PR DESCRIPTION
Closes #2903.

## Summary

Adds `aether-behavior-derive` to the existing 300s nextest CI slow-timeout override for derive trybuild suites, matching the behavior of the other derive crates.

## Test plan

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`

## Generated by

`/implement --quick` — mechanical CI timeout fix from [issue #2903](https://github.com/iamacoffeepot/aether/issues/2903).
