### PR TITLE
feat(kit): add smooth world shape stamps

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -78,7 +78,8 @@ pub use widget::{
 pub use world::{
     CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk, ChunkPos,
     HEIGHT_POINT_INHERIT, HEIGHT_POINTS_PER_CHUNK, Material, Region, SetCellHeights, SetCellPoints,
-    SetChunk, SetRegion, SmoothingProfile, WaterPlane, World, WorldDecodeError, WorldLoad,
+    SetChunk, SetRegion, SmoothingProfile, StampDisc, StampHexagon, StampPolygon, WaterPlane,
+    World, WorldDecodeError, WorldLoad, WorldPoint,
 };
 
 /// Octimeters per tile: `1 tile = 1 meter = 256 octimeters`.

--- a/crates/aether-kit/src/world/data.rs
+++ b/crates/aether-kit/src/world/data.rs
@@ -220,7 +220,7 @@ impl CellPos {
 
     /// Index of this cell within its chunk's row-major planes.
     /// `rem_euclid` so negative cells map into `0..256` correctly.
-    fn chunk_index(self) -> usize {
+    pub(super) fn chunk_index(self) -> usize {
         (self.z.rem_euclid(CELLS_PER_CHUNK) * CELLS_PER_CHUNK + self.x.rem_euclid(CELLS_PER_CHUNK))
             as usize
     }
@@ -872,6 +872,17 @@ impl World {
     /// Insert (or replace) the chunk at `at`.
     pub fn insert_chunk(&mut self, at: ChunkPos, chunk: impl Into<Box<Chunk>>) {
         self.chunks.insert(at, chunk.into());
+    }
+
+    /// The mutable chunk at `at`, creating an empty one when absent. Shape
+    /// stamps use this narrow sibling-module seam to write the overlay
+    /// material and scalar coverage planes without exposing the world's
+    /// chunk map as public API.
+    pub(super) fn chunk_mut_or_insert(&mut self, at: ChunkPos) -> &mut Chunk {
+        self.chunks
+            .entry(at)
+            .or_insert_with(Chunk::empty_boxed)
+            .as_mut()
     }
 
     /// Register a region under a 1-based `id`. The table is positional,

--- a/crates/aether-kit/src/world/kinds.rs
+++ b/crates/aether-kit/src/world/kinds.rs
@@ -7,8 +7,8 @@
 #![allow(clippy::wildcard_imports)]
 
 //! Wire kinds for the world plane stack — the `aether.kit.world.*` mail a
-//! peer sends [`WorldView`] to write chunks, paint cells, register regions,
-//! or load a serialized world.
+//! peer sends [`WorldView`] to write chunks, paint cells or compact vector
+//! stamps, register regions, or load a serialized world.
 
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -143,6 +143,77 @@ impl SetCellPoints {
             z: self.z,
         }
     }
+}
+
+/// A point on the world's XZ plane, expressed in octimeters.
+///
+/// Keeping the axes and unit named in the wire vocabulary prevents callers
+/// from having to infer whether a positional pair is `[x, z]`, `[z, x]`, or
+/// measured in cells rather than octimeters.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorldPoint {
+    pub x_octimeters: i32,
+    pub z_octimeters: i32,
+}
+
+impl WorldPoint {
+    #[must_use]
+    pub const fn new(x_octimeters: i32, z_octimeters: i32) -> Self {
+        Self {
+            x_octimeters,
+            z_octimeters,
+        }
+    }
+}
+
+/// Maximum number of vertices accepted by one polygon stamp.
+pub const MAX_STAMP_VERTICES: usize = 1024;
+/// Maximum raster extent of one stamp along either axis, in subcells.
+pub const MAX_STAMP_EDGE_SUBCELLS: usize = 4096;
+/// Maximum total raster area allocated for one stamp, in subcells.
+pub const MAX_STAMP_SUBCELLS: usize = 1_048_576;
+/// Maximum estimated scanline work accepted by one stamp. The estimate
+/// includes edge tests, intersection sorting, and interval-to-subcell visits.
+pub const MAX_STAMP_RASTER_WORK: usize = 33_554_432;
+
+/// `aether.kit.world.stamp_polygon` — rasterize a polygon directly into the
+/// scalar overlay coverage plane. `points` is a [`WorldPoint`] vertex ring;
+/// concave rings use even-odd fill. `material` is a raw [`Material`] byte.
+/// Fewer than three points, more than [`MAX_STAMP_VERTICES`] points, a
+/// degenerate or oversized ring, or `Material::Void` paints nothing. Across
+/// all stamp kinds, equal materials max-compose coverage; a different
+/// material replaces the mask of each cell it reaches in painter order.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.world.stamp_polygon")]
+pub struct StampPolygon {
+    pub points: Vec<WorldPoint>,
+    pub material: u8,
+}
+
+/// `aether.kit.world.stamp_disc` — rasterize a compact disc description into
+/// the scalar overlay coverage plane. `center` is a [`WorldPoint`],
+/// `radius_octimeters` is center-to-edge distance, and `material` is a raw
+/// [`Material`] byte. A zero radius, oversized raster, or `Material::Void`
+/// paints nothing.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.world.stamp_disc")]
+pub struct StampDisc {
+    pub center: WorldPoint,
+    pub radius_octimeters: u32,
+    pub material: u8,
+}
+
+/// `aether.kit.world.stamp_hexagon` — rasterize a flat-top regular hexagon
+/// into the scalar overlay coverage plane. `center` is a [`WorldPoint`],
+/// `radius_octimeters` is center-to-vertex distance, and `material` is a raw
+/// [`Material`] byte. A zero radius, oversized raster, or `Material::Void`
+/// paints nothing.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.world.stamp_hexagon")]
+pub struct StampHexagon {
+    pub center: WorldPoint,
+    pub radius_octimeters: u32,
+    pub material: u8,
 }
 
 /// `aether.kit.world.set_cell_heights` — stamp one cell's `SUB × SUB` height

--- a/crates/aether-kit/src/world/mod.rs
+++ b/crates/aether-kit/src/world/mod.rs
@@ -23,6 +23,9 @@
 //! - `aether.kit.world.set_cell_heights` — stamp one cell's height deltas
 //!   (subcell relief off the cell height) and remesh that cell's chunk plus
 //!   its eight cached neighbors (the height sibling of `set_cell_points`).
+//! - `aether.kit.world.stamp_{polygon,disc,hexagon}` — rasterize a compact
+//!   world-octimeter shape into scalar subcell coverage and remesh every
+//!   touched chunk plus its cached apron neighbors.
 //! - `aether.kit.world.set_region` — register a region so the underlay
 //!   cascade has a default to resolve to; remeshes every cached chunk
 //!   (a region default can change any chunk's cascade-resolved underlay).
@@ -35,6 +38,7 @@ pub use data::*;
 mod kinds;
 pub use kinds::*;
 pub mod mesher;
+mod raster;
 
 use alloc::collections::BTreeMap;
 
@@ -54,11 +58,12 @@ use self::mesher::style::StyleTable;
 ///
 /// # Agent
 /// Load with the `aether_kit@aether.kit.world` export. Paint the world by
-/// sending `aether.kit.world.set_chunk` (one chunk's planes) and
-/// `aether.kit.world.set_region` (a region default for the underlay
-/// cascade); each send remeshes and the world renders every frame under
-/// the active `aether.view_projection` view. `aether.kit.world.load` swaps a
-/// serialized world from `aether.fs`. Use `capture_frame` to verify.
+/// sending `aether.kit.world.stamp_{polygon,disc,hexagon}` for compact smooth
+/// shapes, `aether.kit.world.set_chunk` for raw planes, and
+/// `aether.kit.world.set_region` for an underlay cascade default; each send
+/// remeshes and the world renders every frame under the active
+/// `aether.view_projection` view. `aether.kit.world.load` swaps a serialized
+/// world from `aether.fs`. Use `capture_frame` to verify.
 pub struct WorldView {
     world: World,
     meshes: BTreeMap<ChunkPos, Vec<DrawTriangle>>,
@@ -103,6 +108,15 @@ impl WorldView {
                         .insert(neighbor, mesh_chunk(&self.world, neighbor, &self.styles));
                 }
             }
+        }
+    }
+
+    /// Rasterize `vertices` into the overlay coverage plane and rebuild every
+    /// changed chunk through the ordinary apron-aware invalidation path.
+    fn stamp_vertices(&mut self, vertices: &[WorldPoint], material: Material) {
+        let touched = raster::stamp_polygon(&mut self.world, vertices, material);
+        for pos in touched {
+            self.remesh_around(pos);
         }
     }
 }
@@ -177,6 +191,45 @@ impl WasmActor for WorldView {
         let cell = msg.cell();
         self.world.set_cell_points(cell, &msg.points);
         self.remesh_around(cell.chunk());
+    }
+
+    /// Rasterize an arbitrary polygon in world-octimeter coordinates into
+    /// anti-aliased scalar overlay coverage, then remesh every touched chunk
+    /// and its cached apron neighbors.
+    ///
+    /// # Agent
+    /// Send `aether.kit.world.stamp_polygon` with a vertex ring in
+    /// `points` (named `x_octimeters` / `z_octimeters` fields) and a raw
+    /// `Material` byte. This is the compact shape-authoring counterpart to
+    /// hand-building `set_cell_points` / `set_chunk` arrays.
+    #[handler::single]
+    fn on_stamp_polygon(&mut self, _ctx: &mut WasmCtx<'_>, msg: StampPolygon) {
+        self.stamp_vertices(&msg.points, Material::from_u8_or_void(msg.material));
+    }
+
+    /// Generate and rasterize a disc vertex ring in world-octimeter
+    /// coordinates, then remesh every touched chunk and apron.
+    ///
+    /// # Agent
+    /// Send `aether.kit.world.stamp_disc` with a `center` world point,
+    /// `radius_octimeters`, and a raw `Material` byte.
+    #[handler::single]
+    fn on_stamp_disc(&mut self, _ctx: &mut WasmCtx<'_>, msg: StampDisc) {
+        let vertices = raster::disc_vertices(msg.center, msg.radius_octimeters);
+        self.stamp_vertices(&vertices, Material::from_u8_or_void(msg.material));
+    }
+
+    /// Generate and rasterize a flat-top regular hexagon in world-octimeter
+    /// coordinates, then remesh every touched chunk and apron.
+    ///
+    /// # Agent
+    /// Send `aether.kit.world.stamp_hexagon` with
+    /// a `center` world point, center-to-vertex `radius_octimeters`, and a raw
+    /// `Material` byte.
+    #[handler::single]
+    fn on_stamp_hexagon(&mut self, _ctx: &mut WasmCtx<'_>, msg: StampHexagon) {
+        let vertices = raster::regular_hexagon_vertices(msg.center, msg.radius_octimeters);
+        self.stamp_vertices(&vertices, Material::from_u8_or_void(msg.material));
     }
 
     /// Stamp one cell's height deltas into the world, then remesh that cell's
@@ -281,5 +334,47 @@ impl WasmActor for WorldView {
                 "world read failed; keeping prior world",
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_border_stamp_remeshes_both_touched_chunks() {
+        let mut view = WorldView {
+            world: World::new(),
+            meshes: BTreeMap::new(),
+            styles: StyleTable::default(),
+        };
+        view.stamp_vertices(
+            &[
+                WorldPoint::new(4080, 256),
+                WorldPoint::new(4112, 256),
+                WorldPoint::new(4112, 512),
+                WorldPoint::new(4080, 512),
+            ],
+            Material::Stone,
+        );
+
+        let west = ChunkPos { x: 0, z: 0 };
+        let east = ChunkPos { x: 1, z: 0 };
+        assert!(
+            view.meshes.contains_key(&west),
+            "west touched chunk remeshed"
+        );
+        assert!(
+            view.meshes.contains_key(&east),
+            "east touched chunk remeshed"
+        );
+        assert!(
+            view.meshes.get(&west).is_some_and(|mesh| !mesh.is_empty()),
+            "west mesh includes the border stamp and its east apron",
+        );
+        assert!(
+            view.meshes.get(&east).is_some_and(|mesh| !mesh.is_empty()),
+            "east mesh includes the border stamp and its west apron",
+        );
     }
 }

--- a/crates/aether-kit/src/world/raster.rs
+++ b/crates/aether-kit/src/world/raster.rs
@@ -1,0 +1,530 @@
+// Raster bounds and vertex-ring trigonometry cross deliberately between the
+// integer octimeter lattice and floating-point area math. Coordinates remain
+// i32 and each output index is bounded by the polygon's i32 bounding box.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+
+//! CPU shape rasterization for world overlay stamps.
+//!
+//! Every public stamp shape becomes a polygon vertex ring in world
+//! octimeters, then passes through [`rasterize_polygon`]. The rasterizer walks
+//! eight horizontal sub-scanlines per semantic subcell, accumulating the
+//! covered horizontal interval length into a scalar `0..=255` area estimate.
+//! That is the sole coverage-producing path for polygons, discs, and regular
+//! hexagons.
+
+use alloc::collections::BTreeSet;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::{f64::consts::TAU, mem};
+
+use super::{
+    CellPos, ChunkPos, MAX_STAMP_EDGE_SUBCELLS, MAX_STAMP_RASTER_WORK, MAX_STAMP_SUBCELLS,
+    MAX_STAMP_VERTICES, Material, SUBCELLS_PER_CELL, SUBCELLS_PER_CELL_EDGE, World, WorldPoint,
+};
+
+/// One cell is 256 octimeters and contains 16 subcells along each edge.
+const OCTIMETERS_PER_SUBCELL: i32 = 256 / SUBCELLS_PER_CELL_EDGE.cast_signed();
+/// Vertical area samples per semantic subcell. Horizontal interval overlap is
+/// integrated exactly at each scanline, so this is the only sampling axis.
+const AREA_SCANLINES_PER_SUBCELL: usize = 8;
+/// A disc is a fixed regular polygon on the wire-independent raster side.
+const DISC_VERTEX_COUNT: usize = 32;
+
+#[derive(Debug)]
+struct RasterizedCoverage {
+    min_subcell_x: i32,
+    min_subcell_z: i32,
+    width: usize,
+    coverage: Vec<u8>,
+}
+
+impl RasterizedCoverage {
+    fn empty() -> Self {
+        Self {
+            min_subcell_x: 0,
+            min_subcell_z: 0,
+            width: 0,
+            coverage: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    fn coverage_at(&self, subcell_x: i32, subcell_z: i32) -> u8 {
+        let local_x = subcell_x - self.min_subcell_x;
+        let local_z = subcell_z - self.min_subcell_z;
+        if local_x < 0 || local_z < 0 {
+            return 0;
+        }
+        let (x, z) = (local_x as usize, local_z as usize);
+        if x >= self.width || z >= self.coverage.len() / self.width {
+            return 0;
+        }
+        self.coverage[z * self.width + x]
+    }
+
+    fn covered_samples(&self) -> impl Iterator<Item = (i32, i32, u8)> + '_ {
+        self.coverage
+            .iter()
+            .copied()
+            .enumerate()
+            .filter(|(_, coverage)| *coverage > 0)
+            .map(|(index, coverage)| {
+                let x = index % self.width;
+                let z = index / self.width;
+                (
+                    self.min_subcell_x + x as i32,
+                    self.min_subcell_z + z as i32,
+                    coverage,
+                )
+            })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SampleAddress {
+    cell: CellPos,
+    subcell_x: i32,
+    subcell_z: i32,
+}
+
+/// Map a global subcell-lattice address into the world's cell-local plane
+/// layout. Euclidean division keeps the mapping correct left/below origin.
+fn sample_address(global_subcell_x: i32, global_subcell_z: i32) -> SampleAddress {
+    let subcells = SUBCELLS_PER_CELL_EDGE.cast_signed();
+    SampleAddress {
+        cell: CellPos {
+            x: global_subcell_x.div_euclid(subcells),
+            z: global_subcell_z.div_euclid(subcells),
+        },
+        subcell_x: global_subcell_x.rem_euclid(subcells),
+        subcell_z: global_subcell_z.rem_euclid(subcells),
+    }
+}
+
+/// Rasterize a polygon vertex ring in world octimeters to scalar coverage.
+/// The even-odd fill rule handles concave rings; fewer than three vertices or
+/// a zero-width/height bounding box produces no samples.
+fn rasterize_polygon(points: &[WorldPoint]) -> RasterizedCoverage {
+    let Some(first) = points.first().copied() else {
+        return RasterizedCoverage::empty();
+    };
+    if points.len() < 3 || points.len() > MAX_STAMP_VERTICES {
+        return RasterizedCoverage::empty();
+    }
+
+    let mut min_x = first.x_octimeters;
+    let mut min_z = first.z_octimeters;
+    let mut max_x = first.x_octimeters;
+    let mut max_z = first.z_octimeters;
+    for point in &points[1..] {
+        min_x = min_x.min(point.x_octimeters);
+        min_z = min_z.min(point.z_octimeters);
+        max_x = max_x.max(point.x_octimeters);
+        max_z = max_z.max(point.z_octimeters);
+    }
+    if min_x == max_x || min_z == max_z {
+        return RasterizedCoverage::empty();
+    }
+
+    let min_subcell_x = min_x.div_euclid(OCTIMETERS_PER_SUBCELL);
+    let min_subcell_z = min_z.div_euclid(OCTIMETERS_PER_SUBCELL);
+    let max_subcell_x = div_ceil(max_x, OCTIMETERS_PER_SUBCELL);
+    let max_subcell_z = div_ceil(max_z, OCTIMETERS_PER_SUBCELL);
+    let Ok(width) = usize::try_from(i64::from(max_subcell_x) - i64::from(min_subcell_x)) else {
+        return RasterizedCoverage::empty();
+    };
+    let Ok(height) = usize::try_from(i64::from(max_subcell_z) - i64::from(min_subcell_z)) else {
+        return RasterizedCoverage::empty();
+    };
+    let Some(len) = width.checked_mul(height) else {
+        return RasterizedCoverage::empty();
+    };
+    if width > MAX_STAMP_EDGE_SUBCELLS
+        || height > MAX_STAMP_EDGE_SUBCELLS
+        || len > MAX_STAMP_SUBCELLS
+    {
+        return RasterizedCoverage::empty();
+    }
+    if estimated_raster_work(width, height, points.len())
+        .is_none_or(|work| work > MAX_STAMP_RASTER_WORK)
+    {
+        return RasterizedCoverage::empty();
+    }
+
+    let mut coverage = vec![0; len];
+    let mut intersections = Vec::with_capacity(points.len());
+    for local_z in 0..height {
+        let global_subcell_z = min_subcell_z + local_z as i32;
+        rasterize_row(
+            points,
+            global_subcell_z,
+            min_subcell_x,
+            width,
+            &mut intersections,
+            &mut coverage[local_z * width..(local_z + 1) * width],
+        );
+    }
+
+    RasterizedCoverage {
+        min_subcell_x,
+        min_subcell_z,
+        width,
+        coverage,
+    }
+}
+
+/// Conservative work estimate for the current scanline implementation.
+/// Every sub-scanline tests each polygon edge and sorts its intersections;
+/// every possible intersection pair may then walk the full raster row.
+fn estimated_raster_work(width: usize, height: usize, vertex_count: usize) -> Option<usize> {
+    let scanlines = height.checked_mul(AREA_SCANLINES_PER_SUBCELL)?;
+    let edge_tests = scanlines.checked_mul(vertex_count)?;
+    let sort_levels = usize::try_from(vertex_count.next_power_of_two().ilog2()).ok()?;
+    let sort_work = edge_tests.checked_mul(sort_levels.max(1))?;
+    let interval_visits = width
+        .checked_mul(scanlines)?
+        .checked_mul(vertex_count / 2)?;
+    edge_tests
+        .checked_add(sort_work)?
+        .checked_add(interval_visits)
+}
+
+fn div_ceil(value: i32, divisor: i32) -> i32 {
+    value.div_euclid(divisor) + i32::from(value.rem_euclid(divisor) != 0)
+}
+
+fn rasterize_row(
+    points: &[WorldPoint],
+    global_subcell_z: i32,
+    min_subcell_x: i32,
+    width: usize,
+    intersections: &mut Vec<f64>,
+    output: &mut [u8],
+) {
+    let mut covered_scanlines = vec![0.0; width];
+    let row_start = f64::from(global_subcell_z) * f64::from(OCTIMETERS_PER_SUBCELL);
+    for sample in 0..AREA_SCANLINES_PER_SUBCELL {
+        let fraction = (sample as f64 + 0.5) / AREA_SCANLINES_PER_SUBCELL as f64;
+        let z = fraction.mul_add(f64::from(OCTIMETERS_PER_SUBCELL), row_start);
+        polygon_scanline_intersections(points, z, intersections);
+        for pair in intersections.chunks_exact(2) {
+            add_interval_coverage(&mut covered_scanlines, min_subcell_x, pair[0], pair[1]);
+        }
+    }
+
+    for (slot, covered) in output.iter_mut().zip(covered_scanlines) {
+        let fraction = covered / AREA_SCANLINES_PER_SUBCELL as f64;
+        *slot = (fraction * 255.0).round().clamp(0.0, 255.0) as u8;
+    }
+}
+
+fn polygon_scanline_intersections(points: &[WorldPoint], z: f64, intersections: &mut Vec<f64>) {
+    intersections.clear();
+    let mut previous = points[points.len() - 1];
+    for &current in points {
+        let (az, bz) = (
+            f64::from(previous.z_octimeters),
+            f64::from(current.z_octimeters),
+        );
+        if (az <= z && z < bz) || (bz <= z && z < az) {
+            let t = (z - az) / (bz - az);
+            intersections.push(
+                (f64::from(current.x_octimeters) - f64::from(previous.x_octimeters))
+                    .mul_add(t, f64::from(previous.x_octimeters)),
+            );
+        }
+        previous = current;
+    }
+    intersections.sort_by(f64::total_cmp);
+}
+
+fn add_interval_coverage(
+    covered_scanlines: &mut [f64],
+    min_subcell_x: i32,
+    mut interval_start: f64,
+    mut interval_end: f64,
+) {
+    if interval_end < interval_start {
+        mem::swap(&mut interval_start, &mut interval_end);
+    }
+    let raster_start = f64::from(min_subcell_x) * f64::from(OCTIMETERS_PER_SUBCELL);
+    for (local_x, covered) in covered_scanlines.iter_mut().enumerate() {
+        let subcell_start =
+            (local_x as f64).mul_add(f64::from(OCTIMETERS_PER_SUBCELL), raster_start);
+        let subcell_end = subcell_start + f64::from(OCTIMETERS_PER_SUBCELL);
+        let overlap = interval_end.min(subcell_end) - interval_start.max(subcell_start);
+        if overlap > 0.0 {
+            *covered += overlap / f64::from(OCTIMETERS_PER_SUBCELL);
+        }
+    }
+}
+
+/// Generate the fixed-resolution polygon ring used by a disc stamp.
+pub(super) fn disc_vertices(center: WorldPoint, radius_octimeters: u32) -> Vec<WorldPoint> {
+    regular_polygon_vertices(center, radius_octimeters, DISC_VERTEX_COUNT)
+}
+
+/// Generate a flat-top regular hexagon vertex ring. The radius is measured
+/// from the center to each vertex.
+pub(super) fn regular_hexagon_vertices(
+    center: WorldPoint,
+    radius_octimeters: u32,
+) -> Vec<WorldPoint> {
+    regular_polygon_vertices(center, radius_octimeters, 6)
+}
+
+fn regular_polygon_vertices(
+    center: WorldPoint,
+    radius_octimeters: u32,
+    vertex_count: usize,
+) -> Vec<WorldPoint> {
+    if radius_octimeters == 0 || vertex_count < 3 {
+        return Vec::new();
+    }
+    let radius = f64::from(radius_octimeters);
+    (0..vertex_count)
+        .map(|index| {
+            let angle = index as f64 * TAU / vertex_count as f64;
+            WorldPoint::new(
+                (angle.cos().mul_add(radius, f64::from(center.x_octimeters))).round() as i32,
+                (angle.sin().mul_add(radius, f64::from(center.z_octimeters))).round() as i32,
+            )
+        })
+        .collect()
+}
+
+/// Rasterize and compose a polygon stamp into the scalar overlay coverage
+/// plane, returning every chunk whose stored planes changed. Same-material
+/// stamps union by maximum coverage. A different material takes painter's
+/// order at the cell ownership boundary and clears that cell's prior mask
+/// before receiving the new shape. `Void` (including an unknown material byte
+/// decoded to `Void`) paints nothing.
+pub(super) fn stamp_polygon(
+    world: &mut World,
+    points: &[WorldPoint],
+    material: Material,
+) -> BTreeSet<ChunkPos> {
+    let mut touched = BTreeSet::new();
+    if material == Material::Void {
+        return touched;
+    }
+    let raster = rasterize_polygon(points);
+    for (global_subcell_x, global_subcell_z, coverage) in raster.covered_samples() {
+        let address = sample_address(global_subcell_x, global_subcell_z);
+        let chunk_pos = address.cell.chunk();
+        let cell_index = address.cell.chunk_index();
+        let base = cell_index * SUBCELLS_PER_CELL;
+        let within =
+            (address.subcell_z * SUBCELLS_PER_CELL_EDGE.cast_signed() + address.subcell_x) as usize;
+        let chunk = world.chunk_mut_or_insert(chunk_pos);
+        let mut changed = if chunk.overlay[cell_index] == material {
+            false
+        } else {
+            chunk.overlay[cell_index] = material;
+            chunk.overlay_mask[base..base + SUBCELLS_PER_CELL].fill(0);
+            true
+        };
+        let slot = &mut chunk.overlay_mask[base + within];
+        let composed = (*slot).max(coverage);
+        if *slot != composed {
+            *slot = composed;
+            changed = true;
+        }
+        if changed {
+            touched.insert(chunk_pos);
+        }
+    }
+    touched
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn point(x_octimeters: i32, z_octimeters: i32) -> WorldPoint {
+        WorldPoint::new(x_octimeters, z_octimeters)
+    }
+
+    #[test]
+    fn polygon_area_coverage_pins_partial_interior_and_exterior_samples() {
+        // Right triangle x + z <= 64. Subcell (0,0) is fully inside,
+        // (2,1) is bisected by the diagonal, and (3,3) is outside while
+        // still lying in the polygon's bounding raster.
+        let raster = rasterize_polygon(&[point(0, 0), point(64, 0), point(0, 64)]);
+        assert_eq!(raster.coverage_at(0, 0), 255, "full interior");
+        assert_eq!(raster.coverage_at(2, 1), 128, "half-covered edge");
+        assert_eq!(raster.coverage_at(3, 3), 0, "exterior");
+    }
+
+    #[test]
+    fn global_subcell_mapping_handles_cells_negatives_and_chunk_borders() {
+        assert_eq!(
+            sample_address(15, -1),
+            SampleAddress {
+                cell: CellPos { x: 0, z: -1 },
+                subcell_x: 15,
+                subcell_z: 15,
+            },
+        );
+        assert_eq!(sample_address(255, 0).cell.chunk(), ChunkPos { x: 0, z: 0 });
+        let across = sample_address(256, 0);
+        assert_eq!(across.cell, CellPos { x: 16, z: 0 });
+        assert_eq!(across.cell.chunk(), ChunkPos { x: 1, z: 0 });
+        assert_eq!((across.subcell_x, across.subcell_z), (0, 0));
+    }
+
+    #[test]
+    fn world_octimeters_map_to_the_expected_cell_local_coverage_slot() {
+        let mut world = World::new();
+        let touched = stamp_polygon(
+            &mut world,
+            &[
+                point(272, -16),
+                point(288, -16),
+                point(288, 0),
+                point(272, 0),
+            ],
+            Material::Sand,
+        );
+        let cell = CellPos { x: 1, z: -1 };
+        assert_eq!(touched, BTreeSet::from([ChunkPos { x: 0, z: -1 }]));
+        assert_eq!(world.overlay(cell), Material::Sand);
+        assert_eq!(
+            world.overlay_coverage(cell, 1, 15),
+            255,
+            "[272,288) × [-16,0) octimeters is cell (1,-1), subcell (1,15)",
+        );
+        assert_eq!(world.overlay_coverage(cell, 0, 15), 0, "adjacent slot");
+    }
+
+    #[test]
+    fn polygon_stamp_writes_both_sides_of_a_chunk_border() {
+        let mut world = World::new();
+        let touched = stamp_polygon(
+            &mut world,
+            &[
+                point(4080, 256),
+                point(4112, 256),
+                point(4112, 512),
+                point(4080, 512),
+            ],
+            Material::Stone,
+        );
+        assert_eq!(
+            touched,
+            BTreeSet::from([ChunkPos { x: 0, z: 0 }, ChunkPos { x: 1, z: 0 }]),
+        );
+        assert_eq!(world.overlay(CellPos { x: 15, z: 1 }), Material::Stone);
+        assert_eq!(world.overlay_coverage(CellPos { x: 15, z: 1 }, 15, 0), 255);
+        assert_eq!(world.overlay(CellPos { x: 16, z: 1 }), Material::Stone);
+        assert_eq!(world.overlay_coverage(CellPos { x: 16, z: 1 }, 0, 0), 255);
+    }
+
+    #[test]
+    fn repeated_stamp_composition_is_max_for_same_material_and_cell_replace_for_different() {
+        let mut world = World::new();
+        let full_first_subcell = [point(0, 0), point(16, 0), point(16, 16), point(0, 16)];
+        stamp_polygon(&mut world, &full_first_subcell, Material::Stone);
+        let half_first_subcell = [point(0, 0), point(16, 0), point(0, 16)];
+        let unchanged = stamp_polygon(&mut world, &half_first_subcell, Material::Stone);
+        assert!(
+            unchanged.is_empty(),
+            "lower same-material coverage cannot reduce the max"
+        );
+        assert_eq!(world.overlay_coverage(CellPos { x: 0, z: 0 }, 0, 0), 255);
+
+        let third_subcell = [point(32, 0), point(48, 0), point(48, 16), point(32, 16)];
+        stamp_polygon(&mut world, &third_subcell, Material::Sand);
+        assert_eq!(world.overlay(CellPos { x: 0, z: 0 }), Material::Sand);
+        assert_eq!(
+            world.overlay_coverage(CellPos { x: 0, z: 0 }, 0, 0),
+            0,
+            "a different material takes cell ownership and clears the old mask",
+        );
+        assert_eq!(world.overlay_coverage(CellPos { x: 0, z: 0 }, 2, 0), 255);
+    }
+
+    #[test]
+    fn regular_hexagon_has_scalar_edge_coverage() {
+        let vertices = regular_hexagon_vertices(point(512, 512), 300);
+        let raster = rasterize_polygon(&vertices);
+        assert!(
+            raster
+                .coverage
+                .iter()
+                .any(|coverage| (1..=254).contains(coverage)),
+            "a non-lattice hexagon should author partial edge coverage",
+        );
+        assert_eq!(vertices.len(), 6);
+    }
+
+    #[test]
+    fn disc_generator_builds_its_fixed_vertex_ring() {
+        let vertices = disc_vertices(point(10, -20), 64);
+        assert_eq!(vertices.len(), DISC_VERTEX_COUNT);
+        assert_eq!(vertices[0], point(74, -20), "first vertex is radius-east");
+        assert!(disc_vertices(point(0, 0), 0).is_empty(), "zero-radius disc");
+    }
+
+    #[test]
+    fn oversized_or_overcomplex_polygon_is_rejected_before_allocation() {
+        let extreme = [
+            point(i32::MIN, i32::MIN),
+            point(i32::MAX, i32::MIN),
+            point(i32::MAX, i32::MAX),
+            point(i32::MIN, i32::MAX),
+        ];
+        assert!(rasterize_polygon(&extreme).coverage.is_empty());
+
+        let too_many = vec![point(0, 0); MAX_STAMP_VERTICES + 1];
+        assert!(rasterize_polygon(&too_many).coverage.is_empty());
+
+        let edge_too_long = [
+            point(0, 0),
+            point(
+                (MAX_STAMP_EDGE_SUBCELLS as i32 + 1) * OCTIMETERS_PER_SUBCELL,
+                0,
+            ),
+            point(
+                (MAX_STAMP_EDGE_SUBCELLS as i32 + 1) * OCTIMETERS_PER_SUBCELL,
+                OCTIMETERS_PER_SUBCELL,
+            ),
+            point(0, OCTIMETERS_PER_SUBCELL),
+        ];
+        assert!(rasterize_polygon(&edge_too_long).coverage.is_empty());
+
+        let area_too_large = [
+            point(0, 0),
+            point(2048 * OCTIMETERS_PER_SUBCELL, 0),
+            point(2048 * OCTIMETERS_PER_SUBCELL, 1024 * OCTIMETERS_PER_SUBCELL),
+            point(0, 1024 * OCTIMETERS_PER_SUBCELL),
+        ];
+        assert!(rasterize_polygon(&area_too_large).coverage.is_empty());
+
+        let mut sorting_too_expensive = Vec::with_capacity(MAX_STAMP_VERTICES);
+        for index in 0..MAX_STAMP_VERTICES {
+            sorting_too_expensive.push(point(
+                if index % 2 == 0 {
+                    0
+                } else {
+                    OCTIMETERS_PER_SUBCELL
+                },
+                if index % 4 < 2 {
+                    0
+                } else {
+                    MAX_STAMP_EDGE_SUBCELLS as i32 * OCTIMETERS_PER_SUBCELL
+                },
+            ));
+        }
+        assert!(
+            rasterize_polygon(&sorting_too_expensive)
+                .coverage
+                .is_empty()
+        );
+    }
+}

--- a/crates/aether-kit/src/world/raster.rs
+++ b/crates/aether-kit/src/world/raster.rs
@@ -291,8 +291,14 @@ fn regular_polygon_vertices(
         .map(|index| {
             let angle = index as f64 * TAU / vertex_count as f64;
             WorldPoint::new(
-                (angle.cos().mul_add(radius, f64::from(center.x_octimeters))).round() as i32,
-                (angle.sin().mul_add(radius, f64::from(center.z_octimeters))).round() as i32,
+                angle
+                    .cos()
+                    .mul_add(radius, f64::from(center.x_octimeters))
+                    .round() as i32,
+                angle
+                    .sin()
+                    .mul_add(radius, f64::from(center.z_octimeters))
+                    .round() as i32,
             )
         })
         .collect()

--- a/crates/aether-kit/tests/world_scenario.rs
+++ b/crates/aether-kit/tests/world_scenario.rs
@@ -1,0 +1,165 @@
+//! World-stamp acceptance coverage through the real wasm component and
+//! `TestBench` render path. The host tests pin scalar area math and chunk-border
+//! remeshing; this test proves a compact `stamp_hexagon` mail reaches the
+//! handler and produces the expected smooth scalar-contour silhouette.
+//!
+//! Skipped when no wgpu adapter is available or the `aether_kit` wasm has not
+//! been pre-built. CI sets `AETHER_REQUIRE_RUNTIME=1` so either condition is a
+//! hard failure there.
+
+use std::fs;
+use std::path::Path;
+
+use aether_actor::Addressable;
+use aether_capabilities::render::ViewProjection;
+use aether_data::Kind;
+use aether_kinds::{LoadComponent, LoadResult, NamedMail, Render};
+use aether_kit::world::{Material, StampHexagon, WorldPoint};
+use aether_math::{Mat4, Vec3};
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
+use aether_substrate_bundle::visual::{
+    background_top_left, bounding_box, centroid, coverage, decode_png,
+};
+
+const COMPONENT_NAME: &str = "world";
+const WIDTH: u32 = 128;
+const HEIGHT: u32 = 128;
+const FRAME_CENTER: f32 = 64.0;
+
+fn component_address() -> String {
+    format!(
+        "aether.component/{}:{COMPONENT_NAME}",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    )
+}
+
+fn envelope<K: Kind>(recipient: &str, mail: &K) -> NamedMail {
+    NamedMail {
+        recipient_name: recipient.to_owned(),
+        kind_name: K::NAME.to_owned(),
+        payload: mail.encode_into_bytes(),
+        count: 1,
+    }
+}
+
+fn load_world(bench: &mut TestBench, wasm_path: &Path) {
+    let wasm = fs::read(wasm_path).expect("read kit wasm");
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: Some(COMPONENT_NAME.to_owned()),
+                    config: Vec::new(),
+                    export: Some("aether.kit.world".to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { name, .. } => assert_eq!(name, component_address()),
+        LoadResult::Err { error } => panic!("load world: {error}"),
+    }
+}
+
+fn top_down_view_projection(center_x: f32, center_z: f32, extent: f32) -> ViewProjection {
+    let eye = Vec3::new(center_x, 10.0, center_z);
+    let target = Vec3::new(center_x, 0.0, center_z);
+    let view = Mat4::look_at_rh(eye, target, Vec3::new(0.0, 0.0, -1.0));
+    let projection = Mat4::orthographic_rh(-extent, extent, -extent, extent, 0.1, 100.0);
+    ViewProjection {
+        view_proj: (projection * view).to_cols_array(),
+    }
+}
+
+#[test]
+fn stamp_hexagon_renders_a_smooth_centered_silhouette() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(WIDTH, HEIGHT).expect("boot");
+    load_world(&mut bench, &wasm_path);
+    let world = component_address();
+
+    // Eight meters from the origin keeps the shape in chunk (0,0). This
+    // non-lattice radius is shown close enough that one subcell spans several
+    // pixels, making a binary staircase distinguishable from scalar coverage.
+    bench
+        .execute(vec![(
+            "stamp",
+            BenchOp::send_mail(
+                world.as_str(),
+                &StampHexagon {
+                    center: WorldPoint::new(2048, 2048),
+                    radius_octimeters: 300,
+                    material: Material::Stone.to_u8(),
+                },
+            ),
+        )])
+        .expect("stamp hexagon");
+
+    let captured = bench
+        .execute(vec![(
+            "capture",
+            BenchOp::capture_with_mails(
+                vec![
+                    envelope("aether.render", &top_down_view_projection(8.0, 8.0, 1.5)),
+                    envelope(world.as_str(), &Render),
+                ],
+                Vec::new(),
+            ),
+        )])
+        .expect("capture stamped world");
+    let image = decode_png(captured.captured("capture").expect("capture bytes"))
+        .expect("decode capture png");
+    let background = background_top_left(&image);
+    let fraction = coverage(&image, background, 5);
+    assert!(
+        (0.30..0.52).contains(&fraction),
+        "regular hexagon should occupy a centered, bounded fraction of the frame; got {fraction}",
+    );
+
+    let (center_x, center_y) = centroid(&image, background, 5).expect("hexagon centroid");
+    assert!(
+        (center_x - FRAME_CENTER).abs() < 5.0 && (center_y - FRAME_CENTER).abs() < 5.0,
+        "hexagon centroid ({center_x}, {center_y}) should be near frame center",
+    );
+    let bounds = bounding_box(&image, background, 5).expect("hexagon bounds");
+    let is_lit = |x: u32, y: u32| {
+        let offset = ((y * image.width + x) * 4) as usize;
+        image.rgba[offset..offset + 3]
+            .iter()
+            .zip(background)
+            .any(|(actual, clear)| actual.abs_diff(clear) > 5)
+    };
+    let left_edges: Vec<_> = (bounds.min_y..=bounds.max_y)
+        .filter_map(|y| (bounds.min_x..=bounds.max_x).find(|&x| is_lit(x, y)))
+        .collect();
+    let mut longest_flat_run = 1usize;
+    let mut flat_run = 1usize;
+    for pair in left_edges.windows(2) {
+        if pair[0] == pair[1] {
+            flat_run += 1;
+            longest_flat_run = longest_flat_run.max(flat_run);
+        } else {
+            flat_run = 1;
+        }
+    }
+    assert!(
+        longest_flat_run <= 4,
+        "scalar coverage should move the zoomed diagonal contour continuously; a binary-coverage \
+         mutation produces long subcell stair steps (longest flat run: {longest_flat_run}, \
+         bounds: {bounds:?})",
+    );
+    let drawn_width = bounds.max_x - bounds.min_x + 1;
+    let drawn_height = bounds.max_y - bounds.min_y + 1;
+    assert!(
+        drawn_width > 85 && drawn_height > 70,
+        "hexagon silhouette should have broad smooth extents; got {drawn_width}x{drawn_height}",
+    );
+}

--- a/docs/guide/systems/rendering.md
+++ b/docs/guide/systems/rendering.md
@@ -89,13 +89,11 @@ requires an R8 texture, thresholds at iso 127.5, and renders a body/rim band
 from the rect parameters. Both are immediate-mode: resend the batch every frame
 or it disappears on the next commit-current frame.
 
-`aether.kit.world` uses the coverage material for painted overlay surfaces. It
-prepares the same smoothed scalar material mask plane the CPU contour oracle
-marches, uploads that plane as an R8 texture per chunk/material, and redraws a
-depth-tested coverage material rect for each ready plane on `Render`. Repainting
-the overlay plane updates the existing texture instead of sending replacement
-overlay triangles; terrain underlay, relief, walls, and raw calibration geometry
-remain ordinary `DrawTriangle` meshes.
+`aether.kit.world` stores painted overlay surfaces as one scalar coverage byte
+per subcell. Its CPU contour marcher reconstructs the fixed 127.5 boundary and
+caches the resulting `DrawTriangle` geometry per chunk. Coverage values between
+0 and 255 put crossings between subcell centers, so shape stamps have smooth
+edges while legacy binary masks retain their midpoint crossings.
 
 **The `view_proj` uniform, latest wins.** The substrate holds one column-major
 4×4 matrix and uploads it verbatim to the shader each frame (column-major matches
@@ -156,6 +154,35 @@ Address the cap by type — `ctx.actor::<RenderCapability>()` — and send
 lifecycle graph omits `Render` (headless), subscribing to it rejects fail-fast at
 wire time, and the actor simply never submits — a no-op where there's no GPU
 anyway.
+
+**Author a sub-cell world shape with one stamp.** Send this payload as
+`aether.kit.world.stamp_hexagon` to the loaded `aether.kit.world` component:
+
+```json
+{
+  "center": {
+    "x_octimeters": 2048,
+    "z_octimeters": 2048
+  },
+  "radius_octimeters": 768,
+  "material": 3
+}
+```
+
+That paints a Stone (`Material` byte `3`) hexagon centered at world cell
+`(8, 8)`, with a three-meter center-to-vertex radius. The component generates
+the six vertices, area-rasterizes the ring into `0..255` subcell coverage, and
+remeshes every touched chunk and apron. Use `stamp_disc` with the same center,
+radius, and material fields, or `stamp_polygon` with `points` containing named
+`{ "x_octimeters": ..., "z_octimeters": ... }` world points. A stamp is
+bounded to 1,024 polygon vertices, 4,096 subcells per axis, and 1,048,576
+subcells of raster area, with a 33,554,432-operation conservative scanline
+work budget; an oversized stamp paints nothing. Repeated stamps of the same
+material max-compose coverage sample by sample. A different material takes
+painter-order ownership at cell granularity and clears that cell's previous
+mask before writing its new samples, because the overlay plane stores one
+material per cell. The existing `set_cell_points` and `set_chunk` raw-array
+paths remain available for direct plane authoring and save compatibility.
 
 **From an agent over MCP — stage, then capture.** Use `capture_frame`: its
 `mails` bundle dispatches before the readback (the state that should appear) and


### PR DESCRIPTION
Closes #2872.

## Summary

- Add compact polygon, disc, and hexagon world mails that rasterize world-octimeter geometry into the scalar overlay coverage plane.
- Route all three shapes through one area-coverage rasterizer, preserve existing raw plane authoring/save formats, and remesh every touched chunk through the apron-aware path.
- Cover partial coverage, negative and border coordinate mapping, cross-chunk remeshing, and the real wasm/TestBench render path; document the authoring workflow.

## Test plan

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- Host raster and remesh tripwires in `aether-kit`
- Strict `world_scenario` TestBench integration in CI

## Generated by

`/implement` — agent execution of [scoped issue #2872](https://github.com/iamacoffeepot/aether/issues/2872).
