### PR TITLE
feat(kinds): add stable text-editing navigation keys

### DIFF
--- a/crates/aether-kinds/src/keycode.rs
+++ b/crates/aether-kinds/src/keycode.rs
@@ -89,21 +89,3 @@ pub const KEY_HOME: u32 = 0x0127;
 pub const KEY_END: u32 = 0x0128;
 pub const KEY_PAGE_UP: u32 = 0x0129;
 pub const KEY_PAGE_DOWN: u32 = 0x012A;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // Tripwire: these five values are the engine's stable wire vocabulary
-    // for text-editing navigation keys — an accidental renumbering here
-    // silently changes what `Key.code` / `KeyRelease.code` mean to every
-    // consumer already matching on them.
-    #[test]
-    fn editing_navigation_keys_have_stable_ordered_values() {
-        assert_eq!(KEY_DELETE, 0x0126);
-        assert_eq!(KEY_HOME, 0x0127);
-        assert_eq!(KEY_END, 0x0128);
-        assert_eq!(KEY_PAGE_UP, 0x0129);
-        assert_eq!(KEY_PAGE_DOWN, 0x012A);
-    }
-}

--- a/crates/aether-kinds/src/keycode.rs
+++ b/crates/aether-kinds/src/keycode.rs
@@ -82,3 +82,28 @@ pub const KEY_CTRL_LEFT: u32 = 0x0122;
 pub const KEY_CTRL_RIGHT: u32 = 0x0123;
 pub const KEY_ALT_LEFT: u32 = 0x0124;
 pub const KEY_ALT_RIGHT: u32 = 0x0125;
+
+/// Text-editing navigation keys.
+pub const KEY_DELETE: u32 = 0x0126;
+pub const KEY_HOME: u32 = 0x0127;
+pub const KEY_END: u32 = 0x0128;
+pub const KEY_PAGE_UP: u32 = 0x0129;
+pub const KEY_PAGE_DOWN: u32 = 0x012A;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tripwire: these five values are the engine's stable wire vocabulary
+    // for text-editing navigation keys — an accidental renumbering here
+    // silently changes what `Key.code` / `KeyRelease.code` mean to every
+    // consumer already matching on them.
+    #[test]
+    fn editing_navigation_keys_have_stable_ordered_values() {
+        assert_eq!(KEY_DELETE, 0x0126);
+        assert_eq!(KEY_HOME, 0x0127);
+        assert_eq!(KEY_END, 0x0128);
+        assert_eq!(KEY_PAGE_UP, 0x0129);
+        assert_eq!(KEY_PAGE_DOWN, 0x012A);
+    }
+}

--- a/crates/aether-kit/src/widget/set/text_field.rs
+++ b/crates/aether-kit/src/widget/set/text_field.rs
@@ -5,15 +5,15 @@
 //! The single-line text field (issue 2660).
 //!
 //! Committed text (`TextInput`, already layout- and IME-resolved) inserts at
-//! the caret; the editing keys the substrate emits scancodes for — Backspace,
-//! Left, Right, Enter — move the caret or commit; an in-flight IME composition
-//! (`ImePreedit`) renders as a trailing underlined span. The caret is a
+//! the caret. `TextFieldWidget` currently handles Backspace, Left, Right, and
+//! Enter to move the caret or commit; an in-flight IME composition (`ImePreedit`)
+//! renders as a trailing underlined span. The caret is a
 //! byte-offset into the string and every move lands on a `char` boundary, so a
 //! multi-byte character is never split. There is no selection in v1.
 //!
-//! Home / End are not handled: the substrate's `keycode` space has no
-//! `KEY_HOME` / `KEY_END` scancode yet (only Backspace / arrows / Enter /
-//! Tab), so those edits await the keycodes landing.
+//! The chassis keycode vocabulary also includes Delete, Home, End, Page Up,
+//! and Page Down. `TextFieldWidget` does not yet implement behavior for those
+//! keys.
 
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/crates/aether-substrate-bundle/src/desktop/driver/input.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver/input.rs
@@ -62,6 +62,11 @@ pub(super) fn map_winit_keycode(k: KeyCode) -> Option<u32> {
         KeyCode::ControlRight => keycode::KEY_CTRL_RIGHT,
         KeyCode::AltLeft => keycode::KEY_ALT_LEFT,
         KeyCode::AltRight => keycode::KEY_ALT_RIGHT,
+        KeyCode::Delete => keycode::KEY_DELETE,
+        KeyCode::Home => keycode::KEY_HOME,
+        KeyCode::End => keycode::KEY_END,
+        KeyCode::PageUp => keycode::KEY_PAGE_UP,
+        KeyCode::PageDown => keycode::KEY_PAGE_DOWN,
         _ => return None,
     })
 }
@@ -300,6 +305,24 @@ mod tests {
             map_winit_keycode(KeyCode::Backquote),
             Some(keycode::KEY_BACKQUOTE)
         );
+    }
+
+    // Tripwire: the five text-editing navigation keys must translate to
+    // their paired stable `aether_kinds::keycode` constant — the desktop
+    // chassis's sole bridge from winit's unstable `KeyCode` discriminants
+    // onto the wire.
+    #[test]
+    fn map_winit_keycode_covers_editing_navigation_keys() {
+        let cases = [
+            (KeyCode::Delete, keycode::KEY_DELETE),
+            (KeyCode::Home, keycode::KEY_HOME),
+            (KeyCode::End, keycode::KEY_END),
+            (KeyCode::PageUp, keycode::KEY_PAGE_UP),
+            (KeyCode::PageDown, keycode::KEY_PAGE_DOWN),
+        ];
+        for (winit_code, expected) in cases {
+            assert_eq!(map_winit_keycode(winit_code), Some(expected));
+        }
     }
 
     #[test]

--- a/docs/guide/systems/input.md
+++ b/docs/guide/systems/input.md
@@ -119,10 +119,13 @@ field consumes that directly on three streams:
   how a component caches `WindowSize`; a late subscriber holds the all-false
   default until the first change arrives.
 
-Editing commands — backspace, arrows, enter, home, end — compose from the
-`aether.key` scancodes paired with the cached modifiers; there's no separate kind
-for them. These three streams come from the desktop chassis only; the headless and
-hub chassis have no window and publish none of them, the same as `Key`.
+Editing commands compose from the `aether.key` scancodes paired with the cached
+modifiers; there's no separate kind for them. The stable
+`aether_kinds::keycode` constants a text-editing field matches on are
+`KEY_BACKSPACE`, `KEY_DELETE`, `KEY_LEFT` / `KEY_RIGHT` / `KEY_UP` / `KEY_DOWN`,
+`KEY_HOME`, `KEY_END`, `KEY_PAGE_UP`, `KEY_PAGE_DOWN`, and `KEY_ENTER`. These
+three streams come from the desktop chassis only; the headless and hub chassis
+have no window and publish none of them, the same as `Key`.
 
 ## How to use it
 


### PR DESCRIPTION
Closes #2922.

## Summary

- append stable `KEY_DELETE`, `KEY_HOME`, `KEY_END`, `KEY_PAGE_UP`, and `KEY_PAGE_DOWN` codes to the engine-owned key vocabulary
- map the corresponding desktop `winit` physical keys through the existing press/release path
- document the additive vocabulary without changing the `Key.code` wire shape or fan-out behavior

## Test plan

- table-driven desktop mapping coverage for all five physical keys
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- GitHub Actions full workspace CI

## Generated by

Aether implement workflow for scoped issue #2922.