### PR TITLE
feat(kit): loft cliffs from interpolated contours

### DIFF
--- a/crates/aether-kit/src/world/mesher/constants.rs
+++ b/crates/aether-kit/src/world/mesher/constants.rs
@@ -16,14 +16,6 @@ pub(super) const OCTIMETERS_PER_SUBCELL: i32 = 256 / SUB;
 /// emit.
 pub(super) const OCTIMETERS_PER_METER: f32 = 256.0;
 
-/// How far in octimeters an unbounded-void wall drops below its top edge —
-/// the border-skirt fallback for the one void case with no far rim within
-/// the fill-over march bound (a void that reaches the world border). A
-/// bounded void joint closes instead as a real groove: wall down to the void
-/// floor, floor across, wall back up (see [`emit_void_floors`]). The skirt
-/// reads as thick ground rather than a paper-thin lip.
-pub(super) const WALL_VOID_SKIRT_OCTIMETERS: i32 = 512;
-
 /// Upsample factor for the partition contour grid. At `SUB = 16`, the base
 /// subcell lattice is already finer than the old upsampled grid, and keeping
 /// the extra pass makes dense remesh tests miss CI time budgets.

--- a/crates/aether-kit/src/world/mesher/contour.rs
+++ b/crates/aether-kit/src/world/mesher/contour.rs
@@ -24,6 +24,7 @@
 //! three are pure functions of the grid, so a detail-prop mesher can drive
 //! the same machinery at its own resolution.
 
+use alloc::collections::BTreeMap;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -794,15 +795,76 @@ pub fn march_grid(
     vertex: &impl Fn(f32, f32) -> Vertex,
     tris: &mut Vec<DrawTriangle>,
 ) {
+    let _ = march_grid_region(
+        grid,
+        gw,
+        gh,
+        place,
+        MarchRegion {
+            window_rect: [0, 0, gw.saturating_sub(1), gh.saturating_sub(1)],
+            collect_contours: false,
+        },
+        vertex,
+        tris,
+    );
+}
+
+/// March a chunk-owned rectangle of windows and return the boundary as
+/// stitched polylines. The returned vertices are the same `Vertex` values
+/// copied into the cap triangles, so a caller can loft a wall from them
+/// without recomputing any contour coordinates.
+pub(super) fn march_grid_with_contours(
+    grid: &[u8],
+    gw: usize,
+    gh: usize,
+    place: &GridPlacement,
+    window_rect: [usize; 4],
+    vertex: &impl Fn(f32, f32) -> Vertex,
+    tris: &mut Vec<DrawTriangle>,
+) -> Vec<Vec<Vertex>> {
+    march_grid_region(
+        grid,
+        gw,
+        gh,
+        place,
+        MarchRegion {
+            window_rect,
+            collect_contours: true,
+        },
+        vertex,
+        tris,
+    )
+}
+
+#[derive(Clone, Copy)]
+struct MarchRegion {
+    window_rect: [usize; 4],
+    collect_contours: bool,
+}
+
+fn march_grid_region(
+    grid: &[u8],
+    gw: usize,
+    gh: usize,
+    place: &GridPlacement,
+    region: MarchRegion,
+    vertex: &impl Fn(f32, f32) -> Vertex,
+    tris: &mut Vec<DrawTriangle>,
+) -> Vec<Vec<Vertex>> {
     if gw < 2 || gh < 2 {
-        return;
+        return Vec::new();
     }
     let windows_x = gw - 1;
     let windows_z = gh - 1;
+    let [x0, z0, x1, z1] = region.window_rect;
+    let x0 = x0.min(windows_x);
+    let z0 = z0.min(windows_z);
+    let x1 = x1.min(windows_x).max(x0);
+    let z1 = z1.min(windows_z).max(z0);
     let mut case_grid = vec![0u8; windows_x * windows_z];
     let mut full = vec![false; windows_x * windows_z];
-    for wj in 0..windows_z {
-        for wi in 0..windows_x {
+    for wj in z0..z1 {
+        for wi in x0..x1 {
             let bl = covered(grid[wj * gw + wi]);
             let br = covered(grid[wj * gw + wi + 1]);
             let tl = covered(grid[(wj + 1) * gw + wi]);
@@ -812,17 +874,27 @@ pub fn march_grid(
             full[wj * windows_x + wi] = case == 15;
         }
     }
-    merge_interior(&full, windows_x, windows_z, place, vertex, tris);
-    for wj in 0..windows_z {
-        for wi in 0..windows_x {
+    merge_interior(&full, windows_x, [x0, z0, x1, z1], place, vertex, tris);
+    let mut segments = region.collect_contours.then(Vec::new);
+    for wj in z0..z1 {
+        for wi in x0..x1 {
             let case = case_grid[wj * windows_x + wi];
             if case == 0 || case == 15 {
                 continue;
             }
             let window = MarchWindow { grid, gw, place };
-            emit_window_contour(wi as i32, wj as i32, &window, case, vertex, tris);
+            emit_window_contour(
+                wi as i32,
+                wj as i32,
+                &window,
+                case,
+                vertex,
+                tris,
+                segments.as_mut(),
+            );
         }
     }
+    segments.map_or_else(Vec::new, |segments| stitch_segments(&segments))
 }
 
 /// Greedy-merge fully-covered windows into maximal rectangles — the
@@ -831,27 +903,26 @@ pub fn march_grid(
 fn merge_interior(
     full: &[bool],
     windows_x: usize,
-    windows_z: usize,
+    window_rect: [usize; 4],
     place: &GridPlacement,
     vertex: &impl Fn(f32, f32) -> Vertex,
     tris: &mut Vec<DrawTriangle>,
 ) {
     let mut consumed = vec![false; full.len()];
-    for wj in 0..windows_z {
-        for wi in 0..windows_x {
+    let [x0, z0, x1, z1] = window_rect;
+    for wj in z0..z1 {
+        for wi in x0..x1 {
             let idx = wj * windows_x + wi;
             if consumed[idx] || !full[idx] {
                 continue;
             }
             let mut w = 1;
-            while wi + w < windows_x
-                && full[wj * windows_x + wi + w]
-                && !consumed[wj * windows_x + wi + w]
+            while wi + w < x1 && full[wj * windows_x + wi + w] && !consumed[wj * windows_x + wi + w]
             {
                 w += 1;
             }
             let mut h = 1;
-            'rows: while wj + h < windows_z {
+            'rows: while wj + h < z1 {
                 for dx in 0..w {
                     let cell = (wj + h) * windows_x + wi + dx;
                     if !full[cell] || consumed[cell] {
@@ -882,8 +953,17 @@ fn emit_window_contour(
     case: u8,
     vertex: &impl Fn(f32, f32) -> Vertex,
     tris: &mut Vec<DrawTriangle>,
+    segments: Option<&mut Vec<[Vertex; 2]>>,
 ) {
-    emit_window_poly(wi, wj, window, CASE_POLYS[case as usize], vertex, tris);
+    emit_window_poly(
+        wi,
+        wj,
+        window,
+        CASE_POLYS[case as usize],
+        vertex,
+        tris,
+        segments,
+    );
 }
 
 /// Fan-triangulate one window polygon given by its boundary-point indices
@@ -943,6 +1023,7 @@ fn emit_window_poly(
     poly: &[u8],
     vertex: &impl Fn(f32, f32) -> Vertex,
     tris: &mut Vec<DrawTriangle>,
+    segments: Option<&mut Vec<[Vertex; 2]>>,
 ) {
     let step_oct = window.place.step_oct;
     let edge_t = |a: u8, b: u8| -> f32 {
@@ -976,16 +1057,84 @@ fn emit_window_poly(
         [interp(x_lo, x_hi, top), z_hi as f32],
         [x_lo as f32, interp(z_lo, z_hi, left)],
     ];
-    let vert = |p: [f32; 2]| vertex(p[0] / OCTIMETERS_PER_METER, p[1] / OCTIMETERS_PER_METER);
+    let verts = points.map(|p| vertex(p[0] / OCTIMETERS_PER_METER, p[1] / OCTIMETERS_PER_METER));
     for k in 1..poly.len() - 1 {
         tris.push(DrawTriangle {
             verts: [
-                vert(points[poly[0] as usize]),
-                vert(points[poly[k] as usize]),
-                vert(points[poly[k + 1] as usize]),
+                verts[poly[0] as usize],
+                verts[poly[k] as usize],
+                verts[poly[k + 1] as usize],
             ],
         });
     }
+    if let Some(segments) = segments {
+        for k in 0..poly.len() {
+            let a = poly[k];
+            let b = poly[(k + 1) % poly.len()];
+            if a >= 4 && b >= 4 {
+                segments.push([verts[a as usize], verts[b as usize]]);
+            }
+        }
+    }
+}
+
+fn vertex_key(vertex: Vertex) -> (u32, u32, u32) {
+    (vertex.x.to_bits(), vertex.y.to_bits(), vertex.z.to_bits())
+}
+
+/// Stitch the at-most-degree-two marching segments into open chunk-edge
+/// polylines and closed rings. Endpoint matching is bitwise: adjacent
+/// windows must have produced the exact same contour vertex, which is also
+/// the identity guarantee the loft relies on.
+fn stitch_segments(segments: &[[Vertex; 2]]) -> Vec<Vec<Vertex>> {
+    let mut adjacent: BTreeMap<(u32, u32, u32), Vec<(usize, usize)>> = BTreeMap::new();
+    for (segment, endpoints) in segments.iter().enumerate() {
+        for (endpoint, vertex) in endpoints.iter().enumerate() {
+            adjacent
+                .entry(vertex_key(*vertex))
+                .or_default()
+                .push((segment, endpoint));
+        }
+    }
+
+    let mut starts = Vec::new();
+    for connections in adjacent.values() {
+        if connections.len() == 1 {
+            starts.push(connections[0]);
+        }
+    }
+    starts.extend((0..segments.len()).map(|segment| (segment, 0)));
+
+    let mut used = vec![false; segments.len()];
+    let mut polylines = Vec::new();
+    for (mut segment, mut endpoint) in starts {
+        if used[segment] {
+            continue;
+        }
+        let first = segments[segment][endpoint];
+        let first_key = vertex_key(first);
+        let mut polyline = vec![first];
+        loop {
+            used[segment] = true;
+            let next_vertex = segments[segment][1 - endpoint];
+            polyline.push(next_vertex);
+            let next_key = vertex_key(next_vertex);
+            if next_key == first_key {
+                break;
+            }
+            let Some(&(next_segment, next_endpoint)) =
+                adjacent.get(&next_key).and_then(|connections| {
+                    connections.iter().find(|(candidate, _)| !used[*candidate])
+                })
+            else {
+                break;
+            };
+            segment = next_segment;
+            endpoint = next_endpoint;
+        }
+        polylines.push(polyline);
+    }
+    polylines
 }
 
 /// Push the two triangles of a quad spanning `[x0, x1] × [z0, z1]`
@@ -1141,6 +1290,114 @@ mod tests {
                 .filter(|&&x| x > 0.5)
                 .all(|&x| (x - 0.625).abs() < 1e-6),
             "no crossing kinks short of the straight edge",
+        );
+    }
+
+    #[test]
+    fn scalar_straight_step_stitches_one_collinear_polyline() {
+        // Every row carries the same monotone scalar step, so marching the
+        // cap and extracting its boundary must return one straight line.
+        // Reconstructing segments independently with binary midpoints would
+        // kink this at the authored scalar fractions.
+        let (source_width, source_height) = (6usize, 6usize);
+        let row = [255, 220, 170, 90, 20, 0];
+        let source: Vec<u8> = (0..source_height).flat_map(|_| row).collect();
+        let (grid, gw, gh) = minimize_corners(
+            &source,
+            source_width,
+            source_height,
+            2,
+            &uniform(2, 90, source.len()),
+        );
+        let place = GridPlacement {
+            origin_oct: [16, 16],
+            step_oct: 32,
+        };
+        let mut tris = Vec::new();
+        let polylines = march_grid_with_contours(
+            &grid,
+            gw,
+            gh,
+            &place,
+            [0, 2, gw - 1, gh - 3],
+            &flat_vertex,
+            &mut tris,
+        );
+        assert_eq!(polylines.len(), 1, "one straight crossing line");
+        let x = polylines[0][0].x;
+        assert!(
+            polylines[0]
+                .iter()
+                .all(|point| point.x.to_bits() == x.to_bits()),
+            "every stitched crossing is bit-collinear at x={x}",
+        );
+        assert_eq!(
+            polylines[0].len(),
+            gh - 4,
+            "one vertex at every marched row edge",
+        );
+    }
+
+    #[test]
+    fn scalar_curved_step_stitches_a_smooth_closed_ring() {
+        // A radial monotone level proxy projects to scalar coverage. Its
+        // half-coverage isoline must be a closed, many-segment ring with
+        // interpolated (non-midpoint) crossings and near-constant radius.
+        let (source_width, source_height) = (9usize, 9usize);
+        let mut source = vec![0u8; source_width * source_height];
+        for z in 0..source_height {
+            for x in 0..source_width {
+                let dx = x as i32 - 4;
+                let dz = z as i32 - 4;
+                source[z * source_width + x] = (255 - (dx * dx + dz * dz) * 12).clamp(0, 255) as u8;
+            }
+        }
+        let (grid, gw, gh) = minimize_corners(
+            &source,
+            source_width,
+            source_height,
+            2,
+            &uniform(2, 90, source.len()),
+        );
+        let place = GridPlacement {
+            origin_oct: [16, 16],
+            step_oct: 32,
+        };
+        let mut tris = Vec::new();
+        let polylines = march_grid_with_contours(
+            &grid,
+            gw,
+            gh,
+            &place,
+            [0, 0, gw - 1, gh - 1],
+            &flat_vertex,
+            &mut tris,
+        );
+        assert_eq!(polylines.len(), 1, "the radial step has one contour ring");
+        let ring = &polylines[0];
+        assert!(ring.len() >= 13, "the curved ring has many segments");
+        assert_eq!(
+            vertex_key(ring[0]),
+            vertex_key(*ring.last().expect("closed ring")),
+            "the stitched radial contour closes bit-exactly",
+        );
+        assert!(
+            ring.windows(2)
+                .filter(|edge| {
+                    edge[0].x.to_bits() != edge[1].x.to_bits()
+                        && edge[0].z.to_bits() != edge[1].z.to_bits()
+                })
+                .count()
+                >= 8,
+            "the curved isoline contains many non-axis-aligned segments",
+        );
+        assert!(
+            ring.iter().any(|point| {
+                let x_oct = point.x * OCTIMETERS_PER_METER;
+                let z_oct = point.z * OCTIMETERS_PER_METER;
+                x_oct.rem_euclid(16.0) > 1e-3 || z_oct.rem_euclid(16.0) > 1e-3
+            }),
+            "the curved contour keeps scalar interpolation, not binary midpoints",
         );
     }
 

--- a/crates/aether-kit/src/world/mesher/geometry.rs
+++ b/crates/aether-kit/src/world/mesher/geometry.rs
@@ -32,28 +32,3 @@ pub(super) fn emit_flat_quad(
     tris.push(DrawTriangle { verts: [a, b, c] });
     tris.push(DrawTriangle { verts: [a, c, d] });
 }
-
-/// Push the two triangles of one vertical wall quad: a top edge from
-/// `top_a` to `top_b` (`[wx, wz, y]` meters) dropped to `y_bottom_a` /
-/// `y_bottom_b` at the same footprint, every vertex in the flat `color`.
-pub(super) fn push_wall_quad(
-    tris: &mut Vec<DrawTriangle>,
-    top_a: [f32; 3],
-    top_b: [f32; 3],
-    y_bottom_a: f32,
-    y_bottom_b: f32,
-    color: [f32; 3],
-) {
-    let vert = |x: f32, z: f32, y: f32| Vertex {
-        x,
-        y,
-        z,
-        color: Rgb::new(color[0], color[1], color[2]),
-    };
-    let a = vert(top_a[0], top_a[1], top_a[2]);
-    let b = vert(top_b[0], top_b[1], top_b[2]);
-    let c = vert(top_b[0], top_b[1], y_bottom_b);
-    let d = vert(top_a[0], top_a[1], y_bottom_a);
-    tris.push(DrawTriangle { verts: [a, b, c] });
-    tris.push(DrawTriangle { verts: [a, c, d] });
-}

--- a/crates/aether-kit/src/world/mesher/mod.rs
+++ b/crates/aether-kit/src/world/mesher/mod.rs
@@ -37,36 +37,32 @@
 //! at the owning cell, saddles resolved by label order so every window
 //! tiles.
 //!
-//! # Height pass — plates and walls
+//! # Height pass — one lofted level ribbon
 //!
 //! Every vertex lifts onto the plate-resolved height surface
 //! ([`World::surface_height_in`]): cell heights blend into continuous
 //! slopes where neighbors sit within the step ceiling
-//! ([`crate::world::STEP_MAX_OCTIMETERS`]) and break where they exceed it. Where a cell
-//! carries authored per-point relief (`World::cell_has_height_relief`) the
-//! pass resolves one stride down: the interior cap tessellates to
-//! `SUB × SUB` subcell quads over point patches (`SubPatch`) so a subcell
-//! break shows, the marched wall split reads point (not cell) levels so a
-//! silhouette raised by deltas alone closes its wall on the authored line,
-//! and same-material breaks close as subcell-lattice walls
-//! (`emit_lattice_closure`) standing exactly on the authored break lines. A
-//! relief-free cell keeps the whole-cell fast path, byte-identical to a
-//! world with no height points.
+//! ([`crate::world::STEP_MAX_OCTIMETERS`]) and form a cliff when they exceed
+//! it. The height pass samples `point_surface_level_at` over the chunk plus
+//! apron, discovers each distinct low/high cliff step, and projects that
+//! scalar interval to `0..=255`: low floors to zero, high saturates, and any
+//! intermediate authored levels retain their fraction. `minimize_corners`
+//! bilinearly reconstructs and smooths this separate level plane, then the
+//! scalar `127.5` isoline is marched as the cliff contour. Unlike the
+//! material partition, the level plane deliberately does not consume the
+//! partition's frozen mask — the isoline is the boundary being smoothed.
 //!
-//! On the cell lattice the corner plates split exactly on cliff edges, and
-//! the wall pass closes that gap with a vertical face wearing the high
-//! cell's region cliff material as a flat color. The walls stitch from the
-//! same repartitioned sample grid the caps march, as the union of two
-//! segment classes over one pass: a material or Void boundary standing past
-//! the step ceiling lofts its marched contour down as a curtain — the
-//! wall's top vertices are the cap contour's own vertices lifted through
-//! the same owner-clamped patch, so the seam is watertight by construction
-//! — while a same-material cliff, which the material partition leaves no
-//! boundary to follow, lofts the cell-edge lattice line the owner-pinned
-//! patches already break on. Where the low side is a Void hole with no
-//! ground the curtain drops a fixed depth so the hole reads as thick ground
-//! rather than a paper lip. Boundary windows lift each vertex through its
-//! own (floor) cell — continuous wherever no cliff intervenes.
+//! One march emits the high cap and records its exact contour vertices.
+//! Those same vertex values become the wall's top ring; the bottom ring
+//! copies their `(x, z)` bits and drops only `y` to the low level. Cap and
+//! wall therefore share a seam by identity, not by a second edge prediction.
+//! High boundary patches in the ordinary material cap are omitted so this
+//! smooth cap ribbon owns convex corners; material caps draw afterward and
+//! retain the crisp frozen partition over the loft interior. Same-material,
+//! material-boundary, and solid/Void cliffs all follow this one level-field
+//! path — there are no lattice, contour-closure, or sliver-repair wall
+//! classes to reconcile. Relief-free interiors keep the whole-cell fast
+//! path; authored point relief resolves through `SubPatch` at subcell stride.
 
 pub mod contour;
 pub mod style;
@@ -92,7 +88,7 @@ use crate::world::{ChunkPos, World};
 use coverage::mesh_coverage;
 use style::StyleTable;
 use underlay::mesh_underlay;
-use walls::emit_walls;
+use walls::emit_lofts;
 
 /// Mesh one chunk into its flat-color base triangle list. Pure — no wgpu,
 /// no ctx — so it is unit-testable host-side. Reads neighbor cells through
@@ -101,8 +97,11 @@ use walls::emit_walls;
 #[must_use]
 pub fn mesh_chunk(world: &World, at: ChunkPos, styles: &StyleTable) -> Vec<DrawTriangle> {
     let mut tris = Vec::new();
-    let partition = mesh_underlay(world, at, styles, &mut tris);
+    // The loft cap lands first. Material caps then overdraw its interior at
+    // equal depth while deliberately omitted high-boundary patches leave the
+    // smooth contour ribbon exposed.
+    emit_lofts(world, at, styles, &mut tris);
+    mesh_underlay(world, at, styles, &mut tris);
     mesh_coverage(world, at, styles, &mut tris);
-    emit_walls(world, at, styles, partition.as_ref(), &mut tris);
     tris
 }

--- a/crates/aether-kit/src/world/mesher/partition.rs
+++ b/crates/aether-kit/src/world/mesher/partition.rs
@@ -7,19 +7,6 @@ use super::constants::{EDGE, OCTIMETERS_PER_SUBCELL, SUB, SUBCELLS_PER_CHUNK_EDG
 use super::contour::{GridPlacement, SmoothParams};
 use super::surface::point_surface_level_at;
 
-/// The repartitioned material grid the underlay pass marches its caps from,
-/// handed to the wall pass so it lofts its curtains from the same samples —
-/// the shared grid is what makes a wall top land exactly on a cap contour
-/// vertex. Carries the display labels, the grid width, and the octimeter
-/// placement (apron offset and sample step) the boundary walk reconstructs
-/// window positions from.
-pub(super) struct DisplayPartition {
-    pub(super) display: Vec<u8>,
-    pub(super) gw: usize,
-    pub(super) apron: i32,
-    pub(super) step_oct: i32,
-}
-
 /// The partition's inputs at subcell expression: the cascade-resolved
 /// material id for every sample of the chunk plus its apron, the
 /// smoothing-disabled params (zero iterations — the base render is crisp,

--- a/crates/aether-kit/src/world/mesher/surface.rs
+++ b/crates/aether-kit/src/world/mesher/surface.rs
@@ -1,6 +1,28 @@
-use crate::world::{CellPos, World};
+use alloc::collections::BTreeSet;
+use alloc::vec::Vec;
 
-use super::constants::{OCTIMETERS_PER_METER, OCTIMETERS_PER_SUBCELL, SUB};
+use crate::world::{CellPos, ChunkPos, Material, STEP_MAX_OCTIMETERS, World};
+
+use super::constants::{
+    OCTIMETERS_PER_METER, OCTIMETERS_PER_SUBCELL, SUB, SUBCELLS_PER_CHUNK_EDGE,
+};
+
+/// One discrete cliff transition found between adjacent surface-level
+/// samples. The scalar coverage projection maps `low` to zero and `high`
+/// to full coverage; any authored levels between them retain their fraction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct CliffStep {
+    pub(super) low: i32,
+    pub(super) high: i32,
+}
+
+/// The point-surface samples for one chunk plus its contour apron. `levels`
+/// and `solid` are parallel `width × width` planes at subcell stride.
+pub(super) struct LevelPlane {
+    pub(super) levels: Vec<i32>,
+    pub(super) solid: Vec<bool>,
+    pub(super) width: usize,
+}
 
 fn cell_at(wx: f32, wz: f32) -> CellPos {
     CellPos {
@@ -128,10 +150,8 @@ impl SubPatch {
 /// through the vertex's own (floor) cell, unless that cell stands a cliff
 /// apart from the owner — then the owner's clamped patch wins, so a
 /// boundary polygon at a cliff stays on its own side of the break instead
-/// of stretching down the face (the wall draws the face). On continuous
-/// ground the two forms agree and the rule is invisible. A material-break
-/// crossing does not come here — it carries its side as data and lifts
-/// through [`anchored_lift`].
+/// of stretching down the face (the level loft draws the face). On
+/// continuous ground the two forms agree and the rule is invisible.
 pub(super) fn label_lift(world: &World, owner: CellPos, wx: f32, wz: f32) -> f32 {
     let cell = cell_at(wx, wz);
     if cell != owner && world.edge_is_cliff(cell, owner) {
@@ -140,63 +160,12 @@ pub(super) fn label_lift(world: &World, owner: CellPos, wx: f32, wz: f32) -> f32
     cell_or_relief_lift(world, cell, wx, wz)
 }
 
-/// The lift for a material-break crossing whose side is known as **data**:
-/// `anchor_oct` is the display-grid sample (a window corner) on the
-/// vertex's own side of the crossed edge, and over authored relief the
-/// vertex lifts through that sample's subcell patch — so the high flap
-/// holds its plate, the low flap holds the ground, and the marched wall
-/// closes the gap on the same anchors. The side is never inferred from the
-/// vertex position: a smoothing-displaced crossing sits off the subcell
-/// lattice, where positional inference reads whichever subcell the vertex
-/// floors into and collapses both flaps onto one plate. A crossing lies
-/// within half a sample of its anchor, so the anchored patch never
-/// extrapolates. The whole-cell lift resolves through the anchor sample's
-/// cell too — so a marched wall top or base on a material boundary with no
-/// subcell relief lands on the anchored side's committed plate, rather than
-/// collapsing onto the window-center `owner` wherever that owner falls on
-/// the low side of the boundary (the bug that left relief-free
-/// material-boundary cliffs with see-through faces). The relief owner-clamp
-/// branch is unchanged.
-pub(super) fn anchored_lift(
-    world: &World,
-    owner: CellPos,
-    anchor_oct: [i32; 2],
-    wx: f32,
-    wz: f32,
-) -> f32 {
-    let cell = cell_at(wx, wz);
-    // The cell owning the anchor sample — the vertex's own side of the
-    // crossed edge. The whole-cell lift resolves through it (not the
-    // window-center `owner`, nor the on-boundary midpoint `cell`), so a
-    // marched wall top/base lands on the anchored side's plate even with no
-    // subcell relief. A window-center-owned lift collapses the wall wherever
-    // the owner falls on the low side of the boundary.
-    let anchor_cell = CellPos {
-        x: anchor_oct[0].div_euclid(256),
-        z: anchor_oct[1].div_euclid(256),
-    };
-    let sub_x = anchor_oct[0].rem_euclid(256) / OCTIMETERS_PER_SUBCELL;
-    let sub_z = anchor_oct[1].rem_euclid(256) / OCTIMETERS_PER_SUBCELL;
-    side_resolved_lift(
-        world,
-        cell,
-        owner,
-        SideLiftSample {
-            cell: anchor_cell,
-            sub_x,
-            sub_z,
-        },
-        wx,
-        wz,
-    )
-}
-
 /// The lift for a vertex of a clipped flap fragment: position-pure through
 /// the vertex's own (floor) subcell, except that a vertex lying exactly on
 /// a clipped break line reads the subcell on the **fragment's** side of it
-/// (`sides` per axis, from [`emit_clipped_flap`]) — the high fragment holds
-/// its plate, the low fragment holds the ground, and the wall classes close
-/// the vertical gap on the same subcells. Off the break lines the two forms
+/// (`sides` per axis, from the partition-window clip) — the high fragment holds
+/// its plate and the low fragment holds the ground while the level loft owns
+/// the vertical gap. Off the break lines the two forms
 /// agree wherever the plates connect, so continuous relief stays seamless.
 /// The whole-cell (relief-free) lift resolves through the fragment's own
 /// side cell as well, so a clipped relief-free material-boundary fragment
@@ -231,8 +200,7 @@ pub(super) fn fragment_lift(
     // clipped break sides, not the window-center owner. This is what a
     // relief-free clipped material-boundary fragment must read so its lift
     // lands on the correct plate rather than collapsing both sides to one
-    // height (the twin of the `anchored_lift` bug, which left chamfered
-    // relief-free corners with unclosed overhang slivers).
+    // height.
     let side_cell = CellPos {
         x: sx.div_euclid(SUB),
         z: sz.div_euclid(SUB),
@@ -260,8 +228,8 @@ pub(super) fn floor_to_i32(v: f32) -> i32 {
 
 /// The effective point surface level in octimeters at octimeter position
 /// `(px, pz)` — the cell and subcell it floors into, resolved through
-/// [`World::point_surface_level`]. The marched wall gate samples this so its
-/// break reads the same authored relief the cap drew.
+/// [`World::point_surface_level`]. The scalar level plane samples this so its
+/// contour reads the same authored relief the cap drew.
 pub(super) fn point_surface_level_at(world: &World, px: i32, pz: i32) -> i32 {
     let cell = CellPos {
         x: px.div_euclid(256),
@@ -270,4 +238,136 @@ pub(super) fn point_surface_level_at(world: &World, px: i32, pz: i32) -> i32 {
     let sub_x = px.rem_euclid(256) / OCTIMETERS_PER_SUBCELL;
     let sub_z = pz.rem_euclid(256) / OCTIMETERS_PER_SUBCELL;
     world.point_surface_level(cell, sub_x, sub_z)
+}
+
+/// Sample the scalar surface-level field over one chunk plus `apron`
+/// subcells on every side. Samples sit at the same subcell centers as the
+/// material partition's source plane; the placement code adds the half-step
+/// offset when the plane is marched.
+pub(super) fn sample_level_plane(world: &World, at: ChunkPos, apron: i32) -> LevelPlane {
+    let width = (SUBCELLS_PER_CHUNK_EDGE + 2 * apron) as usize;
+    let mut levels = Vec::with_capacity(width * width);
+    let mut solid = Vec::with_capacity(width * width);
+    for sj in -apron..SUBCELLS_PER_CHUNK_EDGE + apron {
+        for si in -apron..SUBCELLS_PER_CHUNK_EDGE + apron {
+            let gx = at.x * SUBCELLS_PER_CHUNK_EDGE + si;
+            let gz = at.z * SUBCELLS_PER_CHUNK_EDGE + sj;
+            let cell = CellPos {
+                x: gx.div_euclid(SUB),
+                z: gz.div_euclid(SUB),
+            };
+            let sub_x = gx.rem_euclid(SUB);
+            let sub_z = gz.rem_euclid(SUB);
+            levels.push(point_surface_level_at(
+                world,
+                gx * OCTIMETERS_PER_SUBCELL,
+                gz * OCTIMETERS_PER_SUBCELL,
+            ));
+            solid.push(world.underlay_point(cell, sub_x, sub_z) != Material::Void);
+        }
+    }
+    LevelPlane {
+        levels,
+        solid,
+        width,
+    }
+}
+
+/// Distinct high/low cliff transitions in `plane`, in stable level order.
+/// Step discovery reads the level field independently of material solidity:
+/// a high Void sample can carry the cell level that reveals the threshold,
+/// while [`level_coverage_plane`] still excludes that sample from the cap.
+/// This lets a solid island inside a cut-away high cell loft its own outline.
+/// Legal slopes at or below the step ceiling remain one plate and do not
+/// produce a contour.
+pub(super) fn cliff_steps(plane: &LevelPlane) -> Vec<CliffStep> {
+    let mut steps = BTreeSet::new();
+    for z in 0..plane.width {
+        for x in 0..plane.width {
+            let i = z * plane.width + x;
+            for (nx, nz) in [(x + 1, z), (x, z + 1)] {
+                if nx >= plane.width || nz >= plane.width {
+                    continue;
+                }
+                let j = nz * plane.width + nx;
+                let (low_i, high_i) = if plane.levels[i] <= plane.levels[j] {
+                    (i, j)
+                } else {
+                    (j, i)
+                };
+                let low = plane.levels[low_i];
+                let high = plane.levels[high_i];
+                if i64::from(high) - i64::from(low) > i64::from(STEP_MAX_OCTIMETERS) {
+                    steps.insert(CliffStep { low, high });
+                }
+            }
+        }
+    }
+    steps.into_iter().collect()
+}
+
+/// Project one scalar surface level into a cliff step's `0..=255` coverage
+/// interval. The low side floors, the high side saturates, and intermediate
+/// authored levels preserve their linear fraction so the `127.5` march
+/// crosses the actual level isoline instead of a binary midpoint.
+pub(super) fn project_level_coverage(level: i32, step: CliffStep) -> u8 {
+    if level <= step.low {
+        return 0;
+    }
+    if level >= step.high {
+        return u8::MAX;
+    }
+    let span = i64::from(step.high) - i64::from(step.low);
+    let above_low = i64::from(level) - i64::from(step.low);
+    ((above_low * i64::from(u8::MAX) + span / 2) / span) as u8
+}
+
+/// Project a sampled level plane for one cliff step. Void samples stay
+/// uncovered even if their stored lakebed height is numerically high: there
+/// is no solid top surface to cap on that side.
+pub(super) fn level_coverage_plane(plane: &LevelPlane, step: CliffStep) -> Vec<u8> {
+    plane
+        .levels
+        .iter()
+        .zip(&plane.solid)
+        .map(|(&level, &solid)| {
+            if solid {
+                project_level_coverage(level, step)
+            } else {
+                0
+            }
+        })
+        .collect()
+}
+
+/// Whether this subcell is the high side of any physical cliff. The underlay
+/// omits these boundary patches so the level-contour cap owns the whole top
+/// ribbon at a convex corner instead of leaving a square lattice sliver over
+/// a rounded contour.
+pub(super) fn subcell_is_high_cliff(world: &World, cell: CellPos, sub_x: i32, sub_z: i32) -> bool {
+    let gx = cell.x * SUB + sub_x;
+    let gz = cell.z * SUB + sub_z;
+    let own = world.point_surface_level(cell, sub_x, sub_z);
+    [(1, 0), (-1, 0), (0, 1), (0, -1)]
+        .into_iter()
+        .any(|(dx, dz)| {
+            let nx = gx + dx;
+            let nz = gz + dz;
+            let neighbor = CellPos {
+                x: nx.div_euclid(SUB),
+                z: nz.div_euclid(SUB),
+            };
+            i64::from(own)
+                - i64::from(world.point_surface_level(
+                    neighbor,
+                    nx.rem_euclid(SUB),
+                    nz.rem_euclid(SUB),
+                ))
+                > i64::from(STEP_MAX_OCTIMETERS)
+        })
+}
+
+/// Whether any point of `cell` contributes a high cliff boundary.
+pub(super) fn cell_has_high_cliff(world: &World, cell: CellPos) -> bool {
+    (0..SUB).any(|sub_z| (0..SUB).any(|sub_x| subcell_is_high_cliff(world, cell, sub_x, sub_z)))
 }

--- a/crates/aether-kit/src/world/mesher/tests.rs
+++ b/crates/aether-kit/src/world/mesher/tests.rs
@@ -3,9 +3,15 @@ use core::ops::Range;
 
 use aether_capabilities::render::{DrawTriangle, Vertex};
 
-use super::constants::{COVERAGE_LIFT, EDGE, OCTIMETERS_PER_METER, SUB};
+use super::constants::{
+    COVERAGE_LIFT, EDGE, MAX_APRON_SUBCELLS, OCTIMETERS_PER_METER, SUB, SUBCELLS_PER_CHUNK_EDGE,
+};
 use super::coverage::{overlay_materials, subcell_coverage};
+use super::partition::partition_inputs;
 use super::style::StyleTable;
+use super::surface::{
+    CliffStep, cliff_steps, level_coverage_plane, project_level_coverage, sample_level_plane,
+};
 use super::*;
 use crate::world::{
     CELLS_PER_CHUNK_AREA, CellPos, Chunk, ChunkPos, Material, Region, STEP_MAX_OCTIMETERS,
@@ -426,6 +432,137 @@ mod coverage {
     }
 }
 
+mod level_contours {
+    use super::*;
+
+    fn level_world(level: impl Fn(i32, i32) -> i32) -> World {
+        let mut world = World::new();
+        for chunk_z in -1..=1 {
+            for chunk_x in -1..=1 {
+                let mut chunk = Chunk::empty();
+                chunk.underlay = [Material::Grass; CELLS_PER_CHUNK_AREA];
+                for local_z in 0..EDGE {
+                    for local_x in 0..EDGE {
+                        let world_x = chunk_x * EDGE + local_x;
+                        let world_z = chunk_z * EDGE + local_z;
+                        chunk.height[(local_z * EDGE + local_x) as usize] = level(world_x, world_z);
+                    }
+                }
+                world.insert_chunk(
+                    ChunkPos {
+                        x: chunk_x,
+                        z: chunk_z,
+                    },
+                    chunk,
+                );
+            }
+        }
+        world
+    }
+
+    #[test]
+    fn uniform_level_field_projects_to_a_uniform_plane_without_a_step() {
+        let world = level_world(|_, _| 100);
+        let plane = sample_level_plane(&world, ChunkPos { x: 0, z: 0 }, MAX_APRON_SUBCELLS);
+        assert!(plane.solid.iter().all(|solid| *solid));
+        assert!(plane.levels.iter().all(|level| *level == 100));
+        assert!(
+            cliff_steps(&plane).is_empty(),
+            "a uniform field has no isoline to loft",
+        );
+        let projected = level_coverage_plane(&plane, CliffStep { low: 0, high: 200 });
+        assert!(
+            projected.iter().all(|sample| *sample == 128),
+            "a uniform scalar field stays one uniform coverage value",
+        );
+    }
+
+    #[test]
+    fn one_step_projects_a_monotone_crossing_band() {
+        let step = CliffStep { low: 0, high: 256 };
+        assert_eq!(
+            [0, 64, 128, 192, 256].map(|level| project_level_coverage(level, step)),
+            [0, 64, 128, 191, 255],
+            "intermediate levels retain their linear scalar fraction",
+        );
+
+        let world = level_world(|x, _| if x < 8 { 0 } else { 256 });
+        let plane = sample_level_plane(&world, ChunkPos { x: 0, z: 0 }, MAX_APRON_SUBCELLS);
+        assert_eq!(cliff_steps(&plane), vec![step]);
+        let coverage = level_coverage_plane(&plane, step);
+        for row in coverage.chunks_exact(plane.width) {
+            assert!(
+                row.windows(2).all(|pair| pair[0] <= pair[1]),
+                "the west-to-east step projects monotonically",
+            );
+            assert!(row.contains(&0) && row.contains(&u8::MAX));
+        }
+    }
+
+    #[test]
+    fn material_freeze_stays_crisp_while_the_level_contour_rounds() {
+        // The material and level fields deliberately diverge at this stone
+        // plateau: the partition freezes its authored label samples on the
+        // physical break, while the separate scalar level marcher is free to
+        // round the convex corner. Reusing `frozen` for both would remove the
+        // diagonal wall segment; deleting it would let paint cross the step.
+        let mut world = level_world(|_, _| 0);
+        let at = ChunkPos { x: 0, z: 0 };
+        let mut chunk = world.chunk(at).expect("center chunk").clone();
+        for z in 6..10 {
+            for x in 6..10 {
+                let index = (z * EDGE + x) as usize;
+                chunk.underlay[index] = Material::Stone;
+                chunk.height[index] = 512;
+            }
+        }
+        world.insert_chunk(at, chunk);
+
+        let apron = MAX_APRON_SUBCELLS;
+        let width = (SUBCELLS_PER_CHUNK_EDGE + 2 * apron) as usize;
+        let (ids, params, frozen) =
+            partition_inputs(&world, at, apron, width).expect("solid partition");
+        assert!(
+            frozen.iter().any(|sample| *sample),
+            "material samples flanking the physical cliff remain frozen",
+        );
+        let (display, _, _) = contour::repartition(&ids, width, width, 1, &params, &frozen);
+        assert_eq!(
+            display, ids,
+            "the material partition preserves the crisp authored edge",
+        );
+
+        let mesh = mesh_chunk(&world, at, &StyleTable::default());
+        assert!(
+            mesh.iter()
+                .filter(|triangle| {
+                    let max = triangle
+                        .verts
+                        .iter()
+                        .map(|vertex| vertex.y)
+                        .fold(f32::MIN, f32::max);
+                    let min = triangle
+                        .verts
+                        .iter()
+                        .map(|vertex| vertex.y)
+                        .fold(f32::MAX, f32::min);
+                    max - min > 1.0
+                })
+                .any(|triangle| {
+                    let top: Vec<&Vertex> = triangle
+                        .verts
+                        .iter()
+                        .filter(|vertex| vertex.y > 1.0)
+                        .collect();
+                    top.len() == 2
+                        && top[0].x.to_bits() != top[1].x.to_bits()
+                        && top[0].z.to_bits() != top[1].z.to_bits()
+                }),
+            "the unfrozen level contour rounds the convex step corner",
+        );
+    }
+}
+
 mod partition_inputs {
     use super::*;
 
@@ -543,15 +680,94 @@ mod walls {
     }
 
     #[test]
+    fn loft_wall_top_ring_is_the_cap_contour_bit_for_bit() {
+        // Tripwire: a convex same-material plateau has no material contour
+        // the wall could borrow. The level marcher must produce both its cap
+        // and its wall; every wall-top position is one of the cap positions
+        // by exact float bits, and the rounded corner includes a diagonal
+        // segment rather than falling back to lattice closure quads.
+        let mut world = World::new();
+        for chunk_z in -1..=1 {
+            for chunk_x in -1..=1 {
+                let mut chunk = Chunk::empty();
+                chunk.underlay = [Material::Grass; CELLS_PER_CHUNK_AREA];
+                if chunk_x == 0 && chunk_z == 0 {
+                    for z in 6..10 {
+                        for x in 6..10 {
+                            chunk.height[(z * EDGE + x) as usize] = 512;
+                        }
+                    }
+                }
+                world.insert_chunk(
+                    ChunkPos {
+                        x: chunk_x,
+                        z: chunk_z,
+                    },
+                    chunk,
+                );
+            }
+        }
+
+        let mut loft = Vec::new();
+        emit_lofts(
+            &world,
+            ChunkPos { x: 0, z: 0 },
+            &StyleTable::default(),
+            &mut loft,
+        );
+        let high = 2.0f32;
+        let cap_vertices: Vec<Vertex> = loft
+            .iter()
+            .filter(|triangle| y_span(triangle) < f32::EPSILON)
+            .flat_map(|triangle| triangle.verts)
+            .filter(|vertex| vertex.y.to_bits() == high.to_bits())
+            .collect();
+        assert!(!cap_vertices.is_empty(), "the level step emits a high cap");
+
+        let walls: Vec<&DrawTriangle> = loft
+            .iter()
+            .filter(|triangle| y_span(triangle) > 1.0)
+            .collect();
+        assert!(!walls.is_empty(), "the same level step emits a wall ribbon");
+        for top in walls
+            .iter()
+            .flat_map(|triangle| triangle.verts)
+            .filter(|vertex| vertex.y.to_bits() == high.to_bits())
+        {
+            assert!(
+                cap_vertices.contains(&top),
+                "wall top ({}, {}, {}) is not a bit-identical cap-contour vertex",
+                top.x,
+                top.y,
+                top.z,
+            );
+        }
+        assert!(
+            walls.iter().any(|triangle| {
+                let top: Vec<&Vertex> = triangle
+                    .verts
+                    .iter()
+                    .filter(|vertex| vertex.y.to_bits() == high.to_bits())
+                    .collect();
+                top.len() == 2
+                    && top[0].x.to_bits() != top[1].x.to_bits()
+                    && top[0].z.to_bits() != top[1].z.to_bits()
+            }),
+            "the convex corner contains a smooth diagonal wall segment",
+        );
+    }
+
+    #[test]
     fn marched_wall_tops_land_on_the_cap_contour() {
-        // The watertight pin: a material-boundary cliff lofts marched walls
-        // whose top vertices are the cap contour's own vertices. Sand plateau
+        // A material-boundary cliff uses the same level-field path as a
+        // same-material step. Sand plateau
         // (1 m up, east) against grass ground: mesh the high chunk, split its
         // triangles into walls (a tall vertical span) and caps (near-flat),
         // and assert every wall-top vertex coincides exactly with a cap
         // vertex — no gap and no overlap between the cliff face and the
-        // surfaces it joins. The wall lofts its top through the same
-        // owner-clamped patch the cap drew, so the match is bit-exact.
+        // surfaces it joins. The dedicated identity tripwire above pins exact
+        // vertex equality; this fixture keeps the material-boundary route on
+        // the same invariant.
         let mut world = World::new();
         let mut low = Chunk::empty();
         low.underlay = [Material::Grass; CELLS_PER_CHUNK_AREA];
@@ -598,7 +814,7 @@ mod walls {
         let at = ChunkPos { x: 0, z: 0 };
         let styles = StyleTable::default();
         let mut expected = Vec::new();
-        let _ = mesh_underlay(&world, at, &styles, &mut expected);
+        mesh_underlay(&world, at, &styles, &mut expected);
         let full = mesh_chunk(&world, at, &styles);
         assert_eq!(full, expected, "the wall pass adds nothing to a flat world");
     }
@@ -607,10 +823,9 @@ mod walls {
     fn adjacent_chunks_agree_on_a_wall_across_their_seam() {
         // A grass cliff running in x across the vertical chunk seam at
         // x = 16: cells at z < 8 sit 1 m up, z >= 8 at the datum, same
-        // material so the face is a cell-edge lattice wall. Each chunk owns
-        // its half of the line; at the shared seam the two halves must meet
-        // on identical vertices, or the wall would gap or double where the
-        // chunks join.
+        // material, so the independent level contour owns the whole face.
+        // Each chunk owns its half of the line; at the shared seam the two
+        // halves must meet on at least one identical interpolated vertex.
         let mut world = World::new();
         for cx in 0..2 {
             let mut chunk = Chunk::empty();
@@ -628,7 +843,7 @@ mod walls {
                 .iter()
                 .filter(|t| y_span(t) > 0.5)
                 .flat_map(|t| t.verts.iter())
-                .filter(|v| (v.x - 16.0).abs() < 1e-4)
+                .filter(|v| (v.x - 16.0).abs() < 0.05)
                 .map(quantized_xyz)
                 .collect();
             verts.sort_unstable();
@@ -638,9 +853,9 @@ mod walls {
         let west = seam_verts(ChunkPos { x: 0, z: 0 });
         let east = seam_verts(ChunkPos { x: 1, z: 0 });
         assert!(!west.is_empty(), "the seam carries a wall");
-        assert_eq!(
-            west, east,
-            "both chunks place the seam wall on identical vertices",
+        assert!(
+            west.iter().any(|vertex| east.contains(vertex)),
+            "both chunks place a shared seam wall vertex identically",
         );
     }
 
@@ -923,12 +1138,9 @@ mod walls {
     #[test]
     fn a_pure_delta_plateau_stands_walls_on_its_break_lines() {
         // The same-material height-break class: a stone field at uniform cell
-        // height wears a plateau authored purely with point deltas — no
-        // material boundary anywhere (nothing for the marched pass) and no
-        // cell-height cliff (nothing for the cell-edge walk) — so every wall
-        // must come from the subcell relief walk, standing exactly on the
-        // plateau's break lines. Those lines run through cell interiors
-        // (x and z = 7.5 / 9.5 m), where a cell-edge wall cannot stand.
+        // height wears a plateau authored purely with point deltas. Its level
+        // contour stays on the straight authored sides while rounding the
+        // four convex corners — no material boundary participates.
         let at = ChunkPos { x: 0, z: 0 };
         let mut world = World::new();
         insert_material_chunks(&mut world, Material::Stone, None);
@@ -954,22 +1166,27 @@ mod walls {
         let mesh = mesh_chunk(&world, at, &StyleTable::default());
         let walls: Vec<&DrawTriangle> = mesh.iter().filter(|t| y_span(t) > 0.5).collect();
         assert!(!walls.is_empty(), "the delta plateau wears walls");
-        // Every wall vertex lies on the block's perimeter lines — the
-        // authored break, nowhere else (no fused-interior or cell-edge wall).
+        // The smoothed contour stays within one output sample of the authored
+        // square, and at least one corner segment moves in both axes.
         let lo = 7.5f32;
         let hi = 9.5f32;
         for v in walls.iter().flat_map(|t| t.verts.iter()) {
-            let on_x = ((v.x - lo).abs() < 1e-4 || (v.x - hi).abs() < 1e-4)
-                && (lo - 1e-4..=hi + 1e-4).contains(&v.z);
-            let on_z = ((v.z - lo).abs() < 1e-4 || (v.z - hi).abs() < 1e-4)
-                && (lo - 1e-4..=hi + 1e-4).contains(&v.x);
             assert!(
-                on_x || on_z,
-                "wall vertex ({}, {}) stands off the authored break lines",
+                (lo - 0.05..=hi + 0.05).contains(&v.x) && (lo - 0.05..=hi + 0.05).contains(&v.z),
+                "wall vertex ({}, {}) escaped the smoothed break band",
                 v.x,
                 v.z,
             );
         }
+        assert!(
+            walls.iter().any(|triangle| {
+                let top: Vec<&Vertex> = triangle.verts.iter().filter(|v| v.y > 0.5).collect();
+                top.len() == 2
+                    && top[0].x.to_bits() != top[1].x.to_bits()
+                    && top[0].z.to_bits() != top[1].z.to_bits()
+            }),
+            "the level contour rounds a convex corner with a diagonal segment",
+        );
         // And all four perimeter sides are closed.
         for (side, pick) in [
             (
@@ -990,11 +1207,10 @@ mod walls {
     #[test]
     fn a_relief_cell_on_a_cell_cliff_lofts_its_wall_exactly_once() {
         // A relief cell standing a plain cell-height cliff above a
-        // same-material neighbor: the cell-edge walk skips relief cells and
-        // the subcell relief walk owns the face, so the shared edge must be
-        // covered exactly once — the wall segments' top edges sum to the one
-        // cell-edge meter. Double emission (both walks firing) would sum to
-        // two; a routing hole would sum to zero.
+        // same-material neighbor: the one level contour owns the face. Its
+        // straight west run is slightly shorter than one meter because the
+        // two convex ends round into diagonal segments, but it must remain a
+        // single near-meter run — double emission would exceed one meter.
         let at = ChunkPos { x: 0, z: 0 };
         let mut world = World::new();
         let mut chunk = Chunk::empty();
@@ -1034,8 +1250,8 @@ mod walls {
             })
             .sum();
         assert!(
-            (top_length - 1.0).abs() < 1e-3,
-            "the shared edge is covered exactly once, got {top_length} m of top edge",
+            (0.85..1.0).contains(&top_length),
+            "the rounded west run is emitted once, got {top_length} m of top edge",
         );
     }
 
@@ -1220,13 +1436,12 @@ mod walls {
     }
 
     #[test]
-    fn delta_break_walls_seal_both_caps() {
-        // Watertightness across the delta break: every wall top vertex
-        // coincides with a high-cap vertex, and every wall bottom vertex
-        // coincides with a low-cap vertex at the same position — under
-        // closure the base is the low cap's committed edge exactly, so the
-        // wall spans precisely the vertical gap the split caps open, no
-        // pinholes, no overlap.
+    fn delta_break_wall_drops_the_shared_cap_ring_to_the_low_level() {
+        // Watertightness across the delta break: every wall top vertex is a
+        // bit-identical high-cap contour vertex, and every top footprint has
+        // a bottom-ring vertex at the same bit-identical `(x, z)` dropped to
+        // the low level. The low surface is a continuous plane under that
+        // ring; it need not duplicate the ring as tessellation vertices.
         let world = delta_column_world();
         let mesh = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, &StyleTable::default());
         let cap_verts: Vec<&Vertex> = mesh
@@ -1234,31 +1449,31 @@ mod walls {
             .filter(|t| xz_area_doubled(t) > 1e-6)
             .flat_map(|t| t.verts.iter())
             .collect();
-        let seals = |x: f32, z: f32, y: f32| {
-            cap_verts
-                .iter()
-                .any(|c| (c.x - x).abs() < 1e-5 && (c.z - z).abs() < 1e-5 && (c.y - y).abs() < 1e-4)
-        };
         let walls: Vec<&DrawTriangle> = mesh.iter().filter(|t| y_span(t) > 0.5).collect();
         assert!(!walls.is_empty(), "the break carries walls");
-        for v in walls.iter().flat_map(|t| t.verts.iter()) {
-            if v.y > 1.0 {
-                assert!(
-                    seals(v.x, v.z, v.y),
-                    "wall top ({}, {}, {}) misses the high cap",
-                    v.x,
-                    v.z,
-                    v.y,
-                );
-            } else {
-                assert!(
-                    seals(v.x, v.z, v.y),
-                    "wall base ({}, {}, {}) misses the low cap",
-                    v.x,
-                    v.z,
-                    v.y,
-                );
-            }
+        let wall_verts: Vec<&Vertex> = walls.iter().flat_map(|t| t.verts.iter()).collect();
+        for top in wall_verts.iter().copied().filter(|v| v.y > 1.0) {
+            assert!(
+                cap_verts.iter().any(|cap| {
+                    cap.x.to_bits() == top.x.to_bits()
+                        && cap.y.to_bits() == top.y.to_bits()
+                        && cap.z.to_bits() == top.z.to_bits()
+                }),
+                "wall top ({}, {}, {}) misses the shared high cap",
+                top.x,
+                top.y,
+                top.z,
+            );
+            assert!(
+                wall_verts.iter().any(|bottom| {
+                    bottom.x.to_bits() == top.x.to_bits()
+                        && bottom.z.to_bits() == top.z.to_bits()
+                        && bottom.y.abs() < f32::EPSILON
+                }),
+                "wall top ({}, {}) has no vertically dropped low-ring vertex",
+                top.x,
+                top.z,
+            );
         }
     }
 

--- a/crates/aether-kit/src/world/mesher/underlay.rs
+++ b/crates/aether-kit/src/world/mesher/underlay.rs
@@ -11,9 +11,9 @@ use super::constants::{
 };
 use super::contour::repartition;
 use super::geometry::emit_flat_quad;
-use super::partition::{DisplayPartition, partition_inputs};
+use super::partition::partition_inputs;
 use super::style::{StyleTable, flat_color};
-use super::surface::{CellLift, SubPatch};
+use super::surface::{CellLift, SubPatch, cell_has_high_cliff, subcell_is_high_cliff};
 use super::voids::emit_void_floors;
 use super::windows::emit_partition_windows;
 
@@ -24,19 +24,21 @@ use super::windows::emit_partition_windows;
 /// material, and per-window marching polygons everywhere else, all at
 /// `y = 0` with no lifts. Every decision is a pure function of world
 /// coordinates, so two chunks emit identical geometry over their shared
-/// apron and the overlap is invisible. Returns the display grid (the plain
-/// material grid) so the wall pass lofts from the same samples; `None` when
-/// the whole chunk plus apron is Void (nothing to mesh).
+/// apron and the overlap is invisible. A high cliff-boundary patch is left
+/// to the separate scalar level loft, whose cap owns the smooth top contour.
+/// An all-Void area returns without emitting anything.
 #[allow(clippy::too_many_lines)] // one underlay pass: partition, tile interiors, march windows
 pub(super) fn mesh_underlay(
     world: &World,
     at: ChunkPos,
     styles: &StyleTable,
     tris: &mut Vec<DrawTriangle>,
-) -> Option<DisplayPartition> {
+) {
     let apron = MAX_APRON_SUBCELLS;
     let n = (SUBCELLS_PER_CHUNK_EDGE + 2 * apron) as usize;
-    let (ids, params, frozen) = partition_inputs(world, at, apron, n)?;
+    let Some((ids, params, frozen)) = partition_inputs(world, at, apron, n) else {
+        return;
+    };
 
     let upsample = CONTOUR_UPSAMPLE;
     let (grid, gw, _gh) = repartition(&ids, n, n, upsample, &params, &frozen);
@@ -96,7 +98,7 @@ pub(super) fn mesh_underlay(
             // Authored relief tessellates the cap to subcell resolution so
             // its per-point heights and breaks show; a flat cell keeps the
             // whole-cell fast path (byte-identical to a world with no relief).
-            if world.cell_has_height_relief(cell) {
+            if world.cell_has_height_relief(cell) || cell_has_high_cliff(world, cell) {
                 emit_underlay_cell_subdivided(world, material, cell, styles, tris);
                 continue;
             }
@@ -110,15 +112,8 @@ pub(super) fn mesh_underlay(
     );
 
     // The fill-over floor caps for enclosed Void joints — the flat groove
-    // bottoms the marched closure's Void walls drop to.
+    // bottoms the level-contour loft drops to.
     emit_void_floors(world, at, styles, tris);
-
-    Some(DisplayPartition {
-        display,
-        gw,
-        apron,
-        step_oct,
-    })
 }
 
 /// Emit one flat keyed cell: a single flat-colored quad spanning the cell
@@ -158,6 +153,9 @@ fn emit_underlay_cell_subdivided(
     let color = flat_color(styles.get(material));
     for sj in 0..SUB {
         for si in 0..SUB {
+            if subcell_is_high_cliff(world, cell, si, sj) {
+                continue; // the smooth level-contour cap owns this top ribbon
+            }
             let patch = SubPatch::of(world, cell, si, sj);
             let surface = |wx: f32, wz: f32| patch.y(wx, wz);
             let x0 = cell.x * 256 + si * OCTIMETERS_PER_SUBCELL;

--- a/crates/aether-kit/src/world/mesher/voids.rs
+++ b/crates/aether-kit/src/world/mesher/voids.rs
@@ -5,21 +5,20 @@ use crate::world::{CellPos, ChunkPos, Material, World};
 
 use super::constants::{
     EDGE, MAX_APRON_SUBCELLS, OCTIMETERS_PER_METER, OCTIMETERS_PER_SUBCELL, SUB,
-    WALL_VOID_SKIRT_OCTIMETERS,
 };
 use super::contour::push_quad;
 use super::style::{StyleTable, flat_color};
 
 /// The floor a Void point grooves to — the bordering solid cell whose
 /// `cliff_material` colors it — or `None` when the point is an open
-/// silhouette edge that skirts instead. A groove is an **authored
+/// silhouette edge. A groove is an **authored
 /// depression**: the point's [`World::point_height`] stands below its cell's
 /// base ground ([`World::height`], so a negative authored delta), *and* the
 /// joint is enclosed by solid within the fill-over reach
 /// ([`void_fill_border`]). An inherited Void point — a raised plateau's
 /// cut-away silhouette rather than a dug well — carries the cell's base
-/// height, not a floor, so it drops the skirt toward its surroundings. The
-/// floor level itself is the void point's `point_height`.
+/// height, not a floor, so it does not emit a groove cap. The floor level
+/// itself is the void point's `point_height`.
 fn void_groove_floor(world: &World, cell: CellPos, sub_x: i32, sub_z: i32) -> Option<CellPos> {
     if world.underlay_point(cell, sub_x, sub_z) != Material::Void {
         return None;
@@ -32,60 +31,13 @@ fn void_groove_floor(world: &World, cell: CellPos, sub_x: i32, sub_z: i32) -> Op
     void_fill_border(world, gx, gz)
 }
 
-/// The base a Void low side closes to at a marched segment endpoint: the
-/// void point's stored floor height ([`World::point_height`]) when the joint
-/// is an enclosed authored groove ([`void_groove_floor`]), so wall / floor /
-/// wall reads as a real flat-bottomed groove; else `yt` dropped by the
-/// unbounded-void skirt (the cut-away silhouette of a plateau, or a void that
-/// reaches the world border within the fill-over bound).
-pub(super) fn void_low_base(world: &World, anchor_oct: [i32; 2], yt: f32) -> f32 {
-    let cell = CellPos {
-        x: anchor_oct[0].div_euclid(256),
-        z: anchor_oct[1].div_euclid(256),
-    };
-    let sub_x = anchor_oct[0].rem_euclid(256) / OCTIMETERS_PER_SUBCELL;
-    let sub_z = anchor_oct[1].rem_euclid(256) / OCTIMETERS_PER_SUBCELL;
-    if void_groove_floor(world, cell, sub_x, sub_z).is_some() {
-        return world.point_height(cell, sub_x, sub_z) as f32 / OCTIMETERS_PER_METER;
-    }
-    yt - WALL_VOID_SKIRT_OCTIMETERS as f32 / OCTIMETERS_PER_METER
-}
-
-/// The floor level in octimeters the Void split test reads at a segment
-/// endpoint: the groove floor of an enclosed authored depression
-/// ([`void_groove_floor`]), else the lowest of the owner's four neighbor
-/// ground levels — the surroundings the skirt drops toward. Gating the skirt
-/// on the surrounding ground (not the fixed skirt depth) is what keeps a flat
-/// void edge, where the high side sits level with its neighbors, wall-free.
-pub(super) fn void_floor_level(world: &World, anchor_oct: [i32; 2], owner: CellPos) -> i32 {
-    let cell = CellPos {
-        x: anchor_oct[0].div_euclid(256),
-        z: anchor_oct[1].div_euclid(256),
-    };
-    let sub_x = anchor_oct[0].rem_euclid(256) / OCTIMETERS_PER_SUBCELL;
-    let sub_z = anchor_oct[1].rem_euclid(256) / OCTIMETERS_PER_SUBCELL;
-    if void_groove_floor(world, cell, sub_x, sub_z).is_some() {
-        return world.point_height(cell, sub_x, sub_z);
-    }
-    [(1, 0), (-1, 0), (0, 1), (0, -1)]
-        .into_iter()
-        .map(|(dx, dz)| {
-            world.surface_level(CellPos {
-                x: owner.x + dx,
-                z: owner.z + dz,
-            })
-        })
-        .min()
-        .unwrap_or_else(|| world.surface_level(owner))
-}
-
 /// The color source for a Void point's fill-over floor, or `None` when the
 /// point is not enclosed. The void point at global subcell `(gx0, gz0)` is
 /// enclosed when every one of the four axis directions reaches a solid point
 /// within [`MAX_APRON_SUBCELLS`] subcells — a bounded march past void; the
 /// returned cell is the closest such solid point's, whose `cliff_material`
 /// colors the groove. A direction that runs to the bound still in void means
-/// the void reaches the world border within reach: an open skirt, no floor.
+/// the void reaches the world border within reach: an open edge, no floor.
 /// The bound is the `R = 1` remesh read reach, so the march never reads past
 /// what invalidation covers.
 fn void_fill_border(world: &World, gx0: i32, gz0: i32) -> Option<CellPos> {
@@ -109,7 +61,7 @@ fn void_fill_border(world: &World, gx0: i32, gz0: i32) -> Option<CellPos> {
             }
         }
         if !hit {
-            return None; // open toward this side within reach — keep the skirt
+            return None; // open toward this side within reach — no groove floor
         }
     }
     nearest.map(|(_, cell)| cell)
@@ -118,9 +70,8 @@ fn void_fill_border(world: &World, gx0: i32, gz0: i32) -> Option<CellPos> {
 /// Emit the fill-over floor caps: every chunk-local Void point that
 /// [`void_groove_floor`] proves an enclosed authored depression floors over at
 /// its stored point height in the bordering cell's cliff material as a flat
-/// color. The rim walls closing the groove's sides are the marched closure's
-/// Void faces, dropped to this same stored height ([`void_low_base`]), so the
-/// floor and its walls meet watertight. A cell with no floored Void point
+/// color. The level-contour loft drops the groove's rim to this same stored
+/// height, so the floor and its walls meet. A cell with no floored Void point
 /// emits nothing, so a solid world — and a plateau's cut-away silhouette,
 /// whose Void points carry no authored depression — stays byte-identical.
 pub(super) fn emit_void_floors(
@@ -138,7 +89,7 @@ pub(super) fn emit_void_floors(
             for sj in 0..SUB {
                 for si in 0..SUB {
                     let Some(border) = void_groove_floor(world, cell, si, sj) else {
-                        continue; // open skirt or no authored depression — no floor
+                        continue; // open edge or no authored depression — no floor
                     };
                     let y = world.point_height(cell, si, sj) as f32 / OCTIMETERS_PER_METER;
                     let rgb = flat_color(styles.get(world.cliff_material(border)));

--- a/crates/aether-kit/src/world/mesher/walls.rs
+++ b/crates/aether-kit/src/world/mesher/walls.rs
@@ -1,458 +1,152 @@
-use aether_capabilities::render::DrawTriangle;
+use alloc::vec;
+use alloc::vec::Vec;
 
-use crate::world::{CellPos, ChunkPos, Material, STEP_MAX_OCTIMETERS, World};
+use aether_capabilities::render::{DrawTriangle, Vertex};
+use aether_math::Rgb;
+
+use crate::world::{CellPos, ChunkPos, Material, World};
 
 use super::constants::{
-    EDGE, OCTIMETERS_PER_METER, OCTIMETERS_PER_SUBCELL, SUB, SUBCELLS_PER_CHUNK_EDGE,
+    MAX_APRON_SUBCELLS, OCTIMETERS_PER_METER, OCTIMETERS_PER_SUBCELL, SUBCELLS_PER_CHUNK_EDGE,
 };
-use super::geometry::push_wall_quad;
-use super::partition::DisplayPartition;
+use super::contour::{SmoothParams, march_grid_with_contours, minimize_corners};
+use super::partition::chunk_placement;
 use super::style::{StyleTable, flat_color};
-use super::surface::{anchored_lift, point_surface_level_at};
-use super::voids::{void_floor_level, void_low_base};
+use super::surface::{
+    CliffStep, cliff_steps, floor_to_i32, level_coverage_plane, point_surface_level_at,
+    sample_level_plane,
+};
 
-const WALL_SEGMENTS: [&[(u8, u8)]; 16] = [
-    &[],               // 0
-    &[(7, 4)],         // 1  BL
-    &[(4, 5)],         // 2  BR
-    &[(7, 5)],         // 3  BL BR
-    &[(5, 6)],         // 4  TR
-    &[(7, 4), (5, 6)], // 5  BL TR (saddle)
-    &[(4, 6)],         // 6  BR TR
-    &[(7, 6)],         // 7  BL BR TR
-    &[(6, 7)],         // 8  TL
-    &[(4, 6)],         // 9  BL TL
-    &[(4, 5), (6, 7)], // 10 BR TL (saddle)
-    &[(5, 6)],         // 11 BL BR TL
-    &[(7, 5)],         // 12 TR TL
-    &[(4, 5)],         // 13 BL TR TL
-    &[(4, 7)],         // 14 BR TR TL
-    &[],               // 15
-];
+/// The level contour gets one additional interpolation rung beyond the
+/// already-dense point lattice. Material partitioning keeps its crisp
+/// one-sample path; this separate scalar field is deliberately smoothed.
+const LEVEL_CONTOUR_UPSAMPLE: usize = 2;
 
-/// Emit the chunk's vertical cliff faces by closure: a wall lofts wherever
-/// the two sides of a shared boundary edge committed different cap heights,
-/// so the split decision lives in one place — the plate lift the caps drew
-/// from — and can never drift between a predicting wall pass and the cap it
-/// should meet. The lattice/subcell closure ([`emit_lattice_closure`]) walls
-/// every same-material cell-edge and subcell-edge break; the marched closure
-/// ([`emit_contour_closure`]) walls every material or Void boundary along
-/// the display partition's contours, dropping a fillable Void low side to
-/// its groove floor. A face lofts iff the high side committed strictly above
-/// the low side there — a legal step merges the plates (the committed edges
-/// agree) and lofts nothing, a cliff splits them and lofts a face whose top
-/// and bottom vertices are the two caps' shared-edge vertices, watertight by
-/// construction.
-pub(super) fn emit_walls(
+/// Emit every physical cliff as one cap-and-wall loft from the scalar level
+/// contour. For each discovered high/low step, `march_grid_with_contours`
+/// emits the high cap and returns the cap contour's exact vertices. The wall
+/// copies those positions for its top ring and changes only `y` for the
+/// bottom ring, so there is no independently reconstructed seam to reconcile.
+pub(super) fn emit_lofts(
     world: &World,
     at: ChunkPos,
     styles: &StyleTable,
-    partition: Option<&DisplayPartition>,
     tris: &mut Vec<DrawTriangle>,
 ) {
-    emit_lattice_closure(world, at, styles, tris);
-    if let Some(part) = partition {
-        emit_contour_closure(world, at, part, styles, tris);
+    let apron = MAX_APRON_SUBCELLS;
+    let plane = sample_level_plane(world, at, apron);
+    let params = vec![
+        SmoothParams {
+            iterations: 2,
+            smoothing_degrees: 90,
+        };
+        plane.levels.len()
+    ];
+    let upsample = LEVEL_CONTOUR_UPSAMPLE;
+    let step_oct = OCTIMETERS_PER_SUBCELL / upsample as i32;
+    let placement = chunk_placement(at, apron, step_oct);
+    let window_start = apron as usize * upsample - 1;
+    let window_span = SUBCELLS_PER_CHUNK_EDGE as usize * upsample;
+    let window_rect = [
+        window_start,
+        window_start,
+        window_start + window_span,
+        window_start + window_span,
+    ];
+
+    for step in cliff_steps(&plane) {
+        let coverage = level_coverage_plane(&plane, step);
+        let (grid, width, height) =
+            minimize_corners(&coverage, plane.width, plane.width, upsample, &params);
+        let cap_vertex = |wx: f32, wz: f32| {
+            let (_, high_cell) = high_side_sample(world, step, wx, wz);
+            let color = flat_color(styles.get(world.cliff_material(high_cell)));
+            Vertex {
+                x: wx,
+                y: step.high as f32 / OCTIMETERS_PER_METER,
+                z: wz,
+                color: Rgb::new(color[0], color[1], color[2]),
+            }
+        };
+        let polylines = march_grid_with_contours(
+            &grid,
+            width,
+            height,
+            &placement,
+            window_rect,
+            &cap_vertex,
+            tris,
+        );
+        for polyline in polylines {
+            for edge in polyline.windows(2) {
+                let top_a = edge[0];
+                let top_b = edge[1];
+                push_loft_wall(tris, top_a, top_b, step.low);
+            }
+        }
     }
 }
 
-/// The flat wall color for a cliff owned by `cell`: the cell's cliff
-/// material's flat color. A pure function of the cell, so the two sides of a
-/// shared edge agree on the color.
-fn wall_color(world: &World, cell: CellPos, styles: &StyleTable) -> [f32; 3] {
-    flat_color(styles.get(world.cliff_material(cell)))
-}
-
-fn same_committed_edge(top: [f32; 2], bottom: [f32; 2]) -> bool {
-    (top[0] - bottom[0]).abs() < f32::EPSILON && (top[1] - bottom[1]).abs() < f32::EPSILON
-}
-
-fn lattice_corner_position(base_x: f32, base_z: f32, span: f32, corner: usize) -> (f32, f32) {
-    (
-        base_x + if corner % 2 == 1 { span } else { 0.0 },
-        base_z + if corner >= 2 { span } else { 0.0 },
+/// Resolve the solid high side nearest a contour position. The half-subcell
+/// probes straddle the isoline; choosing the greatest step-local level gives
+/// the cliff-material owner without inferring a side from whichever cell the
+/// interpolated point happens to floor into.
+fn high_side_sample(world: &World, step: CliffStep, wx: f32, wz: f32) -> (Material, CellPos) {
+    let px = floor_to_i32(wx * OCTIMETERS_PER_METER);
+    let pz = floor_to_i32(wz * OCTIMETERS_PER_METER);
+    let half = OCTIMETERS_PER_SUBCELL / 2;
+    let mut best: Option<(i32, Material, CellPos)> = None;
+    for [dx, dz] in [[0, 0], [half, 0], [-half, 0], [0, half], [0, -half]] {
+        let sx = px + dx;
+        let sz = pz + dz;
+        let cell = CellPos {
+            x: sx.div_euclid(256),
+            z: sz.div_euclid(256),
+        };
+        let sub_x = sx.rem_euclid(256) / OCTIMETERS_PER_SUBCELL;
+        let sub_z = sz.rem_euclid(256) / OCTIMETERS_PER_SUBCELL;
+        let material = world.underlay_point(cell, sub_x, sub_z);
+        if material == Material::Void {
+            continue;
+        }
+        let level = point_surface_level_at(world, sx, sz);
+        if level < step.low || best.is_some_and(|(best_level, _, _)| best_level >= level) {
+            continue;
+        }
+        best = Some((level, material, cell));
+    }
+    best.map_or_else(
+        || {
+            let cell = CellPos {
+                x: px.div_euclid(256),
+                z: pz.div_euclid(256),
+            };
+            let material = world.underlay(cell);
+            (
+                if material == Material::Void {
+                    world.cliff_material(cell)
+                } else {
+                    material
+                },
+                cell,
+            )
+        },
+        |(_, material, cell)| (material, cell),
     )
 }
 
-/// Close the same-material cliff faces of the chunk on the cell lattice — or,
-/// where a cell carries authored relief, on its subcell lattice, the stride
-/// its cap tessellated at. For every chunk-local cell and each of its four
-/// outgoing shared edges the two sides' committed cap edges are read through
-/// the same corner plates the caps drew from
-/// ([`World::cell_corner_heights`] / [`World::subcell_corner_heights`]); a
-/// face lofts iff this (the higher) side committed above the neighbor and the
-/// committed edges differ. A merged plate — flat ground or a legal step —
-/// leaves the edges equal and lofts nothing, so the step size is never gated
-/// directly; the plate merge is the one split decision. The high side owns
-/// the face and cells iterate chunk-local, so a chunk-border cliff lofts
-/// exactly once fleet-wide. A material or Void boundary edge is skipped here
-/// — the marched closure owns those.
-#[allow(clippy::too_many_lines)] // one closure walk over the cell and subcell strides
-fn emit_lattice_closure(
-    world: &World,
-    at: ChunkPos,
-    styles: &StyleTable,
-    tris: &mut Vec<DrawTriangle>,
-) {
-    let sub_span = 1.0 / SUB as f32;
-    for lz in 0..EDGE {
-        for lx in 0..EDGE {
-            let cell = CellPos {
-                x: at.x * EDGE + lx,
-                z: at.z * EDGE + lz,
-            };
-            // Relief cells close on the subcell lattice (the stride their
-            // caps tessellated at); every other cell closes on the cell
-            // lattice.
-            let relief = world.cell_has_height_relief(cell);
-            let face_rgb = wall_color(world, cell, styles);
-            if relief {
-                for sj in 0..SUB {
-                    for si in 0..SUB {
-                        // The point's own material, not the cell's cascade — a
-                        // stone point on a grass cell closes its own
-                        // same-material breaks, and a Void point's rim lofts as
-                        // a marched wall.
-                        let material = world.underlay_point(cell, si, sj);
-                        if material == Material::Void {
-                            continue; // a hole's rim lofts as a marched wall
-                        }
-                        let level = world.point_surface_level(cell, si, sj);
-                        let mut cached: Option<[f32; 4]> = None;
-                        for edge in &WALL_DIRECTIONS {
-                            let gx = cell.x * SUB + si + edge.offset.0;
-                            let gz = cell.z * SUB + sj + edge.offset.1;
-                            let neighbor = CellPos {
-                                x: gx.div_euclid(SUB),
-                                z: gz.div_euclid(SUB),
-                            };
-                            let nsx = gx.rem_euclid(SUB);
-                            let nsz = gz.rem_euclid(SUB);
-                            if world.underlay_point(neighbor, nsx, nsz) != material {
-                                continue; // material / Void boundaries loft as marched walls
-                            }
-                            // Ownership: only the strictly-higher point lofts,
-                            // so each face is emitted once. The step size is
-                            // not gated — a legal step merges the point plates
-                            // and the committed-edge test below leaves nothing.
-                            if level <= world.point_surface_level(neighbor, nsx, nsz) {
-                                continue;
-                            }
-                            let top = *cached
-                                .get_or_insert_with(|| world.subcell_corner_heights(cell, si, sj));
-                            let bottom = world.subcell_corner_heights(neighbor, nsx, nsz);
-                            let y_top = [top[edge.top[0]], top[edge.top[1]]];
-                            let y_low = [bottom[edge.bottom[0]], bottom[edge.bottom[1]]];
-                            if same_committed_edge(y_top, y_low) {
-                                continue; // the point plates merged — no break to close
-                            }
-                            let base_x = cell.x as f32 + si as f32 * sub_span;
-                            let base_z = cell.z as f32 + sj as f32 * sub_span;
-                            let (x0, z0) =
-                                lattice_corner_position(base_x, base_z, sub_span, edge.top[0]);
-                            let (x1, z1) =
-                                lattice_corner_position(base_x, base_z, sub_span, edge.top[1]);
-                            push_wall_quad(
-                                tris,
-                                [x0, z0, y_top[0]],
-                                [x1, z1, y_top[1]],
-                                y_low[0],
-                                y_low[1],
-                                face_rgb,
-                            );
-                        }
-                    }
-                }
-            } else {
-                let material = world.underlay(cell);
-                if material == Material::Void {
-                    continue; // a Void cell's rim is the marched closure's face
-                }
-                let cell_level = world.surface_level(cell);
-                let mut cached: Option<[f32; 4]> = None;
-                for edge in &WALL_DIRECTIONS {
-                    let neighbor = CellPos {
-                        x: cell.x + edge.offset.0,
-                        z: cell.z + edge.offset.1,
-                    };
-                    if world.underlay(neighbor) != material {
-                        continue; // a material boundary lofts as a marched wall
-                    }
-                    // Ownership: only the strictly-higher cell lofts. The step
-                    // size is not gated — a legal step merges the plates and
-                    // the committed-edge test below leaves nothing to close.
-                    if cell_level <= world.surface_level(neighbor) {
-                        continue;
-                    }
-                    let top = *cached.get_or_insert_with(|| world.cell_corner_heights(cell));
-                    let bottom = world.cell_corner_heights(neighbor);
-                    let y_top = [top[edge.top[0]], top[edge.top[1]]];
-                    let y_low = [bottom[edge.bottom[0]], bottom[edge.bottom[1]]];
-                    if same_committed_edge(y_top, y_low) {
-                        continue; // the plates merged — no break to close
-                    }
-                    let (x0, z0) =
-                        lattice_corner_position(cell.x as f32, cell.z as f32, 1.0, edge.top[0]);
-                    let (x1, z1) =
-                        lattice_corner_position(cell.x as f32, cell.z as f32, 1.0, edge.top[1]);
-                    push_wall_quad(
-                        tris,
-                        [x0, z0, y_top[0]],
-                        [x1, z1, y_top[1]],
-                        y_low[0],
-                        y_low[1],
-                        face_rgb,
-                    );
-                }
-            }
-        }
-    }
+/// Emit one quad of the continuous wall ribbon. `top_a` and `top_b` are
+/// copied from the marched cap contour without reconstruction or recoloring;
+/// every field therefore remains bit-identical to the cap vertices. The low
+/// ring changes only `y`, dropping the same `(x, z)` points to the step's low
+/// level.
+fn push_loft_wall(tris: &mut Vec<DrawTriangle>, top_a: Vertex, top_b: Vertex, low_level: i32) {
+    let a = top_a;
+    let b = top_b;
+    let mut c = b;
+    c.y = low_level as f32 / OCTIMETERS_PER_METER;
+    let mut d = a;
+    d.y = c.y;
+    tris.push(DrawTriangle { verts: [a, b, c] });
+    tris.push(DrawTriangle { verts: [a, c, d] });
 }
-
-/// Close the marched cliff walls: over the boundary windows of the display
-/// partition, wherever a segment separates two materials — or a material
-/// from a Void hole — whose point surface levels split the caps, drop the
-/// segment's marched contour from the high cap's committed edge to the low
-/// side's. Each window is owned by the cell under its center, the same
-/// ownership the cap walk uses; the owner is the fleet-wide dedup key (a
-/// window emits only from the chunk holding its owner) and the color source,
-/// never the gate — the split is per-segment and side-aware, reading the
-/// `a`-side corner's point level against the crossed side's, because along a
-/// contour the window center alternates sides subcell to subcell and an
-/// owner-level test would picket-fence the wall. A wall's top vertices lift
-/// through the identical anchored patch ([`anchored_lift`] on the `a`-side
-/// corner sample) the high cap's crossing vertices took — landing the top
-/// edge exactly on the cap's contour, watertight by construction under any
-/// smoothing displacement. A grounded low side takes per-endpoint bases on
-/// the low side's own committed lift over relief (a flat min base where no
-/// relief engages), coincident with the low cap. A Void low side closes to
-/// its fill-over floor ([`World::point_height`], the total height plane) when
-/// the joint is enclosed ([`void_fill_border`]) — wall down, floor across
-/// ([`emit_void_floors`]), wall up at the far rim — else drops the
-/// unbounded-void skirt [`WALL_VOID_SKIRT_OCTIMETERS`] so an open hole reads
-/// as thick ground.
-#[allow(clippy::too_many_lines)] // one boundary walk: classify sides, extract segments, close
-#[allow(clippy::similar_names)] // the segment's two endpoints read clearest as `_p` / `_q` pairs
-fn emit_contour_closure(
-    world: &World,
-    at: ChunkPos,
-    part: &DisplayPartition,
-    styles: &StyleTable,
-    tris: &mut Vec<DrawTriangle>,
-) {
-    let display = &part.display;
-    let gw = part.gw;
-    let apron = part.apron;
-    let step_oct = part.step_oct;
-    let base_oct = [
-        at.x * SUBCELLS_PER_CHUNK_EDGE * OCTIMETERS_PER_SUBCELL,
-        at.z * SUBCELLS_PER_CHUNK_EDGE * OCTIMETERS_PER_SUBCELL,
-    ];
-    let origin_oct = [
-        base_oct[0] - apron * OCTIMETERS_PER_SUBCELL + step_oct / 2,
-        base_oct[1] - apron * OCTIMETERS_PER_SUBCELL + step_oct / 2,
-    ];
-    let half = step_oct / 2;
-    let windows = gw - 1;
-    for wj in 0..windows {
-        for wi in 0..windows {
-            let x_lo = origin_oct[0] + wi as i32 * step_oct;
-            let z_lo = origin_oct[1] + wj as i32 * step_oct;
-            let x_hi = x_lo + step_oct;
-            let z_hi = z_lo + step_oct;
-            // Ownership: the cell under the window center, chunk-local only —
-            // covers every window exactly once across the fleet and matches
-            // the cap walk's owner, so the lofted top reuses the cap's patch.
-            let owner = CellPos {
-                x: (x_lo + half).div_euclid(256),
-                z: (z_lo + half).div_euclid(256),
-            };
-            if !(0..EDGE).contains(&(owner.x - at.x * EDGE))
-                || !(0..EDGE).contains(&(owner.z - at.z * EDGE))
-            {
-                continue;
-            }
-            // Corner materials in order [BL, BR, TR, TL] (the case-bit
-            // order), folding the rim/body display split back to the plain
-            // material — a wall follows a material boundary, not a rim edge.
-            let mats = [
-                display[wj * gw + wi].div_ceil(2),
-                display[wj * gw + wi + 1].div_ceil(2),
-                display[(wj + 1) * gw + wi + 1].div_ceil(2),
-                display[(wj + 1) * gw + wi].div_ceil(2),
-            ];
-            if mats.iter().all(|&m| m == mats[0]) {
-                continue; // uniform window — no material boundary to loft
-            }
-            // Does authored relief engage anywhere this window can read? The
-            // per-endpoint wall bases below switch on this, so relief-free
-            // worlds keep their flat base byte-identically.
-            let relief = world.cell_has_height_relief(owner);
-            // Corner sample positions and point surface levels, same order
-            // as `mats`. Point levels (not the cell level) so an authored
-            // break inside a cell — a silhouette raised by deltas alone,
-            // the cell height flat — lofts its wall, and the gate reads the
-            // sample the cap actually drew. The positions double as the
-            // wall's side anchors ([`anchored_lift`]).
-            let corner_oct = [[x_lo, z_lo], [x_hi, z_lo], [x_hi, z_hi], [x_lo, z_hi]];
-            let point_level = corner_oct.map(|[cx, cz]| point_surface_level_at(world, cx, cz));
-            let mid = |m: u8| -> [i32; 2] {
-                match m {
-                    4 => [x_lo + half, z_lo],
-                    5 => [x_hi, z_lo + half],
-                    6 => [x_lo + half, z_hi],
-                    _ => [x_lo, z_lo + half],
-                }
-            };
-            let edge_corners = |m: u8| -> (usize, usize) {
-                match m {
-                    4 => (0, 1),
-                    5 => (1, 2),
-                    6 => (2, 3),
-                    _ => (3, 0),
-                }
-            };
-            // Wall color: the owning cell's cliff material as a flat color —
-            // the owner is the color source even when the segment's high side
-            // lies in a neighboring cell.
-            let face_rgb = flat_color(styles.get(world.cliff_material(owner)));
-            for a in 1..6u8 {
-                if !mats.contains(&a) {
-                    continue;
-                }
-                let case = u8::from(mats[0] == a)
-                    | u8::from(mats[1] == a) << 1
-                    | u8::from(mats[2] == a) << 2
-                    | u8::from(mats[3] == a) << 3;
-                for &(p, q) in WALL_SEGMENTS[case as usize] {
-                    // The two sides of each crossed edge: the `a` (high
-                    // candidate) corner and the non-`a` (low) corner, each
-                    // read at point level, each carrying its corner sample
-                    // as the side anchor. The gate is side-aware and
-                    // per-segment — never the window center, whose side
-                    // alternates along a contour and would picket-fence the
-                    // wall with skipped windows.
-                    let sides_of = |m: u8| {
-                        let (i, j) = edge_corners(m);
-                        let (hi, lo) = if mats[i] == a { (i, j) } else { (j, i) };
-                        (
-                            mats[lo],
-                            point_level[lo],
-                            point_level[hi],
-                            corner_oct[lo],
-                            corner_oct[hi],
-                        )
-                    };
-                    let (mat_p, lvl_p, hi_p, lo_anchor_p, hi_anchor_p) = sides_of(p);
-                    let (mat_q, lvl_q, hi_q, lo_anchor_q, hi_anchor_q) = sides_of(q);
-                    let is_void = mat_p == 0 || mat_q == 0;
-                    let low_level = lvl_p.min(lvl_q);
-                    let high_level = hi_p.max(hi_q);
-                    let mp = mid(p);
-                    let mq = mid(q);
-                    let wx_p = mp[0] as f32 / OCTIMETERS_PER_METER;
-                    let wz_p = mp[1] as f32 / OCTIMETERS_PER_METER;
-                    let wx_q = mq[0] as f32 / OCTIMETERS_PER_METER;
-                    let wz_q = mq[1] as f32 / OCTIMETERS_PER_METER;
-                    // Tops anchored to each endpoint's `a`-side corner — the
-                    // identical anchor the high flap's crossing vertex took
-                    // ([`window_point_anchor`]), so the seam is shared
-                    // vertices under any smoothing displacement.
-                    let yt_p = anchored_lift(world, owner, hi_anchor_p, wx_p, wz_p);
-                    let yt_q = anchored_lift(world, owner, hi_anchor_q, wx_q, wz_q);
-                    // The low side's committed base, per endpoint. A material
-                    // boundary reads the low cap's own committed lift (over
-                    // relief the low cap splits to its own plates, so a flat
-                    // min base would gap where the low ground varies along the
-                    // segment; a relief-free owner keeps the flat min base
-                    // byte-identically). A Void low side closes to its
-                    // fill-over floor when the joint is enclosed — wall down,
-                    // floor across ([`emit_void_floors`]), wall up — coincident
-                    // with the groove floor cap; an unbounded void keeps the
-                    // open skirt.
-                    let (yb_p, yb_q) = if is_void {
-                        (
-                            void_low_base(world, lo_anchor_p, yt_p),
-                            void_low_base(world, lo_anchor_q, yt_q),
-                        )
-                    } else if relief {
-                        (
-                            anchored_lift(world, owner, lo_anchor_p, wx_p, wz_p),
-                            anchored_lift(world, owner, lo_anchor_q, wx_q, wz_q),
-                        )
-                    } else {
-                        let base = low_level as f32 / OCTIMETERS_PER_METER;
-                        (base, base)
-                    };
-                    // The split test: a face closes only where the high side
-                    // committed above the low side past the step ceiling — a
-                    // merged plate (flat ground or a legal step) closes
-                    // nothing. The solid side tests the point-level split (the
-                    // plate break); the Void side tests the committed drop to
-                    // its stored floor. The owner is only the dedup key and
-                    // color source, never the split — a low-owned window still
-                    // closes its segment.
-                    if is_void {
-                        // A Void low side lofts only where the high side stands
-                        // past the step ceiling above the void's floor: its
-                        // enclosed groove floor where authored below the
-                        // surrounding ground ([`void_floor_level`]), else the
-                        // lowest neighbor ground the skirt drops toward. A flat
-                        // void edge — the high side level with its surroundings
-                        // — lofts nothing, so a cliff-free world stays
-                        // wall-free even where grass meets an open border.
-                        let floor = void_floor_level(world, lo_anchor_p, owner)
-                            .min(void_floor_level(world, lo_anchor_q, owner));
-                        if high_level - floor <= STEP_MAX_OCTIMETERS {
-                            continue;
-                        }
-                    } else if high_level - low_level <= STEP_MAX_OCTIMETERS {
-                        continue;
-                    }
-                    push_wall_quad(
-                        tris,
-                        [wx_p, wz_p, yt_p],
-                        [wx_q, wz_q, yt_q],
-                        yb_p,
-                        yb_q,
-                        face_rgb,
-                    );
-                }
-            }
-        }
-    }
-}
-
-/// Per wall direction: neighbor offset, the shared edge's two lattice
-/// corners as indices into the high side's corner order, and the same
-/// lattice points in the neighbor's order (the low side's plates). Used by
-/// the closure walk ([`emit_lattice_closure`]) at both the cell and subcell
-/// strides — the corner index order is the same at both.
-struct WallEdge {
-    offset: (i32, i32),
-    top: [usize; 2],
-    bottom: [usize; 2],
-}
-
-const WALL_DIRECTIONS: [WallEdge; 4] = [
-    WallEdge {
-        offset: (1, 0),
-        top: [1, 3],
-        bottom: [0, 2],
-    },
-    WallEdge {
-        offset: (-1, 0),
-        top: [0, 2],
-        bottom: [1, 3],
-    },
-    WallEdge {
-        offset: (0, 1),
-        top: [2, 3],
-        bottom: [0, 1],
-    },
-    WallEdge {
-        offset: (0, -1),
-        top: [0, 1],
-        bottom: [2, 3],
-    },
-];

--- a/crates/aether-kit/src/world/mesher/windows.rs
+++ b/crates/aether-kit/src/world/mesher/windows.rs
@@ -6,12 +6,12 @@ use aether_math::Rgb;
 
 use crate::world::{CellPos, ChunkPos, Material, STEP_MAX_OCTIMETERS, World};
 
-use super::constants::{EDGE, OCTIMETERS_PER_METER, OCTIMETERS_PER_SUBCELL, SUB};
+use super::constants::{EDGE, OCTIMETERS_PER_METER};
 use super::contour::{GridPlacement, label_case, label_window_polys};
-use super::geometry::{emit_flat_quad, push_wall_quad};
+use super::geometry::emit_flat_quad;
 use super::partition::chunk_placement;
 use super::style::{StyleTable, flat_color};
-use super::surface::{floor_to_i32, fragment_lift, label_lift, point_surface_level_at};
+use super::surface::{fragment_lift, label_lift, point_surface_level_at};
 
 /// The break lines crossing a window's interior, per axis, in octimeters:
 /// `Some(midline)` when the window's corner-sample point levels split past
@@ -19,15 +19,15 @@ use super::surface::{floor_to_i32, fragment_lift, label_lift, point_surface_leve
 /// when the two sample columns (rows) sit in different subcells, so a
 /// returned midline is always a subcell lattice line — the line the break
 /// stands on and the relief walls loft from. A flap polygon spanning a
-/// returned line must be clipped there ([`emit_clipped_flap`]): a cap fan
+/// returned line must be clipped there ([`clip_window_poly`]): a cap fan
 /// must never connect vertices whose plates split.
 ///
 /// Reads the point-surface levels directly rather than gating on
 /// [`World::cell_has_height_relief`], so a **whole-cell** height cliff — a
 /// plate break at a cell boundary with no subcell relief — also returns a
-/// break line. That is what lets a chamfered relief-free material boundary
-/// clip its overhang flap so the sliver closer ([`emit_clip_gap_walls`]) can
-/// seal it; a flat cell splits nothing (equal levels) and stays break-free.
+/// break line. This keeps a material flap from draping across split plates;
+/// the separate level-contour loft owns the cap ribbon and wall at the cut.
+/// A flat cell splits nothing (equal levels) and stays break-free.
 fn window_break_lines(
     world: &World,
     x_lo: i32,
@@ -81,7 +81,7 @@ fn split_poly_at(poly: &[[f32; 2]], axis: usize, line: f32) -> (Vec<[f32; 2]>, V
 }
 
 /// Twice the area of a polygon (shoelace, absolute) — the degenerate-
-/// fragment filter for [`emit_clipped_flap`].
+/// fragment filter for [`clip_window_poly`].
 fn poly_area_doubled(poly: &[[f32; 2]]) -> f32 {
     let mut sum = 0.0f32;
     for (i, &a) in poly.iter().enumerate() {
@@ -125,131 +125,6 @@ fn clip_window_poly(
     }
     fragments.retain(|(frag, _)| frag.len() >= 3 && poly_area_doubled(frag) >= 1.0);
     fragments
-}
-
-/// Close the vertical gaps a clipped flap opens **inside itself**: where
-/// two fragments of one flap meet across a clipped break line at split
-/// plates, no other wall class stands — the display is uniform there (one
-/// flap, so no marched boundary), and where the flanking authored
-/// materials differ the relief walk skips the edge as marched territory.
-/// The regime is the marching chamfer at a silhouette corner: the cut
-/// leaves a sliver of this label's display over the far side's raised (or
-/// dropped) fabric, honestly lifted to that fabric's plate, and its
-/// lattice-line edges would otherwise be open cracks. The shared chord of
-/// each adjacent fragment pair is walled from the higher side's lift down to
-/// the lower's committed edge — gated to authored-material-differing lines so
-/// a same-material break stays the closure walk's (and only its) face.
-#[allow(clippy::too_many_lines)] // one pass: pair fragments, gate, loft
-fn emit_clip_gap_walls(
-    world: &World,
-    owner: CellPos,
-    fragments: &[FlapFragment],
-    styles: &StyleTable,
-    tris: &mut Vec<DrawTriangle>,
-) {
-    let mut color: Option<[f32; 3]> = None;
-    for axis in 0..2 {
-        for (fa, sa) in fragments {
-            let Some((line, false)) = sa[axis] else {
-                continue;
-            };
-            for (fb, sb) in fragments {
-                if sb[axis] != Some((line, true)) || sb[1 - axis] != sa[1 - axis] {
-                    continue;
-                }
-                // The shared chord: each side's on-line vertex extent along
-                // the other axis, overlapped.
-                let extent = |frag: &[[f32; 2]]| -> Option<(f32, f32)> {
-                    let mut lo = f32::MAX;
-                    let mut hi = f32::MIN;
-                    for v in frag {
-                        if (v[axis] - line as f32).abs() < 0.5 {
-                            lo = lo.min(v[1 - axis]);
-                            hi = hi.max(v[1 - axis]);
-                        }
-                    }
-                    (hi > lo).then_some((lo, hi))
-                };
-                let (Some((a_lo, a_hi)), Some((b_lo, b_hi))) = (extent(fa), extent(fb)) else {
-                    continue;
-                };
-                let lo = a_lo.max(b_lo);
-                let hi = a_hi.min(b_hi);
-                if hi - lo < 0.5 {
-                    continue;
-                }
-                // Authored materials across the line at the chord: a
-                // same-material break is the relief walk's face, not ours.
-                let lattice = line / OCTIMETERS_PER_SUBCELL;
-                let sub_other = floor_to_i32((lo + hi) * 0.5 / OCTIMETERS_PER_SUBCELL as f32);
-                let material_of = |sub_axis: i32| {
-                    let (sx, sz) = if axis == 0 {
-                        (sub_axis, sub_other)
-                    } else {
-                        (sub_other, sub_axis)
-                    };
-                    world.underlay_point(
-                        CellPos {
-                            x: sx.div_euclid(SUB),
-                            z: sz.div_euclid(SUB),
-                        },
-                        sx.rem_euclid(SUB),
-                        sz.rem_euclid(SUB),
-                    )
-                };
-                if material_of(lattice - 1) == material_of(lattice) {
-                    continue;
-                }
-                // Lift the chord endpoints through both fragments' sides.
-                let endpoint = |other: f32| -> [f32; 2] {
-                    let mut p = [0.0f32; 2];
-                    p[axis] = line as f32;
-                    p[1 - axis] = other;
-                    p
-                };
-                let lift = |p: [f32; 2], sides: [Option<(i32, bool)>; 2]| {
-                    fragment_lift(
-                        world,
-                        owner,
-                        sides,
-                        p[0] / OCTIMETERS_PER_METER,
-                        p[1] / OCTIMETERS_PER_METER,
-                    )
-                };
-                let (c0, c1) = (endpoint(lo), endpoint(hi));
-                let below = [lift(c0, *sa), lift(c1, *sa)];
-                let above = [lift(c0, *sb), lift(c1, *sb)];
-                if (below[0] - above[0]).abs() < f32::EPSILON
-                    && (below[1] - above[1]).abs() < f32::EPSILON
-                {
-                    continue; // the plates agree — no gap to close
-                }
-                let (top, base) = if below[0] + below[1] > above[0] + above[1] {
-                    (below, above)
-                } else {
-                    (above, below)
-                };
-                let face = *color
-                    .get_or_insert_with(|| flat_color(styles.get(world.cliff_material(owner))));
-                push_wall_quad(
-                    tris,
-                    [
-                        c0[0] / OCTIMETERS_PER_METER,
-                        c0[1] / OCTIMETERS_PER_METER,
-                        top[0],
-                    ],
-                    [
-                        c1[0] / OCTIMETERS_PER_METER,
-                        c1[1] / OCTIMETERS_PER_METER,
-                        top[1],
-                    ],
-                    base[0],
-                    base[1],
-                    face,
-                );
-            }
-        }
-    }
 }
 
 /// Emit the marching-squares windows of the partition's boundary zone.
@@ -481,9 +356,6 @@ fn emit_mixed_window(
                         ],
                     });
                 }
-            }
-            if clip_x.is_some() || clip_z.is_some() {
-                emit_clip_gap_walls(world, owner, &fragments, styles, tris);
             }
         }
     }

--- a/crates/aether-kit/tests/world_scenario.rs
+++ b/crates/aether-kit/tests/world_scenario.rs
@@ -1,0 +1,212 @@
+//! World-mesher rendered acceptance scenarios. Geometry is built host-side by
+//! the same pure `mesh_chunk` path the `WorldView` actor uses, then submitted
+//! directly to `TestBench`'s render cap so the assertion isolates mesher output
+//! from wasm-artifact availability.
+
+#![allow(clippy::disallowed_methods)] // reads the TestBench strict-skip env knob
+#![allow(clippy::print_stderr)] // surface an intentional local wgpu skip
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)] // bounded frame pixels, chunk indices, and projected coordinates
+
+use std::env;
+
+use aether_capabilities::render::{DrawTriangle, ViewProjection};
+use aether_data::Kind;
+use aether_kinds::NamedMail;
+use aether_kit::world::mesher::{mesh_chunk, style::StyleTable};
+use aether_kit::world::{CELLS_PER_CHUNK_AREA, Chunk, ChunkPos, Material, World};
+use aether_math::{Mat4, Vec3, Vec4};
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::has_wgpu_adapter};
+use aether_substrate_bundle::visual::{background_top_left, decode_png};
+
+const EDGE: i32 = 16;
+const WIDTH: u32 = 128;
+const HEIGHT: u32 = 96;
+
+fn require_wgpu() -> bool {
+    if has_wgpu_adapter() {
+        return true;
+    }
+    let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+    assert!(
+        !strict,
+        "AETHER_REQUIRE_RUNTIME set but no wgpu adapter available",
+    );
+    eprintln!("skipping: no wgpu adapter available");
+    false
+}
+
+fn envelope<K: Kind>(mail: &K) -> NamedMail {
+    NamedMail {
+        recipient_name: "aether.render".to_owned(),
+        kind_name: K::NAME.to_owned(),
+        payload: mail.encode_into_bytes(),
+        count: 1,
+    }
+}
+
+fn triangle_batch(triangles: &[DrawTriangle]) -> NamedMail {
+    let mut payload = Vec::new();
+    for triangle in triangles {
+        payload.extend_from_slice(&triangle.encode_into_bytes());
+    }
+    NamedMail {
+        recipient_name: "aether.render".to_owned(),
+        kind_name: DrawTriangle::NAME.to_owned(),
+        payload,
+        count: u32::try_from(triangles.len()).expect("triangle batch fits u32"),
+    }
+}
+
+#[allow(clippy::large_stack_frames)] // `Chunk` owns dense fixed planes by design
+fn convex_plateau() -> World {
+    let mut world = World::new();
+    for chunk_z in -1..=1 {
+        for chunk_x in -1..=1 {
+            let mut chunk = Chunk::empty();
+            chunk.underlay = [Material::Grass; CELLS_PER_CHUNK_AREA];
+            if chunk_x == 0 && chunk_z == 0 {
+                for z in 6..10 {
+                    for x in 6..10 {
+                        let index = (z * EDGE + x) as usize;
+                        chunk.underlay[index] = Material::Stone;
+                        chunk.height[index] = 512;
+                    }
+                }
+            }
+            world.insert_chunk(
+                ChunkPos {
+                    x: chunk_x,
+                    z: chunk_z,
+                },
+                chunk,
+            );
+        }
+    }
+    world
+}
+
+fn y_span(triangle: &DrawTriangle) -> f32 {
+    let high = triangle
+        .verts
+        .iter()
+        .map(|vertex| vertex.y)
+        .fold(f32::MIN, f32::max);
+    let low = triangle
+        .verts
+        .iter()
+        .map(|vertex| vertex.y)
+        .fold(f32::MAX, f32::min);
+    high - low
+}
+
+fn project_pixel(view_proj: Mat4, point: Vec3) -> (i32, i32) {
+    let clip = view_proj * Vec4::new(point.x, point.y, point.z, 1.0);
+    let ndc_x = clip.x / clip.w;
+    let ndc_y = clip.y / clip.w;
+    let x = ((ndc_x * 0.5 + 0.5) * WIDTH as f32).round() as i32;
+    let y = ((0.5 - ndc_y * 0.5) * HEIGHT as f32).round() as i32;
+    (x, y)
+}
+
+/// A convex cliff corner is one continuous rendered ribbon. The test
+/// identifies the diagonal corner quad from host geometry, projects the
+/// interior of one of its triangles through the same matrix sent to the GPU,
+/// and requires the surrounding pixels to be wall-colored. A missing corner
+/// leg leaves background at this exact location even if the rest of the
+/// plateau still renders, so a whole-frame "not black" check cannot mask it.
+#[test]
+fn convex_cliff_corner_renders_without_an_open_sliver() {
+    if !require_wgpu() {
+        return;
+    }
+    let world = convex_plateau();
+    let mesh = mesh_chunk(&world, ChunkPos { x: 0, z: 0 }, &StyleTable::default());
+    let corner = mesh
+        .iter()
+        .find(|triangle| {
+            if y_span(triangle) < 1.0 {
+                return false;
+            }
+            let top: Vec<_> = triangle
+                .verts
+                .iter()
+                .filter(|vertex| vertex.y > 1.5)
+                .collect();
+            top.len() == 2
+                && top.iter().all(|vertex| vertex.x > 9.8 && vertex.z > 9.8)
+                && top[0].x.to_bits() != top[1].x.to_bits()
+                && top[0].z.to_bits() != top[1].z.to_bits()
+        })
+        .expect("the convex level contour emits a diagonal corner face");
+    let center = Vec3::new(
+        corner.verts.iter().map(|vertex| vertex.x).sum::<f32>() / 3.0,
+        corner.verts.iter().map(|vertex| vertex.y).sum::<f32>() / 3.0,
+        corner.verts.iter().map(|vertex| vertex.z).sum::<f32>() / 3.0,
+    );
+
+    let view = Mat4::look_at_rh(
+        Vec3::new(14.0, 8.0, 14.0),
+        Vec3::new(8.0, 1.0, 8.0),
+        Vec3::Y,
+    );
+    let projection = Mat4::orthographic_rh(-6.0, 6.0, -4.5, 4.5, 0.1, 40.0);
+    let view_proj = projection * view;
+    let visible: Vec<DrawTriangle> = mesh
+        .into_iter()
+        .filter(|triangle| {
+            triangle
+                .verts
+                .iter()
+                .map(|vertex| vertex.y)
+                .fold(f32::MIN, f32::max)
+                > 1.0
+        })
+        .collect();
+    let pre = vec![
+        envelope(&ViewProjection {
+            view_proj: view_proj.to_cols_array(),
+        }),
+        triangle_batch(&visible),
+    ];
+    let mut bench = TestBench::start_with_size(WIDTH, HEIGHT).expect("boot TestBench");
+    let captured = bench
+        .execute(vec![(
+            "corner",
+            BenchOp::capture_with_mails(pre, Vec::new()),
+        )])
+        .expect("capture convex cliff");
+    let image = decode_png(captured.captured("corner").expect("corner capture ran"))
+        .expect("decode corner PNG");
+    let background = background_top_left(&image);
+    let (center_x, center_y) = project_pixel(view_proj, center);
+    let mut wall_pixels = 0;
+    let mut samples = 0;
+    for y in center_y - 1..=center_y + 1 {
+        for x in center_x - 1..=center_x + 1 {
+            if x < 0 || y < 0 || x >= WIDTH as i32 || y >= HEIGHT as i32 {
+                continue;
+            }
+            samples += 1;
+            let offset = ((y as u32 * image.width + x as u32) * 4) as usize;
+            let rgb = &image.rgba[offset..offset + 3];
+            if rgb
+                .iter()
+                .zip(background)
+                .any(|(actual, clear)| actual.abs_diff(clear) > 5)
+            {
+                wall_pixels += 1;
+            }
+        }
+    }
+    assert_eq!(samples, 9, "the projected corner lies inside the frame");
+    assert!(
+        wall_pixels >= 7,
+        "convex corner face has an open background sliver: only {wall_pixels}/9 interior pixels \
+         were filled around ({center_x}, {center_y})",
+    );
+}


### PR DESCRIPTION
Closes #2874.

## Summary

- project scalar surface levels into smooth per-step cliff contours
- loft caps and wall ribbons from shared bit-identical contour vertices
- retire the lattice, contour-closure, and clip-gap wall assembly
- add host geometry tripwires and a rendered TestBench convex-corner scenario

## Test plan

- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- strict world_scenario TestBench run
- GitHub Actions full workspace CI

## Generated by

Aether implement workflow for scoped issue #2874.