### PR TITLE
feat(substrate-bundle): add color-aware regional frame probes

### DIFF
--- a/crates/aether-substrate-bundle/src/visual.rs
+++ b/crates/aether-substrate-bundle/src/visual.rs
@@ -226,20 +226,30 @@ impl From<Rect> for FrameRect {
     }
 }
 
+/// A point in absolute frame pixel coordinates. Coordinates may be
+/// fractional when the point is an aggregate such as a pixel centroid;
+/// `x` increases across columns and `y` increases down rows.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FramePoint {
+    pub x: f32,
+    pub y: f32,
+}
+
 /// Bounded target-color statistics for a frame-clamped region, returned
 /// by `target_color_stats`: how many pixels the region walk sampled, how
 /// many matched the requested target within tolerance, the resulting
 /// matching fraction, and the matched pixels' centroid and bounding box
 /// (both in absolute frame coordinates, mirroring `centroid` /
-/// `bounding_box`). `centroid` and `bounding_box` are `None` exactly
-/// when `matching` is `0` — an empty match set has no location or
-/// extent to report.
+/// `bounding_box`). The centroid is a [`FramePoint`] whose named `x`
+/// and `y` fields make the coordinate order explicit. `centroid` and
+/// `bounding_box` are `None` exactly when `matching` is `0` — an empty
+/// match set has no location or extent to report.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ColorRegionStats {
     pub sampled: u64,
     pub matching: u64,
     pub fraction: f32,
-    pub centroid: Option<(f32, f32)>,
+    pub centroid: Option<FramePoint>,
     pub bounding_box: Option<Rect>,
 }
 
@@ -367,13 +377,15 @@ pub fn bounding_box(image: &Image, bg: [u8; 3], tol: u8) -> Option<Rect> {
 /// ignored, matching every other reduction's convention), and return
 /// the aggregate `ColorRegionStats` — sampled and matching pixel
 /// counts, matching fraction, and the matched pixels' centroid and
-/// bounding box in absolute frame coordinates. `region: None` scores
-/// the whole frame. An empty or fully out-of-frame region (an empty
-/// `clamp_region` result — a zero-size frame, a region entirely outside
-/// the frame, or a degenerate `min > max`) yields zero sampled/matching
-/// counts, `0.0` fraction, and no centroid/bounding box; a non-empty
-/// region with no matching pixel reports its non-zero `sampled` count
-/// alongside the same zero `matching`/`fraction`/`None` geometry.
+/// bounding box in absolute frame coordinates. The centroid's named
+/// `FramePoint` `x` and `y` fields identify the axes.
+/// `region: None` scores the whole frame. An empty or fully out-of-frame
+/// region (an empty `clamp_region` result — a zero-size frame, a region
+/// entirely outside the frame, or a degenerate `min > max`) yields zero
+/// sampled/matching counts, `0.0` fraction, and no centroid/bounding
+/// box; a non-empty region with no matching pixel reports its non-zero
+/// `sampled` count alongside the same zero `matching`/`fraction`/`None`
+/// geometry.
 #[must_use]
 #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 pub fn target_color_stats(
@@ -419,10 +431,10 @@ pub fn target_color_stats(
         sampled,
         matching,
         fraction: matching as f32 / sampled as f32,
-        centroid: Some((
-            sum_x as f32 / matching as f32,
-            sum_y as f32 / matching as f32,
-        )),
+        centroid: Some(FramePoint {
+            x: sum_x as f32 / matching as f32,
+            y: sum_y as f32 / matching as f32,
+        }),
         bounding_box: Some(Rect {
             min_x,
             min_y,
@@ -901,6 +913,10 @@ mod tests {
             stats.matching, 0,
             "a pixel one unit past the tolerance boundary must not match"
         );
+        assert_eq!(stats.sampled, 4);
+        assert_eq!(stats.fraction, 0.0);
+        assert_eq!(stats.centroid, None);
+        assert_eq!(stats.bounding_box, None);
     }
 
     #[test]
@@ -983,11 +999,13 @@ mod tests {
             rect,
         );
         let stats = target_color_stats(&img, target, 5, None);
-        let (center_x, center_y) = stats.centroid.expect("a matched region has a centroid");
+        let center = stats.centroid.expect("a matched region has a centroid");
         assert!(
-            (center_x - 5.5).abs() < 1e-6 && (center_y - 7.5).abs() < 1e-6,
-            "centroid ({center_x}, {center_y}) should be the rect's frame-coordinate \
+            (center.x - 5.5).abs() < 1e-6 && (center.y - 7.5).abs() < 1e-6,
+            "centroid ({}, {}) should be the rect's frame-coordinate \
              center (5.5, 7.5)",
+            center.x,
+            center.y,
         );
         assert_eq!(
             stats.bounding_box,

--- a/crates/aether-substrate-bundle/src/visual.rs
+++ b/crates/aether-substrate-bundle/src/visual.rs
@@ -88,6 +88,21 @@ fn is_lit(rgb: &[u8], bg: [u8; 3], tol: u8) -> bool {
     rgb[0].abs_diff(bg[0]) > tol || rgb[1].abs_diff(bg[1]) > tol || rgb[2].abs_diff(bg[2]) > tol
 }
 
+/// A pixel "matches" `target` when every one of its RGB channels is
+/// within an inclusive `tolerance` of the corresponding target channel —
+/// the logical complement of `is_lit` against the same reference color
+/// and tolerance (`matches_target(rgb, c, tol) == !is_lit(rgb, c, tol)`),
+/// but named and used separately: `is_lit` partitions the frame relative
+/// to a *background* for the silhouette reductions, while
+/// `matches_target` asks whether a pixel *is* a known *foreground*
+/// color for `target_color_stats`. `rgb` is the leading three bytes of
+/// an RGBA chunk; alpha is ignored.
+fn matches_target(rgb: &[u8], target: [u8; 3], tolerance: u8) -> bool {
+    rgb[0].abs_diff(target[0]) <= tolerance
+        && rgb[1].abs_diff(target[1]) <= tolerance
+        && rgb[2].abs_diff(target[2]) <= tolerance
+}
+
 /// Clamp a requested region against the frame bounds, yielding the
 /// `Rect` a reduction should walk: `None` (no region requested) maps to
 /// the whole frame; `Some(rect)` maps to the frame-clamped
@@ -211,6 +226,23 @@ impl From<Rect> for FrameRect {
     }
 }
 
+/// Bounded target-color statistics for a frame-clamped region, returned
+/// by `target_color_stats`: how many pixels the region walk sampled, how
+/// many matched the requested target within tolerance, the resulting
+/// matching fraction, and the matched pixels' centroid and bounding box
+/// (both in absolute frame coordinates, mirroring `centroid` /
+/// `bounding_box`). `centroid` and `bounding_box` are `None` exactly
+/// when `matching` is `0` — an empty match set has no location or
+/// extent to report.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ColorRegionStats {
+    pub sampled: u64,
+    pub matching: u64,
+    pub fraction: f32,
+    pub centroid: Option<(f32, f32)>,
+    pub bounding_box: Option<Rect>,
+}
+
 /// Region-scoped core of `coverage`: lit pixels within the
 /// frame-clamped `region` divided by the clamped region's pixel count.
 /// `region: None` scores the whole frame. Guards the divide-by-zero the
@@ -327,6 +359,77 @@ fn bounding_box_in_region(
 #[allow(clippy::cast_possible_truncation)]
 pub fn bounding_box(image: &Image, bg: [u8; 3], tol: u8) -> Option<Rect> {
     bounding_box_in_region(image, None, bg, tol)
+}
+
+/// Bounded target-color statistics for the frame-clamped `region`: walk
+/// the region once, counting pixels whose RGB is within an inclusive
+/// per-channel `tolerance` of `target` (`matches_target`; alpha
+/// ignored, matching every other reduction's convention), and return
+/// the aggregate `ColorRegionStats` — sampled and matching pixel
+/// counts, matching fraction, and the matched pixels' centroid and
+/// bounding box in absolute frame coordinates. `region: None` scores
+/// the whole frame. An empty or fully out-of-frame region (an empty
+/// `clamp_region` result — a zero-size frame, a region entirely outside
+/// the frame, or a degenerate `min > max`) yields zero sampled/matching
+/// counts, `0.0` fraction, and no centroid/bounding box; a non-empty
+/// region with no matching pixel reports its non-zero `sampled` count
+/// alongside the same zero `matching`/`fraction`/`None` geometry.
+#[must_use]
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+pub fn target_color_stats(
+    image: &Image,
+    target: [u8; 3],
+    tolerance: u8,
+    region: Option<Rect>,
+) -> ColorRegionStats {
+    let empty = ColorRegionStats {
+        sampled: 0,
+        matching: 0,
+        fraction: 0.0,
+        centroid: None,
+        bounding_box: None,
+    };
+    let Some(rect) = clamp_region(region, image.width, image.height) else {
+        return empty;
+    };
+    let sampled = region_pixel_count(rect);
+    let mut matching = 0u64;
+    let mut sum_x = 0u64;
+    let mut sum_y = 0u64;
+    let mut min_x = u32::MAX;
+    let mut min_y = u32::MAX;
+    let mut max_x = 0u32;
+    let mut max_y = 0u32;
+    for (x, y, rgb) in region_pixels(image, rect) {
+        if !matches_target(rgb, target, tolerance) {
+            continue;
+        }
+        matching += 1;
+        sum_x += u64::from(x);
+        sum_y += u64::from(y);
+        min_x = min_x.min(x);
+        min_y = min_y.min(y);
+        max_x = max_x.max(x);
+        max_y = max_y.max(y);
+    }
+    if matching == 0 {
+        return ColorRegionStats { sampled, ..empty };
+    }
+    ColorRegionStats {
+        sampled,
+        matching,
+        fraction: matching as f32 / sampled as f32,
+        centroid: Some((
+            sum_x as f32 / matching as f32,
+            sum_y as f32 / matching as f32,
+        )),
+        bounding_box: Some(Rect {
+            min_x,
+            min_y,
+            max_x,
+            max_y,
+        }),
+    }
 }
 
 /// RGB of the top-left pixel — the conventional background reference
@@ -777,6 +880,229 @@ mod tests {
         assert_eq!(coverage_in_region(&img, Some(degenerate), bg, 5), 0.0);
         assert!(centroid_in_region(&img, Some(degenerate), bg, 5).is_none());
         assert!(bounding_box_in_region(&img, Some(degenerate), bg, 5).is_none());
+    }
+
+    #[test]
+    fn target_color_stats_matches_within_inclusive_tolerance_boundary() {
+        // A pixel exactly `tolerance` away on every channel must match
+        // (inclusive bound); one channel a single unit further must not.
+        let target = [200, 32, 32];
+        let tolerance = 5;
+        let on_boundary = solid(2, 2, [205, 37, 27, 255]);
+        let stats = target_color_stats(&on_boundary, target, tolerance, None);
+        assert_eq!(
+            stats.matching, 4,
+            "a pixel exactly at the tolerance boundary must match"
+        );
+
+        let past_boundary = solid(2, 2, [206, 32, 32, 255]);
+        let stats = target_color_stats(&past_boundary, target, tolerance, None);
+        assert_eq!(
+            stats.matching, 0,
+            "a pixel one unit past the tolerance boundary must not match"
+        );
+    }
+
+    #[test]
+    fn target_color_stats_ignores_alpha() {
+        // Same RGB, wildly different alpha — the match predicate must
+        // ignore alpha entirely, matching every other reduction's
+        // convention.
+        let target = [10, 20, 30];
+        let opaque = solid(2, 2, [10, 20, 30, 255]);
+        let transparent = solid(2, 2, [10, 20, 30, 0]);
+        let opaque_stats = target_color_stats(&opaque, target, 0, None);
+        let transparent_stats = target_color_stats(&transparent, target, 0, None);
+        assert_eq!(opaque_stats.matching, 4);
+        assert_eq!(
+            transparent_stats.matching, 4,
+            "alpha must not affect the target-color match"
+        );
+    }
+
+    #[test]
+    fn target_color_stats_excludes_matches_outside_requested_region() {
+        let target = [200, 32, 32];
+        let bg = [69, 79, 105];
+        // Two separate target-colored rects: one the requested region
+        // will include, one it will exclude entirely.
+        let included_rect = Rect {
+            min_x: 4,
+            min_y: 6,
+            max_x: 7,
+            max_y: 9,
+        };
+        let excluded_rect = Rect {
+            min_x: 12,
+            min_y: 12,
+            max_x: 14,
+            max_y: 14,
+        };
+        let mut img = solid_with_rect(
+            16,
+            16,
+            [bg[0], bg[1], bg[2], 255],
+            [target[0], target[1], target[2], 255],
+            included_rect,
+        );
+        for y in excluded_rect.min_y..=excluded_rect.max_y {
+            for x in excluded_rect.min_x..=excluded_rect.max_x {
+                let start = ((y * 16 + x) * 4) as usize;
+                img.rgba[start..start + 4].copy_from_slice(&[target[0], target[1], target[2], 255]);
+            }
+        }
+        // Region covers only `included_rect` (with background padding).
+        let region = Rect {
+            min_x: 0,
+            min_y: 0,
+            max_x: 9,
+            max_y: 11,
+        };
+        let stats = target_color_stats(&img, target, 5, Some(region));
+        assert_eq!(
+            stats.matching, 16,
+            "only the 4x4 included rect should count, not the excluded rect too"
+        );
+    }
+
+    #[test]
+    fn target_color_stats_reports_frame_coordinate_centroid_and_bounds() {
+        let target = [200, 32, 32];
+        let bg = [69, 79, 105];
+        let rect = Rect {
+            min_x: 4,
+            min_y: 6,
+            max_x: 7,
+            max_y: 9,
+        };
+        let img = solid_with_rect(
+            16,
+            16,
+            [bg[0], bg[1], bg[2], 255],
+            [target[0], target[1], target[2], 255],
+            rect,
+        );
+        let stats = target_color_stats(&img, target, 5, None);
+        let (center_x, center_y) = stats.centroid.expect("a matched region has a centroid");
+        assert!(
+            (center_x - 5.5).abs() < 1e-6 && (center_y - 7.5).abs() < 1e-6,
+            "centroid ({center_x}, {center_y}) should be the rect's frame-coordinate \
+             center (5.5, 7.5)",
+        );
+        assert_eq!(
+            stats.bounding_box,
+            Some(rect),
+            "bounding box should recover the exact rect corners in frame coordinates",
+        );
+    }
+
+    #[test]
+    fn target_color_stats_counts_sampled_and_matching_with_fraction() {
+        let target = [200, 32, 32];
+        let bg = [69, 79, 105];
+        // 4x4 target-colored rect on a 16x16 frame: 16 of 256 pixels.
+        let rect = Rect {
+            min_x: 4,
+            min_y: 6,
+            max_x: 7,
+            max_y: 9,
+        };
+        let img = solid_with_rect(
+            16,
+            16,
+            [bg[0], bg[1], bg[2], 255],
+            [target[0], target[1], target[2], 255],
+            rect,
+        );
+        let stats = target_color_stats(&img, target, 5, None);
+        assert_eq!(stats.sampled, 256);
+        assert_eq!(stats.matching, 16);
+        assert!(
+            (stats.fraction - 16.0 / 256.0).abs() < 1e-6,
+            "fraction was {}, expected 16/256",
+            stats.fraction,
+        );
+    }
+
+    #[test]
+    fn target_color_stats_clamps_overhanging_region_to_the_frame() {
+        let target = [200, 32, 32];
+        let bg = [69, 79, 105];
+        // Target-colored rect touching the bottom-right corner of a
+        // 16x16 frame.
+        let rect = Rect {
+            min_x: 12,
+            min_y: 12,
+            max_x: 15,
+            max_y: 15,
+        };
+        let img = solid_with_rect(
+            16,
+            16,
+            [bg[0], bg[1], bg[2], 255],
+            [target[0], target[1], target[2], 255],
+            rect,
+        );
+        // Region overhangs the frame on both far edges; clamping should
+        // restrict sampling to the in-frame intersection (12..=15 x
+        // 12..=15 — exactly the target rect), a 16-pixel area.
+        let overhanging_region = Rect {
+            min_x: 12,
+            min_y: 12,
+            max_x: 100,
+            max_y: 100,
+        };
+        let stats = target_color_stats(&img, target, 5, Some(overhanging_region));
+        assert_eq!(stats.sampled, 16);
+        assert_eq!(stats.matching, 16);
+        assert_eq!(stats.bounding_box, Some(rect));
+    }
+
+    #[test]
+    fn target_color_stats_empty_on_degenerate_or_out_of_bounds_region() {
+        let target = [200, 32, 32];
+        let bg = [69, 79, 105];
+        let rect = Rect {
+            min_x: 4,
+            min_y: 6,
+            max_x: 7,
+            max_y: 9,
+        };
+        let img = solid_with_rect(
+            16,
+            16,
+            [bg[0], bg[1], bg[2], 255],
+            [target[0], target[1], target[2], 255],
+            rect,
+        );
+
+        // Fully out-of-bounds region (frame is 16x16).
+        let out_of_bounds = Rect {
+            min_x: 20,
+            min_y: 20,
+            max_x: 25,
+            max_y: 25,
+        };
+        let stats = target_color_stats(&img, target, 5, Some(out_of_bounds));
+        assert_eq!(stats.sampled, 0);
+        assert_eq!(stats.matching, 0);
+        assert_eq!(stats.fraction, 0.0);
+        assert!(stats.centroid.is_none());
+        assert!(stats.bounding_box.is_none());
+
+        // Degenerate region: min > max on both axes.
+        let degenerate = Rect {
+            min_x: 10,
+            min_y: 10,
+            max_x: 2,
+            max_y: 2,
+        };
+        let stats = target_color_stats(&img, target, 5, Some(degenerate));
+        assert_eq!(stats.sampled, 0);
+        assert_eq!(stats.matching, 0);
+        assert_eq!(stats.fraction, 0.0);
+        assert!(stats.centroid.is_none());
+        assert!(stats.bounding_box.is_none());
     }
 
     #[test]

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -57,7 +57,8 @@ use aether_substrate_bundle::test_bench::{
     test_helpers::{has_wgpu_adapter, init_save_sandbox, require_runtime, test_namespace_roots},
 };
 use aether_substrate_bundle::visual::{
-    Image, background_top_left, bounding_box, centroid, coverage, decode_png,
+    Image, Rect, background_top_left, bounding_box, centroid, coverage, decode_png,
+    target_color_stats,
 };
 use aether_test_fixtures_kinds::{
     Bump, CountQuery, CountReport, DespawnChild, INLINE_WHO_CHILD, INLINE_WHO_PARENT, InlineEcho,

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario/render.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario/render.rs
@@ -365,12 +365,19 @@ fn assert_quadrant_matches(img: &Image, label: &str, region: Rect, target: [u8; 
          (region {region:?})",
         stats.fraction,
     );
-    let (center_x, center_y) = stats.centroid.expect("high-fraction probe has a centroid");
+    let center = stats.centroid.expect("high-fraction probe has a centroid");
     assert!(
-        (region.min_x as f32..=region.max_x as f32).contains(&center_x)
-            && (region.min_y as f32..=region.max_y as f32).contains(&center_y),
-        "{label} centroid ({center_x}, {center_y}) should sit inside its own probe \
+        (region.min_x as f32..=region.max_x as f32).contains(&center.x)
+            && (region.min_y as f32..=region.max_y as f32).contains(&center.y),
+        "{label} centroid ({}, {}) should sit inside its own probe \
          region {region:?}",
+        center.x,
+        center.y,
+    );
+    assert_eq!(
+        stats.bounding_box,
+        Some(region),
+        "{label} target-color extent should exactly recover its inset probe region",
     );
 }
 

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario/render.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario/render.rs
@@ -325,6 +325,178 @@ fn textured_quad_draws_screen_space_rect() {
     );
 }
 
+/// Palette for the four-quadrant texture built by
+/// `four_quadrant_texture_pixels` and probed by
+/// `target_color_stats_distinguishes_quadrant_colors_on_real_capture`.
+const QUADRANT_RED: [u8; 3] = [255, 0, 0];
+const QUADRANT_GREEN: [u8; 3] = [0, 255, 0];
+const QUADRANT_BLUE: [u8; 3] = [0, 0, 255];
+const QUADRANT_YELLOW: [u8; 3] = [255, 255, 0];
+
+/// Build a `size x size` opaque RGBA8 texture split into four solid
+/// color quadrants: red (top-left), green (top-right), blue
+/// (bottom-left), yellow (bottom-right).
+fn four_quadrant_texture_pixels(size: u32) -> Vec<u8> {
+    let mut pixels = Vec::with_capacity((size * size * 4) as usize);
+    for y in 0..size {
+        for x in 0..size {
+            let color = match (x < size / 2, y < size / 2) {
+                (true, true) => QUADRANT_RED,
+                (false, true) => QUADRANT_GREEN,
+                (true, false) => QUADRANT_BLUE,
+                (false, false) => QUADRANT_YELLOW,
+            };
+            pixels.extend_from_slice(&[color[0], color[1], color[2], 255]);
+        }
+    }
+    pixels
+}
+
+/// Assert `target_color_stats` reports a high matching fraction for
+/// `target` within `region`, with a centroid landing inside that same
+/// region — the per-quadrant assertion shared by
+/// `target_color_stats_distinguishes_quadrant_colors_on_real_capture`.
+#[allow(clippy::cast_precision_loss)]
+fn assert_quadrant_matches(img: &Image, label: &str, region: Rect, target: [u8; 3], tolerance: u8) {
+    let stats = target_color_stats(img, target, tolerance, Some(region));
+    assert!(
+        stats.fraction > 0.8,
+        "{label} quadrant probe matched {target:?} at fraction {}, expected > 0.8 \
+         (region {region:?})",
+        stats.fraction,
+    );
+    let (center_x, center_y) = stats.centroid.expect("high-fraction probe has a centroid");
+    assert!(
+        (region.min_x as f32..=region.max_x as f32).contains(&center_x)
+            && (region.min_y as f32..=region.max_y as f32).contains(&center_y),
+        "{label} centroid ({center_x}, {center_y}) should sit inside its own probe \
+         region {region:?}",
+    );
+}
+
+/// Prerequisite for issue #2912's `target_color_stats`: create a
+/// four-quadrant RGBA8 texture, draw it as a known `Screen`-space quad,
+/// decode the capture, and probe an inset rect in each quadrant. Unlike
+/// `textured_quad_draws_screen_space_rect` (which only proves
+/// *something* lit the requested rect against a dark background), this
+/// proves the color-aware probe: the intended color owns a high
+/// matching fraction with a bounded centroid inside its own quadrant,
+/// while the same target has near-zero matches in a neighboring
+/// quadrant that holds a different color. Probe rects are inset from
+/// every quadrant edge (including the internal seams) so
+/// linear-filtered boundary texels never fall inside a probed region.
+#[test]
+fn target_color_stats_distinguishes_quadrant_colors_on_real_capture() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let (frame_width, frame_height) = (64u32, 48u32);
+    let mut bench = TestBench::start_with_size(frame_width, frame_height).expect("boot");
+
+    let texture_size = 8u32;
+    let pixels = four_quadrant_texture_pixels(texture_size);
+    let created = bench
+        .execute(vec![(
+            "create",
+            BenchOp::send_and_await(
+                "aether.render",
+                &CreateTexture {
+                    width: texture_size,
+                    height: texture_size,
+                    format: TextureFormat::Rgba8,
+                    pixels,
+                },
+            ),
+        )])
+        .expect("create_texture sequence");
+    let texture_id = match created
+        .reply::<CreateTextureResult>("create")
+        .expect("decode CreateTextureResult")
+    {
+        CreateTextureResult::Ok { texture_id } => texture_id,
+        CreateTextureResult::Err { error } => panic!("create_texture failed: {error}"),
+    };
+
+    // Screen rect (16, 12) sized 32x24: columns 16..48, rows 12..36,
+    // split at the midlines x=32 / y=24 into four 16x12 quadrants
+    // matching the texture's u/v split.
+    let pre = vec![envelope(
+        "aether.render",
+        &DrawTexturedQuads {
+            texture_id,
+            space: QuadSpace::Screen,
+            clip: None,
+            quads: vec![TexturedQuad {
+                x: 16.0,
+                y: 12.0,
+                width: 32.0,
+                height: 24.0,
+                u0: 0.0,
+                v0: 0.0,
+                u1: 1.0,
+                v1: 1.0,
+                tint: Rgba::new(1.0, 1.0, 1.0, 1.0),
+            }],
+        },
+    )];
+
+    let captured = bench
+        .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+        .expect("capture-with-mails");
+    let png = captured.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
+    let tolerance = 20;
+
+    // Inset 8x4 probe rects, one per quadrant, each pulled at least 4px
+    // back from its quadrant's outer edges and the internal x=32/y=24
+    // seams so no linear-filtered boundary texel falls inside a probe.
+    let top_left = Rect {
+        min_x: 20,
+        min_y: 16,
+        max_x: 27,
+        max_y: 19,
+    };
+    let top_right = Rect {
+        min_x: 36,
+        min_y: 16,
+        max_x: 43,
+        max_y: 19,
+    };
+    let bottom_left = Rect {
+        min_x: 20,
+        min_y: 28,
+        max_x: 27,
+        max_y: 31,
+    };
+    let bottom_right = Rect {
+        min_x: 36,
+        min_y: 28,
+        max_x: 43,
+        max_y: 31,
+    };
+
+    assert_quadrant_matches(&img, "top-left", top_left, QUADRANT_RED, tolerance);
+    assert_quadrant_matches(&img, "top-right", top_right, QUADRANT_GREEN, tolerance);
+    assert_quadrant_matches(&img, "bottom-left", bottom_left, QUADRANT_BLUE, tolerance);
+    assert_quadrant_matches(
+        &img,
+        "bottom-right",
+        bottom_right,
+        QUADRANT_YELLOW,
+        tolerance,
+    );
+
+    // Cross-check: the top-left region's own color (red) does not
+    // appear in the top-right region, which holds green.
+    let cross = target_color_stats(&img, QUADRANT_RED, tolerance, Some(top_right));
+    assert!(
+        cross.fraction < 0.1,
+        "red target matched {} fraction of the top-right (green) quadrant probe, \
+         expected < 0.1",
+        cross.fraction,
+    );
+}
+
 /// Issue #2831: a destroyed texture is removed from the registry, so a
 /// later draw using the old id warn-drops during frame record and the
 /// captured frame returns to clear color.


### PR DESCRIPTION
Closes #2912.

## Summary

TestBench captures could distinguish pixels from a reference background and compute regional silhouette coverage/centroid/bounds, but the reusable visual API had no way to ask how much of a region matches a known target color — so image and widget tests fell back to bespoke pixel loops and channel-dominance checks.

Adds one pure decoded-frame probe, `target_color_stats`, to `aether_substrate_bundle::visual`. It takes an `Image`, an RGB8 target, an inclusive per-channel tolerance, and an optional frame-clamped `Rect`, then walks the region once and returns a `ColorRegionStats` aggregate: sampled and matching pixel counts, matching fraction, target-pixel centroid, and target-pixel bounding box, all in absolute frame coordinates. A pixel matches only when all three RGB channels are within tolerance; alpha is ignored, consistent with the existing reductions. It reuses the existing `clamp_region` / `region_pixel_count` / `region_pixels` anchors, so the decoded-PNG Rust API stays the boundary. No `aether-kinds` frame-check type, capture wire, or MCP surface changes; ADR-0067 already establishes coarse regional color assertions.

## Test plan

- `visual` unit tests: tolerance-boundary inclusivity, alpha-ignoring, out-of-region exclusion, frame-coordinate centroid/bounds, sampled-vs-matching counts and fraction, overhanging-region clamping, and degenerate/out-of-frame empty results.
- A real-capture TestBench acceptance scenario uploads a four-quadrant RGBA8 texture, draws it as a screen quad, and probes inset per-quadrant regions plus a cross-quadrant negative check.
- CI runs the full workspace tier (the rendered scenario rides the existing wgpu availability gate).

## Generated by

`/implement` — agent execution of [scoped issue #2912](https://github.com/iamacoffeepot/aether/issues/2912).
