### PR TITLE
fix(substrate-bundle): enable capture similarity from configured TestBench assets

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -229,6 +229,14 @@ impl TestBenchChassis {
 
         let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
 
+        // Mirrors the desktop chassis's wiring: the `capture_frame`
+        // similarity check (iamacoffeepot/aether#1780) reads its reference
+        // image from the same `assets` root the fs cap serves. Cloned out
+        // ahead of the `io_roots` pre-validation match below, which moves
+        // `namespace_roots` — capture similarity needs only the configured
+        // assets root, independent of whether fs cap boot itself succeeds.
+        let assets_dir = namespace_roots.as_ref().map(|roots| roots.assets.clone());
+
         // Capture handoff lives on `RenderCapability` post-issue-603
         // Phase 2. The cap dispatcher parks the request on
         // `capture_queue`; the embedder loop sees `CaptureRequested`
@@ -237,7 +245,7 @@ impl TestBenchChassis {
         let render_config = RenderConfig {
             vertex_buffer_bytes: VERTEX_BUFFER_BYTES,
             observed_kinds: observed_kinds.clone(),
-            assets_dir: None,
+            assets_dir,
             capture_backend: Some(CaptureBackend {
                 queue: capture_queue,
                 wake: Arc::new(move || {

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -49,7 +49,7 @@ use aether_kinds::{
     CachedFontMetrics, CaptureFrame, CaptureFrameResult, ClipRect, DropComponent, DropResult,
     FrameCheck, FrameCheckResult, FrameRect, FrameReduction, ListComponents, ListComponentsResult,
     LoadComponent, LoadResult, NamedMail, Ping, QuadScale, QuadSpace, ReplaceComponent,
-    ReplaceResult,
+    ReplaceResult, SimilarityCheck,
 };
 use aether_math::{Mat4, Rgb, Rgba, Vec3};
 use aether_substrate_bundle::test_bench::{

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario/render.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario/render.rs
@@ -1111,6 +1111,93 @@ fn capture_frame_checks_return_substrate_verdict() {
     }
 }
 
+/// Issue #2913 regression: a `CaptureFrame.similarity` request resolves
+/// its reference image from the `TestBench`'s configured `assets`
+/// namespace root, the same way the desktop chassis wires
+/// `RenderConfig.assets_dir`. Captures a deterministic clear-color
+/// frame, stores that exact PNG under the sandbox's assets root as the
+/// reference, then requests a second capture with a `SimilarityCheck`
+/// against it. Two captures of the same unchanged scene are pixel-
+/// identical, so the score is `0.0` and the check passes — proving
+/// `TestBenchChassis::build_passive` no longer leaves `assets_dir`
+/// unconditionally `None` (the bug this issue fixes; on unfixed `main`
+/// this fails at reference resolution with "no assets directory is
+/// configured").
+#[test]
+fn capture_frame_similarity_resolves_reference_from_configured_assets_root() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let sandbox = init_save_sandbox("test-bench-render-similarity");
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
+
+    let reference = bench
+        .execute(vec![("reference", BenchOp::capture())])
+        .expect("capture reference frame");
+    let reference_png = reference
+        .captured("reference")
+        .expect("reference step ran")
+        .to_vec();
+    let reference_path = "similarity-reference.png";
+    fs::write(sandbox.join(reference_path), &reference_png)
+        .expect("write reference png under the sandbox assets root");
+
+    let result = bench
+        .execute(vec![(
+            "snap",
+            BenchOp::send_and_await(
+                "aether.render",
+                &CaptureFrame {
+                    mails: vec![],
+                    after_mails: vec![],
+                    checks: vec![],
+                    similarity: Some(SimilarityCheck {
+                        namespace: "assets".to_owned(),
+                        reference_path: reference_path.to_owned(),
+                        threshold: 0.0,
+                    }),
+                },
+            ),
+        )])
+        .expect("send_and_await(CaptureFrame) with similarity");
+    let reply: CaptureFrameResult = result.reply("snap").expect("decode CaptureFrameResult");
+    match reply {
+        CaptureFrameResult::Ok {
+            png,
+            verdict,
+            similarity_score,
+            similarity_pass,
+        } => {
+            assert!(
+                png.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
+                "the PNG still rides back alongside the similarity score",
+            );
+            assert!(
+                verdict.is_none(),
+                "no checks were requested, so no intrinsic verdict should ride back",
+            );
+            assert_eq!(
+                similarity_score,
+                Some(0.0),
+                "an unchanged scene captured twice should score a perfect match",
+            );
+            assert_eq!(
+                similarity_pass,
+                Some(true),
+                "a 0.0 score against a 0.0 threshold must pass",
+            );
+        }
+        CaptureFrameResult::Err { error } => panic!(
+            "capture_frame similarity replied Err (assets root not wired into TestBench?): \
+             {error}"
+        ),
+    }
+}
+
 /// A region-scoped `FrameCheck` restricts a reduction to one screen
 /// rect — the composition primitive a per-widget assertion needs so it
 /// doesn't fold every widget in the scene into one whole-frame number

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario/render.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario/render.rs
@@ -1138,12 +1138,9 @@ fn capture_frame_similarity_resolves_reference_from_configured_assets_root() {
     let reference = bench
         .execute(vec![("reference", BenchOp::capture())])
         .expect("capture reference frame");
-    let reference_png = reference
-        .captured("reference")
-        .expect("reference step ran")
-        .to_vec();
+    let reference_png = reference.captured("reference").expect("reference step ran");
     let reference_path = "similarity-reference.png";
-    fs::write(sandbox.join(reference_path), &reference_png)
+    fs::write(sandbox.join(reference_path), reference_png)
         .expect("write reference png under the sandbox assets root");
 
     let result = bench


### PR DESCRIPTION
Closes #2913.

## Summary

TestBench accepts per-bench namespace roots and boots a render capability with capture support, but `TestBenchChassis::build_passive` discarded the configured assets path by setting `RenderConfig.assets_dir` to `None`. A `CaptureFrame` similarity request therefore failed with "no assets directory is configured" before it could resolve a reference present under the same roots `aether.fs` serves.

Clones `namespace_roots.assets` into `RenderConfig.assets_dir` when roots are configured, mirroring the desktop chassis's existing wiring. The clone is taken before `namespace_roots` moves into the optional `aether.fs` pre-validation path, so capture similarity needs only the configured assets root and an unreadable/invalid reference still fails through `resolve_reference` with its descriptive synchronous error. The `None`-roots case, `ensure_dirs` warn-and-skip behavior, capture backend, and capability composition are unchanged.

## Test plan

- A GPU-gated regression scenario captures a deterministic frame, writes it under the configured assets root, then requests similarity against it and asserts `similarity_score == Some(0.0)`, `similarity_pass == Some(true)`, and no intrinsic verdict. The test was confirmed to catch the bug by reverting the one-line fix (it failed with the exact cited error), then restored to green.
- CI runs the full workspace tier.

## Generated by

`/implement` — agent execution of [scoped issue #2913](https://github.com/iamacoffeepot/aether/issues/2913).
