### PR TITLE
feat(kit): extract reusable text editing state

### DIFF
--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -350,8 +350,8 @@ impl Default for SliderConfig {
 
 /// `aether.kit.widget.text_field.config` — a single-line editable string
 /// starting at `initial`, capped at `max_chars` characters (`0` = no cap).
-/// The field holds a `String` and a byte-offset caret; there is no selection
-/// in v1.
+/// The field keeps its caret and active selection on UTF-8 character boundaries
+/// and places both from resolved font metrics once the font settles.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
 #[kind(name = "aether.kit.widget.text_field.config")]
 pub struct TextFieldConfig {

--- a/crates/aether-kit/src/widget/mod.rs
+++ b/crates/aether-kit/src/widget/mod.rs
@@ -42,6 +42,7 @@ pub mod composite;
 pub mod focus;
 mod panel;
 pub mod set;
+pub mod text_edit;
 pub mod theme;
 
 pub use panel::WidgetPanel;

--- a/crates/aether-kit/src/widget/set/text_field.rs
+++ b/crates/aether-kit/src/widget/set/text_field.rs
@@ -35,7 +35,7 @@ use aether_kinds::{
 use crate::widget::set::{
     APPROX_ADVANCE_RATIO, approx_text_width, push_border, quad, text_origin_y,
 };
-use crate::widget::text_edit::{EditPolicy, SingleLineLayout, TextEditState};
+use crate::widget::text_edit::{EditPolicy, SingleLineLayout, TextEditState, TextSpan};
 use crate::widget::theme::{SetTheme, Theme, WidgetState};
 use crate::widget::{
     Collect, FocusGained, FocusLost, TextCommitted, TextFieldConfig, WidgetDrawItem,
@@ -58,13 +58,24 @@ pub struct TextFieldWidget {
     dragging: bool,
     /// The latest font id the theme asks metrics for.
     desired_font_id: u32,
-    /// The font id whose metrics are currently installed (`0` = none).
-    current_font_id: u32,
+    /// The font id whose metrics are currently installed.
+    current_font_id: Option<u32>,
     /// The font id of the one outstanding `FontMetricsRequest`, if any.
     inflight_font_id: Option<u32>,
     /// The resolved metrics for `current_font_id`, `None` until the first reply
     /// installs.
     metrics: Option<CachedFontMetrics>,
+}
+
+/// The committed editor state projected into the one string rendered this
+/// frame, with every owned span remapped into that string's byte offsets.
+struct DisplayedEdit {
+    text: String,
+    caret_byte: usize,
+    selection_span: Option<TextSpan>,
+    preedit_span: Option<TextSpan>,
+    preedit_cursor_span: Option<TextSpan>,
+    composing: bool,
 }
 
 impl TextFieldWidget {
@@ -77,14 +88,36 @@ impl TextFieldWidget {
         }
     }
 
+    /// Adopt a desired font id. Metrics are only usable for the id that
+    /// produced them, so a change returns placement to the warm-up fallback
+    /// until the replacement request resolves.
+    fn set_desired_font_id(&mut self, desired_font_id: u32) {
+        if self.desired_font_id == desired_font_id {
+            return;
+        }
+        self.desired_font_id = desired_font_id;
+        self.current_font_id = None;
+        self.metrics = None;
+    }
+
+    /// Metrics are exact only while their installed font is still the theme's
+    /// desired font. The id check keeps stale tables out of hit testing and all
+    /// selection / composition / caret geometry.
+    fn resolved_metrics(&self) -> Option<&CachedFontMetrics> {
+        (self.current_font_id == Some(self.desired_font_id))
+            .then_some(self.metrics.as_ref())
+            .flatten()
+    }
+
     /// The font id a pump should request now, or `None` to stay put: only when
-    /// no request is outstanding and the nonzero desired id lacks current
-    /// metrics. Pure over the adapter fields.
+    /// no request is outstanding and the desired id lacks current metrics.
+    /// Font id zero is valid; absence is represented by `Option` instead of a
+    /// numeric sentinel. Pure over the adapter fields.
     fn pending_request(&self) -> Option<u32> {
-        if self.inflight_font_id.is_some() || self.desired_font_id == 0 {
+        if self.inflight_font_id.is_some() {
             return None;
         }
-        if self.current_font_id == self.desired_font_id && self.metrics.is_some() {
+        if self.current_font_id == Some(self.desired_font_id) && self.metrics.is_some() {
             return None;
         }
         Some(self.desired_font_id)
@@ -101,20 +134,22 @@ impl TextFieldWidget {
 
     /// Attribute a metrics reply to the outstanding flight (`Some` for `Ok`,
     /// `None` for `Err`), install it only when its id is still the desired id,
-    /// and always clear the flight. Pure over the adapter fields; the caller
-    /// pumps a deferred newer request after. A late reply for a superseded font
-    /// is dropped rather than replacing current metrics.
-    fn accept_reply(&mut self, metrics: Option<CachedFontMetrics>) {
+    /// and always clear the flight. Returns whether the settled flight was
+    /// superseded and the caller should pump the deferred newer id. A current
+    /// id's error deliberately returns `false`: retrying it immediately would
+    /// form an unbounded request/reply loop.
+    fn accept_reply(&mut self, metrics: Option<CachedFontMetrics>) -> bool {
         let Some(id) = self.inflight_font_id.take() else {
-            return;
+            return false;
         };
         if id != self.desired_font_id {
-            return;
+            return true;
         }
         if let Some(metrics) = metrics {
-            self.current_font_id = id;
+            self.current_font_id = Some(id);
             self.metrics = Some(metrics);
         }
+        false
     }
 
     /// Start a font-metrics request when one is due (single-flight; a duplicate
@@ -127,6 +162,45 @@ impl TextFieldWidget {
         }
     }
 
+    /// Project committed text, selection, and preedit into one render string.
+    /// While composing, the preedit replaces the active selection and its
+    /// cursor span is translated from preedit-local into display byte offsets.
+    fn displayed_edit(&self) -> DisplayedEdit {
+        let selection = self.edit.selection();
+        if self.edit.preedit().is_empty() {
+            return DisplayedEdit {
+                text: String::from(self.edit.value()),
+                caret_byte: self.edit.caret(),
+                selection_span: (!selection.is_collapsed()).then_some(selection),
+                preedit_span: None,
+                preedit_cursor_span: None,
+                composing: false,
+            };
+        }
+
+        let preedit = self.edit.preedit();
+        let mut text = String::with_capacity(self.edit.value().len() + preedit.len());
+        text.push_str(&self.edit.value()[..selection.start_byte]);
+        text.push_str(preedit);
+        text.push_str(&self.edit.value()[selection.end_byte..]);
+        let span_end = selection.start_byte + preedit.len();
+        let cursor = self
+            .edit
+            .preedit_cursor()
+            .unwrap_or_else(|| TextSpan::new(preedit.len(), preedit.len()));
+        DisplayedEdit {
+            text,
+            caret_byte: span_end,
+            selection_span: None,
+            preedit_span: Some(TextSpan::new(selection.start_byte, span_end)),
+            preedit_cursor_span: Some(TextSpan::new(
+                selection.start_byte + cursor.start_byte,
+                selection.start_byte + cursor.end_byte,
+            )),
+            composing: true,
+        }
+    }
+
     /// The `char`-boundary byte offset a pointer at window `event_x` lands on —
     /// exact against the metric table when resolved, else the proportional
     /// approximation.
@@ -134,7 +208,7 @@ impl TextFieldWidget {
         let size = self.theme.value_size_pixels;
         let local_x = event_x - self.frame.x - self.theme.pad;
         let text = self.edit.value();
-        if let Some(metrics) = &self.metrics {
+        if let Some(metrics) = self.resolved_metrics() {
             return SingleLineLayout::build(text, metrics, size).hit_test(local_x);
         }
         let advance = (size * APPROX_ADVANCE_RATIO).max(1.0);
@@ -148,17 +222,6 @@ impl TextFieldWidget {
         text.char_indices()
             .nth(index)
             .map_or(text.len(), |(byte, _)| byte)
-    }
-
-    /// The pixel x of the caret sitting after `byte` bytes of `displayed` at
-    /// `size` — exact against the metric table when resolved, else the
-    /// proportional approximation.
-    fn prefix_width(&self, displayed: &str, byte: usize, size: f32) -> f32 {
-        let chars = displayed[..byte].chars().count();
-        self.metrics.as_ref().map_or_else(
-            || approx_text_width(chars, size),
-            |metrics| metrics.caret_x(displayed, chars, size),
-        )
     }
 }
 
@@ -189,7 +252,7 @@ impl WasmActor for TextFieldWidget {
             modifiers: Modifiers::default(),
             dragging: false,
             desired_font_id,
-            current_font_id: 0,
+            current_font_id: None,
             inflight_font_id: None,
             metrics: None,
         })
@@ -207,7 +270,7 @@ impl WasmActor for TextFieldWidget {
     fn on_config(&mut self, ctx: &mut WasmCtx<'_>, config: TextFieldConfig) {
         self.edit = TextEditState::new(config.initial);
         self.max_chars = config.max_chars;
-        self.desired_font_id = config.theme.font_id;
+        self.set_desired_font_id(config.theme.font_id);
         self.theme = config.theme;
         self.pump_font_metrics(ctx);
     }
@@ -215,7 +278,7 @@ impl WasmActor for TextFieldWidget {
     /// Restyle: adopt the fanned theme and request metrics for its font.
     #[handler::single]
     fn on_set_theme(&mut self, ctx: &mut WasmCtx<'_>, set: SetTheme) {
-        self.desired_font_id = set.theme.font_id;
+        self.set_desired_font_id(set.theme.font_id);
         self.theme = set.theme;
         self.pump_font_metrics(ctx);
     }
@@ -310,7 +373,7 @@ impl WasmActor for TextFieldWidget {
     #[handler::single]
     fn on_ime_preedit(&mut self, _ctx: &mut WasmCtx<'_>, preedit: ImePreedit) {
         let cursor = match (preedit.cursor_begin, preedit.cursor_end) {
-            (Some(begin), Some(end)) => Some((begin as usize, end as usize)),
+            (Some(begin), Some(end)) => Some(TextSpan::new(begin as usize, end as usize)),
             _ => None,
         };
         self.edit.set_composition(preedit.text, cursor);
@@ -320,16 +383,18 @@ impl WasmActor for TextFieldWidget {
     /// stale reply (its font is no longer the desired one) is dropped.
     #[handler::single]
     fn on_font_metrics_result(&mut self, ctx: &mut WasmCtx<'_>, result: FontMetricsResult) {
-        match result {
+        let pump_deferred = match result {
             FontMetricsResult::Ok { metrics } => {
-                self.accept_reply(Some(CachedFontMetrics::new(&metrics)));
+                self.accept_reply(Some(CachedFontMetrics::new(&metrics)))
             }
             FontMetricsResult::Err { error } => {
                 tracing::warn!(target: "aether_kit", %error, "text field font metrics failed");
-                self.accept_reply(None);
+                self.accept_reply(None)
             }
+        };
+        if pump_deferred {
+            self.pump_font_metrics(ctx);
         }
-        self.pump_font_metrics(ctx);
     }
 
     /// Reply the field's local draw: a box, any selection band, the text plus a
@@ -347,40 +412,20 @@ impl WasmActor for TextFieldWidget {
         let text_y = text_origin_y(0.0, height, size);
         let caret_height = pad.mul_add(-2.0, height).max(1.0);
 
-        let (sel_start, sel_end) = self.edit.selection();
-        let composing = !self.edit.preedit().is_empty();
+        let displayed = self.displayed_edit();
 
-        // The visible string, the caret byte within it, an optional selection
-        // band to highlight, and — while composing — the preedit span and its
-        // cursor. Composing renders the preedit inserted at the selection start
-        // (the selection reads as replaced), so no selection band is drawn then.
-        let displayed;
-        let caret_byte;
-        let mut sel_band = None;
-        let mut preedit_span = None;
-        let mut preedit_cursor_byte = None;
-        if composing {
-            let preedit = self.edit.preedit();
-            let mut shown = String::with_capacity(self.edit.value().len() + preedit.len());
-            shown.push_str(&self.edit.value()[..sel_start]);
-            shown.push_str(preedit);
-            shown.push_str(&self.edit.value()[sel_end..]);
-            let span_end = sel_start + preedit.len();
-            preedit_span = Some((sel_start, span_end));
-            let cursor = self
-                .edit
-                .preedit_cursor()
-                .map_or(preedit.len(), |(_, end)| end);
-            preedit_cursor_byte = Some(sel_start + cursor);
-            caret_byte = span_end;
-            displayed = shown;
-        } else {
-            displayed = String::from(self.edit.value());
-            caret_byte = self.edit.caret();
-            if sel_start != sel_end {
-                sel_band = Some((sel_start, sel_end));
-            }
-        }
+        // One measured layout per rendered string. Every geometry lookup below
+        // reads this table; the warm-up fallback remains character-count based
+        // only until the desired font's metrics settle.
+        let layout = self
+            .resolved_metrics()
+            .map(|metrics| SingleLineLayout::build(&displayed.text, metrics, size));
+        let prefix_width = |byte: usize| {
+            layout.as_ref().map_or_else(
+                || approx_text_width(displayed.text[..byte].chars().count(), size),
+                |layout| layout.caret_x(byte),
+            )
+        };
 
         let mut items: Vec<WidgetDrawItem> = Vec::new();
         items.push(quad(
@@ -391,9 +436,9 @@ impl WasmActor for TextFieldWidget {
             self.theme
                 .fill(self.theme.surface_raised, WidgetState::Normal),
         ));
-        if let Some((start, end)) = sel_band {
-            let x0 = pad + self.prefix_width(&displayed, start, size);
-            let x1 = pad + self.prefix_width(&displayed, end, size);
+        if let Some(span) = displayed.selection_span {
+            let x0 = pad + prefix_width(span.start_byte);
+            let x1 = pad + prefix_width(span.end_byte);
             items.push(quad(
                 x0,
                 pad,
@@ -402,19 +447,33 @@ impl WasmActor for TextFieldWidget {
                 self.theme.accent,
             ));
         }
-        if !displayed.is_empty() {
+        if let Some(span) = displayed
+            .preedit_cursor_span
+            .filter(|span| !span.is_collapsed())
+        {
+            let x0 = pad + prefix_width(span.start_byte);
+            let x1 = pad + prefix_width(span.end_byte);
+            items.push(quad(
+                x0,
+                pad,
+                (x1 - x0).max(1.0),
+                caret_height,
+                self.theme.accent,
+            ));
+        }
+        if !displayed.text.is_empty() {
             items.push(WidgetDrawItem::Text {
                 x: pad,
                 y: text_y,
                 font_id: self.theme.font_id,
-                text: displayed.clone(),
+                text: displayed.text.clone(),
                 size_pixels: size,
                 color: self.theme.text_primary,
             });
         }
-        if let Some((start, end)) = preedit_span {
-            let x0 = pad + self.prefix_width(&displayed, start, size);
-            let x1 = pad + self.prefix_width(&displayed, end, size);
+        if let Some(span) = displayed.preedit_span {
+            let x0 = pad + prefix_width(span.start_byte);
+            let x1 = pad + prefix_width(span.end_byte);
             items.push(quad(
                 x0,
                 text_y + size,
@@ -422,13 +481,16 @@ impl WasmActor for TextFieldWidget {
                 1.0,
                 self.theme.accent,
             ));
-            if let Some(byte) = preedit_cursor_byte {
-                let cursor_x = pad + self.prefix_width(&displayed, byte, size);
+            if let Some(cursor) = displayed
+                .preedit_cursor_span
+                .filter(|cursor| cursor.is_collapsed())
+            {
+                let cursor_x = pad + prefix_width(cursor.end_byte);
                 items.push(quad(cursor_x, pad, 1.0, caret_height, self.theme.accent));
             }
         }
-        if self.focused && !composing {
-            let caret_x = pad + self.prefix_width(&displayed, caret_byte, size);
+        if self.focused && !displayed.composing {
+            let caret_x = pad + prefix_width(displayed.caret_byte);
             items.push(quad(caret_x, pad, 1.0, caret_height, self.theme.accent));
         }
         if self.focused {
@@ -465,7 +527,7 @@ mod tests {
             modifiers: Modifiers::default(),
             dragging: false,
             desired_font_id,
-            current_font_id: 0,
+            current_font_id: None,
             inflight_font_id: None,
             metrics: None,
         }
@@ -485,6 +547,25 @@ mod tests {
     }
 
     #[test]
+    fn composition_projection_preserves_the_full_multibyte_cursor_span() {
+        let mut field = adapter_field(7);
+        field.edit = TextEditState::new(String::from("abécd"));
+        field.edit.move_left(true);
+        field.edit.move_left(true); // select `cd` at bytes 4..6
+        field
+            .edit
+            .set_composition(String::from("üx"), Some(TextSpan::new(0, 2)));
+
+        let displayed = field.displayed_edit();
+        assert_eq!(displayed.text, "abéüx");
+        assert_eq!(displayed.selection_span, None);
+        assert_eq!(displayed.preedit_span, Some(TextSpan::new(4, 7)));
+        assert_eq!(displayed.preedit_cursor_span, Some(TextSpan::new(4, 6)));
+        assert_eq!(displayed.caret_byte, 7);
+        assert!(displayed.composing);
+    }
+
+    #[test]
     fn initial_load_requests_desired_once_then_coalesces() {
         let mut field = adapter_field(7);
         assert_eq!(field.take_pending_request(), Some(7));
@@ -496,22 +577,25 @@ mod tests {
     fn a_resolved_reply_installs_and_stops_requesting() {
         let mut field = adapter_field(7);
         assert_eq!(field.take_pending_request(), Some(7));
-        field.accept_reply(Some(some_metrics()));
-        assert_eq!(field.current_font_id, 7);
+        assert!(!field.accept_reply(Some(some_metrics())));
+        assert_eq!(field.current_font_id, Some(7));
         assert!(field.metrics.is_some());
         // Desired is satisfied, so nothing more is requested.
         assert_eq!(field.take_pending_request(), None);
     }
 
     #[test]
-    fn an_error_reply_clears_the_flight_and_retries() {
+    fn an_error_for_the_current_font_does_not_immediately_retry() {
         let mut field = adapter_field(7);
         assert_eq!(field.take_pending_request(), Some(7));
-        field.accept_reply(None);
-        assert_eq!(field.current_font_id, 0);
+        assert!(
+            !field.accept_reply(None),
+            "the result handler must not pump the just-failed id"
+        );
+        assert_eq!(field.current_font_id, None);
         assert!(field.metrics.is_none());
-        // The flight cleared without installing, so the same desired id is
-        // requested again.
+        assert_eq!(field.inflight_font_id, None);
+        // A later config/theme event may retry the id explicitly.
         assert_eq!(field.take_pending_request(), Some(7));
     }
 
@@ -520,18 +604,50 @@ mod tests {
         let mut field = adapter_field(7);
         assert_eq!(field.take_pending_request(), Some(7));
         // The theme font changes while the request for 7 is outstanding.
-        field.desired_font_id = 9;
+        field.set_desired_font_id(9);
         // Still single-flight: no new request until the outstanding one settles.
         assert_eq!(field.take_pending_request(), None);
         // The reply for the superseded font 7 must not install as current.
-        field.accept_reply(Some(some_metrics()));
-        assert_eq!(field.current_font_id, 0);
+        assert!(field.accept_reply(Some(some_metrics())));
+        assert_eq!(field.current_font_id, None);
         assert!(field.metrics.is_none());
         // Now the deferred request for the latest desired id goes out and
         // installs.
         assert_eq!(field.take_pending_request(), Some(9));
-        field.accept_reply(Some(some_metrics()));
-        assert_eq!(field.current_font_id, 9);
+        assert!(!field.accept_reply(Some(some_metrics())));
+        assert_eq!(field.current_font_id, Some(9));
         assert!(field.metrics.is_some());
+    }
+
+    #[test]
+    fn a_stale_error_pumps_the_deferred_newer_font() {
+        let mut field = adapter_field(7);
+        assert_eq!(field.take_pending_request(), Some(7));
+        field.set_desired_font_id(9);
+        assert!(field.accept_reply(None));
+        assert_eq!(field.take_pending_request(), Some(9));
+    }
+
+    #[test]
+    fn a_font_change_clears_installed_metrics_before_new_geometry() {
+        let mut field = adapter_field(7);
+        assert_eq!(field.take_pending_request(), Some(7));
+        assert!(!field.accept_reply(Some(some_metrics())));
+        assert!(field.resolved_metrics().is_some());
+
+        field.set_desired_font_id(9);
+        assert_eq!(field.current_font_id, None);
+        assert!(field.metrics.is_none());
+        assert!(field.resolved_metrics().is_none());
+        assert_eq!(field.take_pending_request(), Some(9));
+    }
+
+    #[test]
+    fn zero_is_a_valid_font_id_and_requests_metrics() {
+        let mut field = adapter_field(0);
+        assert_eq!(field.take_pending_request(), Some(0));
+        assert!(!field.accept_reply(Some(some_metrics())));
+        assert_eq!(field.current_font_id, Some(0));
+        assert!(field.resolved_metrics().is_some());
     }
 }

--- a/crates/aether-kit/src/widget/set/text_field.rs
+++ b/crates/aether-kit/src/widget/set/text_field.rs
@@ -5,7 +5,7 @@
 //! The single-line text field (issue 2660, reworked in issue 2924).
 //!
 //! The field is a thin actor over the reusable
-//! [`TextEditState`](crate::widget::text_edit::TextEditState): committed
+//! [`TextEditState`]: committed
 //! `TextInput` replaces the active selection at the caret; the editing keys the
 //! substrate emits scancodes for (Backspace, Left, Right, Enter) delete, move —
 //! extending the selection while Shift is held — or commit; a pointer press
@@ -17,7 +17,7 @@
 //! Caret placement and pointer hit-testing are exact once the font's metrics
 //! settle: the field drives a single-flight [`FontMetricsRequest`] for its
 //! theme's font and measures against the resolved
-//! [`CachedFontMetrics`](aether_kinds::CachedFontMetrics). Until then it falls
+//! [`CachedFontMetrics`]. Until then it falls
 //! back to the proportional approximation as a bounded font-warm-up placement.
 
 use alloc::string::String;

--- a/crates/aether-kit/src/widget/set/text_field.rs
+++ b/crates/aether-kit/src/widget/set/text_field.rs
@@ -2,96 +2,163 @@
 // dispatch ABI (see `widget/mod.rs`).
 #![allow(clippy::needless_pass_by_value)]
 
-//! The single-line text field (issue 2660).
+//! The single-line text field (issue 2660, reworked in issue 2924).
 //!
-//! Committed text (`TextInput`, already layout- and IME-resolved) inserts at
-//! the caret; the editing keys the substrate emits scancodes for — Backspace,
-//! Left, Right, Enter — move the caret or commit; an in-flight IME composition
-//! (`ImePreedit`) renders as a trailing underlined span. The caret is a
-//! byte-offset into the string and every move lands on a `char` boundary, so a
-//! multi-byte character is never split. There is no selection in v1.
+//! The field is a thin actor over the reusable
+//! [`TextEditState`](crate::widget::text_edit::TextEditState): committed
+//! `TextInput` replaces the active selection at the caret; the editing keys the
+//! substrate emits scancodes for (Backspace, Left, Right, Enter) delete, move —
+//! extending the selection while Shift is held — or commit; a pointer press
+//! places the caret and a drag extends the selection; an in-flight IME
+//! composition (`ImePreedit`) renders underlined at the active selection with
+//! its reported cursor span. Every caret / selection / preedit offset lands on a
+//! `char` boundary, so a multi-byte character is never split.
 //!
-//! Home / End are not handled: the substrate's `keycode` space has no
-//! `KEY_HOME` / `KEY_END` scancode yet (only Backspace / arrows / Enter /
-//! Tab), so those edits await the keycodes landing.
+//! Caret placement and pointer hit-testing are exact once the font's metrics
+//! settle: the field drives a single-flight [`FontMetricsRequest`] for its
+//! theme's font and measures against the resolved
+//! [`CachedFontMetrics`](aether_kinds::CachedFontMetrics). Until then it falls
+//! back to the proportional approximation as a bounded font-warm-up placement.
 
 use alloc::string::String;
 use alloc::vec::Vec;
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::TextCapability;
+use aether_capabilities::text::{FontMetricsRequest, FontMetricsResult, FontRef};
 use aether_kinds::keycode::{KEY_BACKSPACE, KEY_ENTER, KEY_LEFT, KEY_RIGHT};
-use aether_kinds::{ImePreedit, Key, Modifiers, TextInput};
+use aether_kinds::{
+    CachedFontMetrics, ImePreedit, Key, Modifiers, MouseButton, MouseButtonRelease, MouseMove,
+    TextInput, mouse_button,
+};
 
-use crate::widget::set::{approx_text_width, push_border, quad, text_origin_y};
+use crate::widget::set::{
+    APPROX_ADVANCE_RATIO, approx_text_width, push_border, quad, text_origin_y,
+};
+use crate::widget::text_edit::{EditPolicy, SingleLineLayout, TextEditState};
 use crate::widget::theme::{SetTheme, Theme, WidgetState};
 use crate::widget::{
     Collect, FocusGained, FocusLost, TextCommitted, TextFieldConfig, WidgetDrawItem,
     WidgetDrawList, WidgetFrame,
 };
 
-/// A single-line editable string. Holds the text, a byte-offset caret, the
-/// character cap, the latest modifiers, and the in-flight IME preedit span.
+/// A single-line editable string. Holds the reusable editing state, the
+/// character cap, the latest modifiers, whether a pointer drag is live, and the
+/// single-flight font-metrics adapter that feeds exact caret placement.
 pub struct TextFieldWidget {
-    text: String,
-    /// Caret position as a byte offset into `text`, always on a `char`
-    /// boundary.
-    cursor: usize,
+    edit: TextEditState,
     /// Maximum character count (`0` = uncapped).
     max_chars: u32,
     theme: Theme,
     frame: WidgetFrame,
     focused: bool,
     modifiers: Modifiers,
-    /// The current IME composition, drawn underlined after the committed text;
-    /// empty when no composition is active.
-    preedit: String,
+    /// Whether a left-button drag is in progress (a pointer move only extends
+    /// the selection while the button is held, never on a bare hover).
+    dragging: bool,
+    /// The latest font id the theme asks metrics for.
+    desired_font_id: u32,
+    /// The font id whose metrics are currently installed (`0` = none).
+    current_font_id: u32,
+    /// The font id of the one outstanding `FontMetricsRequest`, if any.
+    inflight_font_id: Option<u32>,
+    /// The resolved metrics for `current_font_id`, `None` until the first reply
+    /// installs.
+    metrics: Option<CachedFontMetrics>,
 }
 
 impl TextFieldWidget {
-    /// Whether inserting `count` more characters would exceed the cap.
-    fn would_overflow(&self, count: usize) -> bool {
-        self.max_chars > 0 && self.text.chars().count() + count > self.max_chars as usize
-    }
-
-    /// Insert `s` at the caret, advancing the caret past it. Rejected whole if
-    /// it would exceed the character cap. Owned editing op — unit-tested.
-    fn insert(&mut self, s: &str) {
-        if s.is_empty() || self.would_overflow(s.chars().count()) {
-            return;
+    /// The insert policy the field enforces: single-line, capped at
+    /// `max_chars`.
+    fn policy(&self) -> EditPolicy {
+        EditPolicy {
+            single_line: true,
+            max_chars: self.max_chars,
         }
-        self.text.insert_str(self.cursor, s);
-        self.cursor += s.len();
     }
 
-    /// Delete the character before the caret (Backspace), stepping the caret
-    /// back one `char`. No-op at the start.
-    fn backspace(&mut self) {
-        let Some(prev) = self.text[..self.cursor].chars().next_back() else {
+    /// The font id a pump should request now, or `None` to stay put: only when
+    /// no request is outstanding and the nonzero desired id lacks current
+    /// metrics. Pure over the adapter fields.
+    fn pending_request(&self) -> Option<u32> {
+        if self.inflight_font_id.is_some() || self.desired_font_id == 0 {
+            return None;
+        }
+        if self.current_font_id == self.desired_font_id && self.metrics.is_some() {
+            return None;
+        }
+        Some(self.desired_font_id)
+    }
+
+    /// Reserve the next request — the id to fetch (marking it in-flight) or
+    /// `None` if none is due. Pure over the adapter fields; the caller sends the
+    /// wire request.
+    fn take_pending_request(&mut self) -> Option<u32> {
+        let id = self.pending_request()?;
+        self.inflight_font_id = Some(id);
+        Some(id)
+    }
+
+    /// Attribute a metrics reply to the outstanding flight (`Some` for `Ok`,
+    /// `None` for `Err`), install it only when its id is still the desired id,
+    /// and always clear the flight. Pure over the adapter fields; the caller
+    /// pumps a deferred newer request after. A late reply for a superseded font
+    /// is dropped rather than replacing current metrics.
+    fn accept_reply(&mut self, metrics: Option<CachedFontMetrics>) {
+        let Some(id) = self.inflight_font_id.take() else {
             return;
         };
-        let start = self.cursor - prev.len_utf8();
-        self.text.replace_range(start..self.cursor, "");
-        self.cursor = start;
-    }
-
-    /// Move the caret one `char` left. No-op at the start.
-    fn move_left(&mut self) {
-        if let Some(prev) = self.text[..self.cursor].chars().next_back() {
-            self.cursor -= prev.len_utf8();
+        if id != self.desired_font_id {
+            return;
+        }
+        if let Some(metrics) = metrics {
+            self.current_font_id = id;
+            self.metrics = Some(metrics);
         }
     }
 
-    /// Move the caret one `char` right. No-op at the end.
-    fn move_right(&mut self) {
-        if let Some(next) = self.text[self.cursor..].chars().next() {
-            self.cursor += next.len_utf8();
+    /// Start a font-metrics request when one is due (single-flight; a duplicate
+    /// desired id coalesces onto the outstanding flight).
+    fn pump_font_metrics(&mut self, ctx: &mut WasmCtx<'_>) {
+        if let Some(id) = self.take_pending_request() {
+            ctx.actor::<TextCapability>().send(&FontMetricsRequest {
+                font: FontRef::Id(id),
+            });
         }
     }
 
-    /// The character count before the caret — the caret's column, for its
-    /// approximate pixel placement.
-    fn chars_before_cursor(&self) -> usize {
-        self.text[..self.cursor].chars().count()
+    /// The `char`-boundary byte offset a pointer at window `event_x` lands on —
+    /// exact against the metric table when resolved, else the proportional
+    /// approximation.
+    fn hit_byte(&self, event_x: f32) -> usize {
+        let size = self.theme.value_size_pixels;
+        let local_x = event_x - self.frame.x - self.theme.pad;
+        let text = self.edit.value();
+        if let Some(metrics) = &self.metrics {
+            return SingleLineLayout::build(text, metrics, size).hit_test(local_x);
+        }
+        let advance = (size * APPROX_ADVANCE_RATIO).max(1.0);
+        let index = if local_x <= 0.0 {
+            0
+        } else {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let rounded = (local_x / advance + 0.5) as usize;
+            rounded.min(text.chars().count())
+        };
+        text.char_indices()
+            .nth(index)
+            .map_or(text.len(), |(byte, _)| byte)
+    }
+
+    /// The pixel x of the caret sitting after `byte` bytes of `displayed` at
+    /// `size` — exact against the metric table when resolved, else the
+    /// proportional approximation.
+    fn prefix_width(&self, displayed: &str, byte: usize, size: f32) -> f32 {
+        let chars = displayed[..byte].chars().count();
+        self.metrics.as_ref().map_or_else(
+            || approx_text_width(chars, size),
+            |metrics| metrics.caret_x(displayed, chars, size),
+        )
     }
 }
 
@@ -107,10 +174,9 @@ impl WasmActor for TextFieldWidget {
     const NAMESPACE: &'static str = "aether.kit.widget.text_field";
 
     fn init(config: TextFieldConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
-        let cursor = config.initial.len();
+        let desired_font_id = config.theme.font_id;
         Ok(TextFieldWidget {
-            text: config.initial,
-            cursor,
+            edit: TextEditState::new(config.initial),
             max_chars: config.max_chars,
             theme: config.theme,
             frame: WidgetFrame {
@@ -121,24 +187,37 @@ impl WasmActor for TextFieldWidget {
             },
             focused: false,
             modifiers: Modifiers::default(),
-            preedit: String::new(),
+            dragging: false,
+            desired_font_id,
+            current_font_id: 0,
+            inflight_font_id: None,
+            metrics: None,
         })
     }
 
-    /// Reset the contents / cap / theme in place from a re-sent config.
-    #[handler::single]
-    fn on_config(&mut self, _ctx: &mut WasmCtx<'_>, config: TextFieldConfig) {
-        self.cursor = config.initial.len();
-        self.text = config.initial;
-        self.max_chars = config.max_chars;
-        self.theme = config.theme;
-        self.preedit.clear();
+    /// Kick off the font-metrics request for the initial theme font (inline
+    /// children now run `wire`).
+    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+        self.pump_font_metrics(ctx);
     }
 
-    /// Restyle: adopt the fanned theme.
+    /// Reset the contents / cap / theme in place from a re-sent config, and
+    /// request metrics for the new theme font.
     #[handler::single]
-    fn on_set_theme(&mut self, _ctx: &mut WasmCtx<'_>, set: SetTheme) {
+    fn on_config(&mut self, ctx: &mut WasmCtx<'_>, config: TextFieldConfig) {
+        self.edit = TextEditState::new(config.initial);
+        self.max_chars = config.max_chars;
+        self.desired_font_id = config.theme.font_id;
+        self.theme = config.theme;
+        self.pump_font_metrics(ctx);
+    }
+
+    /// Restyle: adopt the fanned theme and request metrics for its font.
+    #[handler::single]
+    fn on_set_theme(&mut self, ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.desired_font_id = set.theme.font_id;
         self.theme = set.theme;
+        self.pump_font_metrics(ctx);
     }
 
     /// Cache the layout rect the root assigned.
@@ -157,27 +236,31 @@ impl WasmActor for TextFieldWidget {
     #[handler::single]
     fn on_focus_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: FocusLost) {
         self.focused = false;
+        self.dragging = false;
     }
 
-    /// Insert committed text at the caret. `TextInput` is already resolved
-    /// through the layout and IME, so it inserts verbatim.
+    /// Insert committed text over the active selection. `TextInput` is already
+    /// resolved through the layout and IME, so any composition ends here.
     #[handler::single]
     fn on_text_input(&mut self, _ctx: &mut WasmCtx<'_>, input: TextInput) {
-        self.insert(&input.text);
+        self.edit.clear_composition();
+        self.edit.insert(&input.text, self.policy());
     }
 
-    /// Editing keys: Backspace deletes, Left / Right move the caret, Enter
-    /// commits the current contents up to the panel root.
+    /// Editing keys: Backspace deletes, Left / Right move the caret (extending
+    /// the selection while Shift is held), Enter commits the current contents up
+    /// to the panel root.
     #[handler::single]
     fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
+        let extend = self.modifiers.shift;
         match key.code {
-            KEY_BACKSPACE => self.backspace(),
-            KEY_LEFT => self.move_left(),
-            KEY_RIGHT => self.move_right(),
+            KEY_BACKSPACE => self.edit.delete_backward(),
+            KEY_LEFT => self.edit.move_left(extend),
+            KEY_RIGHT => self.edit.move_right(extend),
             KEY_ENTER => {
                 if let Some(parent) = ctx.parent() {
                     parent.send(&TextCommitted {
-                        text: self.text.clone(),
+                        text: String::from(self.edit.value()),
                     });
                 }
             }
@@ -185,21 +268,73 @@ impl WasmActor for TextFieldWidget {
         }
     }
 
-    /// Cache the latest modifier state (Ctrl / Shift / …) so future
-    /// chord-aware edits can consult it.
+    /// A left press places the caret at the pointer and arms a drag; other
+    /// buttons are ignored.
+    #[handler::single]
+    fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        if press.button != mouse_button::LEFT {
+            return;
+        }
+        self.dragging = true;
+        let byte = self.hit_byte(press.x);
+        self.edit.place_caret(byte);
+    }
+
+    /// A move during a live drag extends the selection to the pointer.
+    #[handler::single]
+    fn on_mouse_move(&mut self, _ctx: &mut WasmCtx<'_>, moved: MouseMove) {
+        if !self.dragging {
+            return;
+        }
+        let byte = self.hit_byte(moved.x);
+        self.edit.extend_to(byte);
+    }
+
+    /// A left release ends the drag.
+    #[handler::single]
+    fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
+        if release.button == mouse_button::LEFT {
+            self.dragging = false;
+        }
+    }
+
+    /// Cache the latest modifier state (Ctrl / Shift / …) so Shift-extended
+    /// movement and future chord-aware edits can consult it.
     #[handler::single]
     fn on_modifiers(&mut self, _ctx: &mut WasmCtx<'_>, modifiers: Modifiers) {
         self.modifiers = modifiers;
     }
 
-    /// Track the in-flight IME composition. Empty text clears it.
+    /// Track the in-flight IME composition at the active selection. Empty text
+    /// clears it.
     #[handler::single]
     fn on_ime_preedit(&mut self, _ctx: &mut WasmCtx<'_>, preedit: ImePreedit) {
-        self.preedit = preedit.text;
+        let cursor = match (preedit.cursor_begin, preedit.cursor_end) {
+            (Some(begin), Some(end)) => Some((begin as usize, end as usize)),
+            _ => None,
+        };
+        self.edit.set_composition(preedit.text, cursor);
     }
 
-    /// Reply the field's local draw: a box, the text plus any preedit, a caret
-    /// when focused, and a focus ring.
+    /// Install a font-metrics reply and pump any deferred newer request. A
+    /// stale reply (its font is no longer the desired one) is dropped.
+    #[handler::single]
+    fn on_font_metrics_result(&mut self, ctx: &mut WasmCtx<'_>, result: FontMetricsResult) {
+        match result {
+            FontMetricsResult::Ok { metrics } => {
+                self.accept_reply(Some(CachedFontMetrics::new(&metrics)));
+            }
+            FontMetricsResult::Err { error } => {
+                tracing::warn!(target: "aether_kit", %error, "text field font metrics failed");
+                self.accept_reply(None);
+            }
+        }
+        self.pump_font_metrics(ctx);
+    }
+
+    /// Reply the field's local draw: a box, any selection band, the text plus a
+    /// preedit at the caret, the composition underline / cursor, the caret when
+    /// focused, and a focus ring.
     ///
     /// # Agent
     /// The panel root's per-frame poll; not useful to send manually.
@@ -210,6 +345,42 @@ impl WasmActor for TextFieldWidget {
         let pad = self.theme.pad;
         let size = self.theme.value_size_pixels;
         let text_y = text_origin_y(0.0, height, size);
+        let caret_height = pad.mul_add(-2.0, height).max(1.0);
+
+        let (sel_start, sel_end) = self.edit.selection();
+        let composing = !self.edit.preedit().is_empty();
+
+        // The visible string, the caret byte within it, an optional selection
+        // band to highlight, and — while composing — the preedit span and its
+        // cursor. Composing renders the preedit inserted at the selection start
+        // (the selection reads as replaced), so no selection band is drawn then.
+        let displayed;
+        let caret_byte;
+        let mut sel_band = None;
+        let mut preedit_span = None;
+        let mut preedit_cursor_byte = None;
+        if composing {
+            let preedit = self.edit.preedit();
+            let mut shown = String::with_capacity(self.edit.value().len() + preedit.len());
+            shown.push_str(&self.edit.value()[..sel_start]);
+            shown.push_str(preedit);
+            shown.push_str(&self.edit.value()[sel_end..]);
+            let span_end = sel_start + preedit.len();
+            preedit_span = Some((sel_start, span_end));
+            let cursor = self
+                .edit
+                .preedit_cursor()
+                .map_or(preedit.len(), |(_, end)| end);
+            preedit_cursor_byte = Some(sel_start + cursor);
+            caret_byte = span_end;
+            displayed = shown;
+        } else {
+            displayed = String::from(self.edit.value());
+            caret_byte = self.edit.caret();
+            if sel_start != sel_end {
+                sel_band = Some((sel_start, sel_end));
+            }
+        }
 
         let mut items: Vec<WidgetDrawItem> = Vec::new();
         items.push(quad(
@@ -220,35 +391,47 @@ impl WasmActor for TextFieldWidget {
             self.theme
                 .fill(self.theme.surface_raised, WidgetState::Normal),
         ));
-        let mut shown = self.text.clone();
-        shown.push_str(&self.preedit);
-        if !shown.is_empty() {
+        if let Some((start, end)) = sel_band {
+            let x0 = pad + self.prefix_width(&displayed, start, size);
+            let x1 = pad + self.prefix_width(&displayed, end, size);
+            items.push(quad(
+                x0,
+                pad,
+                (x1 - x0).max(1.0),
+                caret_height,
+                self.theme.accent,
+            ));
+        }
+        if !displayed.is_empty() {
             items.push(WidgetDrawItem::Text {
                 x: pad,
                 y: text_y,
                 font_id: self.theme.font_id,
-                text: shown,
+                text: displayed.clone(),
                 size_pixels: size,
                 color: self.theme.text_primary,
             });
         }
-        if !self.preedit.is_empty() {
-            // Underline the composition span: a thin bar under the preedit,
-            // which trails the committed text.
-            let committed_width = approx_text_width(self.text.chars().count(), size);
-            let preedit_width = approx_text_width(self.preedit.chars().count(), size);
+        if let Some((start, end)) = preedit_span {
+            let x0 = pad + self.prefix_width(&displayed, start, size);
+            let x1 = pad + self.prefix_width(&displayed, end, size);
             items.push(quad(
-                pad + committed_width,
+                x0,
                 text_y + size,
-                preedit_width,
+                (x1 - x0).max(1.0),
                 1.0,
                 self.theme.accent,
             ));
+            if let Some(byte) = preedit_cursor_byte {
+                let cursor_x = pad + self.prefix_width(&displayed, byte, size);
+                items.push(quad(cursor_x, pad, 1.0, caret_height, self.theme.accent));
+            }
+        }
+        if self.focused && !composing {
+            let caret_x = pad + self.prefix_width(&displayed, caret_byte, size);
+            items.push(quad(caret_x, pad, 1.0, caret_height, self.theme.accent));
         }
         if self.focused {
-            let caret_x = pad + approx_text_width(self.chars_before_cursor(), size);
-            let caret_height = pad.mul_add(-2.0, height).max(1.0);
-            items.push(quad(caret_x, pad, 1.0, caret_height, self.theme.accent));
             push_border(&mut items, width, height, 2.0, self.theme.accent);
         }
         if let Some(parent) = ctx.parent() {
@@ -263,12 +446,14 @@ impl WasmActor for TextFieldWidget {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aether_kinds::FontMetrics;
 
-    fn field(text: &str, max_chars: u32) -> TextFieldWidget {
+    /// A field with the given desired font id, no metrics resolved yet — the
+    /// adapter's cold start.
+    fn adapter_field(desired_font_id: u32) -> TextFieldWidget {
         TextFieldWidget {
-            cursor: text.len(),
-            text: String::from(text),
-            max_chars,
+            edit: TextEditState::new(String::new()),
+            max_chars: 0,
             theme: Theme::DEFAULT,
             frame: WidgetFrame {
                 x: 0.0,
@@ -276,74 +461,77 @@ mod tests {
                 width: 100.0,
                 height: 24.0,
             },
-            focused: true,
+            focused: false,
             modifiers: Modifiers::default(),
-            preedit: String::new(),
+            dragging: false,
+            desired_font_id,
+            current_font_id: 0,
+            inflight_font_id: None,
+            metrics: None,
         }
     }
 
-    #[test]
-    fn insert_advances_the_caret_and_respects_the_cap() {
-        let mut f = field("ab", 0);
-        f.insert("c");
-        assert_eq!(f.text, "abc");
-        assert_eq!(f.cursor, 3);
-
-        let mut capped = field("ab", 3);
-        capped.insert("c");
-        assert_eq!(capped.text, "abc", "fills to the cap");
-        capped.insert("d");
-        assert_eq!(
-            capped.text, "abc",
-            "a further insert past the cap is dropped"
-        );
+    /// A minimal resolved metric table — enough to stand in for an installed
+    /// font in the adapter transition tests.
+    fn some_metrics() -> CachedFontMetrics {
+        CachedFontMetrics::new(&FontMetrics {
+            units_per_em: 1000.0,
+            ascent: 800.0,
+            descent: -200.0,
+            line_gap: 0.0,
+            default_advance: 500.0,
+            advances: Vec::new(),
+        })
     }
 
     #[test]
-    fn insert_in_the_middle_lands_at_the_caret() {
-        let mut f = field("ac", 0);
-        f.cursor = 1;
-        f.insert("b");
-        assert_eq!(f.text, "abc");
-        assert_eq!(f.cursor, 2);
+    fn initial_load_requests_desired_once_then_coalesces() {
+        let mut field = adapter_field(7);
+        assert_eq!(field.take_pending_request(), Some(7));
+        // The flight is outstanding, so a second pump requests nothing.
+        assert_eq!(field.take_pending_request(), None);
     }
 
     #[test]
-    fn backspace_deletes_a_whole_multibyte_char() {
-        // "é" is two bytes; the caret sits after it.
-        let mut f = field("é", 0);
-        assert_eq!(f.cursor, 2);
-        f.backspace();
-        assert_eq!(f.text, "");
-        assert_eq!(f.cursor, 0);
-        // Backspace at the start is a no-op.
-        f.backspace();
-        assert_eq!(f.cursor, 0);
+    fn a_resolved_reply_installs_and_stops_requesting() {
+        let mut field = adapter_field(7);
+        assert_eq!(field.take_pending_request(), Some(7));
+        field.accept_reply(Some(some_metrics()));
+        assert_eq!(field.current_font_id, 7);
+        assert!(field.metrics.is_some());
+        // Desired is satisfied, so nothing more is requested.
+        assert_eq!(field.take_pending_request(), None);
     }
 
     #[test]
-    fn caret_moves_on_char_boundaries_across_multibyte_text() {
-        // "aéb": a(1) é(2) b(1). Caret starts at end (byte 4).
-        let mut f = field("aéb", 0);
-        assert_eq!(f.cursor, 4);
-        f.move_left(); // over 'b'
-        assert_eq!(f.cursor, 3);
-        f.move_left(); // over 'é' (two bytes)
-        assert_eq!(f.cursor, 1);
-        f.move_left(); // over 'a'
-        assert_eq!(f.cursor, 0);
-        f.move_left(); // no-op at start
-        assert_eq!(f.cursor, 0);
-        f.move_right(); // over 'a'
-        assert_eq!(f.cursor, 1);
-        f.move_right(); // over 'é'
-        assert_eq!(f.cursor, 3);
+    fn an_error_reply_clears_the_flight_and_retries() {
+        let mut field = adapter_field(7);
+        assert_eq!(field.take_pending_request(), Some(7));
+        field.accept_reply(None);
+        assert_eq!(field.current_font_id, 0);
+        assert!(field.metrics.is_none());
+        // The flight cleared without installing, so the same desired id is
+        // requested again.
+        assert_eq!(field.take_pending_request(), Some(7));
     }
 
     #[test]
-    fn chars_before_cursor_counts_characters_not_bytes() {
-        let mut f = field("aéb", 0);
-        f.cursor = 3; // after 'a' and 'é'
-        assert_eq!(f.chars_before_cursor(), 2);
+    fn a_font_change_mid_flight_drops_the_stale_reply_and_defers_the_new_one() {
+        let mut field = adapter_field(7);
+        assert_eq!(field.take_pending_request(), Some(7));
+        // The theme font changes while the request for 7 is outstanding.
+        field.desired_font_id = 9;
+        // Still single-flight: no new request until the outstanding one settles.
+        assert_eq!(field.take_pending_request(), None);
+        // The reply for the superseded font 7 must not install as current.
+        field.accept_reply(Some(some_metrics()));
+        assert_eq!(field.current_font_id, 0);
+        assert!(field.metrics.is_none());
+        // Now the deferred request for the latest desired id goes out and
+        // installs.
+        assert_eq!(field.take_pending_request(), Some(9));
+        field.accept_reply(Some(some_metrics()));
+        assert_eq!(field.current_font_id, 9);
+        assert!(field.metrics.is_some());
     }
 }

--- a/crates/aether-kit/src/widget/text_edit.rs
+++ b/crates/aether-kit/src/widget/text_edit.rs
@@ -2,7 +2,7 @@
 //!
 //! [`TextEditState`] owns a committed `String`, a selection expressed as an
 //! `anchor` and an active `caret` (both byte offsets), and an in-flight IME
-//! composition (`preedit` plus an optional byte-offset cursor span). Every
+//! composition (`preedit` plus an optional [`TextSpan`] cursor span). Every
 //! stored offset is normalized to a UTF-8 `char` boundary, so a multi-byte
 //! character is never split by a caret, a selection edge, or a preedit span.
 //!
@@ -36,6 +36,36 @@ pub struct EditPolicy {
     pub max_chars: u32,
 }
 
+/// A half-open byte span in edited or preedit text. [`TextEditState`] normalizes
+/// spans before storing them; named fields keep the unit and endpoint ordering
+/// explicit at the public API.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TextSpan {
+    /// Inclusive byte offset where the span begins.
+    pub start_byte: usize,
+    /// Exclusive byte offset where the span ends.
+    pub end_byte: usize,
+}
+
+impl TextSpan {
+    /// Construct a span from byte endpoints. Consumers that pass it into
+    /// [`TextEditState`] may use arbitrary endpoints; the state normalizes them
+    /// before storing the span.
+    #[must_use]
+    pub const fn new(start_byte: usize, end_byte: usize) -> Self {
+        Self {
+            start_byte,
+            end_byte,
+        }
+    }
+
+    /// Whether both endpoints name the same caret position.
+    #[must_use]
+    pub const fn is_collapsed(self) -> bool {
+        self.start_byte == self.end_byte
+    }
+}
+
 impl Default for EditPolicy {
     fn default() -> Self {
         Self {
@@ -59,7 +89,7 @@ pub struct TextEditState {
     preedit: String,
     /// The IME's reported cursor/selection span as byte offsets into `preedit`,
     /// `None` when the IME gives no span.
-    preedit_cursor: Option<(usize, usize)>,
+    preedit_cursor: Option<TextSpan>,
 }
 
 /// Floor `byte` to a `char` boundary of `text`, clamping to `text.len()` first.
@@ -99,14 +129,14 @@ impl TextEditState {
         self.caret
     }
 
-    /// The selection as a sorted `(start, end)` byte range; `start == end` when
-    /// the selection is collapsed to a caret.
+    /// The selection as a sorted byte span; both endpoints match when the
+    /// selection is collapsed to a caret.
     #[must_use]
-    pub fn selection(&self) -> (usize, usize) {
+    pub fn selection(&self) -> TextSpan {
         if self.anchor <= self.caret {
-            (self.anchor, self.caret)
+            TextSpan::new(self.anchor, self.caret)
         } else {
-            (self.caret, self.anchor)
+            TextSpan::new(self.caret, self.anchor)
         }
     }
 
@@ -125,7 +155,7 @@ impl TextEditState {
     /// The IME cursor/selection span as byte offsets into
     /// [`preedit`](Self::preedit), `None` when the IME reported none.
     #[must_use]
-    pub fn preedit_cursor(&self) -> Option<(usize, usize)> {
+    pub fn preedit_cursor(&self) -> Option<TextSpan> {
         self.preedit_cursor
     }
 
@@ -148,7 +178,9 @@ impl TextEditState {
         if filtered.is_empty() {
             return false;
         }
-        let (start, end) = self.selection();
+        let selection = self.selection();
+        let start = selection.start_byte;
+        let end = selection.end_byte;
         if policy.max_chars > 0 {
             let removed = self.text[start..end].chars().count();
             let added = filtered.chars().count();
@@ -195,7 +227,9 @@ impl TextEditState {
     }
 
     fn delete_selection(&mut self) {
-        let (start, end) = self.selection();
+        let selection = self.selection();
+        let start = selection.start_byte;
+        let end = selection.end_byte;
         self.text.replace_range(start..end, "");
         self.anchor = start;
         self.caret = start;
@@ -206,7 +240,7 @@ impl TextEditState {
     /// its left edge and a collapsed caret steps one character.
     pub fn move_left(&mut self, extend: bool) {
         if !extend && self.has_selection() {
-            let (start, _) = self.selection();
+            let start = self.selection().start_byte;
             self.anchor = start;
             self.caret = start;
             return;
@@ -224,7 +258,7 @@ impl TextEditState {
     /// collapsed caret steps one character.
     pub fn move_right(&mut self, extend: bool) {
         if !extend && self.has_selection() {
-            let (_, end) = self.selection();
+            let end = self.selection().end_byte;
             self.anchor = end;
             self.caret = end;
             return;
@@ -277,21 +311,21 @@ impl TextEditState {
     /// span. Empty `text` clears the composition. The span is normalized to
     /// `char` boundaries of `text` and ordered, and dropped entirely when it
     /// falls outside the composition.
-    pub fn set_composition(&mut self, text: String, cursor: Option<(usize, usize)>) {
+    pub fn set_composition(&mut self, text: String, cursor: Option<TextSpan>) {
         if text.is_empty() {
             self.clear_composition();
             return;
         }
-        let cursor = cursor.and_then(|(begin, end)| {
-            if begin > text.len() || end > text.len() {
+        let cursor = cursor.and_then(|cursor| {
+            if cursor.start_byte > text.len() || cursor.end_byte > text.len() {
                 return None;
             }
-            let begin = floor_boundary(&text, begin);
-            let end = floor_boundary(&text, end);
-            Some(if begin <= end {
-                (begin, end)
+            let start_byte = floor_boundary(&text, cursor.start_byte);
+            let end_byte = floor_boundary(&text, cursor.end_byte);
+            Some(if start_byte <= end_byte {
+                TextSpan::new(start_byte, end_byte)
             } else {
-                (end, begin)
+                TextSpan::new(end_byte, start_byte)
             })
         });
         self.preedit = text;
@@ -395,7 +429,7 @@ mod tests {
     fn new_collapses_caret_at_the_end() {
         let s = state("abc");
         assert_eq!(s.caret(), 3);
-        assert_eq!(s.selection(), (3, 3));
+        assert_eq!(s.selection(), TextSpan::new(3, 3));
         assert!(!s.has_selection());
     }
 
@@ -458,7 +492,7 @@ mod tests {
         s.move_to_start(false);
         s.move_right(true); // select "a"
         s.move_right(true); // select "ab"
-        assert_eq!(s.selection(), (0, 2));
+        assert_eq!(s.selection(), TextSpan::new(0, 2));
         assert!(s.has_selection());
         // A non-extending left collapses to the selection's left edge.
         s.move_left(false);
@@ -466,7 +500,7 @@ mod tests {
         assert!(!s.has_selection());
         // Re-select then a non-extending right collapses to the right edge.
         s.select_all();
-        assert_eq!(s.selection(), (0, 4));
+        assert_eq!(s.selection(), TextSpan::new(0, 4));
         s.move_right(false);
         assert_eq!(s.caret(), 4);
         assert!(!s.has_selection());
@@ -478,11 +512,11 @@ mod tests {
         // Caret at end; extend left twice selects "bc" backward.
         s.move_left(true);
         s.move_left(true);
-        assert_eq!(s.selection(), (1, 3));
+        assert_eq!(s.selection(), TextSpan::new(1, 3));
         assert_eq!(s.caret(), 1);
         // Document-edge extend to start selects the whole run.
         s.move_to_start(true);
-        assert_eq!(s.selection(), (0, 3));
+        assert_eq!(s.selection(), TextSpan::new(0, 3));
         assert_eq!(s.caret(), 0);
     }
 
@@ -496,6 +530,36 @@ mod tests {
         assert_eq!(s.value(), "HEllo");
         assert_eq!(s.caret(), 2);
         assert!(!s.has_selection());
+    }
+
+    #[test]
+    fn multibyte_movement_and_selection_keep_byte_boundaries() {
+        let mut s = state("aéb"); // boundaries: 0, 1, 3, 4
+        s.move_left(true);
+        assert_eq!(s.selection(), TextSpan::new(3, 4));
+        assert_eq!(s.caret(), 3);
+        s.move_left(true);
+        assert_eq!(s.selection(), TextSpan::new(1, 4));
+        assert_eq!(s.caret(), 1);
+        s.move_right(true);
+        assert_eq!(s.selection(), TextSpan::new(3, 4));
+        assert_eq!(s.caret(), 3);
+    }
+
+    #[test]
+    fn mid_codepoint_place_and_extend_floor_before_replacement() {
+        let mut s = state("éx"); // boundaries: 0, 2, 3
+        s.place_caret(1);
+        assert_eq!(s.caret(), 0, "a click inside é floors before the char");
+        s.extend_to(2);
+        assert_eq!(s.selection(), TextSpan::new(0, 2));
+        assert!(s.insert("Z", uncapped()));
+        assert_eq!(s.value(), "Zx");
+        assert_eq!(s.caret(), 1);
+
+        s.place_caret(2);
+        s.extend_to(usize::MAX);
+        assert_eq!(s.selection(), TextSpan::new(2, 2));
     }
 
     #[test]
@@ -556,14 +620,14 @@ mod tests {
     fn composition_normalizes_and_clears() {
         let mut s = state("");
         // A span landing mid-`char` floors to the char boundary and orders.
-        s.set_composition(String::from("éà"), Some((3, 1)));
+        s.set_composition(String::from("éà"), Some(TextSpan::new(3, 1)));
         assert_eq!(s.preedit(), "éà");
-        assert_eq!(s.preedit_cursor(), Some((0, 2)));
+        assert_eq!(s.preedit_cursor(), Some(TextSpan::new(0, 2)));
         // An out-of-range span is dropped, not clamped into a lie.
-        s.set_composition(String::from("x"), Some((0, 9)));
+        s.set_composition(String::from("x"), Some(TextSpan::new(0, 9)));
         assert_eq!(s.preedit_cursor(), None);
         // Empty text clears the composition.
-        s.set_composition(String::new(), Some((0, 0)));
+        s.set_composition(String::new(), Some(TextSpan::new(0, 0)));
         assert_eq!(s.preedit(), "");
         assert_eq!(s.preedit_cursor(), None);
     }
@@ -578,7 +642,7 @@ mod tests {
             descent: -200.0,
             line_gap: 0.0,
             default_advance: 500.0,
-            advances: alloc::vec![
+            advances: vec![
                 GlyphAdvance {
                     codepoint: u32::from('i'),
                     advance_units: 200.0,

--- a/crates/aether-kit/src/widget/text_edit.rs
+++ b/crates/aether-kit/src/widget/text_edit.rs
@@ -1,0 +1,632 @@
+//! Reusable single-line plain-text editing state (issue 2924).
+//!
+//! [`TextEditState`] owns a committed `String`, a selection expressed as an
+//! `anchor` and an active `caret` (both byte offsets), and an in-flight IME
+//! composition (`preedit` plus an optional byte-offset cursor span). Every
+//! stored offset is normalized to a UTF-8 `char` boundary, so a multi-byte
+//! character is never split by a caret, a selection edge, or a preedit span.
+//!
+//! The state exposes semantic edits only — replace the selection, insert under
+//! an [`EditPolicy`], delete backward or forward, move by character or document
+//! edge with optional selection extension, select all, and update or clear the
+//! composition. It interprets no physical key codes, no focus or availability,
+//! no clipboard, and no multiline layout; a widget maps its input mail onto
+//! these operations and owns those concerns itself.
+//!
+//! [`SingleLineLayout`] turns a [`CachedFontMetrics`] measurement into an
+//! ordered byte-boundary / x-position table in one linear pass, so a caret's
+//! pixel x and a pointer's nearest caret boundary are exact lookups rather than
+//! a repeated prefix rescan.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_kinds::CachedFontMetrics;
+
+/// How an insert is filtered and capped before it lands. A single-line control
+/// drops line breaks; `max_chars` bounds the committed character count (`0` =
+/// uncapped).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EditPolicy {
+    /// Strip `\n` / `\r` from inserted text, so a paste or a stray newline
+    /// cannot break the single-line invariant.
+    pub single_line: bool,
+    /// Maximum committed character count; `0` leaves the field uncapped. A whole
+    /// insert that would exceed the cap is rejected rather than truncated.
+    pub max_chars: u32,
+}
+
+impl Default for EditPolicy {
+    fn default() -> Self {
+        Self {
+            single_line: true,
+            max_chars: 0,
+        }
+    }
+}
+
+/// A single-line plain-text editing core: committed text, a selection, and an
+/// IME composition, all on `char` boundaries.
+#[derive(Debug, Clone, Default)]
+pub struct TextEditState {
+    text: String,
+    /// The fixed end of the selection — where an extend-movement pivots from.
+    anchor: usize,
+    /// The moving end of the selection — where the caret is drawn and where a
+    /// collapsed selection sits.
+    caret: usize,
+    /// The in-flight IME composition, empty when none is active.
+    preedit: String,
+    /// The IME's reported cursor/selection span as byte offsets into `preedit`,
+    /// `None` when the IME gives no span.
+    preedit_cursor: Option<(usize, usize)>,
+}
+
+/// Floor `byte` to a `char` boundary of `text`, clamping to `text.len()` first.
+fn floor_boundary(text: &str, mut byte: usize) -> usize {
+    if byte >= text.len() {
+        return text.len();
+    }
+    while byte > 0 && !text.is_char_boundary(byte) {
+        byte -= 1;
+    }
+    byte
+}
+
+impl TextEditState {
+    /// A fresh editor over `initial`, caret and anchor collapsed at the end.
+    #[must_use]
+    pub fn new(initial: String) -> Self {
+        let end = initial.len();
+        Self {
+            text: initial,
+            anchor: end,
+            caret: end,
+            preedit: String::new(),
+            preedit_cursor: None,
+        }
+    }
+
+    /// The committed text (never includes the in-flight preedit).
+    #[must_use]
+    pub fn value(&self) -> &str {
+        &self.text
+    }
+
+    /// The active caret as a byte offset into [`value`](Self::value).
+    #[must_use]
+    pub fn caret(&self) -> usize {
+        self.caret
+    }
+
+    /// The selection as a sorted `(start, end)` byte range; `start == end` when
+    /// the selection is collapsed to a caret.
+    #[must_use]
+    pub fn selection(&self) -> (usize, usize) {
+        if self.anchor <= self.caret {
+            (self.anchor, self.caret)
+        } else {
+            (self.caret, self.anchor)
+        }
+    }
+
+    /// Whether any text is selected (the anchor and caret differ).
+    #[must_use]
+    pub fn has_selection(&self) -> bool {
+        self.anchor != self.caret
+    }
+
+    /// The in-flight IME composition, empty when none is active.
+    #[must_use]
+    pub fn preedit(&self) -> &str {
+        &self.preedit
+    }
+
+    /// The IME cursor/selection span as byte offsets into
+    /// [`preedit`](Self::preedit), `None` when the IME reported none.
+    #[must_use]
+    pub fn preedit_cursor(&self) -> Option<(usize, usize)> {
+        self.preedit_cursor
+    }
+
+    /// The filtered form of `s` under `policy` — line breaks dropped for a
+    /// single-line control. Returns `s` unchanged when nothing is filtered.
+    fn filtered(policy: EditPolicy, s: &str) -> String {
+        if policy.single_line && s.contains(['\n', '\r']) {
+            s.chars().filter(|c| *c != '\n' && *c != '\r').collect()
+        } else {
+            String::from(s)
+        }
+    }
+
+    /// Replace the active selection with `s` under `policy`, moving the caret
+    /// past the inserted text. The whole insert is rejected (returns `false`)
+    /// when its filtered form is empty or would push the committed character
+    /// count past the cap.
+    pub fn insert(&mut self, s: &str, policy: EditPolicy) -> bool {
+        let filtered = Self::filtered(policy, s);
+        if filtered.is_empty() {
+            return false;
+        }
+        let (start, end) = self.selection();
+        if policy.max_chars > 0 {
+            let removed = self.text[start..end].chars().count();
+            let added = filtered.chars().count();
+            let after = self.text.chars().count() - removed + added;
+            if after > policy.max_chars as usize {
+                return false;
+            }
+        }
+        self.text.replace_range(start..end, &filtered);
+        let point = start + filtered.len();
+        self.anchor = point;
+        self.caret = point;
+        true
+    }
+
+    /// Delete the selection if any, else the character before the caret
+    /// (Backspace). A no-op at the document start with no selection.
+    pub fn delete_backward(&mut self) {
+        if self.has_selection() {
+            self.delete_selection();
+            return;
+        }
+        let Some(prev) = self.text[..self.caret].chars().next_back() else {
+            return;
+        };
+        let start = self.caret - prev.len_utf8();
+        self.text.replace_range(start..self.caret, "");
+        self.anchor = start;
+        self.caret = start;
+    }
+
+    /// Delete the selection if any, else the character after the caret
+    /// (Delete). A no-op at the document end with no selection.
+    pub fn delete_forward(&mut self) {
+        if self.has_selection() {
+            self.delete_selection();
+            return;
+        }
+        let Some(next) = self.text[self.caret..].chars().next() else {
+            return;
+        };
+        let end = self.caret + next.len_utf8();
+        self.text.replace_range(self.caret..end, "");
+    }
+
+    fn delete_selection(&mut self) {
+        let (start, end) = self.selection();
+        self.text.replace_range(start..end, "");
+        self.anchor = start;
+        self.caret = start;
+    }
+
+    /// Move the caret one character left. `extend` keeps the anchor fixed
+    /// (growing the selection); otherwise a non-collapsed selection collapses to
+    /// its left edge and a collapsed caret steps one character.
+    pub fn move_left(&mut self, extend: bool) {
+        if !extend && self.has_selection() {
+            let (start, _) = self.selection();
+            self.anchor = start;
+            self.caret = start;
+            return;
+        }
+        if let Some(prev) = self.text[..self.caret].chars().next_back() {
+            self.caret -= prev.len_utf8();
+        }
+        if !extend {
+            self.anchor = self.caret;
+        }
+    }
+
+    /// Move the caret one character right. `extend` keeps the anchor fixed;
+    /// otherwise a non-collapsed selection collapses to its right edge and a
+    /// collapsed caret steps one character.
+    pub fn move_right(&mut self, extend: bool) {
+        if !extend && self.has_selection() {
+            let (_, end) = self.selection();
+            self.anchor = end;
+            self.caret = end;
+            return;
+        }
+        if let Some(next) = self.text[self.caret..].chars().next() {
+            self.caret += next.len_utf8();
+        }
+        if !extend {
+            self.anchor = self.caret;
+        }
+    }
+
+    /// Move the caret to the document start. `extend` keeps the anchor fixed.
+    pub fn move_to_start(&mut self, extend: bool) {
+        self.caret = 0;
+        if !extend {
+            self.anchor = 0;
+        }
+    }
+
+    /// Move the caret to the document end. `extend` keeps the anchor fixed.
+    pub fn move_to_end(&mut self, extend: bool) {
+        self.caret = self.text.len();
+        if !extend {
+            self.anchor = self.caret;
+        }
+    }
+
+    /// Select the whole document, anchor at the start and caret at the end.
+    pub fn select_all(&mut self) {
+        self.anchor = 0;
+        self.caret = self.text.len();
+    }
+
+    /// Collapse the selection to a caret at `byte` (a pointer click), normalized
+    /// to a `char` boundary.
+    pub fn place_caret(&mut self, byte: usize) {
+        let point = floor_boundary(&self.text, byte);
+        self.anchor = point;
+        self.caret = point;
+    }
+
+    /// Extend the selection so the active caret lands at `byte` (a pointer
+    /// drag), normalized to a `char` boundary; the anchor stays put.
+    pub fn extend_to(&mut self, byte: usize) {
+        self.caret = floor_boundary(&self.text, byte);
+    }
+
+    /// Set the IME composition to `text` with an optional byte-offset cursor
+    /// span. Empty `text` clears the composition. The span is normalized to
+    /// `char` boundaries of `text` and ordered, and dropped entirely when it
+    /// falls outside the composition.
+    pub fn set_composition(&mut self, text: String, cursor: Option<(usize, usize)>) {
+        if text.is_empty() {
+            self.clear_composition();
+            return;
+        }
+        let cursor = cursor.and_then(|(begin, end)| {
+            if begin > text.len() || end > text.len() {
+                return None;
+            }
+            let begin = floor_boundary(&text, begin);
+            let end = floor_boundary(&text, end);
+            Some(if begin <= end {
+                (begin, end)
+            } else {
+                (end, begin)
+            })
+        });
+        self.preedit = text;
+        self.preedit_cursor = cursor;
+    }
+
+    /// Clear any in-flight IME composition.
+    pub fn clear_composition(&mut self) {
+        self.preedit.clear();
+        self.preedit_cursor = None;
+    }
+}
+
+/// One caret stop in a laid-out single line: a `char`-boundary byte offset and
+/// the pixel x the caret sits at there.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct CaretStop {
+    byte: usize,
+    x: f32,
+}
+
+/// An ordered byte-boundary / x-position table for one line of text at a fixed
+/// draw size, built once from a [`CachedFontMetrics`]. Caret lookup and pointer
+/// hit-testing are exact table reads, so neither rescans the string.
+#[derive(Debug, Clone)]
+pub struct SingleLineLayout {
+    stops: Vec<CaretStop>,
+}
+
+impl SingleLineLayout {
+    /// Build the table for `text` at `size_pixels`, accumulating each glyph's
+    /// measured advance in a single left-to-right pass.
+    #[must_use]
+    pub fn build(text: &str, metrics: &CachedFontMetrics, size_pixels: f32) -> Self {
+        let mut stops = Vec::with_capacity(text.chars().count() + 1);
+        let mut x = 0.0;
+        let mut byte = 0;
+        stops.push(CaretStop { byte, x });
+        let mut buf = [0u8; 4];
+        for ch in text.chars() {
+            let glyph = ch.encode_utf8(&mut buf);
+            x += metrics.measure(glyph, size_pixels);
+            byte += ch.len_utf8();
+            stops.push(CaretStop { byte, x });
+        }
+        Self { stops }
+    }
+
+    /// The pixel x of the caret at `byte`, or the line's full extent when `byte`
+    /// is not a recorded boundary (caller-normalized offsets always match a
+    /// stop).
+    #[must_use]
+    pub fn caret_x(&self, byte: usize) -> f32 {
+        self.stops
+            .iter()
+            .find(|stop| stop.byte == byte)
+            .map_or_else(|| self.width(), |stop| stop.x)
+    }
+
+    /// The `char`-boundary byte offset whose caret sits nearest `x` — the stop
+    /// on the far side of every segment midpoint `x` has passed. Ties (exactly
+    /// at a midpoint) round toward the later boundary.
+    #[must_use]
+    pub fn hit_test(&self, x: f32) -> usize {
+        let mut byte = self.stops.first().map_or(0, |stop| stop.byte);
+        for pair in self.stops.windows(2) {
+            let midpoint = (pair[0].x + pair[1].x) * 0.5;
+            if x >= midpoint {
+                byte = pair[1].byte;
+            } else {
+                break;
+            }
+        }
+        byte
+    }
+
+    /// The line's full pixel extent (the x of its last caret stop).
+    #[must_use]
+    pub fn width(&self) -> f32 {
+        self.stops.last().map_or(0.0, |stop| stop.x)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_kinds::{FontMetrics, GlyphAdvance};
+
+    fn state(text: &str) -> TextEditState {
+        TextEditState::new(String::from(text))
+    }
+
+    fn uncapped() -> EditPolicy {
+        EditPolicy {
+            single_line: true,
+            max_chars: 0,
+        }
+    }
+
+    #[test]
+    fn new_collapses_caret_at_the_end() {
+        let s = state("abc");
+        assert_eq!(s.caret(), 3);
+        assert_eq!(s.selection(), (3, 3));
+        assert!(!s.has_selection());
+    }
+
+    #[test]
+    fn empty_and_boundary_edits_are_no_ops() {
+        let mut s = state("");
+        s.delete_backward();
+        s.delete_forward();
+        s.move_left(false);
+        s.move_right(false);
+        assert_eq!(s.value(), "");
+        assert_eq!(s.caret(), 0);
+
+        // Insert of an all-filtered (empty after filtering) string is rejected.
+        assert!(!s.insert("\n\r", uncapped()));
+        assert_eq!(s.value(), "");
+    }
+
+    #[test]
+    fn ascii_insert_advances_the_caret() {
+        let mut s = state("ac");
+        s.place_caret(1);
+        assert!(s.insert("b", uncapped()));
+        assert_eq!(s.value(), "abc");
+        assert_eq!(s.caret(), 2);
+    }
+
+    #[test]
+    fn multibyte_insert_delete_stay_on_char_boundaries() {
+        let mut s = state("aéb"); // a(1) é(2) b(1)
+        assert_eq!(s.caret(), 4);
+        s.delete_backward(); // over 'b'
+        assert_eq!(s.value(), "aé");
+        s.delete_backward(); // over 'é' (two bytes)
+        assert_eq!(s.value(), "a");
+        assert_eq!(s.caret(), 1);
+        // Insert a multibyte char in the middle.
+        s.place_caret(0);
+        assert!(s.insert("ü", uncapped()));
+        assert_eq!(s.value(), "üa");
+        assert_eq!(s.caret(), 2);
+    }
+
+    #[test]
+    fn delete_forward_removes_a_whole_multibyte_char() {
+        let mut s = state("é!");
+        s.move_to_start(false);
+        s.delete_forward();
+        assert_eq!(s.value(), "!");
+        assert_eq!(s.caret(), 0);
+        s.delete_forward();
+        assert_eq!(s.value(), "");
+        s.delete_forward(); // no-op at end
+        assert_eq!(s.value(), "");
+    }
+
+    #[test]
+    fn collapse_versus_extended_movement() {
+        let mut s = state("abcd");
+        s.move_to_start(false);
+        s.move_right(true); // select "a"
+        s.move_right(true); // select "ab"
+        assert_eq!(s.selection(), (0, 2));
+        assert!(s.has_selection());
+        // A non-extending left collapses to the selection's left edge.
+        s.move_left(false);
+        assert_eq!(s.caret(), 0);
+        assert!(!s.has_selection());
+        // Re-select then a non-extending right collapses to the right edge.
+        s.select_all();
+        assert_eq!(s.selection(), (0, 4));
+        s.move_right(false);
+        assert_eq!(s.caret(), 4);
+        assert!(!s.has_selection());
+    }
+
+    #[test]
+    fn extended_movement_backward_keeps_the_anchor() {
+        let mut s = state("abc");
+        // Caret at end; extend left twice selects "bc" backward.
+        s.move_left(true);
+        s.move_left(true);
+        assert_eq!(s.selection(), (1, 3));
+        assert_eq!(s.caret(), 1);
+        // Document-edge extend to start selects the whole run.
+        s.move_to_start(true);
+        assert_eq!(s.selection(), (0, 3));
+        assert_eq!(s.caret(), 0);
+    }
+
+    #[test]
+    fn typing_replaces_the_active_selection() {
+        let mut s = state("hello");
+        s.move_to_start(false);
+        s.move_right(true);
+        s.move_right(true); // select "he"
+        assert!(s.insert("HE", uncapped()));
+        assert_eq!(s.value(), "HEllo");
+        assert_eq!(s.caret(), 2);
+        assert!(!s.has_selection());
+    }
+
+    #[test]
+    fn select_all_then_replace_clears_and_retypes() {
+        let mut s = state("old");
+        s.select_all();
+        assert!(s.insert("new", uncapped()));
+        assert_eq!(s.value(), "new");
+        // Backspace over a whole selection deletes it, not one char.
+        s.select_all();
+        s.delete_backward();
+        assert_eq!(s.value(), "");
+    }
+
+    #[test]
+    fn whole_insert_respects_the_character_cap() {
+        let policy = EditPolicy {
+            single_line: true,
+            max_chars: 3,
+        };
+        let mut s = state("ab");
+        assert!(s.insert("c", policy), "fills to the cap");
+        assert_eq!(s.value(), "abc");
+        assert!(!s.insert("d", policy), "past-cap insert is rejected whole");
+        assert_eq!(s.value(), "abc");
+        // A multi-char insert that would overflow is rejected whole, not
+        // truncated.
+        let mut fresh = state("a");
+        assert!(!fresh.insert("bcd", policy));
+        assert_eq!(fresh.value(), "a");
+        // Replacing a selection frees cap room: select "abc", insert 3 chars.
+        let mut full = state("abc");
+        full.select_all();
+        assert!(full.insert("xyz", policy));
+        assert_eq!(full.value(), "xyz");
+    }
+
+    #[test]
+    fn single_line_policy_filters_line_breaks() {
+        let policy = EditPolicy {
+            single_line: true,
+            max_chars: 0,
+        };
+        let mut s = state("");
+        assert!(s.insert("a\nb\r\nc", policy));
+        assert_eq!(s.value(), "abc");
+
+        let multiline = EditPolicy {
+            single_line: false,
+            max_chars: 0,
+        };
+        let mut m = state("");
+        assert!(m.insert("a\nb", multiline));
+        assert_eq!(m.value(), "a\nb");
+    }
+
+    #[test]
+    fn composition_normalizes_and_clears() {
+        let mut s = state("");
+        // A span landing mid-`char` floors to the char boundary and orders.
+        s.set_composition(String::from("éà"), Some((3, 1)));
+        assert_eq!(s.preedit(), "éà");
+        assert_eq!(s.preedit_cursor(), Some((0, 2)));
+        // An out-of-range span is dropped, not clamped into a lie.
+        s.set_composition(String::from("x"), Some((0, 9)));
+        assert_eq!(s.preedit_cursor(), None);
+        // Empty text clears the composition.
+        s.set_composition(String::new(), Some((0, 0)));
+        assert_eq!(s.preedit(), "");
+        assert_eq!(s.preedit_cursor(), None);
+    }
+
+    /// A 1000-upm table with three different advances so caret x and hit-test
+    /// midpoints are not the same everywhere (a monospace table would hide a
+    /// per-glyph advance bug).
+    fn variable_metrics() -> CachedFontMetrics {
+        CachedFontMetrics::new(&FontMetrics {
+            units_per_em: 1000.0,
+            ascent: 800.0,
+            descent: -200.0,
+            line_gap: 0.0,
+            default_advance: 500.0,
+            advances: alloc::vec![
+                GlyphAdvance {
+                    codepoint: u32::from('i'),
+                    advance_units: 200.0,
+                },
+                GlyphAdvance {
+                    codepoint: u32::from('m'),
+                    advance_units: 800.0,
+                },
+                GlyphAdvance {
+                    codepoint: u32::from('x'),
+                    advance_units: 500.0,
+                },
+            ],
+        })
+    }
+
+    #[test]
+    fn layout_caret_x_tracks_variable_advances() {
+        let metrics = variable_metrics();
+        let layout = SingleLineLayout::build("imx", &metrics, 100.0);
+        // Advances at 100px / 1000upm: i=20, m=80, x=50.
+        assert_eq!(layout.caret_x(0), 0.0);
+        assert_eq!(layout.caret_x(1), 20.0); // after 'i'
+        assert_eq!(layout.caret_x(2), 100.0); // after 'm'
+        assert_eq!(layout.caret_x(3), 150.0); // after 'x'
+        assert_eq!(layout.width(), 150.0);
+    }
+
+    #[test]
+    fn layout_hit_test_rounds_to_the_nearest_boundary_midpoint() {
+        let metrics = variable_metrics();
+        let layout = SingleLineLayout::build("imx", &metrics, 100.0);
+        // Stops at x = 0, 20, 100, 150; midpoints at 10, 60, 125.
+        assert_eq!(layout.hit_test(-5.0), 0);
+        assert_eq!(layout.hit_test(9.0), 0);
+        assert_eq!(
+            layout.hit_test(10.0),
+            1,
+            "a tie rounds to the later boundary"
+        );
+        assert_eq!(layout.hit_test(59.0), 1);
+        assert_eq!(layout.hit_test(61.0), 2);
+        assert_eq!(layout.hit_test(124.0), 2);
+        assert_eq!(layout.hit_test(126.0), 3);
+        assert_eq!(
+            layout.hit_test(999.0),
+            3,
+            "past the end clamps to the last stop"
+        );
+    }
+}

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -1170,8 +1170,14 @@ fn text_field_selection_and_ime_render_measured_bands_and_commit() {
         "composition underline-band coverage: resting {typed_underline:.3} → composing \
          {preedit_underline:.3}",
     );
+    // The composition mark in this band is a 1px-tall accent underline over the
+    // "xy" preedit plus the 1px composition cursor — only a few pixels of new
+    // ink against a ~195x3px band that already reads ~0.10 from glyph overlap,
+    // so it lifts coverage by only a few thousandths. Assert a presence floor
+    // that a fully-absent mark (delta ~0) still fails, not a large jump a 1px
+    // mark cannot make. CI renders are deterministic, so this floor is stable.
     assert!(
-        preedit_underline > typed_underline + 0.02,
+        preedit_underline > typed_underline + 0.003,
         "an IME composition must render its underline / cursor in the measured band below the \
          baseline, above the resting {typed_underline:.3}; it was {preedit_underline:.3} — the \
          composition-mark-not-rendered class",

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -991,17 +991,13 @@ fn focus_ring_follows_tab() {
     );
 }
 
-/// **Bug class: the reusable editing state's measured pointer placement,
-/// selection, and IME composition not reaching the pixels.** The other text
-/// scenario (`text_field_backspace_...`) proves an editing key round-trips; this
-/// drives the issue-2924 rework end-to-end — a *measured* pointer click that
-/// places the caret at a known character boundary, a Shift-extended selection
-/// that must render an accent band, an `ImePreedit` with a nontrivial cursor
-/// span that must render a composition mark below the glyph baseline, then a
-/// committed `TextInput` replacing the selection and Enter — and asserts each
-/// rendered band plus the final committed UTF-8 value off the log ring. It reads
-/// the field's own resolved font metrics for its expected boundaries, so a
-/// regression in measured placement (not the approximate warm-up) fails here.
+/// **Bug class: measured selection / composition / caret geometry drifting from
+/// the edited UTF-8 value.** The measured click is deliberately chosen where
+/// the warm-up approximation resolves to the *next* character, so the final
+/// committed value proves the field installed its metric table. Tight positive
+/// and neighboring exclusion regions then pin the first selected cell, the full
+/// non-collapsed IME cursor span, the preedit underline at the replaced
+/// selection (not the old trailing position), and the final measured caret.
 #[test]
 #[allow(clippy::too_many_lines)] // one cohesive place → select → compose → commit acceptance run
 fn text_field_selection_and_ime_render_measured_bands_and_commit() {
@@ -1028,42 +1024,10 @@ fn text_field_selection_and_ime_render_measured_bands_and_commit() {
 
     let size = Theme::DEFAULT.value_size_pixels;
     let (text_top, _) = row_band(TEXT_ROW, 1.0);
-    // The field's interior, inset past the focus-ring border, scored against its
-    // raised-surface fill so glyph + selection + caret ink form the mask.
-    let interior = rect(
-        PANEL_X + BORDER + 1.0,
-        text_top + BORDER + 1.0,
-        PANEL_X + PANEL_WIDTH - BORDER,
-        text_top + ROW_HEIGHT - BORDER,
-    );
-    let interior_coverage = || {
-        vec![check(
-            FrameReduction::Coverage,
-            interior,
-            SURFACE_RAISED_SRGB,
-            PARTITION_TOLERANCE,
-        )]
-    };
-    // A thin band straddling the composition underline (`text_origin_y + size`
-    // local, below the lowercase glyph run) — where only the underline and the
-    // full-height composition cursor light up, not the resting glyph ink.
-    let underline_local = (ROW_HEIGHT - size) * 0.5 + size;
-    let underline_band = rect(
-        PANEL_X + BORDER + 1.0,
-        text_top + underline_local - 1.0,
-        PANEL_X + PANEL_WIDTH - BORDER,
-        text_top + underline_local + 2.0,
-    );
-    let underline_coverage = || {
-        vec![check(
-            FrameReduction::Coverage,
-            underline_band,
-            SURFACE_RAISED_SRGB,
-            PARTITION_TOLERANCE,
-        )]
-    };
+    let content_x = PANEL_X + PAD;
+    let typed_text = "abécd";
 
-    // Focus the field with a click, type "abcd", and rasterize the glyphs.
+    // Focus the field, type a value with a multibyte scalar, and rasterize it.
     bench
         .execute(vec![
             (
@@ -1079,7 +1043,7 @@ fn text_field_selection_and_ime_render_measured_bands_and_commit() {
                 BenchOp::send_mail(
                     &panel,
                     &TextInput {
-                        text: "abcd".to_owned(),
+                        text: typed_text.to_owned(),
                     },
                 ),
             ),
@@ -1088,15 +1052,58 @@ fn text_field_selection_and_ime_render_measured_bands_and_commit() {
         ])
         .expect("focus + type");
 
-    let typed_interior = coverage(&capture(&mut bench, interior_coverage()).results[0]);
-    let typed_underline = coverage(&capture(&mut bench, underline_coverage()).results[0]);
+    // Click after "abé" (char index 3, byte 4). Roboto Mono advances 0.6em,
+    // while the bounded warm-up fallback uses 0.5em: at this boundary the
+    // fallback rounds to char index 4. Pin that fixture property so this
+    // scenario cannot silently stop discriminating exact from approximate hit
+    // testing after a font or theme change.
+    let measured_boundary = metrics.caret_x(typed_text, 3, size);
+    let fallback_advance = (size * 0.5).max(1.0);
+    let fallback_index =
+        ((measured_boundary / fallback_advance + 0.5) as usize).min(typed_text.chars().count());
+    assert_eq!(
+        fallback_index, 4,
+        "the measured click fixture must differ from the 0.5em fallback"
+    );
+    let boundary_x = content_x + measured_boundary;
+    let after_two_x = content_x + metrics.caret_x(typed_text, 2, size);
+    let after_four_x = content_x + metrics.caret_x(typed_text, 4, size);
+    let after_five_x = content_x + metrics.caret_x(typed_text, 5, size);
+    let mark_top = text_top + PAD + 1.0;
+    let mark_bottom = text_top + ROW_HEIGHT - PAD - 1.0;
+    let selected_first_cell = rect(boundary_x + 1.0, mark_top, after_four_x - 1.0, mark_bottom);
+    let selection_exclusion = rect(after_two_x + 1.0, mark_top, boundary_x - 1.0, mark_bottom);
+    let second_selected_cell = rect(
+        after_four_x + 1.0,
+        mark_top,
+        after_five_x - 1.0,
+        mark_bottom,
+    );
+    let cell_checks = || {
+        [
+            selected_first_cell,
+            selection_exclusion,
+            second_selected_cell,
+        ]
+        .into_iter()
+        .map(|region| {
+            check(
+                FrameReduction::Coverage,
+                region,
+                SURFACE_RAISED_SRGB,
+                PARTITION_TOLERANCE,
+            )
+        })
+        .collect()
+    };
+    let typed_cells = capture(&mut bench, cell_checks());
+    let typed_first = coverage(&typed_cells.results[0]);
+    let typed_exclusion = coverage(&typed_cells.results[1]);
 
-    // A *measured* click at the boundary after "ab" (char index 2): the field
-    // resolves the pointer to byte 2 via its metric table, placing the caret
-    // between "ab" and "cd".
-    let boundary_x = PANEL_X + PAD + metrics.caret_x("abcd", 2, size);
     let click_y = text_top + 10.0;
-    // Shift-extend two characters right to select "cd".
+    // Shift-extend two characters right to select "cd". If the click takes the
+    // approximate path it starts after `c` and selects only `d`, so the first
+    // expected cell and final committed value both fail.
     bench
         .execute(vec![
             (
@@ -1128,25 +1135,28 @@ fn text_field_selection_and_ime_render_measured_bands_and_commit() {
         ])
         .expect("measured place + Shift-extend");
 
-    let selected_interior = coverage(&capture(&mut bench, interior_coverage()).results[0]);
+    let selected_cells = capture(&mut bench, cell_checks());
+    let selected_first = coverage(&selected_cells.results[0]);
+    let selected_exclusion_coverage = coverage(&selected_cells.results[1]);
     eprintln!(
-        "field interior coverage: typed {typed_interior:.3} → selected {selected_interior:.3}",
+        "selection first-cell coverage: typed {typed_first:.3} → selected {selected_first:.3}; \
+         neighbor {typed_exclusion:.3} → {selected_exclusion_coverage:.3}",
     );
-    // The band is the field accent (#a8c97a) — every channel >95 above the
-    // raised-surface fill, so it fully clears PARTITION_TOLERANCE — but it is
-    // only `caret_height` (~8px) tall over the two "cd" cells (~2 monospace
-    // advances) inside the full ~195x19px interior, so a correctly-placed band
-    // adds only ~0.02-0.03 coverage. Assert a floor comfortably above capture
-    // noise, not a large jump the small band geometry can never produce.
     assert!(
-        selected_interior > typed_interior + 0.01,
-        "a Shift-extended selection must render an accent band over \"cd\", raising interior \
-         coverage above the resting glyphs ({typed_interior:.3}); it was {selected_interior:.3} \
-         — the selection-band-not-rendered class",
+        selected_first > 0.75 && selected_first > typed_first + 0.25,
+        "the first measured selection cell (`c`) must be accent-filled; resting coverage was \
+         {typed_first:.3}, selected was {selected_first:.3}",
+    );
+    assert!(
+        (selected_exclusion_coverage - typed_exclusion).abs() < 0.08,
+        "the preceding `é` cell must remain outside the selection; coverage changed from \
+         {typed_exclusion:.3} to {selected_exclusion_coverage:.3}",
     );
 
-    // An IME composition with a nontrivial cursor span: it renders inserted at
-    // the selection with an underline + composition cursor below the baseline.
+    // Compose `üx` over `cd`, with a non-collapsed byte span selecting the
+    // first, two-byte `ü`. The cursor-span band must fill only the first preedit
+    // cell, while the whole two-cell preedit receives an underline at this
+    // measured selection position.
     bench
         .execute(vec![
             (
@@ -1154,8 +1164,8 @@ fn text_field_selection_and_ime_render_measured_bands_and_commit() {
                 BenchOp::send_mail(
                     &panel,
                     &ImePreedit {
-                        text: "xy".to_owned(),
-                        cursor_begin: Some(1),
+                        text: "üx".to_owned(),
+                        cursor_begin: Some(0),
                         cursor_end: Some(2),
                     },
                 ),
@@ -1165,26 +1175,69 @@ fn text_field_selection_and_ime_render_measured_bands_and_commit() {
         ])
         .expect("ime preedit");
 
-    let preedit_underline = coverage(&capture(&mut bench, underline_coverage()).results[0]);
-    eprintln!(
-        "composition underline-band coverage: resting {typed_underline:.3} → composing \
-         {preedit_underline:.3}",
+    let underline_y = text_top + (ROW_HEIGHT - size) * 0.5 + size;
+    let preedit_underline = rect(
+        boundary_x + 1.0,
+        underline_y,
+        after_five_x - 1.0,
+        underline_y + 2.0,
     );
-    // The composition mark in this band is a 1px-tall accent underline over the
-    // "xy" preedit plus the 1px composition cursor — only a few pixels of new
-    // ink against a ~195x3px band that already reads ~0.10 from glyph overlap,
-    // so it lifts coverage by only a few thousandths. Assert a presence floor
-    // that a fully-absent mark (delta ~0) still fails, not a large jump a 1px
-    // mark cannot make. CI renders are deterministic, so this floor is stable.
+    let underline_exclusion = rect(
+        after_five_x + 1.0,
+        underline_y,
+        after_five_x + (after_four_x - boundary_x) - 1.0,
+        underline_y + 2.0,
+    );
+    let composition = capture(
+        &mut bench,
+        vec![
+            check(
+                FrameReduction::Coverage,
+                selected_first_cell,
+                SURFACE_RAISED_SRGB,
+                PARTITION_TOLERANCE,
+            ),
+            check(
+                FrameReduction::Coverage,
+                second_selected_cell,
+                SURFACE_RAISED_SRGB,
+                PARTITION_TOLERANCE,
+            ),
+            check(
+                FrameReduction::Coverage,
+                preedit_underline,
+                SURFACE_RAISED_SRGB,
+                PARTITION_TOLERANCE,
+            ),
+            check(
+                FrameReduction::Coverage,
+                underline_exclusion,
+                SURFACE_RAISED_SRGB,
+                PARTITION_TOLERANCE,
+            ),
+        ],
+    );
+    let cursor_span = coverage(&composition.results[0]);
+    let cursor_exclusion = coverage(&composition.results[1]);
+    let underline = coverage(&composition.results[2]);
+    let underline_after = coverage(&composition.results[3]);
+    eprintln!(
+        "composition coverage: cursor-span {cursor_span:.3}, next-cell {cursor_exclusion:.3}, \
+         underline {underline:.3}, after-underline {underline_after:.3}",
+    );
     assert!(
-        preedit_underline > typed_underline + 0.003,
-        "an IME composition must render its underline / cursor in the measured band below the \
-         baseline, above the resting {typed_underline:.3}; it was {preedit_underline:.3} — the \
-         composition-mark-not-rendered class",
+        cursor_span > 0.75 && cursor_span > cursor_exclusion + 0.25,
+        "the full IME cursor selection must fill the first preedit cell only; span coverage was \
+         {cursor_span:.3}, neighboring cell was {cursor_exclusion:.3}",
+    );
+    assert!(
+        underline > 0.2 && underline > underline_after + 0.15,
+        "the preedit underline must occupy its two measured cells at the replaced selection; \
+         coverage there was {underline:.3}, after the preedit was {underline_after:.3}",
     );
 
-    // Commit replacement text (clears the composition and replaces the "cd"
-    // selection), then Enter to commit the field. The result is "abZ".
+    // Commit replacement text (clears the composition and replaces `cd`), then
+    // measure the caret at the end of the non-ASCII result `abéZ`.
     bench
         .execute(vec![
             (
@@ -1201,32 +1254,47 @@ fn text_field_selection_and_ime_render_measured_bands_and_commit() {
         ])
         .expect("commit replacement text");
 
-    // The final caret + glyphs still occupy the field interior (a non-empty
-    // mask bounded to the interior band).
+    let final_text = "abéZ";
+    let final_caret_x = content_x + metrics.caret_x(final_text, 4, size);
+    let final_caret = rect(
+        final_caret_x - 1.0,
+        text_top + PAD,
+        final_caret_x + 2.0,
+        text_top + ROW_HEIGHT - PAD,
+    );
+    let final_caret_exclusion = rect(
+        final_caret_x + 3.0,
+        text_top + PAD,
+        final_caret_x + 6.0,
+        text_top + ROW_HEIGHT - PAD,
+    );
     let final_verdict = capture(
         &mut bench,
-        vec![check(
-            FrameReduction::BoundingBox,
-            interior,
-            SURFACE_RAISED_SRGB,
-            PARTITION_TOLERANCE,
-        )],
+        vec![
+            check(
+                FrameReduction::Coverage,
+                final_caret,
+                SURFACE_RAISED_SRGB,
+                PARTITION_TOLERANCE,
+            ),
+            check(
+                FrameReduction::Coverage,
+                final_caret_exclusion,
+                SURFACE_RAISED_SRGB,
+                PARTITION_TOLERANCE,
+            ),
+        ],
     );
-    let final_box =
-        bounding_box(&final_verdict.results[0]).expect("the committed field still renders glyphs");
+    let caret_coverage = coverage(&final_verdict.results[0]);
+    let caret_exclusion = coverage(&final_verdict.results[1]);
     eprintln!(
-        "final field glyph bbox x[{}..{}] y[{}..{}]",
-        final_box.min_x, final_box.max_x, final_box.min_y, final_box.max_y,
+        "final caret coverage: expected {caret_coverage:.3}, neighboring exclusion \
+         {caret_exclusion:.3}",
     );
     assert!(
-        final_box.max_x < (PANEL_X + PANEL_WIDTH) as u32
-            && final_box.max_y < (text_top + ROW_HEIGHT) as u32,
-        "the final caret and glyphs must sit inside the field interior; bbox was \
-         x[{}..{}] y[{}..{}]",
-        final_box.min_x,
-        final_box.max_x,
-        final_box.min_y,
-        final_box.max_y,
+        caret_coverage > 0.2 && caret_coverage > caret_exclusion + 0.2,
+        "the final measured caret must occupy its tight expected band; coverage there was \
+         {caret_coverage:.3}, neighboring coverage was {caret_exclusion:.3}",
     );
 
     bench
@@ -1240,8 +1308,8 @@ fn text_field_selection_and_ime_render_measured_bands_and_commit() {
     let joined = log.join("\n");
     assert!(
         log.iter()
-            .any(|m| m.contains("widget text committed") && m.contains("text=abZ")),
-        "clicking at the measured boundary after \"ab\", extending over \"cd\", and committing \
-         \"Z\" must leave \"abZ\"; log was:\n{joined}",
+            .any(|m| m.contains("widget text committed") && m.contains("text=abéZ")),
+        "clicking after `abé`, extending over `cd`, and committing `Z` must leave the non-ASCII \
+         value `abéZ`; log was:\n{joined}",
     );
 }

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -46,14 +46,16 @@ use std::path::{Path, PathBuf};
 use aether_actor::Addressable;
 use aether_capabilities::RenderCapability;
 use aether_capabilities::fs::NamespaceRoots;
-use aether_capabilities::text::{LoadFont, LoadFontResult};
+use aether_capabilities::text::{
+    FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontResult,
+};
 use aether_data::Kind;
-use aether_kinds::keycode::{KEY_BACKSPACE, KEY_ENTER, KEY_TAB};
+use aether_kinds::keycode::{KEY_BACKSPACE, KEY_ENTER, KEY_RIGHT, KEY_TAB};
 use aether_kinds::mouse_button::LEFT;
 use aether_kinds::{
-    CaptureFrame, CaptureFrameResult, FrameCheck, FrameCheckResult, FrameRect, FrameReduction,
-    FrameVerdict, Key, LoadComponent, LoadResult, LogTailResult, MouseButton, MouseButtonRelease,
-    MouseMove, NamedMail, TextInput, Tick,
+    CachedFontMetrics, CaptureFrame, CaptureFrameResult, FrameCheck, FrameCheckResult, FrameRect,
+    FrameReduction, FrameVerdict, ImePreedit, Key, LoadComponent, LoadResult, LogTailResult,
+    Modifiers, MouseButton, MouseButtonRelease, MouseMove, NamedMail, TextInput, Tick,
 };
 use aether_kit::{PanelConfig, Theme};
 use aether_substrate_bundle::test_bench::{
@@ -166,6 +168,30 @@ fn load_font(bench: &mut TestBench) -> u32 {
     {
         LoadFontResult::Ok { font_id, .. } => font_id,
         LoadFontResult::Err { error, .. } => panic!("load RobotoMono: {error}"),
+    }
+}
+
+/// Grab `RobotoMono`'s resolved metric table (the same one the field measures
+/// against) so the test can compute expected pixel boundaries for pointer
+/// placement and caret geometry.
+fn load_metrics(bench: &mut TestBench, font_id: u32) -> CachedFontMetrics {
+    let got = bench
+        .execute(vec![(
+            "metrics",
+            BenchOp::send_and_await(
+                "aether.text",
+                &FontMetricsRequest {
+                    font: FontRef::Id(font_id),
+                },
+            ),
+        )])
+        .expect("font_metrics sequence");
+    match got
+        .reply::<FontMetricsResult>("metrics")
+        .expect("decode FontMetricsResult")
+    {
+        FontMetricsResult::Ok { metrics } => CachedFontMetrics::new(&metrics),
+        FontMetricsResult::Err { error } => panic!("grab RobotoMono metrics: {error}"),
     }
 }
 
@@ -962,5 +988,248 @@ fn focus_ring_follows_tab() {
         slider_after < 0.1,
         "the ring must leave the slider when focus advances; coverage over its top edge stayed \
          {slider_after:.3} — the ring-follows-focus class",
+    );
+}
+
+/// **Bug class: the reusable editing state's measured pointer placement,
+/// selection, and IME composition not reaching the pixels.** The other text
+/// scenario (`text_field_backspace_...`) proves an editing key round-trips; this
+/// drives the issue-2924 rework end-to-end — a *measured* pointer click that
+/// places the caret at a known character boundary, a Shift-extended selection
+/// that must render an accent band, an `ImePreedit` with a nontrivial cursor
+/// span that must render a composition mark below the glyph baseline, then a
+/// committed `TextInput` replacing the selection and Enter — and asserts each
+/// rendered band plus the final committed UTF-8 value off the log ring. It reads
+/// the field's own resolved font metrics for its expected boundaries, so a
+/// regression in measured placement (not the approximate warm-up) fails here.
+#[test]
+#[allow(clippy::too_many_lines)] // one cohesive place → select → compose → commit acceptance run
+fn text_field_selection_and_ime_render_measured_bands_and_commit() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = build_bench();
+
+    let font_id = load_font(&mut bench);
+    let metrics = load_metrics(&mut bench, font_id);
+    load_panel(&mut bench, &wasm, font_id);
+    let panel = panel_address();
+    // Warm up: spawn + prime the atlas, and give the field's own single-flight
+    // metrics request the extra ticks it needs to round-trip and install before
+    // the measured interactions.
+    bench
+        .execute(vec![
+            ("spawn", BenchOp::send_mail(&panel, &Tick)),
+            ("prime", BenchOp::send_mail(&panel, &Tick)),
+            ("settle", BenchOp::advance(4)),
+        ])
+        .expect("warm-up");
+
+    let size = Theme::DEFAULT.value_size_pixels;
+    let (text_top, _) = row_band(TEXT_ROW, 1.0);
+    // The field's interior, inset past the focus-ring border, scored against its
+    // raised-surface fill so glyph + selection + caret ink form the mask.
+    let interior = rect(
+        PANEL_X + BORDER + 1.0,
+        text_top + BORDER + 1.0,
+        PANEL_X + PANEL_WIDTH - BORDER,
+        text_top + ROW_HEIGHT - BORDER,
+    );
+    let interior_coverage = || {
+        vec![check(
+            FrameReduction::Coverage,
+            interior,
+            SURFACE_RAISED_SRGB,
+            PARTITION_TOLERANCE,
+        )]
+    };
+    // A thin band straddling the composition underline (`text_origin_y + size`
+    // local, below the lowercase glyph run) — where only the underline and the
+    // full-height composition cursor light up, not the resting glyph ink.
+    let underline_local = (ROW_HEIGHT - size) * 0.5 + size;
+    let underline_band = rect(
+        PANEL_X + BORDER + 1.0,
+        text_top + underline_local - 1.0,
+        PANEL_X + PANEL_WIDTH - BORDER,
+        text_top + underline_local + 2.0,
+    );
+    let underline_coverage = || {
+        vec![check(
+            FrameReduction::Coverage,
+            underline_band,
+            SURFACE_RAISED_SRGB,
+            PARTITION_TOLERANCE,
+        )]
+    };
+
+    // Focus the field with a click, type "abcd", and rasterize the glyphs.
+    bench
+        .execute(vec![
+            (
+                "focus",
+                BenchOp::send_mail(&panel, &press(50.0, text_top + 10.0)),
+            ),
+            (
+                "focus_up",
+                BenchOp::send_mail(&panel, &release(50.0, text_top + 10.0)),
+            ),
+            (
+                "type",
+                BenchOp::send_mail(
+                    &panel,
+                    &TextInput {
+                        text: "abcd".to_owned(),
+                    },
+                ),
+            ),
+            ("rasterize", BenchOp::send_mail(&panel, &Tick)),
+            ("settle", BenchOp::advance(2)),
+        ])
+        .expect("focus + type");
+
+    let typed_interior = coverage(&capture(&mut bench, interior_coverage()).results[0]);
+    let typed_underline = coverage(&capture(&mut bench, underline_coverage()).results[0]);
+
+    // A *measured* click at the boundary after "ab" (char index 2): the field
+    // resolves the pointer to byte 2 via its metric table, placing the caret
+    // between "ab" and "cd".
+    let boundary_x = PANEL_X + PAD + metrics.caret_x("abcd", 2, size);
+    let click_y = text_top + 10.0;
+    // Shift-extend two characters right to select "cd".
+    bench
+        .execute(vec![
+            (
+                "place",
+                BenchOp::send_mail(&panel, &press(boundary_x, click_y)),
+            ),
+            (
+                "place_up",
+                BenchOp::send_mail(&panel, &release(boundary_x, click_y)),
+            ),
+            (
+                "shift",
+                BenchOp::send_mail(
+                    &panel,
+                    &Modifiers {
+                        shift: true,
+                        ..Modifiers::default()
+                    },
+                ),
+            ),
+            (
+                "extend1",
+                BenchOp::send_mail(&panel, &Key { code: KEY_RIGHT }),
+            ),
+            (
+                "extend2",
+                BenchOp::send_mail(&panel, &Key { code: KEY_RIGHT }),
+            ),
+        ])
+        .expect("measured place + Shift-extend");
+
+    let selected_interior = coverage(&capture(&mut bench, interior_coverage()).results[0]);
+    eprintln!(
+        "field interior coverage: typed {typed_interior:.3} → selected {selected_interior:.3}",
+    );
+    assert!(
+        selected_interior > typed_interior + 0.05,
+        "a Shift-extended selection must render an accent band over \"cd\", raising interior \
+         coverage above the resting glyphs ({typed_interior:.3}); it was {selected_interior:.3} \
+         — the selection-band-not-rendered class",
+    );
+
+    // An IME composition with a nontrivial cursor span: it renders inserted at
+    // the selection with an underline + composition cursor below the baseline.
+    bench
+        .execute(vec![
+            (
+                "preedit",
+                BenchOp::send_mail(
+                    &panel,
+                    &ImePreedit {
+                        text: "xy".to_owned(),
+                        cursor_begin: Some(1),
+                        cursor_end: Some(2),
+                    },
+                ),
+            ),
+            ("rasterize", BenchOp::send_mail(&panel, &Tick)),
+            ("settle", BenchOp::advance(2)),
+        ])
+        .expect("ime preedit");
+
+    let preedit_underline = coverage(&capture(&mut bench, underline_coverage()).results[0]);
+    eprintln!(
+        "composition underline-band coverage: resting {typed_underline:.3} → composing \
+         {preedit_underline:.3}",
+    );
+    assert!(
+        preedit_underline > typed_underline + 0.02,
+        "an IME composition must render its underline / cursor in the measured band below the \
+         baseline, above the resting {typed_underline:.3}; it was {preedit_underline:.3} — the \
+         composition-mark-not-rendered class",
+    );
+
+    // Commit replacement text (clears the composition and replaces the "cd"
+    // selection), then Enter to commit the field. The result is "abZ".
+    bench
+        .execute(vec![
+            (
+                "commit_text",
+                BenchOp::send_mail(
+                    &panel,
+                    &TextInput {
+                        text: "Z".to_owned(),
+                    },
+                ),
+            ),
+            ("rasterize", BenchOp::send_mail(&panel, &Tick)),
+            ("settle", BenchOp::advance(2)),
+        ])
+        .expect("commit replacement text");
+
+    // The final caret + glyphs still occupy the field interior (a non-empty
+    // mask bounded to the interior band).
+    let final_verdict = capture(
+        &mut bench,
+        vec![check(
+            FrameReduction::BoundingBox,
+            interior,
+            SURFACE_RAISED_SRGB,
+            PARTITION_TOLERANCE,
+        )],
+    );
+    let final_box =
+        bounding_box(&final_verdict.results[0]).expect("the committed field still renders glyphs");
+    eprintln!(
+        "final field glyph bbox x[{}..{}] y[{}..{}]",
+        final_box.min_x, final_box.max_x, final_box.min_y, final_box.max_y,
+    );
+    assert!(
+        final_box.max_x < (PANEL_X + PANEL_WIDTH) as u32
+            && final_box.max_y < (text_top + ROW_HEIGHT) as u32,
+        "the final caret and glyphs must sit inside the field interior; bbox was \
+         x[{}..{}] y[{}..{}]",
+        final_box.min_x,
+        final_box.max_x,
+        final_box.min_y,
+        final_box.max_y,
+    );
+
+    bench
+        .execute(vec![(
+            "commit",
+            BenchOp::send_mail(&panel, &Key { code: KEY_ENTER }),
+        )])
+        .expect("commit");
+
+    let log = panel_log_messages(&mut bench);
+    let joined = log.join("\n");
+    assert!(
+        log.iter()
+            .any(|m| m.contains("widget text committed") && m.contains("text=abZ")),
+        "clicking at the measured boundary after \"ab\", extending over \"cd\", and committing \
+         \"Z\" must leave \"abZ\"; log was:\n{joined}",
     );
 }

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -1132,8 +1132,14 @@ fn text_field_selection_and_ime_render_measured_bands_and_commit() {
     eprintln!(
         "field interior coverage: typed {typed_interior:.3} → selected {selected_interior:.3}",
     );
+    // The band is the field accent (#a8c97a) — every channel >95 above the
+    // raised-surface fill, so it fully clears PARTITION_TOLERANCE — but it is
+    // only `caret_height` (~8px) tall over the two "cd" cells (~2 monospace
+    // advances) inside the full ~195x19px interior, so a correctly-placed band
+    // adds only ~0.02-0.03 coverage. Assert a floor comfortably above capture
+    // noise, not a large jump the small band geometry can never produce.
     assert!(
-        selected_interior > typed_interior + 0.05,
+        selected_interior > typed_interior + 0.01,
         "a Shift-extended selection must render an accent band over \"cd\", raising interior \
          coverage above the resting glyphs ({typed_interior:.3}); it was {selected_interior:.3} \
          — the selection-band-not-rendered class",


### PR DESCRIPTION
Closes #2924.

## Summary

`TextFieldWidget` owned a second, minimal text editor whose byte-offset caret was UTF-8-safe but had no selection or pointer placement, appended IME preedit after the whole value, and placed its caret with a half-em approximation — duplicated editing mechanics that `TextArea` and parameter editors would multiply.

Adds a pure `widget::text_edit` module. `TextEditState` owns the committed `String`, a selection anchor and active caret as char-boundary byte offsets, and the IME preedit plus its optional cursor span; semantic ops replace the active selection, insert under an explicit single-line/character-cap `EditPolicy`, delete/move by character or document edge with optional selection extension, select-all, and update/clear composition. `SingleLineLayout` builds an ordered byte-boundary/x-position table from `CachedFontMetrics` in one linear pass, making caret lookup and nearest-boundary pointer hit testing exact. `TextFieldWidget` becomes the first consumer through a single-flight font-metrics adapter that attributes an untagged `FontMetricsResult` to the in-flight id, installs it only while still the latest desired id, and defers a newer request — preventing a late old-font reply from replacing current metrics. ADR-0105 (local `CachedFontMetrics`) and ADR-0117 Decision 4 already cover this realization, so no new ADR.

## Test plan

- Exhaustive pure `text_edit` tests: boundary no-ops, ASCII/multibyte insertion/replacement/deletion, collapse-vs-extended movement, selection replacement and select-all, whole-insert char caps, single-line filtering, invalid/preedit cursor-span normalization, and variable-advance caret/hit-test midpoints.
- Focused font-metrics-adapter transition tests: initial load, duplicate coalescing, font change during flight, stale success/error replies, deferred latest-id installation.
- One real `WidgetPanel` TestBench sequence drives a measured pointer click, Shift-extended arrow selection, `ImePreedit` with a cursor span, replacement `TextInput`, and Enter, asserting the selection/composition/caret bands and the committed value off the panel log. The existing Backspace scenario is preserved.

## Generated by

`/implement` — agent execution of [scoped issue #2924](https://github.com/iamacoffeepot/aether/issues/2924).
