### PR TITLE
refactor(kit): migrate color fields to color types

### DIFF
--- a/crates/aether-kit/src/console/kinds.rs
+++ b/crates/aether-kit/src/console/kinds.rs
@@ -2,42 +2,43 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use aether_data::MailboxId;
+use aether_math::Rgba;
 use serde::{Deserialize, Serialize};
 
 #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct ConsoleTheme {
-    pub background_color: [f32; 4],
-    pub separator_color: [f32; 4],
-    pub prompt_color: [f32; 4],
-    pub input_color: [f32; 4],
-    pub output_color: [f32; 4],
-    pub error_color: [f32; 4],
-    pub cursor_color: [f32; 4],
+    pub background_color: Rgba,
+    pub separator_color: Rgba,
+    pub prompt_color: Rgba,
+    pub input_color: Rgba,
+    pub output_color: Rgba,
+    pub error_color: Rgba,
+    pub cursor_color: Rgba,
     #[serde(default)]
     pub markdown: ConsoleMarkdownTheme,
 }
 
 #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct ConsoleMarkdownTheme {
-    pub heading_color: [f32; 4],
-    pub emphasis_color: [f32; 4],
-    pub strong_color: [f32; 4],
-    pub inline_code_color: [f32; 4],
-    pub inline_code_background_color: [f32; 4],
-    pub fenced_code_color: [f32; 4],
-    pub fenced_code_background_color: [f32; 4],
-    pub link_color: [f32; 4],
-    pub image_color: [f32; 4],
-    pub quote_marker_color: [f32; 4],
-    pub quote_text_color: [f32; 4],
-    pub list_marker_color: [f32; 4],
-    pub task_marker_color: [f32; 4],
-    pub table_border_color: [f32; 4],
-    pub table_header_color: [f32; 4],
-    pub table_text_color: [f32; 4],
-    pub thematic_break_color: [f32; 4],
-    pub muted_marker_color: [f32; 4],
-    pub escaped_marker_color: [f32; 4],
+    pub heading_color: Rgba,
+    pub emphasis_color: Rgba,
+    pub strong_color: Rgba,
+    pub inline_code_color: Rgba,
+    pub inline_code_background_color: Rgba,
+    pub fenced_code_color: Rgba,
+    pub fenced_code_background_color: Rgba,
+    pub link_color: Rgba,
+    pub image_color: Rgba,
+    pub quote_marker_color: Rgba,
+    pub quote_text_color: Rgba,
+    pub list_marker_color: Rgba,
+    pub task_marker_color: Rgba,
+    pub table_border_color: Rgba,
+    pub table_header_color: Rgba,
+    pub table_text_color: Rgba,
+    pub thematic_break_color: Rgba,
+    pub muted_marker_color: Rgba,
+    pub escaped_marker_color: Rgba,
     pub code_padding_pixels: f32,
     pub strong_offset_pixels: f32,
 }
@@ -45,10 +46,10 @@ pub struct ConsoleMarkdownTheme {
 impl ConsoleMarkdownTheme {
     #[must_use]
     pub fn from_palette(
-        separator_color: [f32; 4],
-        prompt_color: [f32; 4],
-        input_color: [f32; 4],
-        output_color: [f32; 4],
+        separator_color: Rgba,
+        prompt_color: Rgba,
+        input_color: Rgba,
+        output_color: Rgba,
     ) -> Self {
         Self {
             heading_color: prompt_color,
@@ -58,8 +59,8 @@ impl ConsoleMarkdownTheme {
             inline_code_background_color: scaled_color(separator_color, 0.35, 0.45),
             fenced_code_color: input_color,
             fenced_code_background_color: scaled_color(separator_color, 0.25, 0.38),
-            link_color: [0.45, 0.74, 1.0, 1.0],
-            image_color: [0.68, 0.82, 1.0, 1.0],
+            link_color: Rgba::new(0.45, 0.74, 1.0, 1.0),
+            image_color: Rgba::new(0.68, 0.82, 1.0, 1.0),
             quote_marker_color: separator_color,
             quote_text_color: output_color,
             list_marker_color: separator_color,
@@ -79,28 +80,28 @@ impl ConsoleMarkdownTheme {
 impl Default for ConsoleMarkdownTheme {
     fn default() -> Self {
         Self::from_palette(
-            [0.36, 0.40, 0.46, 0.90],
-            [0.65, 0.92, 0.72, 1.0],
-            [0.92, 0.95, 0.98, 1.0],
-            [0.78, 0.82, 0.88, 1.0],
+            Rgba::new(0.36, 0.40, 0.46, 0.90),
+            Rgba::new(0.65, 0.92, 0.72, 1.0),
+            Rgba::new(0.92, 0.95, 0.98, 1.0),
+            Rgba::new(0.78, 0.82, 0.88, 1.0),
         )
     }
 }
 
 impl Default for ConsoleTheme {
     fn default() -> Self {
-        let separator_color = [0.36, 0.40, 0.46, 0.90];
-        let prompt_color = [0.65, 0.92, 0.72, 1.0];
-        let input_color = [0.92, 0.95, 0.98, 1.0];
-        let output_color = [0.78, 0.82, 0.88, 1.0];
+        let separator_color = Rgba::new(0.36, 0.40, 0.46, 0.90);
+        let prompt_color = Rgba::new(0.65, 0.92, 0.72, 1.0);
+        let input_color = Rgba::new(0.92, 0.95, 0.98, 1.0);
+        let output_color = Rgba::new(0.78, 0.82, 0.88, 1.0);
         Self {
-            background_color: [0.02, 0.025, 0.03, 0.88],
+            background_color: Rgba::new(0.02, 0.025, 0.03, 0.88),
             separator_color,
             prompt_color,
             input_color,
             output_color,
-            error_color: [1.0, 0.45, 0.42, 1.0],
-            cursor_color: [1.0, 1.0, 1.0, 1.0],
+            error_color: Rgba::new(1.0, 0.45, 0.42, 1.0),
+            cursor_color: Rgba::WHITE,
             markdown: ConsoleMarkdownTheme::from_palette(
                 separator_color,
                 prompt_color,
@@ -111,13 +112,13 @@ impl Default for ConsoleTheme {
     }
 }
 
-fn scaled_color(color: [f32; 4], rgb_scale: f32, alpha: f32) -> [f32; 4] {
-    [
-        color[0] * rgb_scale,
-        color[1] * rgb_scale,
-        color[2] * rgb_scale,
+fn scaled_color(color: Rgba, rgb_scale: f32, alpha: f32) -> Rgba {
+    Rgba::new(
+        color.r * rgb_scale,
+        color.g * rgb_scale,
+        color.b * rgb_scale,
         alpha,
-    ]
+    )
 }
 
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]

--- a/crates/aether-kit/src/console/mod.rs
+++ b/crates/aether-kit/src/console/mod.rs
@@ -111,14 +111,14 @@ impl ConsoleOverlay {
                 y: 0.0,
                 width,
                 height: panel_height,
-                color: Rgba::from_array(self.config.theme.background_color),
+                color: self.config.theme.background_color,
             },
             SolidQuad {
                 x: 0.0,
                 y: panel_height - SEPARATOR_HEIGHT,
                 width,
                 height: SEPARATOR_HEIGHT,
-                color: Rgba::from_array(self.config.theme.separator_color),
+                color: self.config.theme.separator_color,
             },
         ];
 
@@ -131,7 +131,7 @@ impl ConsoleOverlay {
                 y: input_y,
                 width: self.cursor_width(),
                 height: self.config.font_size,
-                color: Rgba::from_array(self.config.theme.cursor_color),
+                color: self.config.theme.cursor_color,
             });
         }
 
@@ -167,7 +167,7 @@ impl ConsoleOverlay {
             font_id,
             text: self.config.prompt.clone(),
             size_pixels: self.config.font_size,
-            color: Rgba::from_array(self.config.theme.prompt_color),
+            color: self.config.theme.prompt_color,
             origin: [HORIZONTAL_PADDING, input_y],
             space: QuadSpace::Screen,
             clip: None,
@@ -176,7 +176,7 @@ impl ConsoleOverlay {
             font_id,
             text: self.state.input.clone(),
             size_pixels: self.config.font_size,
-            color: Rgba::from_array(self.config.theme.input_color),
+            color: self.config.theme.input_color,
             origin: [
                 HORIZONTAL_PADDING + self.measure(&self.config.prompt),
                 input_y,
@@ -200,7 +200,7 @@ impl ConsoleOverlay {
                 y: self.config.font_size.mul_add(0.55, y),
                 width: HORIZONTAL_PADDING.mul_add(-2.0, width).max(0.0),
                 height: 1.0,
-                color: Rgba::from_array(self.config.theme.markdown.thematic_break_color),
+                color: self.config.theme.markdown.thematic_break_color,
             });
             return;
         }
@@ -210,7 +210,7 @@ impl ConsoleOverlay {
                 y: y - padding,
                 width: padding.mul_add(2.0, HORIZONTAL_PADDING.mul_add(-2.0, width)),
                 height: self.config.font_size + (padding * 2.0),
-                color: Rgba::from_array(self.config.theme.markdown.fenced_code_background_color),
+                color: self.config.theme.markdown.fenced_code_background_color,
             });
             return;
         }
@@ -224,9 +224,7 @@ impl ConsoleOverlay {
                     y: y - padding,
                     width: run_width + (padding * 2.0),
                     height: self.config.font_size + (padding * 2.0),
-                    color: Rgba::from_array(
-                        self.config.theme.markdown.inline_code_background_color,
-                    ),
+                    color: self.config.theme.markdown.inline_code_background_color,
                 });
             }
             x += run_width;
@@ -250,7 +248,7 @@ impl ConsoleOverlay {
                 font_id,
                 text: run.text.clone(),
                 size_pixels: self.config.font_size,
-                color: Rgba::from_array(color),
+                color,
                 origin: [x, y],
                 space: QuadSpace::Screen,
                 clip: None,
@@ -260,7 +258,7 @@ impl ConsoleOverlay {
                     font_id,
                     text: run.text.clone(),
                     size_pixels: self.config.font_size,
-                    color: Rgba::from_array(color),
+                    color,
                     origin: [
                         x + self.config.theme.markdown.strong_offset_pixels.max(0.0),
                         y,
@@ -273,7 +271,7 @@ impl ConsoleOverlay {
         }
     }
 
-    fn markdown_color(&self, style: LineStyle, tone: MarkdownTone) -> [f32; 4] {
+    fn markdown_color(&self, style: LineStyle, tone: MarkdownTone) -> Rgba {
         if style == LineStyle::Error
             && matches!(
                 tone,

--- a/crates/aether-kit/src/console/state.rs
+++ b/crates/aether-kit/src/console/state.rs
@@ -3,6 +3,7 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use aether_data::MailboxId;
+use aether_math::Rgba;
 
 use super::markdown::{MarkdownLine, format_visible_history};
 use super::{ConsoleCommandInvoked, ConsoleConfig, ConsoleTheme};
@@ -92,7 +93,7 @@ impl ConsoleState {
     }
 
     #[must_use]
-    pub fn theme_color(theme: &ConsoleTheme, style: LineStyle) -> [f32; 4] {
+    pub fn theme_color(theme: &ConsoleTheme, style: LineStyle) -> Rgba {
         match style {
             LineStyle::Input => theme.input_color,
             LineStyle::Output => theme.output_color,

--- a/crates/aether-kit/src/mesh/mod.rs
+++ b/crates/aether-kit/src/mesh/mod.rs
@@ -51,20 +51,20 @@ use core::str;
 
 const OUTLINE_WIDTH: f32 = 0.012;
 const OUTLINE_LIFT: f32 = 0.002;
-const OUTLINE_RGB: (f32, f32, f32) = (0.12, 0.12, 0.16);
+const OUTLINE_RGB: Rgb = Rgb::new(0.12, 0.12, 0.16);
 
-const PALETTE: &[(f32, f32, f32)] = &[
-    (0.55, 0.70, 0.92), // 0 — soft blue (default)
-    (0.85, 0.40, 0.30), // 1 — terracotta
-    (0.45, 0.75, 0.45), // 2 — sage green
-    (0.95, 0.85, 0.40), // 3 — mustard
-    (0.80, 0.55, 0.85), // 4 — lilac
-    (0.65, 0.50, 0.35), // 5 — wood brown
-    (0.95, 0.95, 0.95), // 6 — white
-    (0.30, 0.30, 0.35), // 7 — slate
+const PALETTE: &[Rgb] = &[
+    Rgb::new(0.55, 0.70, 0.92), // 0 — soft blue (default)
+    Rgb::new(0.85, 0.40, 0.30), // 1 — terracotta
+    Rgb::new(0.45, 0.75, 0.45), // 2 — sage green
+    Rgb::new(0.95, 0.85, 0.40), // 3 — mustard
+    Rgb::new(0.80, 0.55, 0.85), // 4 — lilac
+    Rgb::new(0.65, 0.50, 0.35), // 5 — wood brown
+    Rgb::new(0.95, 0.95, 0.95), // 6 — white
+    Rgb::new(0.30, 0.30, 0.35), // 7 — slate
 ];
 
-const OBJ_DEFAULT_COLOR: (f32, f32, f32) = PALETTE[0];
+const OBJ_DEFAULT_COLOR: Rgb = PALETTE[0];
 
 pub struct MeshViewer {
     triangles: Vec<DrawTriangle>,
@@ -389,8 +389,7 @@ fn to_draw_triangle_palette(tri: [Point3; 3], color: u32) -> DrawTriangle {
     to_draw_triangle_rgb([tri[0].to_f32(), tri[1].to_f32(), tri[2].to_f32()], rgb)
 }
 
-fn to_draw_triangle_rgb(tri: [Vec3; 3], rgb: (f32, f32, f32)) -> DrawTriangle {
-    let color = Rgb::new(rgb.0, rgb.1, rgb.2);
+fn to_draw_triangle_rgb(tri: [Vec3; 3], color: Rgb) -> DrawTriangle {
     DrawTriangle {
         verts: [
             Vertex {
@@ -429,11 +428,7 @@ pub enum ObjParseError {
 pub fn parse_obj(text: &str) -> Result<Vec<DrawTriangle>, ObjParseError> {
     let mut vertices: Vec<[f32; 3]> = Vec::new();
     let mut triangles: Vec<DrawTriangle> = Vec::new();
-    let default_color = Rgb::new(
-        OBJ_DEFAULT_COLOR.0,
-        OBJ_DEFAULT_COLOR.1,
-        OBJ_DEFAULT_COLOR.2,
-    );
+    let default_color = OBJ_DEFAULT_COLOR;
 
     for line in text.lines() {
         let trimmed = line.trim();

--- a/crates/aether-kit/src/mover/mod.rs
+++ b/crates/aether-kit/src/mover/mod.rs
@@ -104,7 +104,7 @@ const PLAYER_HEIGHT: f32 = 1.8;
 const PLAYER_RADIUS: f32 = 0.3;
 
 /// Marker tint — a warm blue that reads over the meadow-and-lake palette.
-const MARKER_COLOR: (f32, f32, f32) = (0.24, 0.55, 0.95);
+const MARKER_COLOR: Rgb = Rgb::new(0.24, 0.55, 0.95);
 
 /// Direction the scene light travels. The capsule bakes a simple Lambert
 /// shade against it into vertex colors so it reads as a solid 3D form (the
@@ -492,7 +492,7 @@ fn intersect_ground(eye: Vec3, dir: Vec3) -> Option<(f32, f32)> {
 /// band of triangles. Per-vertex normals carry a Lambert shade against
 /// [`LIGHT_DIR`] baked into the color, so the form reads as solid 3D under a
 /// pipeline that has no lighting of its own.
-fn push_capsule(out: &mut Vec<DrawTriangle>, cx: f32, cz: f32, base: (f32, f32, f32)) {
+fn push_capsule(out: &mut Vec<DrawTriangle>, cx: f32, cz: f32, base: Rgb) {
     /// Vertices around each ring.
     const RADIAL: usize = 16;
     /// Rings per hemisphere cap (pole to equator inclusive of the equator).
@@ -538,13 +538,13 @@ fn push_capsule(out: &mut Vec<DrawTriangle>, cx: f32, cz: f32, base: (f32, f32, 
     let shade = |normal: Vec3| {
         let lambert = normal.dot(to_light).max(0.0);
         let f = 0.65f32.mul_add(lambert, 0.35);
-        (base.0 * f, base.1 * f, base.2 * f)
+        Rgb::new(base.r * f, base.g * f, base.b * f)
     };
-    let vert = |p: Vec3, rgb: (f32, f32, f32)| Vertex {
+    let vert = |p: Vec3, color: Rgb| Vertex {
         x: p.x,
         y: p.y,
         z: p.z,
-        color: Rgb::new(rgb.0, rgb.1, rgb.2),
+        color,
     };
 
     for band in 0..rings.len() - 1 {

--- a/crates/aether-kit/src/widget/composite.rs
+++ b/crates/aether-kit/src/widget/composite.rs
@@ -197,6 +197,7 @@ impl Composite {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aether_math::Rgba;
 
     fn quad(x: f32, tag: f32) -> WidgetDrawItem {
         WidgetDrawItem::Quad {
@@ -204,7 +205,7 @@ mod tests {
             y: 0.0,
             width: 1.0,
             height: 1.0,
-            color: [tag, 0.0, 0.0, 1.0],
+            color: Rgba::new(tag, 0.0, 0.0, 1.0),
         }
     }
 

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -31,7 +31,7 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use aether_math::Vec2;
+use aether_math::{Rgba, Vec2};
 use serde::{Deserialize, Serialize};
 
 use crate::widget::theme::Theme;
@@ -92,7 +92,7 @@ pub enum WidgetDrawItem {
         y: f32,
         width: f32,
         height: f32,
-        color: [f32; 4],
+        color: Rgba,
     },
     /// A glyph run. `(x, y)` is the baseline origin in local pixels;
     /// `font_id` names a session-scoped font loaded through `aether.text`;
@@ -103,7 +103,7 @@ pub enum WidgetDrawItem {
         font_id: u32,
         text: String,
         size_pixels: f32,
-        color: [f32; 4],
+        color: Rgba,
     },
 }
 
@@ -500,7 +500,7 @@ mod tests {
             y: 5.0,
             width: 10.0,
             height: 4.0,
-            color: [1.0, 0.0, 0.0, 1.0],
+            color: Rgba::new(1.0, 0.0, 0.0, 1.0),
         };
         assert_eq!(
             item.offset(Vec2::new(100.0, 20.0)),
@@ -509,7 +509,7 @@ mod tests {
                 y: 25.0,
                 width: 10.0,
                 height: 4.0,
-                color: [1.0, 0.0, 0.0, 1.0],
+                color: Rgba::new(1.0, 0.0, 0.0, 1.0),
             },
             "offset moves the corner by the vector and leaves the extent untouched",
         );
@@ -523,7 +523,7 @@ mod tests {
             font_id: 7,
             text: "hp".into(),
             size_pixels: 12.0,
-            color: [1.0, 1.0, 1.0, 1.0],
+            color: Rgba::WHITE,
         };
         assert_eq!(
             item.offset(Vec2::new(10.0, 40.0)),
@@ -533,7 +533,7 @@ mod tests {
                 font_id: 7,
                 text: "hp".into(),
                 size_pixels: 12.0,
-                color: [1.0, 1.0, 1.0, 1.0],
+                color: Rgba::WHITE,
             },
             "offset moves the baseline and preserves the glyph run",
         );

--- a/crates/aether-kit/src/widget/mod.rs
+++ b/crates/aether-kit/src/widget/mod.rs
@@ -55,7 +55,7 @@ use aether_capabilities::text::DrawText;
 use aether_capabilities::{LifecycleCapability, RenderCapability, TextCapability};
 use aether_data::Kind;
 use aether_kinds::{QuadSpace, Tick};
-use aether_math::{Rgba, Vec2};
+use aether_math::Vec2;
 
 use crate::widget::composite::Composite;
 
@@ -189,7 +189,7 @@ pub(crate) fn emit(ctx: &mut WasmCtx<'_, Manual>, list: &WidgetDrawList) {
                 y: *y,
                 width: *width,
                 height: *height,
-                color: Rgba::from_array(*color),
+                color: *color,
             }),
             WidgetDrawItem::Text { .. } => None,
         })
@@ -215,7 +215,7 @@ pub(crate) fn emit(ctx: &mut WasmCtx<'_, Manual>, list: &WidgetDrawList) {
                 font_id: *font_id,
                 text: text.clone(),
                 size_pixels: *size_pixels,
-                color: Rgba::from_array(*color),
+                color: *color,
                 origin: [*x, *y],
                 space: QuadSpace::Screen,
                 clip: None,

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -38,11 +38,13 @@ pub use text_field::TextFieldWidget;
 
 use alloc::vec::Vec;
 
+use aether_math::Rgba;
+
 use crate::widget::WidgetDrawItem;
 
 /// A flat-colored quad in a widget's own local coordinates — the shared
 /// constructor the widgets build their chrome from.
-pub(crate) fn quad(x: f32, y: f32, width: f32, height: f32, color: [f32; 4]) -> WidgetDrawItem {
+pub(crate) fn quad(x: f32, y: f32, width: f32, height: f32, color: Rgba) -> WidgetDrawItem {
     WidgetDrawItem::Quad {
         x,
         y,
@@ -61,7 +63,7 @@ pub(crate) fn push_border(
     width: f32,
     height: f32,
     thickness: f32,
-    color: [f32; 4],
+    color: Rgba,
 ) {
     items.push(quad(0.0, 0.0, width, thickness, color));
     items.push(quad(0.0, height - thickness, width, thickness, color));

--- a/crates/aether-kit/src/widget/theme.rs
+++ b/crates/aether-kit/src/widget/theme.rs
@@ -15,6 +15,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use aether_math::Rgba;
+
 /// Per-frame local interaction state a widget is in. Never serialized
 /// — it's derived fresh each frame from input, not carried on the
 /// wire. Passed by value to [`Theme::fill`].
@@ -24,15 +26,6 @@ pub enum WidgetState {
     Hover,
     Pressed,
     Disabled,
-}
-
-/// Convert one 8-bit sRGB channel to a linear-space float via the same
-/// approximate `channel²` transfer the world mesher uses
-/// (`crates/aether-kit/src/world/mesher/style.rs`, `hsl_to_linear_rgb`):
-/// `(channel / 255)²`.
-const fn srgb_channel_to_linear(channel: u8) -> f32 {
-    let c = channel as f32 / 255.0;
-    c * c
 }
 
 /// The shared visual language every widget draws from: palette role
@@ -49,27 +42,27 @@ const fn srgb_channel_to_linear(channel: u8) -> f32 {
 #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Theme {
     /// Base background fill — panel / window backdrop.
-    pub surface: [f32; 4],
+    pub surface: Rgba,
     /// A surface lifted one step above `surface` — cards, rows,
     /// raised panels within a panel.
-    pub surface_raised: [f32; 4],
+    pub surface_raised: Rgba,
     /// Borders, dividers, and control outlines.
-    pub outline: [f32; 4],
+    pub outline: Rgba,
     /// Primary text and iconography.
-    pub text_primary: [f32; 4],
+    pub text_primary: Rgba,
     /// De-emphasized text — captions, disabled labels, hints.
-    pub text_muted: [f32; 4],
+    pub text_muted: Rgba,
     /// The interactive / highlight role — buttons, active track
     /// fills, selection.
-    pub accent: [f32; 4],
+    pub accent: Rgba,
     /// Text/iconography drawn on top of an `accent`-filled surface.
-    pub accent_text: [f32; 4],
+    pub accent_text: Rgba,
     /// Role-agnostic lift composited over a base color on
     /// [`WidgetState::Hover`] — a subtle white brighten.
-    pub hover_overlay: [f32; 4],
+    pub hover_overlay: Rgba,
     /// Role-agnostic press composited over a base color on
     /// [`WidgetState::Pressed`] — a subtle black darken.
-    pub pressed_overlay: [f32; 4],
+    pub pressed_overlay: Rgba,
     /// Alpha multiplier applied to a base color on
     /// [`WidgetState::Disabled`].
     pub disabled_alpha: f32,
@@ -101,26 +94,23 @@ impl Theme {
     /// for `Hover` / `Pressed`; `base`'s alpha scaled by
     /// `disabled_alpha` for `Disabled`.
     #[must_use]
-    pub fn fill(&self, base: [f32; 4], state: WidgetState) -> [f32; 4] {
+    pub fn fill(&self, base: Rgba, state: WidgetState) -> Rgba {
         match state {
             WidgetState::Normal => base,
             WidgetState::Hover => Self::composite_over(base, self.hover_overlay),
             WidgetState::Pressed => Self::composite_over(base, self.pressed_overlay),
-            WidgetState::Disabled => [base[0], base[1], base[2], base[3] * self.disabled_alpha],
+            WidgetState::Disabled => {
+                Rgba::new(base.r, base.g, base.b, base.a * self.disabled_alpha)
+            }
         }
     }
 
     /// Standard src-over blend of `overlay` atop `base`, preserving
     /// `base`'s own alpha channel: each RGB channel lerps toward the
     /// overlay's channel by the overlay's alpha.
-    fn composite_over(base: [f32; 4], overlay: [f32; 4]) -> [f32; 4] {
-        let a = overlay[3];
-        [
-            (overlay[0] - base[0]).mul_add(a, base[0]),
-            (overlay[1] - base[1]).mul_add(a, base[1]),
-            (overlay[2] - base[2]).mul_add(a, base[2]),
-            base[3],
-        ]
+    fn composite_over(base: Rgba, overlay: Rgba) -> Rgba {
+        let blended = base.lerp(overlay, overlay.a);
+        Rgba::new(blended.r, blended.g, blended.b, base.a)
     }
 
     /// The compiled-in default theme, seeded from the settled
@@ -129,56 +119,21 @@ impl Theme {
     /// during widget-set bring-up.
     pub const DEFAULT: Self = Self {
         // `#191b15` — workbench `--bg`.
-        surface: [
-            srgb_channel_to_linear(0x19),
-            srgb_channel_to_linear(0x1b),
-            srgb_channel_to_linear(0x15),
-            1.0,
-        ],
+        surface: Rgba::from_srgb8(0x19, 0x1b, 0x15, 0xff),
         // `#20231b` — workbench `--panel`.
-        surface_raised: [
-            srgb_channel_to_linear(0x20),
-            srgb_channel_to_linear(0x23),
-            srgb_channel_to_linear(0x1b),
-            1.0,
-        ],
+        surface_raised: Rgba::from_srgb8(0x20, 0x23, 0x1b, 0xff),
         // `#32362a` — workbench `--line`.
-        outline: [
-            srgb_channel_to_linear(0x32),
-            srgb_channel_to_linear(0x36),
-            srgb_channel_to_linear(0x2a),
-            1.0,
-        ],
+        outline: Rgba::from_srgb8(0x32, 0x36, 0x2a, 0xff),
         // `#e6e4d6` — workbench `--ink`.
-        text_primary: [
-            srgb_channel_to_linear(0xe6),
-            srgb_channel_to_linear(0xe4),
-            srgb_channel_to_linear(0xd6),
-            1.0,
-        ],
+        text_primary: Rgba::from_srgb8(0xe6, 0xe4, 0xd6, 0xff),
         // `#9aa08c` — workbench `--dim`.
-        text_muted: [
-            srgb_channel_to_linear(0x9a),
-            srgb_channel_to_linear(0xa0),
-            srgb_channel_to_linear(0x8c),
-            1.0,
-        ],
+        text_muted: Rgba::from_srgb8(0x9a, 0xa0, 0x8c, 0xff),
         // `#a8c97a` — workbench `--accent`.
-        accent: [
-            srgb_channel_to_linear(0xa8),
-            srgb_channel_to_linear(0xc9),
-            srgb_channel_to_linear(0x7a),
-            1.0,
-        ],
+        accent: Rgba::from_srgb8(0xa8, 0xc9, 0x7a, 0xff),
         // `#191b15` — dark ink on the light accent (= `surface`).
-        accent_text: [
-            srgb_channel_to_linear(0x19),
-            srgb_channel_to_linear(0x1b),
-            srgb_channel_to_linear(0x15),
-            1.0,
-        ],
-        hover_overlay: [1.0, 1.0, 1.0, 0.08],
-        pressed_overlay: [0.0, 0.0, 0.0, 0.12],
+        accent_text: Rgba::from_srgb8(0x19, 0x1b, 0x15, 0xff),
+        hover_overlay: Rgba::new(1.0, 1.0, 1.0, 0.08),
+        pressed_overlay: Rgba::new(0.0, 0.0, 0.0, 0.12),
         disabled_alpha: 0.4,
         pad: 8.0,
         gap: 6.0,
@@ -215,7 +170,7 @@ mod tests {
         // Tripwire: Normal must return the base color untouched — no
         // overlay, no alpha scaling.
         let theme = Theme::DEFAULT;
-        let base = [0.2, 0.4, 0.6, 0.8];
+        let base = Rgba::new(0.2, 0.4, 0.6, 0.8);
         assert_eq!(theme.fill(base, WidgetState::Normal), base);
     }
 
@@ -225,11 +180,14 @@ mod tests {
         // each RGB channel lerps toward the overlay by the overlay's
         // alpha, and base's own alpha survives untouched.
         let theme = Theme {
-            hover_overlay: [1.0, 0.0, 0.0, 0.5],
+            hover_overlay: Rgba::new(1.0, 0.0, 0.0, 0.5),
             ..Theme::DEFAULT
         };
-        let base = [0.0, 1.0, 0.0, 1.0];
-        assert_eq!(theme.fill(base, WidgetState::Hover), [0.5, 0.5, 0.0, 1.0]);
+        let base = Rgba::new(0.0, 1.0, 0.0, 1.0);
+        assert_eq!(
+            theme.fill(base, WidgetState::Hover),
+            Rgba::new(0.5, 0.5, 0.0, 1.0)
+        );
     }
 
     #[test]
@@ -240,10 +198,10 @@ mod tests {
             disabled_alpha: 0.4,
             ..Theme::DEFAULT
         };
-        let base = [0.1, 0.2, 0.3, 1.0];
+        let base = Rgba::new(0.1, 0.2, 0.3, 1.0);
         assert_eq!(
             theme.fill(base, WidgetState::Disabled),
-            [0.1, 0.2, 0.3, 0.4]
+            Rgba::new(0.1, 0.2, 0.3, 0.4)
         );
     }
 }

--- a/crates/aether-kit/src/world/mesher/coverage.rs
+++ b/crates/aether-kit/src/world/mesher/coverage.rs
@@ -2,7 +2,6 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use aether_capabilities::render::{DrawTriangle, Vertex};
-use aether_math::Rgb;
 
 use crate::world::{CellPos, ChunkPos, Material, World};
 
@@ -12,7 +11,7 @@ use super::constants::{
 };
 use super::contour::{SmoothParams, march_grid, minimize_corners};
 use super::partition::chunk_placement;
-use super::style::{StyleTable, hsl_to_linear_rgb};
+use super::style::{StyleTable, flat_color};
 
 /// Distinct non-void overlay materials present in the chunk, in stable
 /// material-id order.
@@ -84,13 +83,12 @@ pub(super) fn mesh_coverage(
             }
         }
         let (samples, width, height) = minimize_corners(&field, n, n, upsample, &params);
-        let style = styles.get(material);
-        let color = hsl_to_linear_rgb(style.base_hue, style.base_sat, style.base_light);
+        let color = flat_color(styles.get(material));
         let vertex = |wx: f32, wz: f32| Vertex {
             x: wx,
             y: COVERAGE_LIFT,
             z: wz,
-            color: Rgb::new(color[0], color[1], color[2]),
+            color,
         };
         march_grid(&samples, width, height, &placement, &vertex, tris);
     }

--- a/crates/aether-kit/src/world/mesher/geometry.rs
+++ b/crates/aether-kit/src/world/mesher/geometry.rs
@@ -11,7 +11,7 @@ use super::constants::OCTIMETERS_PER_METER;
 #[allow(clippy::many_single_char_names)]
 pub(super) fn emit_flat_quad(
     rect: [i32; 4],
-    color: [f32; 3],
+    color: Rgb,
     surface: &impl Fn(f32, f32) -> f32,
     tris: &mut Vec<DrawTriangle>,
 ) {
@@ -22,7 +22,7 @@ pub(super) fn emit_flat_quad(
             x: wx,
             y: surface(wx, wz),
             z: wz,
-            color: Rgb::new(color[0], color[1], color[2]),
+            color,
         }
     };
     let a = corner(rect[0], rect[1]);
@@ -42,14 +42,9 @@ pub(super) fn push_wall_quad(
     top_b: [f32; 3],
     y_bottom_a: f32,
     y_bottom_b: f32,
-    color: [f32; 3],
+    color: Rgb,
 ) {
-    let vert = |x: f32, z: f32, y: f32| Vertex {
-        x,
-        y,
-        z,
-        color: Rgb::new(color[0], color[1], color[2]),
-    };
+    let vert = |x: f32, z: f32, y: f32| Vertex { x, y, z, color };
     let a = vert(top_a[0], top_a[1], top_a[2]);
     let b = vert(top_b[0], top_b[1], top_b[2]);
     let c = vert(top_b[0], top_b[1], y_bottom_b);

--- a/crates/aether-kit/src/world/mesher/style.rs
+++ b/crates/aether-kit/src/world/mesher/style.rs
@@ -1,21 +1,11 @@
-// The style layer works in continuous f32 color space; the coordinate and
-// index casts (percent values to unit range) are small and the pedantic
-// precision / sign / truncation lints flag them as non-issues in this
-// bounded domain.
+// Material discriminants are bounded table indices, so the pedantic cast
+// lints do not signal a real truncation or sign hazard here.
 #![allow(
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap
 )]
-// Color math reads clearest with the conventional single-letter channel
-// names (h/s/l, r/g/b).
-#![allow(clippy::many_single_char_names)]
-// The color arithmetic is written as explicit multiply-add chains for
-// readability; a fused mul_add would need a libm symbol on the wasm target
-// and does not change the result meaningfully here.
-#![allow(clippy::suboptimal_flops)]
-
 //! The material style table and the flat color each material renders.
 //!
 //! A [`MaterialStyle`] row carries a material's base color in HSL.
@@ -24,18 +14,16 @@
 //! cell's color is a pure function of its material alone, so two chunks
 //! agree on their shared border with no shared state.
 
+use aether_math::{Hsl, Rgb};
+
 use crate::world::Material;
 
 /// One material's render style — its base color in HSL. Indexed by
 /// [`Material`] through [`StyleTable::get`]; the [`Material::Void`] row is a
 /// placeholder that is never painted.
 pub struct MaterialStyle {
-    /// Base hue in degrees `[0, 360)`.
-    pub base_hue: f32,
-    /// Base saturation in percent `[0, 100]`.
-    pub base_sat: f32,
-    /// Base lightness in percent `[0, 100]`.
-    pub base_light: f32,
+    /// Base color: hue in degrees and saturation/lightness in `[0, 1]`.
+    pub base: Hsl,
 }
 
 /// Per-material style rows. Base colors are the HSL of the ground palette's
@@ -45,39 +33,27 @@ pub struct MaterialStyle {
 const STYLES: [MaterialStyle; 6] = [
     // Void — never painted.
     MaterialStyle {
-        base_hue: 0.0,
-        base_sat: 0.0,
-        base_light: 0.0,
+        base: Hsl::new(0.0, 0.0, 0.0),
     },
     // Grass — hsl(110, 37.5, 40).
     MaterialStyle {
-        base_hue: 110.0,
-        base_sat: 37.5,
-        base_light: 40.0,
+        base: Hsl::new(110.0, 0.375, 0.4),
     },
     // Dirt — hsl(31, 42.9, 31.5).
     MaterialStyle {
-        base_hue: 31.0,
-        base_sat: 42.9,
-        base_light: 31.5,
+        base: Hsl::new(31.0, 0.429, 0.315),
     },
     // Stone — hsl(240, 3.45, 56.5).
     MaterialStyle {
-        base_hue: 240.0,
-        base_sat: 3.45,
-        base_light: 56.5,
+        base: Hsl::new(240.0, 0.0345, 0.565),
     },
     // Sand — hsl(46, 50, 70).
     MaterialStyle {
-        base_hue: 46.0,
-        base_sat: 50.0,
-        base_light: 70.0,
+        base: Hsl::new(46.0, 0.5, 0.7),
     },
     // Water — hsl(216, 55.6, 45).
     MaterialStyle {
-        base_hue: 216.0,
-        base_sat: 55.6,
-        base_light: 45.0,
+        base: Hsl::new(216.0, 0.556, 0.45),
     },
 ];
 
@@ -99,41 +75,10 @@ impl StyleTable {
     }
 }
 
-/// The flat linear-RGB color for a material style row — its base HSL passed
-/// straight through [`hsl_to_linear_rgb`].
+/// The flat linear-RGB color for a material style row.
 #[must_use]
-pub fn flat_color(style: &MaterialStyle) -> [f32; 3] {
-    hsl_to_linear_rgb(style.base_hue, style.base_sat, style.base_light)
-}
-
-/// Convert HSL (hue degrees, saturation / lightness percent) to linear RGB
-/// in `[0, 1]`. The HSL-to-sRGB step is the standard piecewise chroma
-/// construction; the sRGB channels are then squared as an approximate
-/// transfer into the linear space the render pipeline multiplies by
-/// `view_proj`.
-#[must_use]
-pub fn hsl_to_linear_rgb(hue: f32, sat: f32, light: f32) -> [f32; 3] {
-    let s = (sat / 100.0).clamp(0.0, 1.0);
-    let l = (light / 100.0).clamp(0.0, 1.0);
-    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
-    let hp = (((hue % 360.0) + 360.0) % 360.0) / 60.0;
-    let x = c * (1.0 - ((hp % 2.0) - 1.0).abs());
-    let (r, g, b) = if hp < 1.0 {
-        (c, x, 0.0)
-    } else if hp < 2.0 {
-        (x, c, 0.0)
-    } else if hp < 3.0 {
-        (0.0, c, x)
-    } else if hp < 4.0 {
-        (0.0, x, c)
-    } else if hp < 5.0 {
-        (x, 0.0, c)
-    } else {
-        (c, 0.0, x)
-    };
-    let m = l - c / 2.0;
-    let srgb = [r + m, g + m, b + m];
-    [srgb[0] * srgb[0], srgb[1] * srgb[1], srgb[2] * srgb[2]]
+pub fn flat_color(style: &MaterialStyle) -> Rgb {
+    style.base.to_rgb()
 }
 
 #[cfg(test)]
@@ -147,7 +92,7 @@ mod tests {
         // row, or an HSL conversion that flattened them), two materials would
         // render indistinguishably.
         let styles = StyleTable::default();
-        let colors: Vec<[f32; 3]> = [
+        let colors: Vec<Rgb> = [
             Material::Grass,
             Material::Dirt,
             Material::Stone,

--- a/crates/aether-kit/src/world/mesher/style.rs
+++ b/crates/aether-kit/src/world/mesher/style.rs
@@ -41,7 +41,9 @@ const STYLES: [MaterialStyle; 6] = [
     },
     // Dirt — hsl(31, 42.9, 31.5).
     MaterialStyle {
-        base: Hsl::new(31.0, 0.429, 0.315),
+        // Preserve the exact `f32` produced by the former percentage
+        // conversion so this type migration cannot move rendered colors.
+        base: Hsl::new(31.0, 42.9 / 100.0, 0.315),
     },
     // Stone — hsl(240, 3.45, 56.5).
     MaterialStyle {

--- a/crates/aether-kit/src/world/mesher/voids.rs
+++ b/crates/aether-kit/src/world/mesher/voids.rs
@@ -1,5 +1,4 @@
 use aether_capabilities::render::{DrawTriangle, Vertex};
-use aether_math::Rgb;
 
 use crate::world::{CellPos, ChunkPos, Material, World};
 
@@ -148,7 +147,7 @@ pub(super) fn emit_void_floors(
                         x: wx,
                         y,
                         z: wz,
-                        color: Rgb::new(rgb[0], rgb[1], rgb[2]),
+                        color: rgb,
                     };
                     push_quad(
                         tris,

--- a/crates/aether-kit/src/world/mesher/walls.rs
+++ b/crates/aether-kit/src/world/mesher/walls.rs
@@ -1,4 +1,5 @@
 use aether_capabilities::render::DrawTriangle;
+use aether_math::Rgb;
 
 use crate::world::{CellPos, ChunkPos, Material, STEP_MAX_OCTIMETERS, World};
 
@@ -59,7 +60,7 @@ pub(super) fn emit_walls(
 /// The flat wall color for a cliff owned by `cell`: the cell's cliff
 /// material's flat color. A pure function of the cell, so the two sides of a
 /// shared edge agree on the color.
-fn wall_color(world: &World, cell: CellPos, styles: &StyleTable) -> [f32; 3] {
+fn wall_color(world: &World, cell: CellPos, styles: &StyleTable) -> Rgb {
     flat_color(styles.get(world.cliff_material(cell)))
 }
 

--- a/crates/aether-kit/src/world/mesher/windows.rs
+++ b/crates/aether-kit/src/world/mesher/windows.rs
@@ -147,7 +147,7 @@ fn emit_clip_gap_walls(
     styles: &StyleTable,
     tris: &mut Vec<DrawTriangle>,
 ) {
-    let mut color: Option<[f32; 3]> = None;
+    let mut color: Option<Rgb> = None;
     for axis in 0..2 {
         for (fa, sa) in fragments {
             let Some((line, false)) = sa[axis] else {
@@ -462,7 +462,7 @@ fn emit_mixed_window(
                 x: wx,
                 y,
                 z: wz,
-                color: Rgb::new(color[0], color[1], color[2]),
+                color,
             }
         };
         for poly in label_window_polys(case, connected) {

--- a/crates/aether-substrate-bundle/tests/widget_compositing.rs
+++ b/crates/aether-substrate-bundle/tests/widget_compositing.rs
@@ -34,16 +34,17 @@ use std::fs;
 use aether_data::Kind;
 use aether_kinds::{LoadComponent, LoadResult, NamedMail};
 use aether_kit::{WidgetChildSpec, WidgetConfig, WidgetDrawItem, WidgetKind};
+use aether_math::Rgba;
 use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
 use aether_substrate_bundle::visual::{Image, background_top_left, decode_png};
 
 /// Linear RGBA primaries chosen so each survives the sRGB encode as a
 /// single dominant channel — the compositing order is then read off the
 /// captured pixels by which channel wins, gamma-invariant.
-const BLUE: [f32; 4] = [0.05, 0.05, 0.90, 1.0];
-const RED: [f32; 4] = [0.90, 0.05, 0.05, 1.0];
-const GREEN: [f32; 4] = [0.05, 0.90, 0.05, 1.0];
-const WHITE: [f32; 4] = [0.95, 0.95, 0.95, 1.0];
+const BLUE: Rgba = Rgba::new(0.05, 0.05, 0.90, 1.0);
+const RED: Rgba = Rgba::new(0.90, 0.05, 0.05, 1.0);
+const GREEN: Rgba = Rgba::new(0.05, 0.90, 0.05, 1.0);
+const WHITE: Rgba = Rgba::new(0.95, 0.95, 0.95, 1.0);
 
 /// The full trampoline address a loaded component registers at (ADR-0099
 /// §4) — `aether.component` `/`-joined to the trampoline node named
@@ -57,7 +58,7 @@ fn panel_address() -> String {
 }
 
 /// A flat-colored quad draw item in the widget's own local coordinates.
-fn quad(x: f32, y: f32, width: f32, height: f32, color: [f32; 4]) -> WidgetDrawItem {
+fn quad(x: f32, y: f32, width: f32, height: f32, color: Rgba) -> WidgetDrawItem {
     WidgetDrawItem::Quad {
         x,
         y,
@@ -69,7 +70,7 @@ fn quad(x: f32, y: f32, width: f32, height: f32, color: [f32; 4]) -> WidgetDrawI
 
 /// A leaf `WidgetConfig` (no children) whose only draw is one local quad,
 /// pre-encoded to the bytes a parent's `WidgetChildSpec` carries.
-fn leaf_config(width: f32, height: f32, color: [f32; 4]) -> Vec<u8> {
+fn leaf_config(width: f32, height: f32, color: Rgba) -> Vec<u8> {
     WidgetConfig {
         root: false,
         chrome: vec![quad(0.0, 0.0, width, height, color)],

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/cube.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/cube.rs
@@ -92,14 +92,14 @@ impl Cube {
         let ppp = corner(1.0, 1.0, 1.0);
 
         // One vertex with a face color baked in.
-        let vert = |position: (f32, f32, f32), color: [f32; 3]| Vertex {
+        let vert = |position: (f32, f32, f32), color: Rgb| Vertex {
             x: position.0,
             y: position.1,
             z: position.2,
-            color: Rgb::new(color[0], color[1], color[2]),
+            color,
         };
         // A quad as two triangles, all six vertices sharing `color`.
-        let quad = |a, b, c, d, color: [f32; 3]| {
+        let quad = |a, b, c, d, color: Rgb| {
             [
                 DrawTriangle {
                     verts: [vert(a, color), vert(b, color), vert(c, color)],
@@ -110,12 +110,12 @@ impl Cube {
             ]
         };
 
-        let [front_0, front_1] = quad(nnp, pnp, ppp, npp, [0.85, 0.20, 0.20]); // +Z
-        let [back_0, back_1] = quad(pnn, nnn, npn, ppn, [0.20, 0.30, 0.85]); // -Z
-        let [right_0, right_1] = quad(pnp, pnn, ppn, ppp, [0.20, 0.75, 0.30]); // +X
-        let [left_0, left_1] = quad(nnn, nnp, npp, npn, [0.85, 0.75, 0.20]); // -X
-        let [top_0, top_1] = quad(npp, ppp, ppn, npn, [0.80, 0.45, 0.85]); // +Y
-        let [bottom_0, bottom_1] = quad(nnn, pnn, pnp, nnp, [0.30, 0.80, 0.80]); // -Y
+        let [front_0, front_1] = quad(nnp, pnp, ppp, npp, Rgb::new(0.85, 0.20, 0.20)); // +Z
+        let [back_0, back_1] = quad(pnn, nnn, npn, ppn, Rgb::new(0.20, 0.30, 0.85)); // -Z
+        let [right_0, right_1] = quad(pnp, pnn, ppn, ppp, Rgb::new(0.20, 0.75, 0.30)); // +X
+        let [left_0, left_1] = quad(nnn, nnp, npp, npn, Rgb::new(0.85, 0.75, 0.20)); // -X
+        let [top_0, top_1] = quad(npp, ppp, ppn, npn, Rgb::new(0.80, 0.45, 0.85)); // +Y
+        let [bottom_0, bottom_1] = quad(nnn, pnn, pnp, nnp, Rgb::new(0.30, 0.80, 0.80)); // -Y
 
         [
             front_0, front_1, back_0, back_1, right_0, right_1, left_0, left_1, top_0, top_1,


### PR DESCRIPTION
## Summary

- migrate public aether-kit color fields from primitive tuples to schema color types
- update fixtures, widgets, mesh loading, and world meshing consumers
- preserve wire behavior while making color semantics explicit

## Validation

- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings

Closes #2866