### PR TITLE
chore(ci): cancel superseded in-flight runs per branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
   push:
     branches: [ main ]
 
+# A push to a branch supersedes that branch's in-flight run: cancel it
+# instead of letting it hold 8-vCPU runners to completion (the account
+# spot quota is the scarce resource). Main is exempt — every main push
+# is a distinct merge whose full run carries the cache-save and scan
+# signal.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
A push to a branch supersedes that branch's in-flight CI run, but without a concurrency group the stale run holds its 8-vCPU runners to completion — real contention now that peak CI concurrency sits exactly at the account's 32-vCPU spot quota (`MaxSpotInstanceCountExceeded` alerts on overlap). Cancel in-progress runs per ref; main is exempt since every main push is a distinct merge whose full run carries the cache-save and scan signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)