### PR TITLE
feat(workflow): add a claude review skill wrapping the review workflow

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: review
+description: Pre-land review of a code change against five judgment pillars that mechanical gates (clippy/rustc/Qodana/fmt) cannot decide — spec fidelity (asked-vs-changed delta), correctness (named bug-shapes), test integrity (does the test catch an owned bug), economy (fewest chars that still make sense), and convention/architecture (stated rules + ADR conformance). Returns an issue-ready rollup with soft-hold flags on high-severity correctness/spec findings; never gates CI, never touches GitHub. Use at the end of /implement (before un-draft) to review a change against its issue, or in backfill mode to audit existing whole files per crate. Distinct from the global /code-review skill — this wraps the repo's five-pillar review workflow.
+---
+
+# /review — five-pillar pre-land review
+
+The Claude entry point to the `review` workflow (`.claude/workflows/review.js`). Where the workflow holds the multi-agent orchestration — a cheap whole-PR scope filter, then per-file specialist finders, then a two-sided verify funnel — this skill is the thin invocation surface around it: it resolves the caller-side file set the workflow sandbox cannot, selects integrated or backfill mode, invokes the workflow in a single pass, and reports the returned soft-hold rollup. The mirror of the Codex wrapper at `.agents/skills/review/SKILL.md`, invoking the same workflow through the `Workflow` tool.
+
+**Distinct from the global `/code-review` skill.** `/code-review` is a separately-owned tool that reviews the working diff; `/review` here wraps this repo's five-pillar `review.js` workflow. When you mean the repo workflow, use `/review`.
+
+`/review` never touches GitHub, never gates CI, and files nothing — surfacing confirmed findings as follow-up issues and clearing soft-holds are separate human-gated steps.
+
+## Invocation
+
+```
+/review                        integrated — review the current change against its issue
+/review --backfill <crate|path>   whole-file audit of existing code, no issue (sharded per crate)
+```
+
+- **Integrated mode** runs when an issue and its diff are in hand — the spec-fidelity lens runs (the asked-vs-changed delta), so this is the mode to run at the end of `/implement` before un-draft.
+- **Backfill mode** runs against a crate or path's whole-file set with no issue — the spec lens does not run; the other four pillars audit existing code.
+
+## Inputs
+
+The skill assembles the workflow's arg contract (`{issue?, files, testFiles?, diffs?}`, grounded against `.claude/workflows/review.js`):
+
+- `files` — a non-empty array of absolute `.rs` paths for the code lenses (correctness, economy, convention).
+- `testFiles` — absolute `.rs` paths for the test-integrity lens.
+- `issue` — the issue or scope text for the spec-fidelity lens. Omit for backfill; its presence is what selects integrated mode.
+- `diffs` — per-file diff hunks keyed by path, so the finders judge the change rather than the whole file (integrated mode).
+
+## Caller-side prep
+
+The workflow sandbox cannot run `git` or `grep`, so the skill resolves the file set before invoking it:
+
+1. **Integrated** — resolve the changed files and their per-file diffs from the branch against `origin/main` (`git diff --name-only origin/main...HEAD` for the `.rs` set; `git diff origin/main...HEAD -- <file>` per file for `diffs`). Split test files (`tests/`, `#[cfg(test)]`-heavy) into `testFiles`. Read the issue body as `issue`.
+2. **Backfill** — resolve the crate's whole-file `.rs` set (`git ls-files -- <crate>/src '*.rs'`), shard per crate to keep each run bounded, and pass no `issue`.
+
+The workflow reads source itself; there is no live MCP harness precondition (unlike `/dogfood`, `/review` does not drive a running engine).
+
+## Workflow handoff
+
+Invoke the workflow with the assembled args, in a single pass — there is no approval gate:
+
+```
+Workflow({name: "review", args: {issue, files, testFiles, diffs}})
+```
+
+## Rollup report
+
+On completion the workflow returns `{rollup, files}`. Report the rollup to the user:
+
+- **confirmed findings** — grouped by file then pillar, each with a file/line reference, the current form, the suggested action, and the rationale. Ordered most-severe first.
+- **soft-holds** — high-severity spec-fidelity or correctness findings. Advisory only — `/review` never blocks a land; the soft-hold is a flag for the reviewer to clear.
+- **lint candidates** — mechanically-decidable observations seeded for a `clippy.toml` / custom lint / `check-*.sh` rule, kept out of the judgment rollup.
+- **spared / uncertain** — findings refuted in the verify funnel, or ones whose relevant code could not be read.
+
+## What `/review` does NOT do
+
+- File follow-up issues. Confirmed findings are triaged via a separate `/sketch` step — the user's call which.
+- Clear soft-holds. A high-severity spec/correctness soft-hold is resolved by a human before un-draft, not by this skill.
+- Touch GitHub or gate CI. The review is advisory; the rollup is the surface.
+- Reimplement the orchestration. The `review.js` workflow is the single source of the Scope → Find → Verify logic; this skill only invokes it.
+- Duplicate `/code-review`. That is a separate global tool; `/review` wraps the repo's five-pillar workflow.

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 !.claude/skills/release-init/
 !.claude/skills/scope/
 !.claude/skills/retrospect/
+!.claude/skills/review/
 !.claude/skills/scope-spinoff/
 !.claude/skills/sketch/
 !.claude/skills/secretary/


### PR DESCRIPTION
Closes #2953.

## Summary

The five-pillar `review` pre-land review existed as the workflow `.claude/workflows/review.js` plus a Codex wrapper, with no Claude entry point. This adds `.claude/skills/review/SKILL.md` as the Claude-native `/review`, the mirror of the Codex wrapper. The skill resolves the caller-side file set the workflow sandbox cannot (changed `.rs` files and per-file diffs, or a crate's whole-file set), selects integrated vs backfill mode (an issue in hand runs the spec lens; no issue runs backfill), invokes the workflow in a single pass (no approval gate), and reports the returned soft-hold rollup. Disambiguated from the separately-owned global `/code-review` skill. The workflow logic is unchanged.

Note: `.claude/skills/*` is gitignored with per-skill un-ignore entries, so the skill dir is registered via a `!.claude/skills/review/` negation — the scope plan's "the file alone registers the skill" assumption missed this gitignore mechanism.

## Test plan

Skill text — validated by invoking `/review` on a change. Auto-discovery confirmed: no skills manifest on `origin/main`; the `.gitignore` negation makes the file trackable.

## Generated by

`/implement` — agent execution of [scoped issue #2953](https://github.com/iamacoffeepot/aether/issues/2953).
