### PR TITLE
fix(ci): key main-push concurrency group by sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,12 @@ on:
 # instead of letting it hold 8-vCPU runners to completion (the account
 # spot quota is the scarce resource). Main is exempt — every main push
 # is a distinct merge whose full run carries the cache-save and scan
-# signal.
+# signal — and each main push gets its own group (keyed by sha):
+# GitHub allows only one running + one queued run per group, so a
+# shared main group would serialize back-to-back merges and silently
+# cancel the intermediate runs.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:


### PR DESCRIPTION
GitHub allows one running + one queued run per concurrency group, so the shared `ci-refs/heads/main` group from #2954 serialized back-to-back merges and silently cancelled the intermediate runs — visible today when three merges landed within 15 minutes: the first run was cancelled, the second stuck pending, and only the newest ran. Keying the group by `github.sha` on main gives every merge its own group so runs proceed independently; PR refs keep the shared cancelling group, which is the behavior #2954 was actually after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)