### PR TITLE
feat(kit): add revisioned terrain annotations with stable ids

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -20,6 +20,9 @@
 //! - [`mesh::MeshViewer`] — loads a `.dsl` / `.obj` mesh file and replays it
 //!   to the render sink, selected by the `aether_kit@aether.kit.mesh`
 //!   export. Its `aether.kit.mesh.load` kind lives in [`mesh`].
+//! - [`mark::MarkBook`] — owns revisioned terrain annotations with stable ids,
+//!   selected by the `aether_kit@aether.kit.mark` export. Its CRUD and
+//!   snapshot vocabulary lives in [`mark`].
 //! - [`world::WorldView`] — meshes the chunked world plane stack into a
 //!   flat-color marching-squares base render, selected by the
 //!   `aether_kit@aether.kit.world` export. The [`world`] module also holds
@@ -58,6 +61,7 @@ extern crate alloc;
 pub mod camera;
 pub mod camera_controller;
 pub mod console;
+pub mod mark;
 pub mod mesh;
 pub mod mover;
 pub mod widget;
@@ -66,6 +70,11 @@ pub mod world;
 pub use console::{
     ConsoleCommandInvoked, ConsoleCommandOutput, ConsoleConfig, ConsoleTheme,
     RegisterConsoleCommand, UnregisterConsoleCommand,
+};
+pub use mark::{
+    Mark, MarkCreate, MarkCreateResult, MarkDelete, MarkDeleteResult, MarkGeometry, MarkGet,
+    MarkGetResult, MarkId, MarkList, MarkListResult, MarkMutationError, MarkRef, MarkUpdate,
+    MarkUpdateResult, SavedMarks,
 };
 pub use mover::MoverTeleport;
 pub use widget::theme::{SetTheme, Theme, WidgetState};
@@ -106,6 +115,7 @@ aether_actor::export!(
     entry = console::ConsoleOverlay,
     camera::CameraComponent,
     camera_controller::CameraController,
+    mark::MarkBook,
     mesh::MeshViewer,
     world::WorldView,
     mover::WorldMover,
@@ -123,6 +133,7 @@ aether_actor::export!(
     entry = console::ConsoleOverlay,
     camera::CameraComponent,
     camera_controller::CameraController,
+    mark::MarkBook,
     mesh::MeshViewer,
     world::WorldView,
     mover::WorldMover,

--- a/crates/aether-kit/src/mark/kinds.rs
+++ b/crates/aether-kit/src/mark/kinds.rs
@@ -1,0 +1,183 @@
+//! Wire vocabulary for the revisioned terrain-mark store.
+
+use alloc::{string::String, vec::Vec};
+
+use serde::{Deserialize, Serialize};
+
+use crate::world::WorldPoint;
+
+/// Stable identity for a terrain mark.
+///
+/// The scalar stays wrapped so a mark id cannot be confused with a revision
+/// or an unrelated counter at API boundaries.
+#[derive(
+    aether_data::Schema,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+)]
+pub struct MarkId(u32);
+
+impl MarkId {
+    /// Wrap a scalar mark id.
+    #[must_use]
+    pub const fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Return the wrapped scalar id.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+/// A stable mark identity paired with the revision observed by the caller.
+#[derive(
+    aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord,
+)]
+pub struct MarkRef {
+    pub id: MarkId,
+    pub revision: u32,
+}
+
+/// Geometry attached to a terrain mark, expressed in named world points.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum MarkGeometry {
+    Point(WorldPoint),
+    Path(Vec<WorldPoint>),
+    Area(Vec<WorldPoint>),
+}
+
+/// One stored terrain annotation.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Mark {
+    pub id: MarkId,
+    pub revision: u32,
+    pub geometry: MarkGeometry,
+    pub label: String,
+}
+
+impl Mark {
+    /// Return the mark's identity and current revision as one named value.
+    #[must_use]
+    pub const fn reference(&self) -> MarkRef {
+        MarkRef {
+            id: self.id,
+            revision: self.revision,
+        }
+    }
+}
+
+/// A rejected mutation leaves the store unchanged.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum MarkMutationError {
+    InvalidGeometry { reason: String },
+    EmptyUpdate,
+    IdExhausted,
+    RevisionExhausted,
+}
+
+/// `aether.kit.mark.create` — allocate and store one terrain mark.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.mark.create")]
+pub struct MarkCreate {
+    pub geometry: MarkGeometry,
+    pub label: String,
+}
+
+/// Reply to [`MarkCreate`].
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "aether.kit.mark.create_result")]
+pub enum MarkCreateResult {
+    Created { reference: MarkRef },
+    Rejected { error: MarkMutationError },
+}
+
+/// `aether.kit.mark.update` — replace either or both mutable mark fields.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.mark.update")]
+pub struct MarkUpdate {
+    pub id: MarkId,
+    pub geometry: Option<MarkGeometry>,
+    pub label: Option<String>,
+}
+
+/// Reply to [`MarkUpdate`].
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "aether.kit.mark.update_result")]
+pub enum MarkUpdateResult {
+    Updated { reference: MarkRef },
+    NotFound { id: MarkId },
+    Rejected { error: MarkMutationError },
+}
+
+/// `aether.kit.mark.delete` — remove one mark without reusing its id.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.mark.delete")]
+pub struct MarkDelete {
+    pub id: MarkId,
+}
+
+/// Reply to [`MarkDelete`].
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "aether.kit.mark.delete_result")]
+pub enum MarkDeleteResult {
+    Deleted { reference: MarkRef },
+    NotFound { id: MarkId },
+}
+
+/// `aether.kit.mark.get` — fetch one mark by stable identity.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.mark.get")]
+pub struct MarkGet {
+    pub id: MarkId,
+}
+
+/// Reply to [`MarkGet`].
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "aether.kit.mark.get_result")]
+pub struct MarkGetResult {
+    pub mark: Option<Mark>,
+}
+
+/// `aether.kit.mark.list` — fetch every mark in ascending id order.
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, Default,
+)]
+#[kind(name = "aether.kit.mark.list")]
+pub struct MarkList;
+
+/// Reply to [`MarkList`].
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "aether.kit.mark.list_result")]
+pub struct MarkListResult {
+    pub marks: Vec<Mark>,
+}
+
+/// Hot-swap snapshot for [`super::MarkBook`](super::MarkBook).
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "aether.kit.mark.saved_state")]
+pub struct SavedMarks {
+    pub marks: Vec<Mark>,
+    pub next_id: u32,
+}

--- a/crates/aether-kit/src/mark/mod.rs
+++ b/crates/aether-kit/src/mark/mod.rs
@@ -1,0 +1,472 @@
+//! Revisioned terrain annotations with stable ids.
+//!
+//! [`MarkBook`] is a selector-only actor at `aether.kit.mark`. It owns a
+//! deterministic in-memory store and exposes create, update, delete, get, and
+//! list mail. Every accepted mutation returns a named [`MarkRef`], while
+//! rejected mutations are transactional and leave state untouched. The full
+//! store and its allocation watermark survive component replacement.
+
+#![allow(clippy::needless_pass_by_value)]
+
+mod kinds;
+pub use kinds::*;
+
+use alloc::{collections::BTreeMap, string::String};
+
+use aether_actor::{
+    ActorInitError, Manual, OutboundReply, PriorState, WasmActor, WasmCtx, WasmDropCtx,
+    WasmInitCtx, actor,
+};
+
+use crate::world::MAX_STAMP_VERTICES;
+
+const INITIAL_MARK_ID: u32 = 1;
+const INITIAL_REVISION: u32 = 1;
+
+/// Pure storage core used by [`MarkBook`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MarkStore {
+    marks: BTreeMap<MarkId, Mark>,
+    next_id: u32,
+}
+
+impl Default for MarkStore {
+    fn default() -> Self {
+        Self {
+            marks: BTreeMap::new(),
+            next_id: INITIAL_MARK_ID,
+        }
+    }
+}
+
+impl MarkStore {
+    fn create(&mut self, geometry: MarkGeometry, label: String) -> MarkCreateResult {
+        if let Err(error) = validate_geometry(&geometry) {
+            return MarkCreateResult::Rejected { error };
+        }
+
+        let Some(next_id) = self.next_id.checked_add(1) else {
+            return MarkCreateResult::Rejected {
+                error: MarkMutationError::IdExhausted,
+            };
+        };
+        let id = MarkId::new(self.next_id);
+        let mark = Mark {
+            id,
+            revision: INITIAL_REVISION,
+            geometry,
+            label,
+        };
+        let reference = mark.reference();
+        self.marks.insert(id, mark);
+        self.next_id = next_id;
+        MarkCreateResult::Created { reference }
+    }
+
+    fn update(
+        &mut self,
+        id: MarkId,
+        geometry: Option<MarkGeometry>,
+        label: Option<String>,
+    ) -> MarkUpdateResult {
+        let Some(mark) = self.marks.get(&id) else {
+            return MarkUpdateResult::NotFound { id };
+        };
+        if geometry.is_none() && label.is_none() {
+            return MarkUpdateResult::Rejected {
+                error: MarkMutationError::EmptyUpdate,
+            };
+        }
+        if let Some(geometry) = &geometry
+            && let Err(error) = validate_geometry(geometry)
+        {
+            return MarkUpdateResult::Rejected { error };
+        }
+        let Some(revision) = mark.revision.checked_add(1) else {
+            return MarkUpdateResult::Rejected {
+                error: MarkMutationError::RevisionExhausted,
+            };
+        };
+
+        let mark = self
+            .marks
+            .get_mut(&id)
+            .expect("mark existence was established before validation");
+        if let Some(geometry) = geometry {
+            mark.geometry = geometry;
+        }
+        if let Some(label) = label {
+            mark.label = label;
+        }
+        mark.revision = revision;
+        MarkUpdateResult::Updated {
+            reference: mark.reference(),
+        }
+    }
+
+    fn delete(&mut self, id: MarkId) -> MarkDeleteResult {
+        self.marks
+            .remove(&id)
+            .map_or(MarkDeleteResult::NotFound { id }, |mark| {
+                MarkDeleteResult::Deleted {
+                    reference: mark.reference(),
+                }
+            })
+    }
+
+    fn get(&self, id: MarkId) -> MarkGetResult {
+        MarkGetResult {
+            mark: self.marks.get(&id).cloned(),
+        }
+    }
+
+    fn list(&self) -> MarkListResult {
+        MarkListResult {
+            marks: self.marks.values().cloned().collect(),
+        }
+    }
+
+    fn snapshot(&self) -> SavedMarks {
+        SavedMarks {
+            marks: self.marks.values().cloned().collect(),
+            next_id: self.next_id,
+        }
+    }
+
+    fn restore(saved: SavedMarks) -> Self {
+        Self {
+            marks: saved
+                .marks
+                .into_iter()
+                .map(|mark| (mark.id, mark))
+                .collect(),
+            next_id: saved.next_id,
+        }
+    }
+}
+
+fn validate_geometry(geometry: &MarkGeometry) -> Result<(), MarkMutationError> {
+    let (kind, length, minimum) = match geometry {
+        MarkGeometry::Point(_) => return Ok(()),
+        MarkGeometry::Path(points) => ("path", points.len(), 2),
+        MarkGeometry::Area(points) => ("area", points.len(), 3),
+    };
+    if !(minimum..=MAX_STAMP_VERTICES).contains(&length) {
+        return Err(MarkMutationError::InvalidGeometry {
+            reason: alloc::format!(
+                "{kind} requires {minimum}..={MAX_STAMP_VERTICES} world points; got {length}"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Actor wrapper around the deterministic terrain-mark store.
+pub struct MarkBook {
+    store: MarkStore,
+}
+
+#[actor]
+impl WasmActor for MarkBook {
+    const NAMESPACE: &'static str = "aether.kit.mark";
+
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Self {
+            store: MarkStore::default(),
+        })
+    }
+
+    #[handler::manual]
+    fn on_create(&mut self, ctx: &mut WasmCtx<'_, Manual>, request: MarkCreate) {
+        let result = self.store.create(request.geometry, request.label);
+        if ctx.reply_target().is_some() {
+            ctx.reply(&result);
+        }
+    }
+
+    #[handler::manual]
+    fn on_update(&mut self, ctx: &mut WasmCtx<'_, Manual>, request: MarkUpdate) {
+        let result = self
+            .store
+            .update(request.id, request.geometry, request.label);
+        if ctx.reply_target().is_some() {
+            ctx.reply(&result);
+        }
+    }
+
+    #[handler::manual]
+    fn on_delete(&mut self, ctx: &mut WasmCtx<'_, Manual>, request: MarkDelete) {
+        let result = self.store.delete(request.id);
+        if ctx.reply_target().is_some() {
+            ctx.reply(&result);
+        }
+    }
+
+    #[handler::manual]
+    fn on_get(&mut self, ctx: &mut WasmCtx<'_, Manual>, request: MarkGet) {
+        let result = self.store.get(request.id);
+        if ctx.reply_target().is_some() {
+            ctx.reply(&result);
+        }
+    }
+
+    #[handler::manual]
+    fn on_list(&mut self, ctx: &mut WasmCtx<'_, Manual>, _request: MarkList) {
+        let result = self.store.list();
+        if ctx.reply_target().is_some() {
+            ctx.reply(&result);
+        }
+    }
+
+    fn on_dehydrate(&mut self, ctx: &mut WasmDropCtx<'_>) {
+        ctx.save_state_kind::<SavedMarks>(0, &self.store.snapshot());
+    }
+
+    fn on_rehydrate(&mut self, _ctx: &mut WasmCtx<'_>, prior: PriorState<'_>) {
+        if let Some(saved) = prior.decode_kind::<SavedMarks>() {
+            self.store = MarkStore::restore(saved);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::world::WorldPoint;
+
+    fn point(x: i32, z: i32) -> WorldPoint {
+        WorldPoint::new(x, z)
+    }
+
+    fn create(store: &mut MarkStore, geometry: MarkGeometry, label: &str) -> MarkRef {
+        match store.create(geometry, label.into()) {
+            MarkCreateResult::Created { reference } => reference,
+            MarkCreateResult::Rejected { error } => panic!("create rejected: {error:?}"),
+        }
+    }
+
+    #[test]
+    fn geometry_boundaries_accept_only_scoped_vertex_counts() {
+        for length in [0, 1, MAX_STAMP_VERTICES + 1] {
+            let geometry = MarkGeometry::Path(vec![point(0, 0); length]);
+            assert!(matches!(
+                validate_geometry(&geometry),
+                Err(MarkMutationError::InvalidGeometry { .. })
+            ));
+        }
+        for length in [0, 1, 2, MAX_STAMP_VERTICES + 1] {
+            let geometry = MarkGeometry::Area(vec![point(0, 0); length]);
+            assert!(matches!(
+                validate_geometry(&geometry),
+                Err(MarkMutationError::InvalidGeometry { .. })
+            ));
+        }
+
+        assert!(validate_geometry(&MarkGeometry::Point(point(0, 0))).is_ok());
+        assert!(validate_geometry(&MarkGeometry::Path(vec![point(0, 0); 2])).is_ok());
+        assert!(
+            validate_geometry(&MarkGeometry::Path(vec![point(0, 0); MAX_STAMP_VERTICES])).is_ok()
+        );
+        assert!(validate_geometry(&MarkGeometry::Area(vec![point(0, 0); 3])).is_ok());
+        assert!(
+            validate_geometry(&MarkGeometry::Area(vec![point(0, 0); MAX_STAMP_VERTICES])).is_ok()
+        );
+    }
+
+    #[test]
+    fn create_allocates_stable_ids_and_rejects_without_mutation() {
+        let mut store = MarkStore::default();
+        let first = create(&mut store, MarkGeometry::Point(point(1, 2)), "first");
+        let second = create(&mut store, MarkGeometry::Point(point(3, 4)), "second");
+        assert_eq!(
+            first,
+            MarkRef {
+                id: MarkId::new(1),
+                revision: 1
+            }
+        );
+        assert_eq!(
+            second,
+            MarkRef {
+                id: MarkId::new(2),
+                revision: 1
+            }
+        );
+
+        let before = store.clone();
+        let rejected = store.create(MarkGeometry::Path(vec![point(0, 0)]), "bad".into());
+        assert!(matches!(
+            rejected,
+            MarkCreateResult::Rejected {
+                error: MarkMutationError::InvalidGeometry { .. }
+            }
+        ));
+        assert_eq!(store, before);
+    }
+
+    #[test]
+    fn update_validates_before_one_revision_bump_and_is_transactional() {
+        let mut store = MarkStore::default();
+        let created = create(&mut store, MarkGeometry::Point(point(1, 2)), "old");
+        let updated_geometry = MarkGeometry::Path(vec![point(2, 3), point(4, 5)]);
+        assert_eq!(
+            store.update(
+                created.id,
+                Some(updated_geometry.clone()),
+                Some("new".into()),
+            ),
+            MarkUpdateResult::Updated {
+                reference: MarkRef {
+                    id: created.id,
+                    revision: 2,
+                }
+            }
+        );
+        assert_eq!(
+            store.get(created.id).mark,
+            Some(Mark {
+                id: created.id,
+                revision: 2,
+                geometry: updated_geometry,
+                label: "new".into(),
+            })
+        );
+
+        for (geometry, label, expected) in [
+            (None, None, MarkMutationError::EmptyUpdate),
+            (
+                Some(MarkGeometry::Area(vec![point(0, 0), point(1, 1)])),
+                Some("ignored".into()),
+                MarkMutationError::InvalidGeometry {
+                    reason: "ignored".into(),
+                },
+            ),
+        ] {
+            let before = store.clone();
+            let result = store.update(created.id, geometry, label);
+            match expected {
+                MarkMutationError::EmptyUpdate => assert_eq!(
+                    result,
+                    MarkUpdateResult::Rejected {
+                        error: MarkMutationError::EmptyUpdate
+                    }
+                ),
+                MarkMutationError::InvalidGeometry { .. } => assert!(matches!(
+                    result,
+                    MarkUpdateResult::Rejected {
+                        error: MarkMutationError::InvalidGeometry { .. }
+                    }
+                )),
+                _ => unreachable!(),
+            }
+            assert_eq!(store, before);
+        }
+    }
+
+    #[test]
+    fn missing_update_and_delete_are_no_ops() {
+        let mut store = MarkStore::default();
+        let before = store.clone();
+        let missing = MarkId::new(40);
+        assert_eq!(
+            store.update(missing, None, Some("new".into())),
+            MarkUpdateResult::NotFound { id: missing }
+        );
+        assert_eq!(
+            store.delete(missing),
+            MarkDeleteResult::NotFound { id: missing }
+        );
+        assert_eq!(store, before);
+    }
+
+    #[test]
+    fn delete_returns_last_revision_and_ids_are_not_reused() {
+        let mut store = MarkStore::default();
+        let first = create(&mut store, MarkGeometry::Point(point(0, 0)), "first");
+        assert_eq!(
+            store.update(first.id, None, Some("edited".into())),
+            MarkUpdateResult::Updated {
+                reference: MarkRef {
+                    id: first.id,
+                    revision: 2,
+                }
+            }
+        );
+        assert_eq!(
+            store.delete(first.id),
+            MarkDeleteResult::Deleted {
+                reference: MarkRef {
+                    id: first.id,
+                    revision: 2,
+                }
+            }
+        );
+        let second = create(&mut store, MarkGeometry::Point(point(1, 1)), "second");
+        assert_eq!(second.id, MarkId::new(2));
+    }
+
+    #[test]
+    fn list_is_deterministic_by_mark_id() {
+        let mut store = MarkStore::default();
+        for label in ["one", "two", "three"] {
+            create(&mut store, MarkGeometry::Point(point(0, 0)), label);
+        }
+        store.delete(MarkId::new(2));
+        let ids: Vec<_> = store
+            .list()
+            .marks
+            .into_iter()
+            .map(|mark| mark.id.get())
+            .collect();
+        assert_eq!(ids, vec![1, 3]);
+    }
+
+    #[test]
+    fn both_counters_reject_exhaustion_without_mutation() {
+        let mut id_exhausted = MarkStore {
+            marks: BTreeMap::new(),
+            next_id: u32::MAX,
+        };
+        let before = id_exhausted.clone();
+        assert_eq!(
+            id_exhausted.create(MarkGeometry::Point(point(0, 0)), "nope".into()),
+            MarkCreateResult::Rejected {
+                error: MarkMutationError::IdExhausted
+            }
+        );
+        assert_eq!(id_exhausted, before);
+
+        let mut revision_exhausted = MarkStore::default();
+        let reference = create(
+            &mut revision_exhausted,
+            MarkGeometry::Point(point(0, 0)),
+            "max",
+        );
+        revision_exhausted
+            .marks
+            .get_mut(&reference.id)
+            .expect("created mark")
+            .revision = u32::MAX;
+        let before = revision_exhausted.clone();
+        assert_eq!(
+            revision_exhausted.update(reference.id, None, Some("nope".into())),
+            MarkUpdateResult::Rejected {
+                error: MarkMutationError::RevisionExhausted
+            }
+        );
+        assert_eq!(revision_exhausted, before);
+    }
+
+    #[test]
+    fn snapshot_restores_marks_and_allocation_watermark() {
+        let mut store = MarkStore::default();
+        let first = create(&mut store, MarkGeometry::Point(point(0, 0)), "first");
+        create(&mut store, MarkGeometry::Point(point(1, 1)), "second");
+        store.delete(first.id);
+
+        let mut restored = MarkStore::restore(store.snapshot());
+        assert_eq!(restored, store);
+        let next = create(&mut restored, MarkGeometry::Point(point(2, 2)), "third");
+        assert_eq!(next.id, MarkId::new(3));
+    }
+}

--- a/crates/aether-kit/tests/mark_scenario.rs
+++ b/crates/aether-kit/tests/mark_scenario.rs
@@ -1,0 +1,283 @@
+//! Terrain-mark CRUD and hot-swap coverage through the real wasm component.
+//!
+//! The scenario selects the non-entry `aether.kit.mark` actor, exercises its
+//! typed request/reply surface, and replaces the component at the same mailbox
+//! with the same wasm. The final allocation proves both live marks and the
+//! deleted-id watermark crossed the lifecycle boundary.
+
+use std::fs;
+use std::path::Path;
+
+use aether_actor::Addressable;
+use aether_kinds::{LoadComponent, LoadResult, ReplaceComponent, ReplaceResult};
+use aether_kit::mark::{
+    Mark, MarkCreate, MarkCreateResult, MarkDelete, MarkDeleteResult, MarkGeometry, MarkGet,
+    MarkGetResult, MarkId, MarkList, MarkListResult, MarkRef, MarkUpdate, MarkUpdateResult,
+};
+use aether_kit::world::WorldPoint;
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
+
+// Retain all of the kit's native inventory submissions in this integration
+// test binary, matching the other component scenarios.
+#[allow(unused_imports)]
+use aether_kit as _;
+
+const COMPONENT_NAME: &str = "marks";
+
+fn component_address() -> String {
+    format!(
+        "aether.component/{}:{COMPONENT_NAME}",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    )
+}
+
+fn load_mark_book(bench: &mut TestBench, wasm_path: &Path) -> aether_data::MailboxId {
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: fs::read(wasm_path).expect("read kit wasm"),
+                    name: Some(COMPONENT_NAME.to_owned()),
+                    config: Vec::new(),
+                    export: Some("aether.kit.mark".to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok {
+            name, mailbox_id, ..
+        } => {
+            assert_eq!(name, component_address());
+            mailbox_id
+        }
+        LoadResult::Err { error } => panic!("load mark book: {error}"),
+    }
+}
+
+#[test]
+#[allow(clippy::too_many_lines)] // one cohesive CRUD → replace → allocation-watermark proof
+fn mark_crud_and_allocation_survive_component_replace() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mailbox_id = load_mark_book(&mut bench, &wasm_path);
+    let address = component_address();
+
+    let created = bench
+        .execute(vec![
+            (
+                "create_point",
+                BenchOp::send_and_await(
+                    address.as_str(),
+                    &MarkCreate {
+                        geometry: MarkGeometry::Point(WorldPoint::new(128, 256)),
+                        label: "camp".to_owned(),
+                    },
+                ),
+            ),
+            (
+                "create_path",
+                BenchOp::send_and_await(
+                    address.as_str(),
+                    &MarkCreate {
+                        geometry: MarkGeometry::Path(vec![
+                            WorldPoint::new(0, 0),
+                            WorldPoint::new(256, 256),
+                        ]),
+                        label: "trail".to_owned(),
+                    },
+                ),
+            ),
+        ])
+        .expect("create sequence");
+    let point_ref = match created
+        .reply::<MarkCreateResult>("create_point")
+        .expect("decode point MarkCreateResult")
+    {
+        MarkCreateResult::Created { reference } => reference,
+        MarkCreateResult::Rejected { error } => panic!("create point rejected: {error:?}"),
+    };
+    let path_ref = match created
+        .reply::<MarkCreateResult>("create_path")
+        .expect("decode path MarkCreateResult")
+    {
+        MarkCreateResult::Created { reference } => reference,
+        MarkCreateResult::Rejected { error } => panic!("create path rejected: {error:?}"),
+    };
+    assert_eq!(
+        point_ref,
+        MarkRef {
+            id: MarkId::new(1),
+            revision: 1,
+        }
+    );
+    assert_eq!(
+        path_ref,
+        MarkRef {
+            id: MarkId::new(2),
+            revision: 1,
+        }
+    );
+
+    let updated_geometry = MarkGeometry::Area(vec![
+        WorldPoint::new(64, 64),
+        WorldPoint::new(192, 64),
+        WorldPoint::new(128, 192),
+    ]);
+    let changed = bench
+        .execute(vec![
+            (
+                "update",
+                BenchOp::send_and_await(
+                    address.as_str(),
+                    &MarkUpdate {
+                        id: point_ref.id,
+                        geometry: Some(updated_geometry.clone()),
+                        label: Some("rally point".to_owned()),
+                    },
+                ),
+            ),
+            (
+                "get",
+                BenchOp::send_and_await(address.as_str(), &MarkGet { id: point_ref.id }),
+            ),
+            ("list", BenchOp::send_and_await(address.as_str(), &MarkList)),
+            (
+                "delete",
+                BenchOp::send_and_await(address.as_str(), &MarkDelete { id: path_ref.id }),
+            ),
+            (
+                "get_deleted",
+                BenchOp::send_and_await(address.as_str(), &MarkGet { id: path_ref.id }),
+            ),
+        ])
+        .expect("update, read, and delete sequence");
+    assert_eq!(
+        changed
+            .reply::<MarkUpdateResult>("update")
+            .expect("decode MarkUpdateResult"),
+        MarkUpdateResult::Updated {
+            reference: MarkRef {
+                id: point_ref.id,
+                revision: 2,
+            }
+        }
+    );
+    let expected_mark = Mark {
+        id: point_ref.id,
+        revision: 2,
+        geometry: updated_geometry,
+        label: "rally point".to_owned(),
+    };
+    assert_eq!(
+        changed
+            .reply::<MarkGetResult>("get")
+            .expect("decode MarkGetResult"),
+        MarkGetResult {
+            mark: Some(expected_mark.clone())
+        }
+    );
+    assert_eq!(
+        changed
+            .reply::<MarkListResult>("list")
+            .expect("decode MarkListResult")
+            .marks
+            .iter()
+            .map(|mark| mark.id)
+            .collect::<Vec<_>>(),
+        vec![point_ref.id, path_ref.id],
+        "list order must follow stable ids"
+    );
+    assert_eq!(
+        changed
+            .reply::<MarkDeleteResult>("delete")
+            .expect("decode MarkDeleteResult"),
+        MarkDeleteResult::Deleted {
+            reference: path_ref
+        }
+    );
+    assert_eq!(
+        changed
+            .reply::<MarkGetResult>("get_deleted")
+            .expect("decode deleted MarkGetResult"),
+        MarkGetResult { mark: None }
+    );
+
+    let replaced = bench
+        .execute(vec![(
+            "replace",
+            BenchOp::send_and_await(
+                "aether.component",
+                &ReplaceComponent {
+                    mailbox_id,
+                    wasm: fs::read(&wasm_path).expect("re-read kit wasm"),
+                    drain_timeout_ms: None,
+                    config: Vec::new(),
+                    export: None,
+                },
+            ),
+        )])
+        .expect("replace sequence");
+    match replaced
+        .reply::<ReplaceResult>("replace")
+        .expect("decode ReplaceResult")
+    {
+        ReplaceResult::Ok { .. } => {}
+        ReplaceResult::Err { error } => panic!("replace mark book: {error}"),
+    }
+
+    let after = bench
+        .execute(vec![
+            (
+                "get",
+                BenchOp::send_and_await(address.as_str(), &MarkGet { id: point_ref.id }),
+            ),
+            ("list", BenchOp::send_and_await(address.as_str(), &MarkList)),
+            (
+                "create",
+                BenchOp::send_and_await(
+                    address.as_str(),
+                    &MarkCreate {
+                        geometry: MarkGeometry::Point(WorldPoint::new(512, 768)),
+                        label: "lookout".to_owned(),
+                    },
+                ),
+            ),
+        ])
+        .expect("post-replace sequence");
+    assert_eq!(
+        after
+            .reply::<MarkGetResult>("get")
+            .expect("decode post-replace MarkGetResult"),
+        MarkGetResult {
+            mark: Some(expected_mark.clone())
+        }
+    );
+    assert_eq!(
+        after
+            .reply::<MarkListResult>("list")
+            .expect("decode post-replace MarkListResult"),
+        MarkListResult {
+            marks: vec![expected_mark]
+        }
+    );
+    assert_eq!(
+        after
+            .reply::<MarkCreateResult>("create")
+            .expect("decode post-replace MarkCreateResult"),
+        MarkCreateResult::Created {
+            reference: MarkRef {
+                id: MarkId::new(3),
+                revision: 1,
+            }
+        },
+        "replacement must retain the next-id watermark above the deleted id"
+    );
+}


### PR DESCRIPTION
Closes #2927.

## Summary

Add the `aether.kit.mark` MarkBook actor with stable checked `MarkId` allocation, shared named `MarkRef`, revisioned point/path/area annotations, exact typed CRUD replies, and transactional validation.

Persist marks and allocation watermark across component replacement, export the non-entry actor, and prove CRUD/order/revision/replacement behavior through unit tests and a real TestBench scenario.

## Test plan

- `cargo test -p aether-kit mark`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- GitHub Actions full workspace and wasm/TestBench tiers

## Generated by

`/implement` — agent execution of scoped issue #2927.

