### PR TITLE
feat(ci): review github action running the five-pillar review workflow on prs

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,237 @@
+name: Review
+
+# Producer-side quality check: run the repo's five-pillar review workflow
+# (.claude/workflows/review.js) over a PR's diff via headless Claude Code,
+# and post the rollup as inline PR annotations + a summary comment with an
+# advisory `review:unresolved` label. Never a required status check — the
+# five-pillar verdicts are agent judgment; the teeth are the implement
+# loop's obligation to address the comment, not a merge gate.
+#
+# Trigger is first-green, once-only. The workflow fires when a PR's CI run
+# completes successfully (`workflow_run` on "CI"), resolves the PR from the
+# run's head branch, and exits as a no-op if the PR already carries the
+# `<!-- aether-review -->` marker comment — so the pre-green push churn
+# never fires a review and a post-review fix push never re-fires one. State
+# lives on the PR itself (the marker comment), no external bookkeeping.
+# Deliberate re-runs go through `workflow_dispatch` with a `pr` input, which
+# bypasses the once-only guard (findings already posted are deduped by the
+# poster's fingerprints, so a re-run never double-annotates).
+#
+# Same security posture as the dogfood runner: subscription OAuth token
+# (CLAUDE_CODE_OAUTH_TOKEN), same-repo head only, and a least-privilege
+# split — the code-executing `review` job is read-only on the repo, and
+# only the `post` job (which never runs branch code) holds write scopes.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to review (bypasses the once-only guard)
+        required: true
+
+# One review per PR; a newer trigger supersedes an in-flight one. Keyed by
+# the head branch on the workflow_run path, or the dispatched PR number.
+concurrency:
+  group: review-${{ github.event.workflow_run.head_branch || github.event.inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Five-pillar review
+    runs-on: ubuntu-latest
+    # Read-only on the repo. This job checks out and executes PR-head code
+    # (headless Claude Code drives the review over the branch's checkout),
+    # so it must never hold a write scope — all posting is the `post` job's.
+    permissions:
+      contents: read
+    # Job-level guard: on the workflow_run path the parent CI must have
+    # succeeded and the head must be this repo (fork PRs never see the
+    # secret and never run here); the manual dispatch path is always
+    # allowed and resolves its own PR.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
+    env:
+      # Present at job level so step-level `if: env... != ''` gating works
+      # (mirrors the dogfood runner). Absent secret => the CC steps skip
+      # cleanly and no rollup artifact is produced, so `post` no-ops.
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      rollup_produced: ${{ steps.rollup.outputs.produced }}
+    steps:
+      # Resolve the PR and apply the run gates BEFORE any checkout — these
+      # are pure GitHub API calls. Sets proceed=false (a clean no-op) when
+      # there is no open PR, the opt-in `review` label is absent, or the
+      # once-only marker is already present. head_sha feeds the checkout.
+      - name: Resolve PR and apply gates
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          DISPATCH_PR: ${{ github.event.inputs.pr }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            pr="$DISPATCH_PR"
+          else
+            # Resolve the PR from the CI run's head branch. `head` is
+            # owner:branch; state=open bounds it to a live PR.
+            pr="$(gh api "repos/${REPO}/pulls?head=iamacoffeepot:${HEAD_BRANCH}&state=open" \
+              --jq '.[0].number // empty')"
+          fi
+          if [ -z "${pr:-}" ]; then
+            echo "No open PR for branch '${HEAD_BRANCH}' — nothing to review."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "pr_number=$pr" >> "$GITHUB_OUTPUT"
+
+          # Bring-up gate (plan step 6): the opt-in `review` label is
+          # required while the annotation contract proves out on real PRs.
+          # A follow-up one-liner removes this block once it has.
+          has_label="$(gh api "repos/${REPO}/issues/${pr}/labels" --jq 'any(.[]; .name == "review")')"
+          if [ "$has_label" != "true" ]; then
+            echo "PR #$pr lacks the opt-in 'review' label — skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Once-only guard: the marker comment is the run-once state. A
+          # manual dispatch bypasses it (deliberate re-review); the poster
+          # dedupes already-posted findings by fingerprint.
+          if [ "$EVENT" != "workflow_dispatch" ]; then
+            if gh api "repos/${REPO}/issues/${pr}/comments" --paginate --jq '.[].body' \
+              | grep -q '<!-- aether-review -->'; then
+              echo "PR #$pr already reviewed (marker present) — skipping."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          echo "head_sha=$(gh api "repos/${REPO}/pulls/${pr}" --jq '.head.sha')" >> "$GITHUB_OUTPUT"
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      # Check out the PR head with full history so the /review skill's
+      # `git diff origin/main...HEAD` prep resolves. The base ref is not
+      # present after a single-ref checkout, so fetch it explicitly.
+      - uses: actions/checkout@v4
+        if: steps.resolve.outputs.proceed == 'true'
+        with:
+          ref: ${{ steps.resolve.outputs.head_sha }}
+          fetch-depth: 0
+      - name: Fetch the diff base (origin/main)
+        if: steps.resolve.outputs.proceed == 'true'
+        run: git fetch origin main:refs/remotes/origin/main
+
+      - name: Note when the OAuth token secret is absent
+        if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN == ''
+        run: |
+          echo "CLAUDE_CODE_OAUTH_TOKEN secret is not set — the review is skipped."
+          echo "Mint one with 'claude setup-token' and add it: gh secret set CLAUDE_CODE_OAUTH_TOKEN"
+
+      - name: Install Claude Code
+        if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        run: npm install -g @anthropic-ai/claude-code
+
+      # Pre-trust the checkout so settings.json permissions aren't ignored
+      # with a warning under skip-permissions.
+      - name: Pre-trust the workspace for headless Claude
+        if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        run: printf '{"projects":{"%s":{"hasTrustDialogAccepted":true}}}\n' "$PWD" > "$HOME/.claude.json"
+
+      # Auth in isolation before the real run: a one-line prompt, no tools.
+      # --max-turns 3 (not 1) because the model occasionally spends a turn
+      # before emitting the reply, and a 1-turn cap turns that into a
+      # spurious failure that reads like an auth problem (spike #2961).
+      - name: Auth probe (no tools)
+        if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        run: |
+          claude -p "Reply with exactly: AUTH-OK" \
+            --model claude-sonnet-5 \
+            --max-turns 3 | tee /tmp/auth.log
+          grep -q "AUTH-OK" /tmp/auth.log
+
+      # The review itself. Headless Claude invokes the repo's /review skill
+      # in integrated mode (it owns the caller-side prep — changed-file set,
+      # per-file diffs, issue text from the PR's closing reference) and
+      # writes the workflow's returned rollup JSON verbatim to
+      # review-rollup.json. GH_TOKEN lets the skill resolve the closing
+      # issue via gh. `|| true` so a review failure never fails the job —
+      # a missing rollup file is the signal that no post happens.
+      - name: Run the five-pillar review
+        if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+        run: |
+          claude -p "You are running headless in CI on a checkout of PR #${PR_NUMBER}'s head branch.
+          The diff base is origin/main; the head is the current HEAD.
+          Invoke the repo's /review skill in INTEGRATED mode against origin/main...HEAD:
+          resolve the changed .rs files and their per-file diffs from git, and read the issue
+          text this PR closes (use gh to find the PR's closing reference for issue #${PR_NUMBER}
+          if needed). Let the skill run the review.js workflow in a single pass.
+          When the workflow returns { rollup, files }, write the returned ROLLUP object as JSON
+          verbatim to review-rollup.json in the repo root (the rollup, not the whole return).
+          Do not edit any source. Print exactly REVIEW-DONE when the file is written." \
+            --dangerously-skip-permissions \
+            --model claude-sonnet-5 \
+            --max-turns 80 | tee /tmp/review.log || true
+
+      # Whether the run produced a rollup gates the `post` job. Kept as a
+      # step so `post` can `needs`-read it without inspecting the artifact.
+      - name: Note whether a rollup was produced
+        id: rollup
+        if: always() && steps.resolve.outputs.proceed == 'true'
+        run: |
+          if [ -f review-rollup.json ]; then
+            echo "produced=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "produced=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always() && steps.rollup.outputs.produced == 'true'
+        with:
+          name: review-rollup
+          path: review-rollup.json
+          if-no-files-found: ignore
+
+  post:
+    name: Post review rollup
+    needs: review
+    # No-op when the review job produced no rollup (token absent, no open
+    # PR, gated out, or the review itself failed).
+    if: needs.review.outputs.rollup_produced == 'true'
+    runs-on: ubuntu-latest
+    # The only job with write scopes, and it never executes branch code:
+    # the default checkout is the base repo (main), so the poster script is
+    # the trusted version — the PR head is only ever read as data.
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: review-rollup
+      - name: Fetch the PR's changed files + diff hunks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/pulls/${{ needs.review.outputs.pr_number }}/files" \
+            --paginate > pr-files.json
+      - name: Post the rollup as annotations + summary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.review.outputs.pr_number }}
+          ROLLUP_PATH: review-rollup.json
+          FILES_PATH: pr-files.json
+        run: node scripts/post-review-rollup.mjs

--- a/scripts/post-review-rollup.mjs
+++ b/scripts/post-review-rollup.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+// Post a five-pillar review rollup onto its PR: inline annotations for
+// findings that land on a changed diff line, everything else folded into
+// one COMMENT review body, plus a marker-anchored summary comment and the
+// advisory `review:unresolved` label.
+//
+// The posture is load-bearing: the review event is ALWAYS `COMMENT`, never
+// `REQUEST_CHANGES` — a bot changes-requested review would hard-gate the
+// merge, and the five-pillar verdicts are agent judgment. The teeth are the
+// label + the implement loop's obligation to address the comment.
+//
+// Inputs (env):
+//   GITHUB_TOKEN        least-privilege token (pull-requests + issues write)
+//   GITHUB_REPOSITORY   owner/repo
+//   PR_NUMBER           the PR to annotate
+//   ROLLUP_PATH         review-rollup.json (the workflow's returned rollup)
+//   FILES_PATH          pr-files.json (gh api pulls/{n}/files --paginate)
+//
+// No external deps — Node built-ins + global fetch only.
+
+import { readFile } from 'node:fs/promises'
+
+const TOKEN = requireEnv('GITHUB_TOKEN')
+const REPO = requireEnv('GITHUB_REPOSITORY')
+const PR = Number(requireEnv('PR_NUMBER'))
+const ROLLUP_PATH = process.env.ROLLUP_PATH || 'review-rollup.json'
+const FILES_PATH = process.env.FILES_PATH || 'pr-files.json'
+
+const MARKER = '<!-- aether-review -->'
+const FP_RE = /aether-review-fp:([^\s>]+)/g
+const LABEL = 'review:unresolved'
+const API = 'https://api.github.com'
+
+function requireEnv(name) {
+  const v = process.env[name]
+  if (!v) throw new Error(`post-review-rollup: ${name} is required`)
+  return v
+}
+
+async function api(method, path, body) {
+  const res = await fetch(`${API}/${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${TOKEN}`,
+      accept: 'application/vnd.github+json',
+      'x-github-api-version': '2022-11-28',
+      'content-type': 'application/json',
+      'user-agent': 'aether-review-poster',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  const text = await res.text()
+  const data = text ? safeJson(text) : null
+  return { ok: res.ok, status: res.status, data, text }
+}
+
+function safeJson(t) {
+  try { return JSON.parse(t) } catch { return null }
+}
+
+// Paginate a GitHub list endpoint via the Link header.
+async function apiList(path) {
+  const out = []
+  let url = `${API}/${path}${path.includes('?') ? '&' : '?'}per_page=100`
+  while (url) {
+    const res = await fetch(url, {
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        accept: 'application/vnd.github+json',
+        'x-github-api-version': '2022-11-28',
+        'user-agent': 'aether-review-poster',
+      },
+    })
+    if (!res.ok) throw new Error(`GET ${url} -> ${res.status} ${await res.text()}`)
+    const page = await res.json()
+    if (Array.isArray(page)) out.push(...page)
+    url = nextLink(res.headers.get('link'))
+  }
+  return out
+}
+
+function nextLink(link) {
+  if (!link) return null
+  for (const part of link.split(',')) {
+    const m = part.match(/<([^>]+)>;\s*rel="next"/)
+    if (m) return m[1]
+  }
+  return null
+}
+
+// The set of new-side (RIGHT) line numbers a unified-diff patch makes
+// commentable — added and context lines. Deleted lines don't exist on the
+// new side, so they can't anchor an inline comment. Anchoring only to lines
+// in this set is what keeps the review POST from 422-ing on a bad position.
+function commentableLines(patch) {
+  const lines = new Set()
+  if (!patch) return lines
+  let newLine = 0
+  for (const row of patch.split('\n')) {
+    const hunk = row.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+    if (hunk) { newLine = Number(hunk[1]); continue }
+    if (row.startsWith('+')) { lines.add(newLine); newLine++ }
+    else if (row.startsWith('-')) { /* old side only */ }
+    else if (row.startsWith('\\')) { /* "\ No newline at end of file" */ }
+    else { lines.add(newLine); newLine++ } // context line
+  }
+  return lines
+}
+
+// The rollup stores each confirmed finding's `file` as a basename (review.js
+// bases it). Resolve it back to a full changed-file path; null when the
+// basename is ambiguous or unknown, in which case the finding degrades to
+// the review body rather than being dropped.
+function resolvePath(fileField, changed) {
+  if (!fileField) return null
+  if (changed.has(fileField)) return fileField
+  const matches = [...changed].filter(
+    (p) => p === fileField || p.endsWith(`/${fileField}`) || p.split('/').pop() === fileField,
+  )
+  return matches.length === 1 ? matches[0] : null
+}
+
+function fingerprint(path, line, pillar) {
+  return `${path || '?'}|${line ?? '-'}|${pillar || '?'}`
+}
+
+function findingBody(f) {
+  const rec = f.recommendation ? `${f.recommendation}: ` : ''
+  const sev = f.severity ? ` _(${f.severity})_` : ''
+  const suggestion = f.suggested_form || f.description || ''
+  const cat = f.category ? `/${f.category}` : ''
+  return `**${f.pillar}${cat}**${sev} — ${f.symbol || ''} ${rec}${suggestion}`.trim()
+}
+
+async function main() {
+  const rawRollup = JSON.parse(await readFile(ROLLUP_PATH, 'utf8'))
+  // Accept either the bare rollup or the workflow's full { rollup, files }.
+  const rollup = rawRollup && rawRollup.rollup ? rawRollup.rollup : rawRollup
+  const confirmed = Array.isArray(rollup.confirmed) ? rollup.confirmed : []
+  const softHolds = Array.isArray(rollup.softHolds) ? rollup.softHolds : []
+  const specFindings = rollup.spec && Array.isArray(rollup.spec.findings) ? rollup.spec.findings : []
+
+  const filesData = JSON.parse(await readFile(FILES_PATH, 'utf8'))
+  const changed = new Set(filesData.map((f) => f.filename))
+  const hunks = new Map(filesData.map((f) => [f.filename, commentableLines(f.patch)]))
+
+  // Gather fingerprints already posted, from every surface that could carry
+  // one, so a dispatched re-run never double-annotates.
+  const posted = new Set()
+  const [reviewComments, reviews, issueComments] = await Promise.all([
+    apiList(`repos/${REPO}/pulls/${PR}/comments`),
+    apiList(`repos/${REPO}/pulls/${PR}/reviews`),
+    apiList(`repos/${REPO}/issues/${PR}/comments`),
+  ])
+  for (const c of [...reviewComments, ...reviews, ...issueComments]) {
+    for (const m of String(c.body || '').matchAll(FP_RE)) posted.add(m[1])
+  }
+
+  // Partition findings into inline (anchored on a changed line) and body
+  // (everything else, including spec-fidelity findings, which carry no
+  // line). Each finding is normalized to a common shape first.
+  const normalized = [
+    ...confirmed.map((f) => ({ ...f, path: resolvePath(f.file, changed) })),
+    ...specFindings.map((f) => ({
+      ...f, pillar: 'spec-fidelity', line: undefined, recommendation: undefined,
+      suggested_form: f.description, path: resolvePath(f.file, changed),
+    })),
+  ]
+
+  const inline = []
+  const folded = []
+  const allFingerprints = []
+  for (const f of normalized) {
+    const anchor = f.path && f.line != null && hunks.get(f.path)?.has(Number(f.line))
+    const fp = fingerprint(anchor ? f.path : f.path || f.file, anchor ? f.line : undefined, f.pillar)
+    allFingerprints.push(fp)
+    if (posted.has(fp)) continue
+    if (anchor) {
+      inline.push({
+        path: f.path,
+        line: Number(f.line),
+        side: 'RIGHT',
+        body: `${findingBody(f)}\n<!-- aether-review-fp:${fp} -->`,
+      })
+    } else {
+      folded.push({ f, fp })
+    }
+  }
+
+  // The COMMENT review: inline annotations + the folded findings in its
+  // body. Only posted when there is genuinely new content — a re-run that
+  // annotates nothing new stays silent.
+  if (inline.length || folded.length) {
+    const commit = await api('GET', `repos/${REPO}/pulls/${PR}`)
+    const commitId = commit.ok ? commit.data.head.sha : undefined
+    const bodyLines = ['## Five-pillar review', '']
+    if (folded.length) {
+      bodyLines.push('Findings not anchored to a changed line:', '')
+      for (const { f, fp } of folded) {
+        bodyLines.push(`- ${findingBody(f)} \`${f.path || f.file || ''}${f.line != null ? `:${f.line}` : ''}\``)
+        bodyLines.push(`  <!-- aether-review-fp:${fp} -->`)
+      }
+      bodyLines.push('')
+    }
+    if (softHolds.length) {
+      bodyLines.push(`**${softHolds.length} soft-hold** finding(s) — clear before un-draft.`, '')
+    }
+    bodyLines.push('_Advisory: this review never gates the merge._')
+
+    const review = { event: 'COMMENT', body: bodyLines.join('\n') }
+    if (inline.length && commitId) { review.commit_id = commitId; review.comments = inline }
+    let res = await api('POST', `repos/${REPO}/pulls/${PR}/reviews`, review)
+    if (!res.ok && review.comments) {
+      // A rejected inline position (e.g. an outdated hunk) 422s the whole
+      // review. Fold the inline findings into the body and retry so the
+      // findings still land rather than being dropped.
+      console.warn(`inline review rejected (${res.status}) — retrying folded into the body`)
+      const extra = inline.map((c) => `- ${c.body.split('\n')[0]} \`${c.path}:${c.line}\``)
+      res = await api('POST', `repos/${REPO}/pulls/${PR}/reviews`, {
+        event: 'COMMENT',
+        body: `${review.body}\n\n${extra.join('\n')}`,
+      })
+    }
+    if (!res.ok) console.error(`review POST failed: ${res.status} ${res.text}`)
+    else console.log(`posted review: ${inline.length} inline, ${folded.length} folded`)
+  } else {
+    console.log('no new findings to annotate')
+  }
+
+  // Upsert the marker-anchored summary comment — the human-readable rollup
+  // AND the once-only guard state. Regenerated in full each run, and it
+  // carries every fingerprint so re-runs dedup against it.
+  const summary = renderSummary(rollup, normalized, allFingerprints)
+  const existing = issueComments.find((c) => String(c.body || '').includes(MARKER))
+  if (existing) {
+    await api('PATCH', `repos/${REPO}/issues/comments/${existing.id}`, { body: summary })
+    console.log('updated summary comment')
+  } else {
+    await api('POST', `repos/${REPO}/issues/${PR}/comments`, { body: summary })
+    console.log('posted summary comment')
+  }
+
+  // Advisory label: set when there is something actionable (a confirmed
+  // finding, a soft-hold, or a high-severity spec finding), cleared clean.
+  const actionable =
+    confirmed.length > 0 || softHolds.length > 0 || specFindings.some((f) => f.severity === 'high')
+  if (actionable) {
+    const res = await api('POST', `repos/${REPO}/issues/${PR}/labels`, { labels: [LABEL] })
+    if (!res.ok) console.error(`add label failed: ${res.status} ${res.text}`)
+    else console.log(`set ${LABEL}`)
+  } else {
+    const res = await api('DELETE', `repos/${REPO}/issues/${PR}/labels/${encodeURIComponent(LABEL)}`)
+    // 404 = the label was not present; a clean no-op.
+    if (res.ok || res.status === 404) console.log(`cleared ${LABEL}`)
+    else console.error(`remove label failed: ${res.status} ${res.text}`)
+  }
+}
+
+function renderSummary(rollup, normalized, fingerprints) {
+  const t = rollup.totals || {}
+  const lines = [MARKER, '## Five-pillar review — summary', '']
+  lines.push(
+    `Confirmed: **${(rollup.confirmed || []).length}** · ` +
+      `Soft-holds: **${(rollup.softHolds || []).length}** · ` +
+      `Spec: **${normalized.filter((f) => f.pillar === 'spec-fidelity').length}** · ` +
+      `Lint candidates: ${(rollup.lintCandidates || []).length} · ` +
+      `Spared: ${(rollup.spared || []).length} · ` +
+      `Uncertain: ${(rollup.uncertain || []).length}`,
+    '',
+  )
+
+  const grouped = new Map()
+  for (const f of normalized) {
+    const key = f.path || f.file || '(unknown)'
+    if (!grouped.has(key)) grouped.set(key, [])
+    grouped.get(key).push(f)
+  }
+  if (grouped.size) {
+    lines.push('### Findings', '')
+    for (const [file, fs] of grouped) {
+      lines.push(`**\`${file}\`**`)
+      for (const f of fs) {
+        const loc = f.line != null ? `:${f.line}` : ''
+        lines.push(`- ${findingBody(f)}${loc ? ` \`${loc}\`` : ''}`)
+      }
+      lines.push('')
+    }
+  } else {
+    lines.push('_No confirmed findings — the change is clean under all five pillars._', '')
+  }
+
+  lines.push('_Advisory only: this review never gates the merge._')
+  // Hidden fingerprints so a dispatched re-run dedups against this comment.
+  for (const fp of fingerprints) lines.push(`<!-- aether-review-fp:${fp} -->`)
+  return lines.join('\n')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes #2973.

## Summary

The five-pillar review runs only when an implementer remembers to invoke /review, and its rollup evaporates as chat output. This adds the automated form: a two-job workflow on GitHub-hosted ubuntu-latest (review needs no engine and no build — the runner orchestrates, the compute is inference-side). Trigger is first-green, once-only: it fires on workflow_run when a PR's CI completes successfully, resolves the PR from the run's head branch, and no-ops if the PR already carries the review marker comment — pre-green push churn never fires a review, and a post-review fix push never re-fires one. Deliberate re-runs go through workflow_dispatch with a pr input. The review job (contents: read, executes PR-head code) runs the isolated auth probe then headless Claude invoking the /review skill in integrated mode, uploading the rollup as an artifact; the post job (write scopes, never runs branch code) posts one review with event COMMENT — findings inline where their file+line lands in a diff hunk, folded into the body otherwise — upserts the marker-anchored summary, fingerprints findings so re-runs never double-annotate, and sets/clears the advisory review:unresolved label. Bring-up is gated on an opt-in review label; a follow-up removes the gate once the contract proves out.

## Test plan

No cargo-ownable surface (workflow YAML + posting glue). Verification is the live bring-up run on a real PR with the opt-in label; auth, runner, and headless-CC mechanics were de-risked end-to-end by spike #2961. The poster's hunk parser was exercised against a mixed add/delete/context patch during implementation.

## Generated by

`/implement` — agent execution of [scoped issue #2973](https://github.com/iamacoffeepot/aether/issues/2973).
