### PR TITLE
fix(ci): review bring-up — hold the session for the rollup, widen the runner

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -177,6 +177,11 @@ jobs:
           resolve the changed .rs files and their per-file diffs from git, and read the issue
           text this PR closes (use gh to find the PR's closing reference for issue #${PR_NUMBER}
           if needed). Let the skill run the review.js workflow in a single pass.
+          LOAD-BEARING: the Workflow tool runs in the BACKGROUND and re-invokes you when it
+          completes. Your run is NOT complete until review-rollup.json exists on disk. Never
+          produce a final reply while the workflow is still running — in headless mode your
+          final reply exits the process and KILLS the in-flight workflow. Wait for the
+          workflow's completion notification, however long it takes.
           When the workflow returns { rollup, files }, write the returned ROLLUP object as JSON
           verbatim to review-rollup.json in the repo root (the rollup, not the whole return).
           Do not edit any source. Print exactly REVIEW-DONE when the file is written." \
@@ -186,12 +191,23 @@ jobs:
 
       # Whether the run produced a rollup gates the `post` job. Kept as a
       # step so `post` can `needs`-read it without inspecting the artifact.
+      # A missing rollup after the review actually ran (gates passed, token
+      # present) is a FAILURE, not a quiet skip — the inaugural run
+      # (iamacoffeepot/aether#2979) skipped silently and reported success
+      # when the headless session exited with the workflow still in flight.
+      # The quiet-skip path exists only for the absent-secret case, which
+      # never reaches the else branch here.
       - name: Note whether a rollup was produced
         id: rollup
         if: always() && steps.resolve.outputs.proceed == 'true'
         run: |
           if [ -f review-rollup.json ]; then
             echo "produced=true" >> "$GITHUB_OUTPUT"
+          elif [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "produced=false" >> "$GITHUB_OUTPUT"
+            echo "review ran but produced no rollup — failing loudly. Tail of the session log:"
+            tail -n 40 /tmp/review.log 2>/dev/null || echo "(no session log)"
+            exit 1
           else
             echo "produced=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -41,7 +41,16 @@ concurrency:
 jobs:
   review:
     name: Five-pillar review
-    runs-on: ubuntu-latest
+    # Runs-On 8cpu, not ubuntu-latest: the Workflow tool caps concurrent
+    # agents at ~min(16, cores - 2), so the 4-core GitHub-hosted box
+    # squeezes the per-file finder fan-out to ~2-wide while every agent
+    # just waits on inference. 8 cores buys ~6-wide fan-out; the job's
+    # own compute stays trivial (no cargo build, no s3-cache needed).
+    runs-on: runs-on=${{ github.run_id }}/runner=8cpu-linux-x64
+    # Bring-up leash: a wedged in-flight workflow (the session now waits
+    # for it indefinitely, iamacoffeepot/aether#2979) must not idle an
+    # EC2 runner toward the 6h default.
+    timeout-minutes: 45
     # Read-only on the repo. This job checks out and executes PR-head code
     # (headless Claude Code drives the review over the branch's checkout),
     # so it must never hold a write scope — all posting is the `post` job's.
@@ -64,6 +73,7 @@ jobs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       rollup_produced: ${{ steps.rollup.outputs.produced }}
     steps:
+      - uses: runs-on/action@v2
       # Resolve the PR and apply the run gates BEFORE any checkout — these
       # are pure GitHub API calls. Sets proceed=false (a clean no-op) when
       # there is no open PR, the opt-in `review` label is absent, or the


### PR DESCRIPTION
Closes #2979.

## Summary

Two bring-up fixes from the inaugural live review run (dispatch on #2971), which produced no review yet reported success. First, the headless session ended its final reply with the review workflow still running in the background — in print mode the final reply exits the process and kills the in-flight workflow — so the prompt now states the wait contract explicitly (the run is not complete until review-rollup.json exists; replying while the workflow runs kills it), and the rollup-check step fails loudly with the session log tail when the gates passed and the token was present but no rollup exists, reserving the quiet skip for the absent-secret case only. Second, the review job moves from ubuntu-latest to an 8cpu Runs-On shape with a 45min leash: the Workflow tool derives agent concurrency from core count, so the 4-core GitHub-hosted box squeezed the per-file finder fan-out to ~2-wide while every agent idled on inference; 8 cores buys ~6-wide.

## Test plan

Workflow YAML only, no cargo surface. Verification is re-dispatching the review on #2971 after this lands — the same trial that surfaced both issues.

## Generated by

`/implement --quick` — fix for [issue #2979](https://github.com/iamacoffeepot/aether/issues/2979), found live during the review action's bring-up.
