### PR TITLE
feat(kit): add image widget fit modes

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -87,10 +87,10 @@ pub use terrain_editor::{
 };
 pub use widget::theme::{SetTheme, Theme, ThemeState};
 pub use widget::{
-    ButtonClicked, ButtonConfig, ChildrenChanged, Collect, FocusGained, FocusLost, HoverGained, HoverLost, LabelConfig,
-    MembershipEntry, PanelConfig, RadioConfig, RadioSelected, SetWidgetState, SliderChanged, SliderConfig,
-    TextCommitted, TextFieldConfig, WidgetChildSpec, WidgetClipRect, WidgetConfig, WidgetControlState, WidgetDrawItem,
-    WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged, WidgetValidation,
+    ButtonClicked, ButtonConfig, ChildrenChanged, Collect, FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig,
+    ImageFit, LabelConfig, MembershipEntry, PanelConfig, RadioConfig, RadioSelected, SetWidgetState, SliderChanged,
+    SliderConfig, TextCommitted, TextFieldConfig, WidgetChildSpec, WidgetClipRect, WidgetConfig, WidgetControlState,
+    WidgetDrawItem, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged, WidgetValidation,
 };
 pub use world::{
     ApplyBrush, AutomatonRule, BrushParameters, CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk,
@@ -135,6 +135,7 @@ aether_actor::export!(
     widget::set::RadioGroupWidget,
     widget::set::ButtonWidget,
     widget::set::LabelWidget,
+    widget::set::ImageWidget,
     widget::WidgetPanel
 );
 
@@ -154,6 +155,7 @@ aether_actor::export!(
     widget::set::RadioGroupWidget,
     widget::set::ButtonWidget,
     widget::set::LabelWidget,
+    widget::set::ImageWidget,
     widget::WidgetPanel,
     aether_behavior::BehaviorHost
 );

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -304,6 +304,9 @@ pub enum WidgetKind {
     /// (`aether-behavior`'s `BehaviorHost`) instead of a widget. Only spawnable
     /// under the kit's `behavior` feature; without it the slot is skipped.
     BehaviorHost,
+    /// A static image — `config` decodes as [`ImageConfig`]. Not focusable.
+    /// Appended to preserve the established wire discriminants above.
+    Image,
 }
 
 impl WidgetKind {
@@ -325,6 +328,7 @@ impl WidgetKind {
     pub const fn type_tag(self) -> Option<u64> {
         let tag = match self {
             Self::Label => aether_data::mailbox_id_from_name("aether.kit.widget.label").0,
+            Self::Image => aether_data::mailbox_id_from_name("aether.kit.widget.image").0,
             Self::Slider => aether_data::mailbox_id_from_name("aether.kit.widget.slider").0,
             Self::Radio => aether_data::mailbox_id_from_name("aether.kit.widget.radio").0,
             Self::TextField => aether_data::mailbox_id_from_name("aether.kit.widget.text_field").0,
@@ -554,6 +558,54 @@ pub struct LabelConfig {
     pub theme: Theme,
     #[serde(default)]
     pub state: WidgetControlState,
+}
+
+/// How an [`ImageConfig`]'s natural size maps into its parent-owned frame.
+///
+/// Schema-only: this value is nested in `ImageConfig`, not addressable as its
+/// own mail kind.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ImageFit {
+    /// Distort the full image to fill the assigned frame.
+    Fill,
+    /// Preserve aspect ratio, show the whole image, and center any letterbox.
+    #[default]
+    Contain,
+    /// Preserve aspect ratio, fill the frame, and center-crop through UVs.
+    Cover,
+    /// Draw at the configured natural pixel size, centered in the frame.
+    Natural,
+}
+
+/// `aether.kit.widget.image.config` — a non-interactive image whose texture
+/// lifecycle remains owned by the consumer that created `texture_id` through
+/// `aether.render`. Natural dimensions drive fit arithmetic and the inherited
+/// `WidgetDrawList::intrinsic` channel; they do not resize the parent slot.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.image.config")]
+pub struct ImageConfig {
+    pub texture_id: u32,
+    pub natural_width_pixels: f32,
+    pub natural_height_pixels: f32,
+    pub fit: ImageFit,
+    pub tint: Rgba,
+    pub theme: Theme,
+    #[serde(default)]
+    pub state: WidgetControlState,
+}
+
+impl Default for ImageConfig {
+    fn default() -> Self {
+        Self {
+            texture_id: 0,
+            natural_width_pixels: 0.0,
+            natural_height_pixels: 0.0,
+            fit: ImageFit::default(),
+            tint: Rgba::WHITE,
+            theme: Theme::default(),
+            state: WidgetControlState::default(),
+        }
+    }
 }
 
 /// `aether.kit.widget.slider.changed` — a slider's value-up event.

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -58,12 +58,14 @@ use crate::widget::composite::Composite;
 use crate::widget::focus::{
     AvailabilityEffects, Focus, FocusDirection, FocusEligibility, FocusRect, FocusTransition, HoverTransition,
 };
-use crate::widget::set::{ButtonWidget, LabelWidget, RadioGroupWidget, SliderWidget, TextFieldWidget, quad};
+use crate::widget::set::{
+    ButtonWidget, ImageWidget, LabelWidget, RadioGroupWidget, SliderWidget, TextFieldWidget, quad,
+};
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{
-    ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, HoverGained, HoverLost, LabelConfig, PanelConfig,
-    RadioConfig, RadioSelected, SliderChanged, SliderConfig, TextCommitted, TextFieldConfig, WidgetChildSpec,
-    WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged,
+    ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig, LabelConfig,
+    PanelConfig, RadioConfig, RadioSelected, SliderChanged, SliderConfig, TextCommitted, TextFieldConfig,
+    WidgetChildSpec, WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged,
 };
 use crate::widget::{accept_child_list, emit, flush_membership};
 
@@ -210,6 +212,17 @@ fn spawn_panel_child(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, row:
                 focusable: false,
                 state,
                 type_namespace: <LabelWidget as Addressable>::NAMESPACE,
+            })
+        }),
+        WidgetKind::Image => decode_child::<ImageConfig>(spec).and_then(|config| {
+            let state = config.state.clone();
+            spawn::<ImageWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
+                id,
+                height: row,
+                pointer_eligible: false,
+                focusable: false,
+                state,
+                type_namespace: <ImageWidget as Addressable>::NAMESPACE,
             })
         }),
         WidgetKind::Slider => decode_child::<SliderConfig>(spec).and_then(|config| {
@@ -438,6 +451,10 @@ fn spawn_behavior_host(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, ro
             let config = decode_named::<LabelConfig>(&spec.subname, &host_spec.wrapped_config)?;
             (row, false, false, config.state)
         }
+        WidgetKind::Image => {
+            let config = decode_named::<ImageConfig>(&spec.subname, &host_spec.wrapped_config)?;
+            (row, false, false, config.state)
+        }
         WidgetKind::Slider => {
             let config = decode_named::<SliderConfig>(&spec.subname, &host_spec.wrapped_config)?;
             (row, true, true, config.state)
@@ -485,6 +502,7 @@ fn spawn_behavior_host(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, ro
         frame_trigger: Collect::ID.0,
         mirror_kinds: vec![
             LabelConfig::ID.0,
+            ImageConfig::ID.0,
             SliderConfig::ID.0,
             TextFieldConfig::ID.0,
             ButtonConfig::ID.0,
@@ -547,7 +565,8 @@ fn spawn_behavior_host(_ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, _
 /// Load `aether_kit.wasm` with `export: "aether.kit.widget.panel"` and a
 /// `PanelConfig` (top-left, width, theme, a font to load, and the `children`
 /// it stacks). With an empty `children` list it spawns a demonstration stack
-/// of every widget; otherwise it stacks exactly the declared specs. It routes
+/// of the original interactive/reference widgets; otherwise it stacks exactly
+/// the declared specs (including `Image` children). It routes
 /// real input through the focus model and logs each value-up event. Fork it
 /// into a real editor panel by handing it your own `children` and translating
 /// the value-up handlers into your own world-knob driver mail.
@@ -835,6 +854,7 @@ mod behavior_tests {
         assert_eq!(WidgetKind::Slider.type_tag(), Some(ActorTypeTag::of::<SliderWidget>().0));
         assert_eq!(WidgetKind::Button.type_tag(), Some(ActorTypeTag::of::<ButtonWidget>().0));
         assert_eq!(WidgetKind::Label.type_tag(), Some(ActorTypeTag::of::<LabelWidget>().0));
+        assert_eq!(WidgetKind::Image.type_tag(), Some(ActorTypeTag::of::<ImageWidget>().0));
         assert_eq!(WidgetKind::Radio.type_tag(), Some(ActorTypeTag::of::<RadioGroupWidget>().0));
         assert_eq!(WidgetKind::TextField.type_tag(), Some(ActorTypeTag::of::<TextFieldWidget>().0));
         assert_eq!(WidgetKind::Composite.type_tag(), None);

--- a/crates/aether-kit/src/widget/set/image.rs
+++ b/crates/aether-kit/src/widget/set/image.rs
@@ -34,6 +34,16 @@ struct ImagePlacement {
     uv_bottom: f32,
 }
 
+struct WideImageExtent {
+    width_pixels: f64,
+    height_pixels: f64,
+}
+
+struct WideUvCrop {
+    left: f64,
+    top: f64,
+}
+
 impl ImagePlacement {
     fn is_valid(self) -> bool {
         self.destination_x_pixels.is_finite()
@@ -106,9 +116,28 @@ impl ImageWidget {
         let placement = match self.fit {
             ImageFit::Fill => full(),
             ImageFit::Contain => {
-                let scale = (frame_width / natural_width).min(frame_height / natural_height);
-                let width = natural_width * scale;
-                let height = natural_height * scale;
+                // Compare cross-products and derive the unconstrained axis in
+                // f64. Every input is a finite f32, so both products and the
+                // resulting dimension fit in f64 even when the equivalent
+                // f32 fit ratios would overflow (for example 1e30 / 1e-30).
+                let frame_width_wide = f64::from(frame_width);
+                let frame_height_wide = f64::from(frame_height);
+                let natural_width_wide = f64::from(natural_width);
+                let natural_height_wide = f64::from(natural_height);
+                let source_is_wider = natural_width_wide * frame_height_wide > natural_height_wide * frame_width_wide;
+                let extent = if source_is_wider {
+                    WideImageExtent {
+                        width_pixels: frame_width_wide,
+                        height_pixels: frame_width_wide * natural_height_wide / natural_width_wide,
+                    }
+                } else {
+                    WideImageExtent {
+                        width_pixels: frame_height_wide * natural_width_wide / natural_height_wide,
+                        height_pixels: frame_height_wide,
+                    }
+                };
+                let width = positive_f32(extent.width_pixels)?;
+                let height = positive_f32(extent.height_pixels)?;
                 ImagePlacement {
                     destination_x_pixels: (frame_width - width) * 0.5,
                     destination_y_pixels: (frame_height - height) * 0.5,
@@ -118,11 +147,23 @@ impl ImageWidget {
                 }
             }
             ImageFit::Cover => {
-                let scale = (frame_width / natural_width).max(frame_height / natural_height);
-                let sampled_width = frame_width / scale;
-                let sampled_height = frame_height / scale;
-                let uv_left = 0.5 * (1.0 - sampled_width / natural_width);
-                let uv_top = 0.5 * (1.0 - sampled_height / natural_height);
+                // Work directly in normalized crop fractions. Cross-products
+                // in f64 avoid overflowing either f32 scale ratio, while a
+                // final narrowing that cannot represent distinct UV endpoints
+                // is rejected by `ImagePlacement::is_valid` below.
+                let frame_width_wide = f64::from(frame_width);
+                let frame_height_wide = f64::from(frame_height);
+                let natural_width_wide = f64::from(natural_width);
+                let natural_height_wide = f64::from(natural_height);
+                let source_cross = natural_width_wide * frame_height_wide;
+                let frame_cross = natural_height_wide * frame_width_wide;
+                let crop = if source_cross > frame_cross {
+                    WideUvCrop { left: 0.5 * (1.0 - frame_cross / source_cross), top: 0.0 }
+                } else {
+                    WideUvCrop { left: 0.0, top: 0.5 * (1.0 - source_cross / frame_cross) }
+                };
+                let uv_left = finite_f32(crop.left)?;
+                let uv_top = finite_f32(crop.top)?;
                 ImagePlacement { uv_left, uv_top, uv_right: 1.0 - uv_left, uv_bottom: 1.0 - uv_top, ..full() }
             }
             ImageFit::Natural => ImagePlacement {
@@ -172,6 +213,17 @@ impl ImageWidget {
         self.theme = config.theme;
         self.state.replace(config.state)
     }
+}
+
+fn positive_f32(value: f64) -> Option<f32> {
+    let value = finite_f32(value)?;
+    (value > 0.0).then_some(value)
+}
+
+fn finite_f32(value: f64) -> Option<f32> {
+    #[allow(clippy::cast_possible_truncation)]
+    let narrowed = value as f32;
+    narrowed.is_finite().then_some(narrowed)
 }
 
 /// A static image widget. Spawned inline by a panel root with an
@@ -314,6 +366,54 @@ mod tests {
                 uv_right: 1.0,
                 uv_bottom: 1.0,
             }
+        );
+    }
+
+    #[test]
+    fn contain_keeps_extreme_positive_finite_sizes_visible() {
+        let mut widget = image(ImageFit::Contain);
+        widget.natural_width_pixels = 1.0e-30;
+        widget.natural_height_pixels = 1.0e-30;
+        widget.frame.width = 1.0e30;
+        widget.frame.height = 5.0e29;
+
+        assert_eq!(
+            placement(&widget),
+            ImagePlacement {
+                destination_x_pixels: 2.5e29,
+                destination_y_pixels: 0.0,
+                destination_width_pixels: 5.0e29,
+                destination_height_pixels: 5.0e29,
+                uv_left: 0.0,
+                uv_top: 0.0,
+                uv_right: 1.0,
+                uv_bottom: 1.0,
+            },
+            "valid extreme ratios must not overflow to an absent image",
+        );
+    }
+
+    #[test]
+    fn cover_keeps_extreme_positive_finite_sizes_visible() {
+        let mut widget = image(ImageFit::Cover);
+        widget.natural_width_pixels = 1.0e-30;
+        widget.natural_height_pixels = 1.0e-30;
+        widget.frame.width = 1.0e30;
+        widget.frame.height = 5.0e29;
+
+        assert_eq!(
+            placement(&widget),
+            ImagePlacement {
+                destination_x_pixels: 0.0,
+                destination_y_pixels: 0.0,
+                destination_width_pixels: 1.0e30,
+                destination_height_pixels: 5.0e29,
+                uv_left: 0.0,
+                uv_top: 0.25,
+                uv_right: 1.0,
+                uv_bottom: 0.75,
+            },
+            "valid extreme ratios must retain a representable crop",
         );
     }
 

--- a/crates/aether-kit/src/widget/set/image.rs
+++ b/crates/aether-kit/src/widget/set/image.rs
@@ -1,0 +1,427 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `widget/mod.rs`).
+#![allow(clippy::needless_pass_by_value)]
+
+//! The static image widget (issue 2917).
+//!
+//! The image borrows a consumer-created render texture id, fits that texture
+//! into its parent-owned slot, and reports the configured natural pixel size
+//! through the existing widget intrinsic channel. It never acquires or
+//! releases texture lifecycle authority.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_math::Rgba;
+
+use crate::widget::state::{InteractionState, emit_state_changed};
+use crate::widget::theme::{SetTheme, Theme};
+use crate::widget::{Collect, ImageConfig, ImageFit, SetWidgetState, WidgetDrawItem, WidgetDrawList, WidgetFrame};
+
+/// Pure fit output. Destination fields are widget-local pixels; UV fields are
+/// normalized texture coordinates. Keeping each semantic named avoids the
+/// width/height and UV-endpoint transpositions positional aggregates invite.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ImagePlacement {
+    destination_x_pixels: f32,
+    destination_y_pixels: f32,
+    destination_width_pixels: f32,
+    destination_height_pixels: f32,
+    uv_left: f32,
+    uv_top: f32,
+    uv_right: f32,
+    uv_bottom: f32,
+}
+
+impl ImagePlacement {
+    fn is_valid(self) -> bool {
+        self.destination_x_pixels.is_finite()
+            && self.destination_y_pixels.is_finite()
+            && self.destination_width_pixels.is_finite()
+            && self.destination_height_pixels.is_finite()
+            && self.destination_width_pixels > 0.0
+            && self.destination_height_pixels > 0.0
+            && self.uv_left.is_finite()
+            && self.uv_top.is_finite()
+            && self.uv_right.is_finite()
+            && self.uv_bottom.is_finite()
+            && (0.0..self.uv_right).contains(&self.uv_left)
+            && self.uv_right <= 1.0
+            && (0.0..self.uv_bottom).contains(&self.uv_top)
+            && self.uv_bottom <= 1.0
+    }
+}
+
+/// A non-interactive image leaf. The parent owns its frame and the consumer
+/// owns its texture; this actor owns only presentation state.
+pub struct ImageWidget {
+    texture_id: u32,
+    natural_width_pixels: f32,
+    natural_height_pixels: f32,
+    fit: ImageFit,
+    tint: Rgba,
+    theme: Theme,
+    frame: WidgetFrame,
+    /// Read-only and validation are inapplicable to a static image;
+    /// visibility and enabled still control absence and muted presentation.
+    state: InteractionState,
+}
+
+impl ImageWidget {
+    fn has_valid_natural_size(&self) -> bool {
+        self.natural_width_pixels.is_finite()
+            && self.natural_height_pixels.is_finite()
+            && self.natural_width_pixels > 0.0
+            && self.natural_height_pixels > 0.0
+    }
+
+    fn placement(&self) -> Option<ImagePlacement> {
+        if !self.has_valid_natural_size()
+            || !self.frame.x.is_finite()
+            || !self.frame.y.is_finite()
+            || !self.frame.width.is_finite()
+            || !self.frame.height.is_finite()
+            || self.frame.width <= 0.0
+            || self.frame.height <= 0.0
+        {
+            return None;
+        }
+
+        let frame_width = self.frame.width;
+        let frame_height = self.frame.height;
+        let natural_width = self.natural_width_pixels;
+        let natural_height = self.natural_height_pixels;
+        let full = || ImagePlacement {
+            destination_x_pixels: 0.0,
+            destination_y_pixels: 0.0,
+            destination_width_pixels: frame_width,
+            destination_height_pixels: frame_height,
+            uv_left: 0.0,
+            uv_top: 0.0,
+            uv_right: 1.0,
+            uv_bottom: 1.0,
+        };
+
+        let placement = match self.fit {
+            ImageFit::Fill => full(),
+            ImageFit::Contain => {
+                let scale = (frame_width / natural_width).min(frame_height / natural_height);
+                let width = natural_width * scale;
+                let height = natural_height * scale;
+                ImagePlacement {
+                    destination_x_pixels: (frame_width - width) * 0.5,
+                    destination_y_pixels: (frame_height - height) * 0.5,
+                    destination_width_pixels: width,
+                    destination_height_pixels: height,
+                    ..full()
+                }
+            }
+            ImageFit::Cover => {
+                let scale = (frame_width / natural_width).max(frame_height / natural_height);
+                let sampled_width = frame_width / scale;
+                let sampled_height = frame_height / scale;
+                let uv_left = 0.5 * (1.0 - sampled_width / natural_width);
+                let uv_top = 0.5 * (1.0 - sampled_height / natural_height);
+                ImagePlacement { uv_left, uv_top, uv_right: 1.0 - uv_left, uv_bottom: 1.0 - uv_top, ..full() }
+            }
+            ImageFit::Natural => ImagePlacement {
+                destination_x_pixels: (frame_width - natural_width) * 0.5,
+                destination_y_pixels: (frame_height - natural_height) * 0.5,
+                destination_width_pixels: natural_width,
+                destination_height_pixels: natural_height,
+                ..full()
+            },
+        };
+        placement.is_valid().then_some(placement)
+    }
+
+    fn draw_list(&self) -> WidgetDrawList {
+        let intrinsic =
+            self.has_valid_natural_size().then_some([self.natural_width_pixels, self.natural_height_pixels]);
+        if !self.state.is_visible() {
+            return WidgetDrawList { intrinsic, items: Vec::new() };
+        }
+        let Some(placement) = self.placement() else {
+            return WidgetDrawList { intrinsic, items: Vec::new() };
+        };
+        if self.texture_id == 0 {
+            return WidgetDrawList { intrinsic, items: Vec::new() };
+        }
+        WidgetDrawList {
+            intrinsic,
+            items: vec![WidgetDrawItem::TexturedQuad {
+                texture_id: self.texture_id,
+                x: placement.destination_x_pixels,
+                y: placement.destination_y_pixels,
+                width: placement.destination_width_pixels,
+                height: placement.destination_height_pixels,
+                u0: placement.uv_left,
+                v0: placement.uv_top,
+                u1: placement.uv_right,
+                v1: placement.uv_bottom,
+                tint: self.theme.fill(self.tint, self.state.theme_state(false)),
+                clip: None,
+            }],
+        }
+    }
+
+    fn apply_config(&mut self, config: ImageConfig) -> bool {
+        self.texture_id = config.texture_id;
+        self.natural_width_pixels = config.natural_width_pixels;
+        self.natural_height_pixels = config.natural_height_pixels;
+        self.fit = config.fit;
+        self.tint = config.tint;
+        self.theme = config.theme;
+        self.state.replace(config.state)
+    }
+}
+
+/// A static image widget. Spawned inline by a panel root with an
+/// [`ImageConfig`]. The texture id is borrowed: its creator remains
+/// responsible for update and destruction.
+///
+/// # Agent
+/// Not loaded directly — the panel root spawns it as an inline child. Send it
+/// its `ImageConfig` again to replace texture or presentation in place.
+#[actor(instanced)]
+impl WasmActor for ImageWidget {
+    type Config = ImageConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.image";
+
+    fn init(config: ImageConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Self {
+            texture_id: config.texture_id,
+            natural_width_pixels: config.natural_width_pixels,
+            natural_height_pixels: config.natural_height_pixels,
+            fit: config.fit,
+            tint: config.tint,
+            theme: config.theme,
+            frame: WidgetFrame { x: 0.0, y: 0.0, width: 0.0, height: 0.0 },
+            state: InteractionState::new(config.state),
+        })
+    }
+
+    /// Replace the borrowed texture and presentation without changing the
+    /// parent-owned frame.
+    #[handler::single]
+    fn on_config(&mut self, ctx: &mut WasmCtx<'_>, config: ImageConfig) {
+        if self.apply_config(config) {
+            emit_state_changed(ctx, &self.state);
+        }
+    }
+
+    /// Update external availability without changing image presentation.
+    #[handler::single]
+    fn on_set_widget_state(&mut self, ctx: &mut WasmCtx<'_>, set: SetWidgetState) {
+        if self.state.replace(set.state) {
+            emit_state_changed(ctx, &self.state);
+        }
+    }
+
+    /// Restyle disabled presentation.
+    #[handler::single]
+    fn on_set_theme(&mut self, _ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.theme = set.theme;
+    }
+
+    /// Cache the layout rect the root assigned without taking layout
+    /// authority from it.
+    #[handler::single]
+    fn on_frame(&mut self, _ctx: &mut WasmCtx<'_>, frame: WidgetFrame) {
+        self.frame = frame;
+    }
+
+    /// Reply with valid intrinsic size and at most one fitted textured item.
+    #[handler::single]
+    fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
+        if let Some(parent) = ctx.parent() {
+            parent.send(&self.draw_list());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widget::WidgetControlState;
+    use crate::widget::theme::ThemeState;
+
+    fn image(fit: ImageFit) -> ImageWidget {
+        ImageWidget {
+            texture_id: 7,
+            natural_width_pixels: 60.0,
+            natural_height_pixels: 30.0,
+            fit,
+            tint: Rgba::WHITE,
+            theme: Theme::DEFAULT,
+            frame: WidgetFrame { x: 0.0, y: 0.0, width: 90.0, height: 60.0 },
+            state: InteractionState::new(WidgetControlState::default()),
+        }
+    }
+
+    fn placement(widget: &ImageWidget) -> ImagePlacement {
+        widget.placement().expect("valid placement")
+    }
+
+    #[test]
+    fn fit_modes_name_exact_destination_and_uv_semantics() {
+        assert_eq!(
+            placement(&image(ImageFit::Fill)),
+            ImagePlacement {
+                destination_x_pixels: 0.0,
+                destination_y_pixels: 0.0,
+                destination_width_pixels: 90.0,
+                destination_height_pixels: 60.0,
+                uv_left: 0.0,
+                uv_top: 0.0,
+                uv_right: 1.0,
+                uv_bottom: 1.0,
+            }
+        );
+        assert_eq!(
+            placement(&image(ImageFit::Contain)),
+            ImagePlacement {
+                destination_x_pixels: 0.0,
+                destination_y_pixels: 7.5,
+                destination_width_pixels: 90.0,
+                destination_height_pixels: 45.0,
+                uv_left: 0.0,
+                uv_top: 0.0,
+                uv_right: 1.0,
+                uv_bottom: 1.0,
+            }
+        );
+        assert_eq!(
+            placement(&image(ImageFit::Cover)),
+            ImagePlacement {
+                destination_x_pixels: 0.0,
+                destination_y_pixels: 0.0,
+                destination_width_pixels: 90.0,
+                destination_height_pixels: 60.0,
+                uv_left: 0.125,
+                uv_top: 0.0,
+                uv_right: 0.875,
+                uv_bottom: 1.0,
+            }
+        );
+        assert_eq!(
+            placement(&image(ImageFit::Natural)),
+            ImagePlacement {
+                destination_x_pixels: 15.0,
+                destination_y_pixels: 15.0,
+                destination_width_pixels: 60.0,
+                destination_height_pixels: 30.0,
+                uv_left: 0.0,
+                uv_top: 0.0,
+                uv_right: 1.0,
+                uv_bottom: 1.0,
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_natural_size_and_frame_never_emit_texture() {
+        for invalid in [0.0, -1.0, f32::NAN, f32::INFINITY] {
+            let mut width = image(ImageFit::Contain);
+            width.natural_width_pixels = invalid;
+            let invalid_natural = width.draw_list();
+            assert_eq!(invalid_natural.intrinsic, None);
+            assert!(invalid_natural.items.is_empty());
+
+            let mut height = image(ImageFit::Contain);
+            height.natural_height_pixels = invalid;
+            let invalid_natural = height.draw_list();
+            assert_eq!(invalid_natural.intrinsic, None);
+            assert!(invalid_natural.items.is_empty());
+
+            let mut frame_width = image(ImageFit::Contain);
+            frame_width.frame.width = invalid;
+            let invalid_frame = frame_width.draw_list();
+            assert_eq!(invalid_frame.intrinsic, Some([60.0, 30.0]));
+            assert!(invalid_frame.items.is_empty());
+
+            let mut frame_height = image(ImageFit::Contain);
+            frame_height.frame.height = invalid;
+            let invalid_frame = frame_height.draw_list();
+            assert_eq!(invalid_frame.intrinsic, Some([60.0, 30.0]));
+            assert!(invalid_frame.items.is_empty());
+        }
+
+        for invalid in [f32::NAN, f32::INFINITY] {
+            let mut frame_x = image(ImageFit::Contain);
+            frame_x.frame.x = invalid;
+            assert!(frame_x.draw_list().items.is_empty());
+
+            let mut frame_y = image(ImageFit::Contain);
+            frame_y.frame.y = invalid;
+            assert!(frame_y.draw_list().items.is_empty());
+        }
+
+        let mut widget = image(ImageFit::Contain);
+        widget.texture_id = 0;
+        assert!(widget.draw_list().items.is_empty());
+    }
+
+    #[test]
+    fn hidden_retains_intrinsic_and_disabled_applies_theme_tint() {
+        let mut widget = image(ImageFit::Natural);
+        let mut hidden = widget.state.control().clone();
+        hidden.visible = false;
+        assert!(widget.state.replace(hidden));
+        let hidden = widget.draw_list();
+        assert_eq!(hidden.intrinsic, Some([60.0, 30.0]));
+        assert!(hidden.items.is_empty());
+
+        let mut disabled = widget.state.control().clone();
+        disabled.visible = true;
+        disabled.enabled = false;
+        assert!(widget.state.replace(disabled));
+        let disabled = widget.draw_list();
+        assert_eq!(disabled.items.len(), 1);
+        let WidgetDrawItem::TexturedQuad { tint, .. } = disabled.items[0] else {
+            panic!("image emits one textured quad")
+        };
+        assert_eq!(tint, Theme::DEFAULT.fill(Rgba::WHITE, ThemeState::Disabled));
+    }
+
+    #[test]
+    fn replacement_updates_presentation_without_relayout() {
+        let mut widget = image(ImageFit::Fill);
+        let frame = WidgetFrame {
+            x: widget.frame.x,
+            y: widget.frame.y,
+            width: widget.frame.width,
+            height: widget.frame.height,
+        };
+        let replacement_tint = Rgba::new(0.2, 0.4, 0.6, 0.8);
+        let state = widget.state.control().clone();
+        assert!(!widget.apply_config(ImageConfig {
+            texture_id: 19,
+            natural_width_pixels: 30.0,
+            natural_height_pixels: 45.0,
+            fit: ImageFit::Natural,
+            tint: replacement_tint,
+            theme: Theme { disabled_alpha: 0.25, ..Theme::DEFAULT },
+            state,
+        }));
+
+        assert_eq!(widget.frame.width, frame.width);
+        assert_eq!(widget.frame.height, frame.height);
+        let list = widget.draw_list();
+        assert_eq!(list.intrinsic, Some([30.0, 45.0]));
+        assert_eq!(list.items.len(), 1);
+        assert!(matches!(
+            list.items[0],
+            WidgetDrawItem::TexturedQuad {
+                texture_id: 19,
+                x: 30.0,
+                y: 7.5,
+                width: 30.0,
+                height: 45.0,
+                tint,
+                ..
+            } if tint == replacement_tint
+        ));
+    }
+}

--- a/crates/aether-kit/src/widget/set/image.rs
+++ b/crates/aether-kit/src/widget/set/image.rs
@@ -145,9 +145,6 @@ impl ImageWidget {
         let Some(placement) = self.placement() else {
             return WidgetDrawList { intrinsic, items: Vec::new() };
         };
-        if self.texture_id == 0 {
-            return WidgetDrawList { intrinsic, items: Vec::new() };
-        }
         WidgetDrawList {
             intrinsic,
             items: vec![WidgetDrawItem::TexturedQuad {
@@ -358,9 +355,12 @@ mod tests {
             assert!(frame_y.draw_list().items.is_empty());
         }
 
-        let mut widget = image(ImageFit::Contain);
-        widget.texture_id = 0;
-        assert!(widget.draw_list().items.is_empty());
+        let mut first_consumer_texture = image(ImageFit::Contain);
+        first_consumer_texture.texture_id = 0;
+        assert!(matches!(
+            first_consumer_texture.draw_list().items[0],
+            WidgetDrawItem::TexturedQuad { texture_id: 0, .. }
+        ));
     }
 
     #[test]

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -1,4 +1,4 @@
-//! The concrete widget set (issue 2660): five plain `#[actor(instanced)]`
+//! The concrete widget set: plain `#[actor(instanced)]`
 //! types a panel root spawns as inline children and drives by mail in four
 //! lanes — config / style / layout-frame data-down, value events-up — over the
 //! ADR-0117 draw-compositing protocol.
@@ -9,6 +9,7 @@
 //! - [`RadioGroupWidget`] — a vertical list of exclusive options.
 //! - [`ButtonWidget`] — a momentary push button.
 //! - [`LabelWidget`] — static, non-interactive text.
+//! - [`ImageWidget`] — a static, non-interactive borrowed texture.
 //!
 //! Each caches its assigned [`WidgetFrame`](crate::widget::WidgetFrame) rect
 //! and its [`Theme`], answers every
@@ -24,12 +25,14 @@
 //! their first draw.
 
 pub mod button;
+pub mod image;
 pub mod label;
 pub mod radio;
 pub mod slider;
 pub mod text_field;
 
 pub use button::ButtonWidget;
+pub use image::ImageWidget;
 pub use label::LabelWidget;
 pub use radio::RadioGroupWidget;
 pub use slider::SliderWidget;

--- a/crates/aether-substrate-bundle/tests/widget_image.rs
+++ b/crates/aether-substrate-bundle/tests/widget_image.rs
@@ -1,0 +1,307 @@
+//! Image-widget end-to-end acceptance (issue 2917).
+//!
+//! The current `TestBench` creates consumer-owned textures, drives one image
+//! child through every fit and control state by its public inline lineage, and
+//! reads exact typed committed-overlay geometry plus a bounded raster probe.
+
+// Integration-test skip diagnostic: emit via stderr so `cargo test` surfaces
+// "skipping: ..." alongside `test ... ok` (issue 891).
+#![allow(clippy::print_stderr)]
+
+use std::fs;
+
+use aether_actor::Addressable;
+use aether_capabilities::render::{
+    CreateTexture, CreateTextureResult, DestroyTexture, DrawTexturedQuads, TextureFormat,
+    TexturedQuad as RenderTexturedQuad, WHITE_TEXTURE_ID,
+};
+use aether_data::Kind;
+use aether_kinds::{ClipRect, LoadComponent, LoadResult, NamedMail, QuadSpace, Tick};
+use aether_kit::{
+    ImageConfig, ImageFit, PanelConfig, SetWidgetState, Theme, WidgetChildSpec, WidgetControlState, WidgetKind,
+};
+use aether_math::Rgba;
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
+use aether_substrate_bundle::visual::{Image, Rect, decode_png, target_color_stats};
+
+const PANEL_X: f32 = 8.0;
+const PANEL_Y: f32 = 9.0;
+const PANEL_WIDTH: f32 = 30.0;
+const ROW_HEIGHT: f32 = 20.0;
+
+fn first_texture_pixels() -> Vec<u8> {
+    vec![
+        255, 0, 0, 255, 0, 255, 0, 255, // red, green
+        0, 0, 255, 255, 255, 255, 0, 255, // blue, yellow
+    ]
+}
+
+fn second_texture_pixels() -> Vec<u8> {
+    vec![
+        0, 255, 255, 255, 255, 0, 255, 255, // cyan, magenta
+        255, 255, 255, 255, 32, 32, 32, 255, // white, charcoal
+    ]
+}
+
+fn create_texture(bench: &mut TestBench, label: &'static str, pixels: Vec<u8>) -> u32 {
+    let created = bench
+        .execute(vec![(
+            label,
+            BenchOp::send_and_await(
+                "aether.render",
+                &CreateTexture { width: 2, height: 2, format: TextureFormat::Rgba8, pixels },
+            ),
+        )])
+        .expect("create image texture");
+    match created.reply::<CreateTextureResult>(label).expect("decode CreateTextureResult") {
+        CreateTextureResult::Ok { texture_id } => texture_id,
+        CreateTextureResult::Err { error } => panic!("create texture: {error}"),
+    }
+}
+
+fn theme() -> Theme {
+    Theme { row_height: ROW_HEIGHT, disabled_alpha: 0.25, ..Theme::DEFAULT }
+}
+
+fn image_config(texture_id: u32, fit: ImageFit, state: WidgetControlState) -> ImageConfig {
+    ImageConfig {
+        texture_id,
+        natural_width_pixels: 20.0,
+        natural_height_pixels: 10.0,
+        fit,
+        tint: Rgba::new(0.8, 0.9, 1.0, 0.8),
+        theme: theme(),
+        state,
+    }
+}
+
+fn load_panel(bench: &mut TestBench, wasm: &[u8], config: &ImageConfig) -> String {
+    let panel_config = PanelConfig {
+        x: PANEL_X,
+        y: PANEL_Y,
+        width: PANEL_WIDTH,
+        font_namespace: String::new(),
+        font_path: String::new(),
+        theme: theme(),
+        children: vec![WidgetChildSpec {
+            subname: "image".to_owned(),
+            kind: WidgetKind::Image,
+            origin: [0.0, 0.0],
+            clip: None,
+            config: config.encode_into_bytes(),
+        }],
+    };
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: wasm.to_vec(),
+                    name: Some("panel".to_owned()),
+                    config: panel_config.encode_into_bytes(),
+                    export: Some("aether.kit.widget.panel".to_owned()),
+                },
+            ),
+        )])
+        .expect("load image panel");
+    match loaded.reply::<LoadResult>("load").expect("decode LoadResult") {
+        LoadResult::Ok { name, .. } => name,
+        LoadResult::Err { error } => panic!("load image panel: {error}"),
+    }
+}
+
+fn tick_to(panel: &str) -> NamedMail {
+    NamedMail { recipient_name: panel.to_owned(), kind_name: Tick::NAME.to_owned(), payload: Vec::new(), count: 1 }
+}
+
+fn capture(bench: &mut TestBench, panel: &str) -> Image {
+    let captured = bench
+        .execute(vec![("capture", BenchOp::capture_with_mails(vec![tick_to(panel)], Vec::new()))])
+        .expect("capture image panel");
+    decode_png(captured.captured("capture").expect("capture bytes")).expect("decode image capture")
+}
+
+fn image_batch(snapshot: &[DrawTexturedQuads], texture_id: u32) -> &DrawTexturedQuads {
+    let matching: Vec<_> = snapshot.iter().filter(|batch| batch.texture_id == texture_id).collect();
+    assert_eq!(matching.len(), 1, "exactly one batch uses texture {texture_id}");
+    matching[0]
+}
+
+fn assert_image_batch(snapshot: &[DrawTexturedQuads], texture_id: u32, expected_quad: RenderTexturedQuad) {
+    assert_eq!(snapshot.len(), 2, "panel background plus one image batch");
+    assert_eq!(snapshot[0].texture_id, WHITE_TEXTURE_ID);
+    let batch = image_batch(snapshot, texture_id);
+    assert_eq!(batch.space, QuadSpace::Screen);
+    assert_eq!(batch.clip, Some(ClipRect { x: PANEL_X, y: PANEL_Y, width: PANEL_WIDTH, height: ROW_HEIGHT }));
+    assert_eq!(batch.quads, vec![expected_quad]);
+}
+
+#[test]
+#[allow(clippy::too_many_lines)] // one sequential public fit/state/replacement scenario
+fn image_fit_state_and_replacement_hold_through_real_wasm() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = TestBench::start_with_size(48, 40).expect("boot");
+    let first_texture_id = create_texture(&mut bench, "first_texture", first_texture_pixels());
+    let second_texture_id = create_texture(&mut bench, "second_texture", second_texture_pixels());
+    let tint = Rgba::new(0.8, 0.9, 1.0, 0.8);
+    let panel =
+        load_panel(&mut bench, &wasm, &image_config(first_texture_id, ImageFit::Fill, WidgetControlState::default()));
+    let image = format!("{panel}/{}:image", aether_capabilities::WasmTrampoline::NAMESPACE,);
+
+    let fill_pixels = capture(&mut bench, &panel);
+    assert_image_batch(
+        &bench.committed_overlay_snapshot(),
+        first_texture_id,
+        RenderTexturedQuad {
+            x: PANEL_X,
+            y: PANEL_Y,
+            width: PANEL_WIDTH,
+            height: ROW_HEIGHT,
+            u0: 0.0,
+            v0: 0.0,
+            u1: 1.0,
+            v1: 1.0,
+            tint,
+        },
+    );
+    let red =
+        target_color_stats(&fill_pixels, [255, 0, 0], 40, Some(Rect { min_x: 10, min_y: 11, max_x: 18, max_y: 16 }));
+    assert!(red.fraction > 0.8, "bounded top-left probe should see the four-color texture's red quadrant: {red:?}",);
+
+    for (fit, expected) in [
+        (
+            ImageFit::Contain,
+            RenderTexturedQuad {
+                x: PANEL_X,
+                y: PANEL_Y + 2.5,
+                width: PANEL_WIDTH,
+                height: 15.0,
+                u0: 0.0,
+                v0: 0.0,
+                u1: 1.0,
+                v1: 1.0,
+                tint,
+            },
+        ),
+        (
+            ImageFit::Cover,
+            RenderTexturedQuad {
+                x: PANEL_X,
+                y: PANEL_Y,
+                width: PANEL_WIDTH,
+                height: ROW_HEIGHT,
+                u0: 0.125,
+                v0: 0.0,
+                u1: 0.875,
+                v1: 1.0,
+                tint,
+            },
+        ),
+    ] {
+        bench
+            .execute(vec![(
+                "reconfigure_fit",
+                BenchOp::send_mail(&image, &image_config(first_texture_id, fit, WidgetControlState::default())),
+            )])
+            .expect("reconfigure image fit");
+        let _ = capture(&mut bench, &panel);
+        assert_image_batch(&bench.committed_overlay_snapshot(), first_texture_id, expected);
+    }
+
+    let natural = ImageConfig {
+        natural_width_pixels: 50.0,
+        natural_height_pixels: 30.0,
+        fit: ImageFit::Natural,
+        ..image_config(first_texture_id, ImageFit::Natural, WidgetControlState::default())
+    };
+    bench
+        .execute(vec![("reconfigure_natural", BenchOp::send_mail(&image, &natural))])
+        .expect("configure oversized natural image");
+    let _ = capture(&mut bench, &panel);
+    assert_image_batch(
+        &bench.committed_overlay_snapshot(),
+        first_texture_id,
+        RenderTexturedQuad {
+            x: PANEL_X - 10.0,
+            y: PANEL_Y - 5.0,
+            width: 50.0,
+            height: 30.0,
+            u0: 0.0,
+            v0: 0.0,
+            u1: 1.0,
+            v1: 1.0,
+            tint,
+        },
+    );
+
+    let hidden = WidgetControlState { visible: false, ..WidgetControlState::default() };
+    bench.execute(vec![("hide", BenchOp::send_mail(&image, &SetWidgetState { state: hidden }))]).expect("hide image");
+    let _ = capture(&mut bench, &panel);
+    let hidden_snapshot = bench.committed_overlay_snapshot();
+    assert_eq!(hidden_snapshot.len(), 1, "hidden image leaves only panel chrome");
+    assert_eq!(hidden_snapshot[0].texture_id, WHITE_TEXTURE_ID);
+
+    let disabled = WidgetControlState { enabled: false, ..WidgetControlState::default() };
+    bench
+        .execute(vec![("disable", BenchOp::send_mail(&image, &SetWidgetState { state: disabled }))])
+        .expect("disable image");
+    let _ = capture(&mut bench, &panel);
+    assert_image_batch(
+        &bench.committed_overlay_snapshot(),
+        first_texture_id,
+        RenderTexturedQuad {
+            x: PANEL_X - 10.0,
+            y: PANEL_Y - 5.0,
+            width: 50.0,
+            height: 30.0,
+            u0: 0.0,
+            v0: 0.0,
+            u1: 1.0,
+            v1: 1.0,
+            tint: Rgba::new(tint.r, tint.g, tint.b, tint.a * 0.25),
+        },
+    );
+
+    let replacement = ImageConfig {
+        texture_id: second_texture_id,
+        natural_width_pixels: 10.0,
+        natural_height_pixels: 16.0,
+        fit: ImageFit::Natural,
+        tint: Rgba::WHITE,
+        theme: theme(),
+        state: WidgetControlState::default(),
+    };
+    bench.execute(vec![("replace", BenchOp::send_mail(&image, &replacement))]).expect("replace image config in place");
+    let _ = capture(&mut bench, &panel);
+    let replacement_snapshot = bench.committed_overlay_snapshot();
+    assert!(
+        replacement_snapshot.iter().all(|batch| batch.texture_id != first_texture_id),
+        "replacement frame must not retain the old texture batch",
+    );
+    assert_image_batch(
+        &replacement_snapshot,
+        second_texture_id,
+        RenderTexturedQuad {
+            x: PANEL_X + 10.0,
+            y: PANEL_Y + 2.0,
+            width: 10.0,
+            height: 16.0,
+            u0: 0.0,
+            v0: 0.0,
+            u1: 1.0,
+            v1: 1.0,
+            tint: Rgba::WHITE,
+        },
+    );
+
+    bench
+        .execute(vec![
+            ("destroy_first", BenchOp::send_mail("aether.render", &DestroyTexture { texture_id: first_texture_id })),
+            ("destroy_second", BenchOp::send_mail("aether.render", &DestroyTexture { texture_id: second_texture_id })),
+        ])
+        .expect("consumer destroys borrowed image textures after the last capture");
+}

--- a/crates/aether-substrate-bundle/tests/widget_image.rs
+++ b/crates/aether-substrate-bundle/tests/widget_image.rs
@@ -69,7 +69,7 @@ fn image_config(texture_id: u32, fit: ImageFit, state: WidgetControlState) -> Im
         natural_width_pixels: 20.0,
         natural_height_pixels: 10.0,
         fit,
-        tint: Rgba::new(0.8, 0.9, 1.0, 0.8),
+        tint: Rgba::WHITE,
         theme: theme(),
         state,
     }
@@ -147,7 +147,7 @@ fn image_fit_state_and_replacement_hold_through_real_wasm() {
     let mut bench = TestBench::start_with_size(48, 40).expect("boot");
     let first_texture_id = create_texture(&mut bench, "first_texture", first_texture_pixels());
     let second_texture_id = create_texture(&mut bench, "second_texture", second_texture_pixels());
-    let tint = Rgba::new(0.8, 0.9, 1.0, 0.8);
+    let tint = Rgba::WHITE;
     let panel =
         load_panel(&mut bench, &wasm, &image_config(first_texture_id, ImageFit::Fill, WidgetControlState::default()));
     let image = format!("{panel}/{}:image", aether_capabilities::WasmTrampoline::NAMESPACE,);
@@ -169,7 +169,7 @@ fn image_fit_state_and_replacement_hold_through_real_wasm() {
         },
     );
     let red =
-        target_color_stats(&fill_pixels, [255, 0, 0], 40, Some(Rect { min_x: 10, min_y: 11, max_x: 18, max_y: 16 }));
+        target_color_stats(&fill_pixels, [255, 0, 0], 24, Some(Rect { min_x: 9, min_y: 10, max_x: 12, max_y: 13 }));
     assert!(red.fraction > 0.8, "bounded top-left probe should see the four-color texture's red quadrant: {red:?}",);
 
     for (fit, expected) in [

--- a/crates/aether-substrate-bundle/tests/widget_image.rs
+++ b/crates/aether-substrate-bundle/tests/widget_image.rs
@@ -150,7 +150,7 @@ fn image_fit_state_and_replacement_hold_through_real_wasm() {
     let tint = Rgba::WHITE;
     let panel =
         load_panel(&mut bench, &wasm, &image_config(first_texture_id, ImageFit::Fill, WidgetControlState::default()));
-    let image = format!("{panel}/{}:image", aether_capabilities::WasmTrampoline::NAMESPACE,);
+    let image = format!("{panel}/{}:image", aether_capabilities::WasmTrampoline::NAMESPACE);
 
     let fill_pixels = capture(&mut bench, &panel);
     assert_image_batch(
@@ -170,7 +170,7 @@ fn image_fit_state_and_replacement_hold_through_real_wasm() {
     );
     let red =
         target_color_stats(&fill_pixels, [255, 0, 0], 24, Some(Rect { min_x: 9, min_y: 10, max_x: 12, max_y: 13 }));
-    assert!(red.fraction > 0.8, "bounded top-left probe should see the four-color texture's red quadrant: {red:?}",);
+    assert!(red.fraction > 0.8, "bounded top-left probe should see the four-color texture's red quadrant: {red:?}");
 
     for (fit, expected) in [
         (

--- a/docs/guide/systems/widgets.md
+++ b/docs/guide/systems/widgets.md
@@ -1,7 +1,8 @@
 # The widget set & focus model
 
 `aether-kit` ships a set of guest-side widgets — a slider, a text field, a
-radio group, a button, and a label — as ordinary `#[actor(instanced)]` types.
+radio group, a button, a label, and an image — as ordinary
+`#[actor(instanced)]` types.
 A panel root spawns them as inline children (ADR-0114) and drives them entirely
 by mail, so composing an editor panel is a matter of laying out widgets and
 translating their value events, never re-deriving hit rects, focus, or per-row
@@ -25,7 +26,8 @@ recorded at spawn, so a widget's identity is its inline subname and nothing a
 widget sends can misreport it.
 
 - **Config, down.** One `Config` kind per widget — `SliderConfig`,
-  `TextFieldConfig`, `RadioConfig`, `ButtonConfig`, `LabelConfig` — each
+  `TextFieldConfig`, `RadioConfig`, `ButtonConfig`, `LabelConfig`,
+  `ImageConfig` — each
   embedding a `theme: Theme`. The config is both the value
   `spawn_inline_child::<W>(subname, &config)` boots the widget with and a
   re-sendable mail: send a widget its config kind again to reconfigure it in
@@ -61,6 +63,33 @@ widget sends can misreport it.
   `ctx.parent()`. A slider streams `committed: false` values through a drag and
   a final `committed: true` on release, so a consumer previews the drag and
   commits the expensive work once.
+
+## Image widget
+
+`WidgetKind::Image` spawns a non-interactive `ImageWidget` from
+`ImageConfig`. The config borrows a session-scoped `texture_id` previously
+created through `aether.render`; the creator still owns updates and
+`DestroyTexture`. Re-sending `ImageConfig` replaces the borrowed texture and
+presentation in place without resizing or respawning the parent slot.
+
+The config names its natural pixel size with `natural_width_pixels` and
+`natural_height_pixels`. `ImageFit::Fill` stretches the full texture into the
+row, `Contain` preserves aspect ratio and centers the whole image, `Cover`
+fills the row and center-crops through UV coordinates, and `Natural` centers
+the configured natural size. Natural content larger than the row is clipped by
+the parent-owned slot. `Contain` is the default. Texture id `0`, zero or
+non-finite natural dimensions, and non-positive or non-finite frame dimensions
+produce no textured draw; the inert `ImageConfig::default()` therefore cannot
+draw the renderer's reserved white texture.
+
+Valid natural dimensions are reported through the existing
+`WidgetDrawList::intrinsic` field, including while the image is hidden. The
+reference panel does not yet consume child intrinsic values for layout, so
+this report does not make its row content-sized. Hidden images keep their slot
+but draw nothing. Disabled images stay visible with the theme's disabled alpha
+applied to their configured tint. Images are never pointer- or focus-eligible;
+read-only and validation state have no visual or behavioral meaning for this
+static leaf.
 
 ## Root-owned focus and input
 
@@ -103,7 +132,7 @@ test vehicle and the template a real editor forks. It embeds `Composite` and
 `Focus`, spawns the vertical stack its `PanelConfig` declares on its first
 frame (each `WidgetChildSpec` names a `WidgetKind` and carries that widget's
 pre-encoded config; an empty child list falls back to the built-in reference
-stack of every widget), loads a font through `aether.text` and stamps the
+original reference stack), loads a font through `aether.text` and stamps the
 session `font_id` into its theme when `load_font_result` arrives, drives the
 collect/emit loop each frame, and routes input through `Focus`. Row height,
 initial state, and static eligibility derive from each child's decoded config.

--- a/docs/guide/systems/widgets.md
+++ b/docs/guide/systems/widgets.md
@@ -77,10 +77,10 @@ The config names its natural pixel size with `natural_width_pixels` and
 row, `Contain` preserves aspect ratio and centers the whole image, `Cover`
 fills the row and center-crops through UV coordinates, and `Natural` centers
 the configured natural size. Natural content larger than the row is clipped by
-the parent-owned slot. `Contain` is the default. Texture id `0`, zero or
-non-finite natural dimensions, and non-positive or non-finite frame dimensions
-produce no textured draw; the inert `ImageConfig::default()` therefore cannot
-draw the renderer's reserved white texture.
+the parent-owned slot. `Contain` is the default. Consumer-created texture ids,
+including the registry's first id `0`, are valid. Zero or non-finite natural
+dimensions and non-positive or non-finite frame dimensions produce no textured
+draw; the inert `ImageConfig::default()` therefore paints nothing.
 
 Valid natural dimensions are reported through the existing
 `WidgetDrawList::intrinsic` field, including while the image is hidden. The


### PR DESCRIPTION
Closes #2917.

## Summary

- add the stock `ImageWidget`, its inert public config, and Fill/Contain/Cover/Natural fit modes over the existing textured widget item
- wire image children through panel, behavior-host, exports, external state, intrinsic reporting, and parent-owned clipping without taking texture lifecycle authority
- document the consumer surface and cover exact fit geometry, UVs, state, replacement, and texture cleanup through focused unit and TestBench scenarios

## Test plan

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p aether-kit --lib`
- `cargo test -p aether-kit --features behavior wrapped_tag_maps_each_stock_widget_and_rejects_unwrappable`
- `cargo test -p aether-substrate-bundle --test widget_image --no-run`
- CI strict runtime scenario: `widget_image`

## Generated by

`/implement` — agent execution of [scoped issue #2917](https://github.com/iamacoffeepot/aether/issues/2917).
