### PR TITLE
chore(ci): remove the review bring-up label gate

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -76,8 +76,8 @@ jobs:
       - uses: runs-on/action@v2
       # Resolve the PR and apply the run gates BEFORE any checkout — these
       # are pure GitHub API calls. Sets proceed=false (a clean no-op) when
-      # there is no open PR, the opt-in `review` label is absent, or the
-      # once-only marker is already present. head_sha feeds the checkout.
+      # there is no open PR or the once-only marker is already present.
+      # head_sha feeds the checkout.
       - name: Resolve PR and apply gates
         id: resolve
         env:
@@ -102,16 +102,6 @@ jobs:
             exit 0
           fi
           echo "pr_number=$pr" >> "$GITHUB_OUTPUT"
-
-          # Bring-up gate (plan step 6): the opt-in `review` label is
-          # required while the annotation contract proves out on real PRs.
-          # A follow-up one-liner removes this block once it has.
-          has_label="$(gh api "repos/${REPO}/issues/${pr}/labels" --jq 'any(.[]; .name == "review")')"
-          if [ "$has_label" != "true" ]; then
-            echo "PR #$pr lacks the opt-in 'review' label — skipping."
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
 
           # Once-only guard: the marker comment is the run-once state. A
           # manual dispatch bypasses it (deliberate re-review); the poster


### PR DESCRIPTION
Closes #2990.

## Summary

Removes the bring-up leash from the review action: the resolve step no longer requires the opt-in `review` label, so the review runs on every same-repo PR at its first green CI. The leash existed while the annotation contract proved out; the seeded probe (PR #2984, run 29085307724) validated the full chain — rollup, one COMMENT review with inline annotations, marker summary, `review:unresolved` — and the /land gate on unresolved findings (#2969) landed first per the agreed sequencing, so findings now have teeth the moment the action runs fleet-wide. The once-only marker guard, the same-repo guard, and the dispatch re-run path are unchanged.

## Test plan

Workflow YAML only. Verification is the next PR to go green on CI without any label: the review fires, posts, and its once-only marker prevents a second run.

## Generated by

`/implement --quick` — [issue #2990](https://github.com/iamacoffeepot/aether/issues/2990), the ungate one-liner anticipated in the gate's own comment.
