### PR TITLE
feat(kit): add terrain mark picking and overlays

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -93,11 +93,18 @@ pub use widget::{
     WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged, WidgetValidation,
 };
 pub use world::{
-    ApplyBrush, AutomatonRule, BrushParameters, CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk,
-    ChunkPos, HEIGHT_POINT_INHERIT, HEIGHT_POINTS_PER_CHUNK, Material, OperatorBudget, OperatorCell, OperatorChunk,
-    OperatorError, OperatorResult, OperatorStats, Region, RunAutomaton, SetCellHeights, SetCellPoints, SetChunk,
-    SetRegion, SmoothingProfile, StampDisc, StampHexagon, StampPolygon, WaterPlane, World, WorldDecodeError, WorldLoad,
-    WorldPoint,
+    ApplyBrush, AutomatonRule, BrushParameters, CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS,
+    CellPos, Chunk, ChunkPos, HEIGHT_POINT_INHERIT, HEIGHT_POINTS_PER_CHUNK, MARK_OVERLAY_COLOR,
+    MARK_OVERLAY_LIFT_METERS, MARK_PATH_HALF_WIDTH_METERS, MARK_POINT_RADIUS_METERS,
+    MARK_SELECTED_COLOR, MARK_SELECTED_HALF_WIDTH_METERS, MARK_SELECTED_HANDLE_RADIUS_METERS,
+    MAX_TERRAIN_PICK_DISTANCE_METERS, Material, OperatorBudget, OperatorCell, OperatorChunk,
+    OperatorError, OperatorResult, OperatorStats, PickTerrain, PickTerrainResult, Region,
+    RunAutomaton, SetCellHeights, SetCellPoints, SetChunk, SetMarkOverlaySelection,
+    SetMarkOverlaySelectionResult, SetMarkOverlayVisibility, SetMarkOverlayVisibilityResult,
+    SetRegion, SmoothingProfile, StampDisc, StampHexagon, StampPolygon,
+    TERRAIN_PICK_REFINEMENT_STEPS, TERRAIN_PICK_STEP_METERS, TerrainPickError, TerrainRay,
+    TerrainSurface, TerrainSurfaceHit, WaterPlane, World, WorldDecodeError, WorldDirection,
+    WorldLoad, WorldPoint, WorldPositionMeters,
 };
 
 /// Octimeters per tile: `1 tile = 1 meter = 256 octimeters`.

--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -93,18 +93,17 @@ pub use widget::{
     WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged, WidgetValidation,
 };
 pub use world::{
-    ApplyBrush, AutomatonRule, BrushParameters, CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS,
-    CellPos, Chunk, ChunkPos, HEIGHT_POINT_INHERIT, HEIGHT_POINTS_PER_CHUNK, MARK_OVERLAY_COLOR,
-    MARK_OVERLAY_LIFT_METERS, MARK_PATH_HALF_WIDTH_METERS, MARK_POINT_RADIUS_METERS,
-    MARK_SELECTED_COLOR, MARK_SELECTED_HALF_WIDTH_METERS, MARK_SELECTED_HANDLE_RADIUS_METERS,
-    MAX_TERRAIN_PICK_DISTANCE_METERS, Material, OperatorBudget, OperatorCell, OperatorChunk,
-    OperatorError, OperatorResult, OperatorStats, PickTerrain, PickTerrainResult, Region,
-    RunAutomaton, SetCellHeights, SetCellPoints, SetChunk, SetMarkOverlaySelection,
-    SetMarkOverlaySelectionResult, SetMarkOverlayVisibility, SetMarkOverlayVisibilityResult,
-    SetRegion, SmoothingProfile, StampDisc, StampHexagon, StampPolygon,
-    TERRAIN_PICK_REFINEMENT_STEPS, TERRAIN_PICK_STEP_METERS, TerrainPickError, TerrainRay,
-    TerrainSurface, TerrainSurfaceHit, WaterPlane, World, WorldDecodeError, WorldDirection,
-    WorldLoad, WorldPoint, WorldPositionMeters,
+    ApplyBrush, AutomatonRule, BrushParameters, CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk,
+    ChunkPos, HEIGHT_POINT_INHERIT, HEIGHT_POINTS_PER_CHUNK, MARK_OVERLAY_COLOR, MARK_OVERLAY_LIFT_METERS,
+    MARK_PATH_HALF_WIDTH_METERS, MARK_POINT_RADIUS_METERS, MARK_SELECTED_COLOR, MARK_SELECTED_HALF_WIDTH_METERS,
+    MARK_SELECTED_HANDLE_RADIUS_METERS, MAX_MARK_OVERLAY_TRIANGLES, MAX_MARK_OVERLAY_VERTICES,
+    MAX_TERRAIN_PICK_DISTANCE_METERS, Material, OperatorBudget, OperatorCell, OperatorChunk, OperatorError,
+    OperatorResult, OperatorStats, PickTerrain, PickTerrainResult, Region, RunAutomaton, SetCellHeights, SetCellPoints,
+    SetChunk, SetMarkOverlaySelection, SetMarkOverlaySelectionResult, SetMarkOverlayVisibility,
+    SetMarkOverlayVisibilityResult, SetRegion, SmoothingProfile, StampDisc, StampHexagon, StampPolygon,
+    TERRAIN_PICK_EPSILON_METERS, TERRAIN_PICK_REFINEMENT_STEPS, TERRAIN_PICK_STEP_METERS, TerrainPickError, TerrainRay,
+    TerrainSurface, TerrainSurfaceHit, WaterPlane, World, WorldDecodeError, WorldDirection, WorldLoad, WorldPoint,
+    WorldPositionMeters,
 };
 
 /// Octimeters per tile: `1 tile = 1 meter = 256 octimeters`.

--- a/crates/aether-kit/src/world/data.rs
+++ b/crates/aether-kit/src/world/data.rs
@@ -181,19 +181,7 @@ const OCTIMETER_BITS: u32 = 8;
 
 /// A cell address on the world lattice. Cells are addresses; their
 /// properties live in the plane stack.
-#[derive(
-    aether_data::Schema,
-    Serialize,
-    Deserialize,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Debug,
-    Hash,
-)]
+#[derive(aether_data::Schema, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct CellPos {
     pub x: i32,
     pub z: i32,
@@ -553,6 +541,48 @@ impl World {
         chunk.overlay_mask[cell.chunk_index() * SUBCELLS_PER_CELL + within]
     }
 
+    fn overlay_material_coverage(&self, global_subcell_x: i32, global_subcell_z: i32, material: Material) -> u8 {
+        let subcells = SUBCELLS_PER_CELL_EDGE.cast_signed();
+        let cell = CellPos { x: global_subcell_x.div_euclid(subcells), z: global_subcell_z.div_euclid(subcells) };
+        if self.overlay(cell) != material {
+            return 0;
+        }
+        self.overlay_coverage(cell, global_subcell_x.rem_euclid(subcells), global_subcell_z.rem_euclid(subcells))
+    }
+
+    fn reconstructed_overlay_coverage(&self, global_subcell_x: i32, global_subcell_z: i32, material: Material) -> u8 {
+        super::mesher::contour::reconstructed_coverage(
+            self.overlay_material_coverage(global_subcell_x, global_subcell_z, material),
+            self.overlay_material_coverage(global_subcell_x.saturating_add(1), global_subcell_z, material),
+            self.overlay_material_coverage(global_subcell_x, global_subcell_z.saturating_add(1), material),
+            self.overlay_material_coverage(
+                global_subcell_x.saturating_add(1),
+                global_subcell_z.saturating_add(1),
+                material,
+            ),
+            0.5,
+            0.5,
+        )
+    }
+
+    fn continuous_overlay_coverage_at(&self, x_meters: f32, z_meters: f32, material: Material) -> f32 {
+        let subcells = SUBCELLS_PER_CELL_EDGE as f32;
+        let sample_x = x_meters.mul_add(subcells, -0.5);
+        let sample_z = z_meters.mul_add(subcells, -0.5);
+        let base_x = floor_to_i32(sample_x);
+        let base_z = floor_to_i32(sample_z);
+        let fraction_x = sample_x - base_x as f32;
+        let fraction_z = sample_z - base_z as f32;
+        super::mesher::contour::interpolated_coverage(
+            self.reconstructed_overlay_coverage(base_x, base_z, material),
+            self.reconstructed_overlay_coverage(base_x.saturating_add(1), base_z, material),
+            self.reconstructed_overlay_coverage(base_x, base_z.saturating_add(1), material),
+            self.reconstructed_overlay_coverage(base_x.saturating_add(1), base_z.saturating_add(1), material),
+            fraction_x,
+            fraction_z,
+        )
+    }
+
     /// Elevation at `cell` in octimeters — the raw lakebed read. Unset
     /// cells read `0`. Under a water cell this is the ground beneath the
     /// surface, not the water level ([`World::water_level`] resolves that).
@@ -827,24 +857,24 @@ impl World {
         if !x_meters.is_finite() || !z_meters.is_finite() {
             return None;
         }
-        let cell = CellPos {
-            x: floor_to_i32(x_meters),
-            z: floor_to_i32(z_meters),
-        };
+        let cell = CellPos { x: floor_to_i32(x_meters), z: floor_to_i32(z_meters) };
         let subcells = SUBCELLS_PER_CELL_EDGE.cast_signed();
         let subcells_f32 = subcells as f32;
         let sub_x = floor_to_i32((x_meters - cell.x as f32) * subcells_f32).clamp(0, subcells - 1);
         let sub_z = floor_to_i32((z_meters - cell.z as f32) * subcells_f32).clamp(0, subcells - 1);
         let underlay_present = self.underlay_point(cell, sub_x, sub_z) != Material::Void;
-        let overlay_present = self.overlay(cell) != Material::Void
-            && self.overlay_coverage(cell, sub_x, sub_z) >= SCALAR_COVERAGE_THRESHOLD;
+        let overlay_present = [Material::Grass, Material::Dirt, Material::Stone, Material::Sand, Material::Water]
+            .into_iter()
+            .any(|material| {
+                super::mesher::contour::scalar_coverage_is_inside(
+                    self.continuous_overlay_coverage_at(x_meters, z_meters, material),
+                )
+            });
         if !underlay_present && !overlay_present {
             return None;
         }
-        let x_octimeters =
-            i32::try_from((x_meters * OCTIMETERS_PER_CELL as f32).round() as i64).ok()?;
-        let z_octimeters =
-            i32::try_from((z_meters * OCTIMETERS_PER_CELL as f32).round() as i64).ok()?;
+        let x_octimeters = i32::try_from((x_meters * OCTIMETERS_PER_CELL as f32).round() as i64).ok()?;
+        let z_octimeters = i32::try_from((z_meters * OCTIMETERS_PER_CELL as f32).round() as i64).ok()?;
         Some(TerrainSurface {
             cell,
             mark_point: WorldPoint::new(x_octimeters, z_octimeters),
@@ -1029,6 +1059,8 @@ pub enum WorldDecodeError {
     BadVersion(u8),
     /// A region name was not valid UTF-8.
     BadName,
+    /// A table count exceeded the format's addressable or operational cap.
+    LimitExceeded,
 }
 
 /// The current write version. Version 7 expands the per-cell packed
@@ -1053,6 +1085,23 @@ const WORLD_FORMAT_VERSION: u8 = 7;
 
 /// The oldest version [`World::from_bytes`] still decodes.
 const WORLD_FORMAT_VERSION_MIN: u8 = 1;
+
+const MAX_DECODED_REGIONS: usize = u16::MAX as usize;
+const MAX_DECODED_SMOOTHING_PROFILES: usize = u8::MAX as usize;
+const MAX_DECODED_WATER_PLANES: usize = u16::MAX as usize;
+const MAX_DECODED_CHUNKS: usize = 65_536;
+
+fn chunk_record_bytes(version: u8) -> usize {
+    let overlay_mask_bytes = if version >= 7 { OVERLAY_MASK_WIRE_BYTES } else { 2 * CELLS_PER_CHUNK_AREA };
+    8 + 2 * CELLS_PER_CHUNK_AREA
+        + overlay_mask_bytes
+        + 4 * CELLS_PER_CHUNK_AREA
+        + if version >= 4 { 2 * CELLS_PER_CHUNK_AREA } else { 0 }
+        + 2 * CELLS_PER_CHUNK_AREA
+        + if version >= 2 { CELLS_PER_CHUNK_AREA } else { 0 }
+        + if version >= 5 { UNDERLAY_POINTS_PER_CHUNK } else { 0 }
+        + if version >= 6 { 2 * HEIGHT_POINTS_PER_CHUNK } else { 0 }
+}
 
 impl World {
     /// Serialize to the compact `aether.kit.world.load` binary format: a
@@ -1124,7 +1173,9 @@ impl World {
         if !(WORLD_FORMAT_VERSION_MIN..=WORLD_FORMAT_VERSION).contains(&version) {
             return Err(WorldDecodeError::BadVersion(version));
         }
-        let region_count = reader.u32()? as usize;
+        let region_count_raw = reader.u32()?;
+        let region_count =
+            reader.checked_count(region_count_raw, 2 + 1 + usize::from(version >= 3), MAX_DECODED_REGIONS)?;
         let mut regions = Vec::with_capacity(region_count);
         for _ in 0..region_count {
             let name_len = reader.u16()? as usize;
@@ -1136,7 +1187,8 @@ impl World {
         }
         let mut smoothing_profiles = Vec::new();
         if version >= 2 {
-            let profile_count = reader.u32()? as usize;
+            let profile_count_raw = reader.u32()?;
+            let profile_count = reader.checked_count(profile_count_raw, 3, MAX_DECODED_SMOOTHING_PROFILES)?;
             smoothing_profiles.reserve(profile_count);
             for _ in 0..profile_count {
                 let iterations = u32::from(reader.u8()?);
@@ -1146,13 +1198,15 @@ impl World {
         }
         let mut water_planes = Vec::new();
         if version >= 4 {
-            let plane_count = reader.u32()? as usize;
+            let plane_count_raw = reader.u32()?;
+            let plane_count = reader.checked_count(plane_count_raw, 4, MAX_DECODED_WATER_PLANES)?;
             water_planes.reserve(plane_count);
             for _ in 0..plane_count {
                 water_planes.push(WaterPlane { level_octimeters: reader.i32()? });
             }
         }
-        let chunk_count = reader.u32()? as usize;
+        let chunk_count_raw = reader.u32()?;
+        let chunk_count = reader.checked_count(chunk_count_raw, chunk_record_bytes(version), MAX_DECODED_CHUNKS)?;
         let mut chunks = BTreeMap::new();
         for _ in 0..chunk_count {
             let x = reader.i32()?;
@@ -1241,6 +1295,27 @@ impl<'a> Reader<'a> {
         Ok(slice)
     }
 
+    fn remaining(&self) -> usize {
+        self.bytes.len() - self.pos
+    }
+
+    fn checked_count(
+        &self,
+        count: u32,
+        minimum_record_bytes: usize,
+        maximum_count: usize,
+    ) -> Result<usize, WorldDecodeError> {
+        let count = usize::try_from(count).map_err(|_| WorldDecodeError::LimitExceeded)?;
+        if count > maximum_count {
+            return Err(WorldDecodeError::LimitExceeded);
+        }
+        let required = count.checked_mul(minimum_record_bytes).ok_or(WorldDecodeError::LimitExceeded)?;
+        if required > self.remaining() {
+            return Err(WorldDecodeError::Truncated);
+        }
+        Ok(count)
+    }
+
     fn u8(&mut self) -> Result<u8, WorldDecodeError> {
         Ok(self.take(1)?[0])
     }
@@ -1269,7 +1344,7 @@ impl<'a> Reader<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::world::SetChunk;
+    use crate::world::{SetChunk, mesher::contour::COVERAGE_CROSSING};
 
     fn cell(x: i32, z: i32) -> CellPos {
         CellPos { x, z }
@@ -1615,6 +1690,29 @@ mod tests {
         let mut buf = vec![WORLD_FORMAT_VERSION];
         buf.extend_from_slice(&1u32.to_le_bytes());
         assert_eq!(World::from_bytes(&buf), Err(WorldDecodeError::Truncated));
+
+        let mut oversized_regions = vec![WORLD_FORMAT_VERSION];
+        oversized_regions
+            .extend_from_slice(&u32::try_from(MAX_DECODED_REGIONS + 1).expect("region cap fits u32").to_le_bytes());
+        assert_eq!(World::from_bytes(&oversized_regions), Err(WorldDecodeError::LimitExceeded),);
+
+        let mut oversized_profiles = vec![WORLD_FORMAT_VERSION];
+        oversized_profiles.extend_from_slice(&0u32.to_le_bytes());
+        oversized_profiles.extend_from_slice(&u32::MAX.to_le_bytes());
+        assert_eq!(World::from_bytes(&oversized_profiles), Err(WorldDecodeError::LimitExceeded),);
+
+        let mut oversized_water = vec![WORLD_FORMAT_VERSION];
+        oversized_water.extend_from_slice(&0u32.to_le_bytes());
+        oversized_water.extend_from_slice(&0u32.to_le_bytes());
+        oversized_water.extend_from_slice(&u32::MAX.to_le_bytes());
+        assert_eq!(World::from_bytes(&oversized_water), Err(WorldDecodeError::LimitExceeded),);
+
+        let mut oversized_chunks = vec![WORLD_FORMAT_VERSION];
+        oversized_chunks.extend_from_slice(&0u32.to_le_bytes());
+        oversized_chunks.extend_from_slice(&0u32.to_le_bytes());
+        oversized_chunks.extend_from_slice(&0u32.to_le_bytes());
+        oversized_chunks.extend_from_slice(&u32::MAX.to_le_bytes());
+        assert_eq!(World::from_bytes(&oversized_chunks), Err(WorldDecodeError::LimitExceeded),);
     }
 
     /// A world with one chunk whose heights come from `f(x, z)` over the
@@ -2126,35 +2224,53 @@ mod tests {
         chunk.height[0] = 256;
         world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
 
-        let surface = world
-            .terrain_surface_at(0.5, 0.5)
-            .expect("resolved underlay is markable");
+        let surface = world.terrain_surface_at(0.5, 0.5).expect("resolved underlay is markable");
         assert_eq!(surface.cell, cell(0, 0));
         assert_eq!(surface.mark_point, WorldPoint::new(128, 128));
         assert!((surface.height_meters - 1.0).abs() < 1e-4);
 
         let subcell = (8 * SUBCELLS_PER_CELL_EDGE + 8) as usize;
-        world
-            .chunk_mut_or_insert(ChunkPos { x: 0, z: 0 })
-            .underlay_points[subcell] = Material::Void.to_u8();
-        assert!(
-            world.terrain_surface_at(0.5, 0.5).is_none(),
-            "an explicit underlay-point hole is not markable"
-        );
+        world.chunk_mut_or_insert(ChunkPos { x: 0, z: 0 }).underlay_points[subcell] = Material::Void.to_u8();
+        assert!(world.terrain_surface_at(0.5, 0.5).is_none(), "an explicit underlay-point hole is not markable");
 
         let chunk = world.chunk_mut_or_insert(ChunkPos { x: 0, z: 0 });
         chunk.overlay[0] = Material::Sand;
-        chunk.overlay_mask[subcell] = SCALAR_COVERAGE_THRESHOLD - 1;
-        assert!(
-            world.terrain_surface_at(0.5, 0.5).is_none(),
-            "coverage below the contour threshold stays absent"
-        );
-        world
-            .chunk_mut_or_insert(ChunkPos { x: 0, z: 0 })
-            .overlay_mask[subcell] = SCALAR_COVERAGE_THRESHOLD;
+        chunk.overlay_mask[..SUBCELLS_PER_CELL].fill(SCALAR_COVERAGE_THRESHOLD - 1);
+        assert!(world.terrain_surface_at(0.5, 0.5).is_none(), "coverage below the contour threshold stays absent");
+        world.chunk_mut_or_insert(ChunkPos { x: 0, z: 0 }).overlay_mask[..SUBCELLS_PER_CELL]
+            .fill(SCALAR_COVERAGE_THRESHOLD);
         assert!(
             world.terrain_surface_at(0.5, 0.5).is_some(),
             "the exact contour threshold makes an overlay-only sample markable"
+        );
+    }
+
+    #[test]
+    fn terrain_surface_sampler_matches_a_continuous_scalar_overlay_crossing() {
+        let mut world = World::new();
+        let mut chunk = Chunk::empty();
+        chunk.overlay[0] = Material::Stone;
+        let subcells = SUBCELLS_PER_CELL_EDGE as usize;
+        for subcell_z in 0..subcells {
+            for subcell_x in 0..subcells {
+                chunk.overlay_mask[subcell_z * subcells + subcell_x] = if subcell_x < subcells / 2 { 100 } else { 200 };
+            }
+        }
+        world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
+
+        let low_sample_x = (subcells / 2 - 2) as f32 / subcells as f32 + 0.5 / subcells as f32;
+        let high_sample_x = (subcells / 2 - 1) as f32 / subcells as f32 + 0.5 / subcells as f32;
+        let high_reconstructed = 150.0;
+        let crossing_fraction = (COVERAGE_CROSSING - 100.0) / (high_reconstructed - 100.0);
+        let crossing_x = low_sample_x + (high_sample_x - low_sample_x) * crossing_fraction;
+
+        assert!(
+            world.terrain_surface_at(crossing_x - 0.001, 0.5).is_none(),
+            "the point immediately before the rendered 100→200 crossing stays absent"
+        );
+        assert!(
+            world.terrain_surface_at(crossing_x + 0.001, 0.5).is_some(),
+            "the point immediately after the rendered 100→200 crossing is markable"
         );
     }
 
@@ -2168,14 +2284,36 @@ mod tests {
         deltas[8 * SUBCELLS_PER_CELL_EDGE as usize + 8] = 128;
         world.set_cell_heights(cell(0, 0), &deltas);
 
-        let surface = world
-            .terrain_surface_at(0.53125, 0.53125)
-            .expect("relief remains markable");
-        assert!(
-            surface.height_meters > 0.0,
-            "the sampler uses the same relief-aware surface-height path"
-        );
+        let surface = world.terrain_surface_at(0.53125, 0.53125).expect("relief remains markable");
+        assert!(surface.height_meters > 0.0, "the sampler uses the same relief-aware surface-height path");
         assert!(world.terrain_surface_at(f32::NAN, 0.5).is_none());
         assert!(world.terrain_surface_at(0.5, f32::INFINITY).is_none());
+    }
+
+    #[test]
+    fn terrain_surface_sampler_resolves_water_and_negative_coordinates_directly() {
+        let mut water = World::new();
+        water.insert_water_plane(1, WaterPlane { level_octimeters: 512 });
+        let mut water_chunk = Chunk::empty();
+        water_chunk.underlay[0] = Material::Water;
+        water_chunk.height[0] = -256;
+        water_chunk.water_plane[0] = 1;
+        water.insert_chunk(ChunkPos { x: 0, z: 0 }, water_chunk);
+        let water_surface = water.terrain_surface_at(0.5, 0.5).expect("water is a markable top surface");
+        assert_eq!(water_surface.cell, cell(0, 0));
+        assert_eq!(water_surface.mark_point, WorldPoint::new(128, 128));
+        assert!((water_surface.height_meters - 2.0).abs() < 1e-4);
+
+        let negative_cell = cell(-1, -1);
+        let mut negative_chunk = Chunk::empty();
+        negative_chunk.underlay[negative_cell.chunk_index()] = Material::Grass;
+        negative_chunk.height[negative_cell.chunk_index()] = 128;
+        let mut negative = World::new();
+        negative.insert_chunk(negative_cell.chunk(), negative_chunk);
+        let negative_surface =
+            negative.terrain_surface_at(-0.5, -0.5).expect("negative lattice coordinates remain markable");
+        assert_eq!(negative_surface.cell, negative_cell);
+        assert_eq!(negative_surface.mark_point, WorldPoint::new(-128, -128));
+        assert!((negative_surface.height_meters - 0.5).abs() < 1e-4);
     }
 }

--- a/crates/aether-kit/src/world/data.rs
+++ b/crates/aether-kit/src/world/data.rs
@@ -101,6 +101,9 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::ptr;
+use serde::{Deserialize, Serialize};
+
+use super::kinds::{TerrainSurface, WorldPoint};
 
 /// Cells along one edge of a chunk. Chunks are `16 × 16` cells.
 pub const CELLS_PER_CHUNK: i32 = 16;
@@ -119,6 +122,11 @@ pub const CELLS_PER_CHUNK_AREA: usize = 256;
 /// change; the wire plane length is derived from it
 /// ([`OVERLAY_MASK_WIRE_BYTES`]), never hard-coded.
 pub const SUBCELLS_PER_CELL_EDGE: u32 = 16;
+
+/// Scalar-coverage samples at or above this value belong to the rendered
+/// overlay surface. The contour marcher and terrain sampler share this exact
+/// threshold so a picked overlay cannot disagree with the visible field.
+pub const SCALAR_COVERAGE_THRESHOLD: u8 = 128;
 
 /// Coverage samples in one cell's overlay plane: `SUB²`.
 pub const SUBCELLS_PER_CELL: usize = (SUBCELLS_PER_CELL_EDGE * SUBCELLS_PER_CELL_EDGE) as usize;
@@ -173,7 +181,19 @@ const OCTIMETER_BITS: u32 = 8;
 
 /// A cell address on the world lattice. Cells are addresses; their
 /// properties live in the plane stack.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(
+    aether_data::Schema,
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Debug,
+    Hash,
+)]
 pub struct CellPos {
     pub x: i32,
     pub z: i32,
@@ -793,6 +813,43 @@ impl World {
     pub fn surface_height(&self, wx: f32, wz: f32) -> f32 {
         let cell = CellPos { x: floor_to_i32(wx), z: floor_to_i32(wz) };
         self.surface_height_in(cell, wx, wz)
+    }
+
+    /// Sample the markable top surface at meter-space XZ coordinates.
+    ///
+    /// Presence follows the same authored fields the mesher consumes: a
+    /// non-Void resolved underlay point or a non-Void overlay sample at the
+    /// shared half-coverage threshold. Missing terrain and explicit holes
+    /// return None. Height resolves through the existing stood-on surface,
+    /// including relief, plate breaks, and water levels.
+    #[must_use]
+    pub fn terrain_surface_at(&self, x_meters: f32, z_meters: f32) -> Option<TerrainSurface> {
+        if !x_meters.is_finite() || !z_meters.is_finite() {
+            return None;
+        }
+        let cell = CellPos {
+            x: floor_to_i32(x_meters),
+            z: floor_to_i32(z_meters),
+        };
+        let subcells = SUBCELLS_PER_CELL_EDGE.cast_signed();
+        let subcells_f32 = subcells as f32;
+        let sub_x = floor_to_i32((x_meters - cell.x as f32) * subcells_f32).clamp(0, subcells - 1);
+        let sub_z = floor_to_i32((z_meters - cell.z as f32) * subcells_f32).clamp(0, subcells - 1);
+        let underlay_present = self.underlay_point(cell, sub_x, sub_z) != Material::Void;
+        let overlay_present = self.overlay(cell) != Material::Void
+            && self.overlay_coverage(cell, sub_x, sub_z) >= SCALAR_COVERAGE_THRESHOLD;
+        if !underlay_present && !overlay_present {
+            return None;
+        }
+        let x_octimeters =
+            i32::try_from((x_meters * OCTIMETERS_PER_CELL as f32).round() as i64).ok()?;
+        let z_octimeters =
+            i32::try_from((z_meters * OCTIMETERS_PER_CELL as f32).round() as i64).ok()?;
+        Some(TerrainSurface {
+            cell,
+            mark_point: WorldPoint::new(x_octimeters, z_octimeters),
+            height_meters: self.surface_height_in(cell, x_meters, z_meters),
+        })
     }
 
     /// The material `cell`'s cliff faces wear — its region's
@@ -2059,5 +2116,66 @@ mod tests {
         // the raise outward across the break.
         let outside = world.surface_height(5.0 + 0.5 / sub_f, 5.0 + 0.5 / sub_f);
         assert!(outside.abs() < 1e-4, "a flat subcell outside the plateau stays at the base, got {outside}");
+    }
+
+    #[test]
+    fn terrain_surface_sampler_shares_presence_and_height_truth() {
+        let mut world = World::new();
+        let mut chunk = Chunk::empty();
+        chunk.underlay[0] = Material::Stone;
+        chunk.height[0] = 256;
+        world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
+
+        let surface = world
+            .terrain_surface_at(0.5, 0.5)
+            .expect("resolved underlay is markable");
+        assert_eq!(surface.cell, cell(0, 0));
+        assert_eq!(surface.mark_point, WorldPoint::new(128, 128));
+        assert!((surface.height_meters - 1.0).abs() < 1e-4);
+
+        let subcell = (8 * SUBCELLS_PER_CELL_EDGE + 8) as usize;
+        world
+            .chunk_mut_or_insert(ChunkPos { x: 0, z: 0 })
+            .underlay_points[subcell] = Material::Void.to_u8();
+        assert!(
+            world.terrain_surface_at(0.5, 0.5).is_none(),
+            "an explicit underlay-point hole is not markable"
+        );
+
+        let chunk = world.chunk_mut_or_insert(ChunkPos { x: 0, z: 0 });
+        chunk.overlay[0] = Material::Sand;
+        chunk.overlay_mask[subcell] = SCALAR_COVERAGE_THRESHOLD - 1;
+        assert!(
+            world.terrain_surface_at(0.5, 0.5).is_none(),
+            "coverage below the contour threshold stays absent"
+        );
+        world
+            .chunk_mut_or_insert(ChunkPos { x: 0, z: 0 })
+            .overlay_mask[subcell] = SCALAR_COVERAGE_THRESHOLD;
+        assert!(
+            world.terrain_surface_at(0.5, 0.5).is_some(),
+            "the exact contour threshold makes an overlay-only sample markable"
+        );
+    }
+
+    #[test]
+    fn terrain_surface_sampler_follows_relief_and_rejects_nonfinite_coordinates() {
+        let mut world = World::new();
+        let mut chunk = Chunk::empty();
+        chunk.underlay.fill(Material::Grass);
+        world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
+        let mut deltas = [0; SUBCELLS_PER_CELL];
+        deltas[8 * SUBCELLS_PER_CELL_EDGE as usize + 8] = 128;
+        world.set_cell_heights(cell(0, 0), &deltas);
+
+        let surface = world
+            .terrain_surface_at(0.53125, 0.53125)
+            .expect("relief remains markable");
+        assert!(
+            surface.height_meters > 0.0,
+            "the sampler uses the same relief-aware surface-height path"
+        );
+        assert!(world.terrain_surface_at(f32::NAN, 0.5).is_none());
+        assert!(world.terrain_surface_at(0.5, f32::INFINITY).is_none());
     }
 }

--- a/crates/aether-kit/src/world/kinds.rs
+++ b/crates/aether-kit/src/world/kinds.rs
@@ -218,9 +218,7 @@ pub struct PickTerrain {
 }
 
 /// Reply to [`PickTerrain`].
-#[derive(
-    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq,
-)]
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 #[kind(name = "aether.kit.world.pick_terrain_result")]
 pub enum PickTerrainResult {
     Hit { hit: TerrainSurfaceHit },
@@ -237,17 +235,7 @@ pub struct SetMarkOverlayVisibility {
 }
 
 /// Visibility state after [`SetMarkOverlayVisibility`].
-#[derive(
-    aether_data::Kind,
-    aether_data::Schema,
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-)]
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[kind(name = "aether.kit.world.set_mark_overlay_visibility_result")]
 pub struct SetMarkOverlayVisibilityResult {
     pub visible: bool,
@@ -263,31 +251,13 @@ pub struct SetMarkOverlaySelection {
 }
 
 /// Result of applying an exact-revision overlay selection.
-#[derive(
-    aether_data::Kind,
-    aether_data::Schema,
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-)]
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[kind(name = "aether.kit.world.set_mark_overlay_selection_result")]
 pub enum SetMarkOverlaySelectionResult {
-    Selected {
-        reference: MarkRef,
-    },
+    Selected { reference: MarkRef },
     Cleared,
-    Stale {
-        requested: MarkRef,
-        current: MarkRef,
-    },
-    Unsynchronized {
-        requested: MarkRef,
-        cached: Option<MarkRef>,
-    },
+    Stale { requested: MarkRef, current: MarkRef },
+    Unsynchronized { requested: MarkRef, cached: Option<MarkRef> },
 }
 
 /// Maximum number of vertices accepted by one polygon stamp.
@@ -513,35 +483,4 @@ impl SetRegion {
 pub struct WorldLoad {
     pub namespace: String,
     pub path: String,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use aether_data::Kind as _;
-
-    #[test]
-    fn terrain_pick_and_overlay_kind_names_are_stable() {
-        assert_eq!(PickTerrain::NAME, "aether.kit.world.pick_terrain");
-        assert_eq!(
-            PickTerrainResult::NAME,
-            "aether.kit.world.pick_terrain_result"
-        );
-        assert_eq!(
-            SetMarkOverlayVisibility::NAME,
-            "aether.kit.world.set_mark_overlay_visibility"
-        );
-        assert_eq!(
-            SetMarkOverlayVisibilityResult::NAME,
-            "aether.kit.world.set_mark_overlay_visibility_result"
-        );
-        assert_eq!(
-            SetMarkOverlaySelection::NAME,
-            "aether.kit.world.set_mark_overlay_selection"
-        );
-        assert_eq!(
-            SetMarkOverlaySelectionResult::NAME,
-            "aether.kit.world.set_mark_overlay_selection_result"
-        );
-    }
 }

--- a/crates/aether-kit/src/world/kinds.rs
+++ b/crates/aether-kit/src/world/kinds.rs
@@ -158,6 +158,138 @@ impl WorldPoint {
     }
 }
 
+/// A position in the rendered world's meter-space coordinate system.
+///
+/// Axes and units stay named so callers never have to infer the ordering or
+/// scale of a positional vector.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct WorldPositionMeters {
+    pub x_meters: f32,
+    pub y_meters: f32,
+    pub z_meters: f32,
+}
+
+/// A ray direction. Components need not normalize it before sending.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct WorldDirection {
+    pub x_unitless: f32,
+    pub y_unitless: f32,
+    pub z_unitless: f32,
+}
+
+/// A bounded world-space ray used for terrain-surface picking.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct TerrainRay {
+    pub origin: WorldPositionMeters,
+    pub direction: WorldDirection,
+    pub max_distance_meters: f32,
+}
+
+/// The markable terrain sample underneath a picked world position.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct TerrainSurface {
+    pub cell: CellPos,
+    pub mark_point: WorldPoint,
+    pub height_meters: f32,
+}
+
+/// First top-surface intersection of a validated terrain ray.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct TerrainSurfaceHit {
+    pub position: WorldPositionMeters,
+    pub surface: TerrainSurface,
+    pub ray_distance_meters: f32,
+}
+
+/// Why a terrain ray cannot be evaluated.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerrainPickError {
+    NonFiniteRay,
+    ZeroDirection,
+    InvalidMaxDistance,
+}
+
+/// `aether.kit.world.pick_terrain` — intersect a bounded world ray with the
+/// first markable terrain top surface.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy)]
+#[kind(name = "aether.kit.world.pick_terrain")]
+pub struct PickTerrain {
+    pub ray: TerrainRay,
+}
+
+/// Reply to [`PickTerrain`].
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq,
+)]
+#[kind(name = "aether.kit.world.pick_terrain_result")]
+pub enum PickTerrainResult {
+    Hit { hit: TerrainSurfaceHit },
+    Miss,
+    Rejected { error: TerrainPickError },
+}
+
+/// `aether.kit.world.set_mark_overlay_visibility` — show or hide the
+/// read-only `MarkBook` projection rendered by [`WorldView`].
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy)]
+#[kind(name = "aether.kit.world.set_mark_overlay_visibility")]
+pub struct SetMarkOverlayVisibility {
+    pub visible: bool,
+}
+
+/// Visibility state after [`SetMarkOverlayVisibility`].
+#[derive(
+    aether_data::Kind,
+    aether_data::Schema,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+)]
+#[kind(name = "aether.kit.world.set_mark_overlay_visibility_result")]
+pub struct SetMarkOverlayVisibilityResult {
+    pub visible: bool,
+    pub synchronized: bool,
+}
+
+/// `aether.kit.world.set_mark_overlay_selection` — select an exact cached
+/// mark revision for highlighted overlay rendering, or clear the selection.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy)]
+#[kind(name = "aether.kit.world.set_mark_overlay_selection")]
+pub struct SetMarkOverlaySelection {
+    pub selected: Option<MarkRef>,
+}
+
+/// Result of applying an exact-revision overlay selection.
+#[derive(
+    aether_data::Kind,
+    aether_data::Schema,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+)]
+#[kind(name = "aether.kit.world.set_mark_overlay_selection_result")]
+pub enum SetMarkOverlaySelectionResult {
+    Selected {
+        reference: MarkRef,
+    },
+    Cleared,
+    Stale {
+        requested: MarkRef,
+        current: MarkRef,
+    },
+    Unsynchronized {
+        requested: MarkRef,
+        cached: Option<MarkRef>,
+    },
+}
+
 /// Maximum number of vertices accepted by one polygon stamp.
 pub const MAX_STAMP_VERTICES: usize = 1024;
 /// Maximum raster extent of one stamp along either axis, in subcells.
@@ -381,4 +513,35 @@ impl SetRegion {
 pub struct WorldLoad {
     pub namespace: String,
     pub path: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_data::Kind as _;
+
+    #[test]
+    fn terrain_pick_and_overlay_kind_names_are_stable() {
+        assert_eq!(PickTerrain::NAME, "aether.kit.world.pick_terrain");
+        assert_eq!(
+            PickTerrainResult::NAME,
+            "aether.kit.world.pick_terrain_result"
+        );
+        assert_eq!(
+            SetMarkOverlayVisibility::NAME,
+            "aether.kit.world.set_mark_overlay_visibility"
+        );
+        assert_eq!(
+            SetMarkOverlayVisibilityResult::NAME,
+            "aether.kit.world.set_mark_overlay_visibility_result"
+        );
+        assert_eq!(
+            SetMarkOverlaySelection::NAME,
+            "aether.kit.world.set_mark_overlay_selection"
+        );
+        assert_eq!(
+            SetMarkOverlaySelectionResult::NAME,
+            "aether.kit.world.set_mark_overlay_selection_result"
+        );
+    }
 }

--- a/crates/aether-kit/src/world/mesher/contour.rs
+++ b/crates/aether-kit/src/world/mesher/contour.rs
@@ -27,6 +27,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
+use crate::world::SCALAR_COVERAGE_THRESHOLD;
 use aether_capabilities::render::{DrawTriangle, Vertex};
 /// Octimeters per meter (`1 cell = 1 m = 256 octimeters`), for the
 /// octimeter-to-meter conversion at vertex emit.
@@ -61,11 +62,10 @@ pub struct SmoothParams {
     pub smoothing_degrees: u32,
 }
 
-const COVERAGE_THRESHOLD: u8 = 128;
 const COVERAGE_CROSSING: f32 = 127.5;
 
 fn covered(sample: u8) -> bool {
-    sample >= COVERAGE_THRESHOLD
+    sample >= SCALAR_COVERAGE_THRESHOLD
 }
 
 fn binary_coverage(sample: u8) -> bool {

--- a/crates/aether-kit/src/world/mesher/contour.rs
+++ b/crates/aether-kit/src/world/mesher/contour.rs
@@ -62,10 +62,10 @@ pub struct SmoothParams {
     pub smoothing_degrees: u32,
 }
 
-const COVERAGE_CROSSING: f32 = 127.5;
+pub(crate) const COVERAGE_CROSSING: f32 = SCALAR_COVERAGE_THRESHOLD as f32 - 0.5;
 
 fn covered(sample: u8) -> bool {
-    sample >= SCALAR_COVERAGE_THRESHOLD
+    scalar_coverage_is_inside(f32::from(sample))
 }
 
 fn binary_coverage(sample: u8) -> bool {
@@ -95,14 +95,44 @@ fn scalar_zone(coverage: &[u8], width: usize, height: usize, x: i32, z: i32) -> 
         .any(|(dx, dz)| !binary_coverage(sample_at(coverage, width, height, x + dx, z + dz, 0)))
 }
 
-fn bilinear_coverage(coverage: &[u8], width: usize, height: usize, x: i32, z: i32, fx: f32, fz: f32) -> u8 {
-    let bl = f32::from(sample_at(coverage, width, height, x, z, 0));
-    let br = f32::from(sample_at(coverage, width, height, x + 1, z, 0));
-    let tl = f32::from(sample_at(coverage, width, height, x, z + 1, 0));
-    let tr = f32::from(sample_at(coverage, width, height, x + 1, z + 1, 0));
+pub(crate) fn interpolated_coverage(
+    bottom_left: u8,
+    bottom_right: u8,
+    top_left: u8,
+    top_right: u8,
+    fraction_x: f32,
+    fraction_z: f32,
+) -> f32 {
+    let bl = f32::from(bottom_left);
+    let br = f32::from(bottom_right);
+    let tl = f32::from(top_left);
+    let tr = f32::from(top_right);
+    let fx = fraction_x.clamp(0.0, 1.0);
+    let fz = fraction_z.clamp(0.0, 1.0);
     let bottom = bl + (br - bl) * fx;
     let top = tl + (tr - tl) * fx;
-    (bottom + (top - bottom) * fz).round().clamp(0.0, 255.0) as u8
+    bottom + (top - bottom) * fz
+}
+
+pub(crate) fn reconstructed_coverage(
+    bottom_left: u8,
+    bottom_right: u8,
+    top_left: u8,
+    top_right: u8,
+    fraction_x: f32,
+    fraction_z: f32,
+) -> u8 {
+    if [bottom_left, bottom_right, top_left, top_right].into_iter().all(binary_coverage) {
+        bottom_left
+    } else {
+        interpolated_coverage(bottom_left, bottom_right, top_left, top_right, fraction_x, fraction_z)
+            .round()
+            .clamp(0.0, 255.0) as u8
+    }
+}
+
+pub(crate) fn scalar_coverage_is_inside(coverage: f32) -> bool {
+    coverage >= COVERAGE_CROSSING
 }
 
 /// The corner-flip test: the two orthogonal neighbors and the diagonal
@@ -167,13 +197,16 @@ pub fn minimize_corners(
         for gx in 0..gw {
             let cx = (gx / upsample) as i32;
             let cz = (gz / upsample) as i32;
-            grid[gz * gw + gx] = if scalar_zone(coverage, width, height, cx, cz) {
-                let fx = ((gx % upsample) as f32 + 0.5) * inv;
-                let fz = ((gz % upsample) as f32 + 0.5) * inv;
-                bilinear_coverage(coverage, width, height, cx, cz, fx, fz)
-            } else {
-                sample_at(coverage, width, height, cx, cz, 0)
-            };
+            let fx = ((gx % upsample) as f32 + 0.5) * inv;
+            let fz = ((gz % upsample) as f32 + 0.5) * inv;
+            grid[gz * gw + gx] = reconstructed_coverage(
+                sample_at(coverage, width, height, cx, cz, 0),
+                sample_at(coverage, width, height, cx + 1, cz, 0),
+                sample_at(coverage, width, height, cx, cz + 1, 0),
+                sample_at(coverage, width, height, cx + 1, cz + 1, 0),
+                fx,
+                fz,
+            );
         }
     }
     let max_iterations = params.iter().map(|p| p.iterations).max().unwrap_or(0);

--- a/crates/aether-kit/src/world/mod.rs
+++ b/crates/aether-kit/src/world/mod.rs
@@ -29,6 +29,10 @@
 //! - `aether.kit.world.{apply_brush,run_automaton}` — execute a bounded,
 //!   mark-attributed terrain operator, reply with exact partial statistics,
 //!   and remesh its deduplicated touched-chunk apron even on exhaustion.
+//! - `aether.kit.world.pick_terrain` — intersect a bounded named world ray
+//!   with the first markable rendered top surface.
+//! - `aether.kit.world.set_mark_overlay_{visibility,selection}` — control a
+//!   read-only, revision-exact projection of the default-loaded `MarkBook`.
 //! - `aether.kit.world.set_region` — register a region so the underlay
 //!   cascade has a default to resolve to; remeshes every cached chunk
 //!   (a region default can change any chunk's cascade-resolved underlay).
@@ -42,20 +46,41 @@ mod kinds;
 pub use kinds::*;
 pub mod mesher;
 mod operator;
+mod overlay;
+mod pick;
 mod raster;
+pub use overlay::{
+    MARK_OVERLAY_COLOR, MARK_OVERLAY_LIFT_METERS, MARK_PATH_HALF_WIDTH_METERS,
+    MARK_POINT_RADIUS_METERS, MARK_SELECTED_COLOR, MARK_SELECTED_HALF_WIDTH_METERS,
+    MARK_SELECTED_HANDLE_RADIUS_METERS,
+};
+pub use pick::{
+    MAX_TERRAIN_PICK_DISTANCE_METERS, TERRAIN_PICK_REFINEMENT_STEPS, TERRAIN_PICK_STEP_METERS,
+};
 
 use alloc::collections::{BTreeMap, BTreeSet};
 
-use aether_actor::{ActorInitError, Manual, OutboundReply, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{
+    ActorInitError, Manual, OutboundReply, ReplyMode, RequestId, WasmActor, WasmCtx, WasmInitCtx,
+    actor,
+};
+use aether_capabilities::component::ComponentHostWasmExt;
 use aether_capabilities::fs::{Read, ReadResult};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::render::DrawTriangle;
-use aether_capabilities::{FsCapability, LifecycleCapability, RenderCapability};
+use aether_capabilities::{
+    ComponentHostCapability, FsCapability, LifecycleCapability, RenderCapability,
+};
 use aether_kinds::Render;
 use serde::{Deserialize, Serialize};
 
+use crate::mark::{Mark, MarkBook, MarkId, MarkList, MarkListResult, MarkRef};
+
 use self::mesher::mesh_chunk;
 use self::mesher::style::StyleTable;
+
+/// Default load name of the authoritative `MarkBook` peer.
+const MARK_BOOK_COMPONENT: &str = "aether.kit.mark";
 
 /// World-view component: holds the world plane stack and a per-chunk
 /// mesh cache, and replays the cache to the render sink each frame.
@@ -75,6 +100,7 @@ pub struct WorldView {
     world: World,
     meshes: BTreeMap<ChunkPos, Vec<DrawTriangle>>,
     styles: StyleTable,
+    mark_overlay: MarkOverlayProjection,
 }
 
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
@@ -84,7 +110,90 @@ struct WorldLoadContext {
     path: String,
 }
 
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy)]
+#[kind(name = "aether.kit.world.mark_overlay_refresh_context")]
+struct MarkOverlayRefreshContext {
+    generation: u64,
+}
+
+#[derive(Default)]
+struct MarkOverlayProjection {
+    visible: bool,
+    synchronized: bool,
+    marks: BTreeMap<MarkId, Mark>,
+    selected: Option<MarkRef>,
+    pending_request: Option<RequestId>,
+    generation: u64,
+}
+
+impl MarkOverlayProjection {
+    fn set_visibility(&mut self, visible: bool) -> SetMarkOverlayVisibilityResult {
+        if visible != self.visible {
+            self.generation = self.generation.wrapping_add(1);
+        }
+        self.visible = visible;
+        if !visible {
+            self.synchronized = false;
+            self.marks.clear();
+            self.selected = None;
+            self.pending_request = None;
+        }
+        SetMarkOverlayVisibilityResult {
+            visible,
+            synchronized: visible && self.synchronized,
+        }
+    }
+
+    fn set_selection(&mut self, requested: Option<MarkRef>) -> SetMarkOverlaySelectionResult {
+        let Some(requested) = requested else {
+            self.selected = None;
+            return SetMarkOverlaySelectionResult::Cleared;
+        };
+        let cached = self.marks.get(&requested.id).map(Mark::reference);
+        match cached {
+            Some(current) if current == requested && self.visible && self.synchronized => {
+                self.selected = Some(requested);
+                SetMarkOverlaySelectionResult::Selected {
+                    reference: requested,
+                }
+            }
+            Some(current) if current.revision > requested.revision => {
+                SetMarkOverlaySelectionResult::Stale { requested, current }
+            }
+            _ => SetMarkOverlaySelectionResult::Unsynchronized { requested, cached },
+        }
+    }
+
+    fn replace_snapshot(&mut self, marks: Vec<Mark>) {
+        let replacement: BTreeMap<MarkId, Mark> =
+            marks.into_iter().map(|mark| (mark.id, mark)).collect();
+        if let Some(selected) = self.selected
+            && replacement
+                .get(&selected.id)
+                .is_none_or(|mark| mark.reference() != selected)
+        {
+            self.selected = None;
+        }
+        self.marks = replacement;
+        self.synchronized = true;
+    }
+}
+
 impl WorldView {
+    fn request_mark_overlay_refresh<M: ReplyMode>(&mut self, ctx: &WasmCtx<'_, M>) {
+        if !self.mark_overlay.visible || self.mark_overlay.pending_request.is_some() {
+            return;
+        }
+        let context = MarkOverlayRefreshContext {
+            generation: self.mark_overlay.generation,
+        };
+        let request = ctx
+            .actor::<ComponentHostCapability>()
+            .loaded::<MarkBook>(MARK_BOOK_COMPONENT)
+            .send_with_context(&MarkList, &context);
+        self.mark_overlay.pending_request = Some(request);
+    }
+
     /// Rebuild every chunk's cached mesh from the current world — used
     /// after a whole-world change (region default, world load) that can
     /// alter any chunk's mesh.
@@ -155,7 +264,12 @@ impl WasmActor for WorldView {
     const NAMESPACE: &'static str = "aether.kit.world";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
-        Ok(WorldView { world: World::new(), meshes: BTreeMap::new(), styles: StyleTable::default() })
+        Ok(WorldView {
+            world: World::new(),
+            meshes: BTreeMap::new(),
+            styles: StyleTable::default(),
+            mark_overlay: MarkOverlayProjection::default(),
+        })
     }
 
     /// Subscribe the `Render` lifecycle stage so the cached meshes
@@ -178,11 +292,90 @@ impl WasmActor for WorldView {
     /// no camera is active.
     #[handler::single]
     fn on_render(&mut self, ctx: &mut WasmCtx<'_>, _render: Render) {
+        self.request_mark_overlay_refresh(ctx);
         for mesh in self.meshes.values() {
             if !mesh.is_empty() {
                 ctx.actor::<RenderCapability>().send_many(mesh);
             }
         }
+        if self.mark_overlay.visible {
+            let triangles = overlay::mark_overlay_triangles(
+                &self.world,
+                &self.mark_overlay.marks,
+                self.mark_overlay.selected,
+            );
+            if !triangles.is_empty() {
+                ctx.actor::<RenderCapability>().send_many(&triangles);
+            }
+        }
+    }
+
+    /// Intersect a bounded world-space ray with the first markable terrain
+    /// top surface.
+    #[handler::manual]
+    fn on_pick_terrain(&mut self, ctx: &mut WasmCtx<'_, Manual>, msg: PickTerrain) {
+        if ctx.reply_target().is_some() {
+            ctx.reply(&pick::pick_terrain(&self.world, msg.ray));
+        }
+    }
+
+    /// Show or hide the read-only `MarkBook` projection. Enabling starts one
+    /// correlated refresh; the immediate result reports whether a snapshot
+    /// was already synchronized.
+    #[handler::manual]
+    fn on_set_mark_overlay_visibility(
+        &mut self,
+        ctx: &mut WasmCtx<'_, Manual>,
+        msg: SetMarkOverlayVisibility,
+    ) {
+        let result = self.mark_overlay.set_visibility(msg.visible);
+        if msg.visible {
+            self.request_mark_overlay_refresh(ctx);
+        }
+        if ctx.reply_target().is_some() {
+            ctx.reply(&result);
+        }
+    }
+
+    /// Select an exact cached mark revision for highlighted rendering.
+    /// Missing or ahead revisions request a refresh and remain unchanged.
+    #[handler::manual]
+    fn on_set_mark_overlay_selection(
+        &mut self,
+        ctx: &mut WasmCtx<'_, Manual>,
+        msg: SetMarkOverlaySelection,
+    ) {
+        let result = self.mark_overlay.set_selection(msg.selected);
+        if matches!(result, SetMarkOverlaySelectionResult::Unsynchronized { .. }) {
+            self.request_mark_overlay_refresh(ctx);
+        }
+        if ctx.reply_target().is_some() {
+            ctx.reply(&result);
+        }
+    }
+
+    /// Atomically replace the cached render projection from the correlated
+    /// `MarkBook` list reply. Ordinary present-source sends, stale requests,
+    /// and late replies after hiding are ignored.
+    #[handler::single]
+    fn on_mark_list_result(&mut self, ctx: &mut WasmCtx<'_>, result: MarkListResult) {
+        if ctx.source_mailbox().is_some() {
+            return;
+        }
+        let Some(request) = ctx.in_reply_to() else {
+            return;
+        };
+        if self.mark_overlay.pending_request != Some(request) {
+            return;
+        }
+        let Some(context) = ctx.take_context::<MarkOverlayRefreshContext>() else {
+            return;
+        };
+        self.mark_overlay.pending_request = None;
+        if !self.mark_overlay.visible || context.generation != self.mark_overlay.generation {
+            return;
+        }
+        self.mark_overlay.replace_snapshot(result.marks);
     }
 
     /// Write one chunk's planes into the world, then remesh that chunk and
@@ -392,10 +585,16 @@ impl WasmActor for WorldView {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mark::MarkGeometry;
 
     #[test]
     fn chunk_border_stamp_remeshes_both_touched_chunks() {
-        let mut view = WorldView { world: World::new(), meshes: BTreeMap::new(), styles: StyleTable::default() };
+        let mut view = WorldView {
+            world: World::new(),
+            meshes: BTreeMap::new(),
+            styles: StyleTable::default(),
+            mark_overlay: MarkOverlayProjection::default(),
+        };
         view.stamp_vertices(
             &[
                 WorldPoint::new(4080, 256),
@@ -417,6 +616,106 @@ mod tests {
         assert!(
             view.meshes.get(&east).is_some_and(|mesh| !mesh.is_empty()),
             "east mesh includes the border stamp and its west apron",
+        );
+    }
+
+    fn projected_mark(id: u32, revision: u32) -> Mark {
+        Mark {
+            id: MarkId::new(id),
+            revision,
+            geometry: MarkGeometry::Point(WorldPoint::new(128, 128)),
+            label: alloc::format!("mark-{id}"),
+        }
+    }
+
+    #[test]
+    fn overlay_projection_selection_is_revision_exact() {
+        let mut projection = MarkOverlayProjection::default();
+        assert_eq!(
+            projection.set_visibility(true),
+            SetMarkOverlayVisibilityResult {
+                visible: true,
+                synchronized: false,
+            }
+        );
+        projection.replace_snapshot(vec![projected_mark(1, 3), projected_mark(2, 1)]);
+        let selected = MarkRef {
+            id: MarkId::new(1),
+            revision: 3,
+        };
+        assert_eq!(
+            projection.set_selection(Some(selected)),
+            SetMarkOverlaySelectionResult::Selected {
+                reference: selected,
+            }
+        );
+        assert_eq!(projection.selected, Some(selected));
+
+        let stale = MarkRef {
+            id: MarkId::new(1),
+            revision: 2,
+        };
+        assert_eq!(
+            projection.set_selection(Some(stale)),
+            SetMarkOverlaySelectionResult::Stale {
+                requested: stale,
+                current: selected,
+            }
+        );
+        assert_eq!(projection.selected, Some(selected));
+
+        let ahead = MarkRef {
+            id: MarkId::new(1),
+            revision: 4,
+        };
+        assert_eq!(
+            projection.set_selection(Some(ahead)),
+            SetMarkOverlaySelectionResult::Unsynchronized {
+                requested: ahead,
+                cached: Some(selected),
+            }
+        );
+        assert_eq!(projection.selected, Some(selected));
+
+        projection.replace_snapshot(vec![projected_mark(1, 4), projected_mark(2, 1)]);
+        assert_eq!(
+            projection.selected, None,
+            "a newer atomic snapshot clears the old highlighted revision"
+        );
+    }
+
+    #[test]
+    fn overlay_projection_snapshot_removes_deleted_marks_and_hiding_clears_state() {
+        let mut projection = MarkOverlayProjection::default();
+        projection.set_visibility(true);
+        projection.replace_snapshot(vec![projected_mark(1, 1), projected_mark(2, 1)]);
+        assert_eq!(projection.marks.len(), 2);
+
+        projection.replace_snapshot(vec![projected_mark(2, 1)]);
+        assert!(!projection.marks.contains_key(&MarkId::new(1)));
+        assert!(projection.synchronized);
+
+        assert_eq!(
+            projection.set_visibility(false),
+            SetMarkOverlayVisibilityResult {
+                visible: false,
+                synchronized: false,
+            }
+        );
+        assert!(projection.marks.is_empty());
+        assert_eq!(projection.selected, None);
+        assert_eq!(
+            projection.set_selection(Some(MarkRef {
+                id: MarkId::new(2),
+                revision: 1,
+            })),
+            SetMarkOverlaySelectionResult::Unsynchronized {
+                requested: MarkRef {
+                    id: MarkId::new(2),
+                    revision: 1,
+                },
+                cached: None,
+            }
         );
     }
 }

--- a/crates/aether-kit/src/world/mod.rs
+++ b/crates/aether-kit/src/world/mod.rs
@@ -50,27 +50,26 @@ mod overlay;
 mod pick;
 mod raster;
 pub use overlay::{
-    MARK_OVERLAY_COLOR, MARK_OVERLAY_LIFT_METERS, MARK_PATH_HALF_WIDTH_METERS,
-    MARK_POINT_RADIUS_METERS, MARK_SELECTED_COLOR, MARK_SELECTED_HALF_WIDTH_METERS,
-    MARK_SELECTED_HANDLE_RADIUS_METERS,
+    MARK_OVERLAY_COLOR, MARK_OVERLAY_LIFT_METERS, MARK_PATH_HALF_WIDTH_METERS, MARK_POINT_RADIUS_METERS,
+    MARK_SELECTED_COLOR, MARK_SELECTED_HALF_WIDTH_METERS, MARK_SELECTED_HANDLE_RADIUS_METERS,
+    MAX_MARK_OVERLAY_TRIANGLES, MAX_MARK_OVERLAY_VERTICES,
 };
 pub use pick::{
-    MAX_TERRAIN_PICK_DISTANCE_METERS, TERRAIN_PICK_REFINEMENT_STEPS, TERRAIN_PICK_STEP_METERS,
+    MAX_TERRAIN_PICK_DISTANCE_METERS, TERRAIN_PICK_EPSILON_METERS, TERRAIN_PICK_REFINEMENT_STEPS,
+    TERRAIN_PICK_STEP_METERS,
 };
 
 use alloc::collections::{BTreeMap, BTreeSet};
 
 use aether_actor::{
-    ActorInitError, Manual, OutboundReply, ReplyMode, RequestId, WasmActor, WasmCtx, WasmInitCtx,
-    actor,
+    ActorInitError, Manual, OutboundReply, ReplyMode, RequestId, WasmActor, WasmCtx, WasmInitCtx, actor,
 };
 use aether_capabilities::component::ComponentHostWasmExt;
 use aether_capabilities::fs::{Read, ReadResult};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::render::DrawTriangle;
-use aether_capabilities::{
-    ComponentHostCapability, FsCapability, LifecycleCapability, RenderCapability,
-};
+use aether_capabilities::{ComponentHostCapability, FsCapability, LifecycleCapability, RenderCapability};
+use aether_data::Source;
 use aether_kinds::Render;
 use serde::{Deserialize, Serialize};
 
@@ -81,6 +80,7 @@ use self::mesher::style::StyleTable;
 
 /// Default load name of the authoritative `MarkBook` peer.
 const MARK_BOOK_COMPONENT: &str = "aether.kit.mark";
+const MARK_OVERLAY_REFRESH_ATTEMPT_LIMIT: u8 = 3;
 
 /// World-view component: holds the world plane stack and a per-chunk
 /// mesh cache, and replays the cache to the render sink each frame.
@@ -124,6 +124,8 @@ struct MarkOverlayProjection {
     selected: Option<MarkRef>,
     pending_request: Option<RequestId>,
     generation: u64,
+    budget_overflowed: bool,
+    refresh_attempts: u8,
 }
 
 impl MarkOverlayProjection {
@@ -137,11 +139,10 @@ impl MarkOverlayProjection {
             self.marks.clear();
             self.selected = None;
             self.pending_request = None;
+            self.budget_overflowed = false;
+            self.refresh_attempts = 0;
         }
-        SetMarkOverlayVisibilityResult {
-            visible,
-            synchronized: visible && self.synchronized,
-        }
+        SetMarkOverlayVisibilityResult { visible, synchronized: visible && self.synchronized }
     }
 
     fn set_selection(&mut self, requested: Option<MarkRef>) -> SetMarkOverlaySelectionResult {
@@ -153,9 +154,7 @@ impl MarkOverlayProjection {
         match cached {
             Some(current) if current == requested && self.visible && self.synchronized => {
                 self.selected = Some(requested);
-                SetMarkOverlaySelectionResult::Selected {
-                    reference: requested,
-                }
+                SetMarkOverlaySelectionResult::Selected { reference: requested }
             }
             Some(current) if current.revision > requested.revision => {
                 SetMarkOverlaySelectionResult::Stale { requested, current }
@@ -165,33 +164,70 @@ impl MarkOverlayProjection {
     }
 
     fn replace_snapshot(&mut self, marks: Vec<Mark>) {
-        let replacement: BTreeMap<MarkId, Mark> =
-            marks.into_iter().map(|mark| (mark.id, mark)).collect();
+        let replacement: BTreeMap<MarkId, Mark> = marks.into_iter().map(|mark| (mark.id, mark)).collect();
         if let Some(selected) = self.selected
-            && replacement
-                .get(&selected.id)
-                .is_none_or(|mark| mark.reference() != selected)
+            && replacement.get(&selected.id).is_none_or(|mark| mark.reference() != selected)
         {
             self.selected = None;
         }
         self.marks = replacement;
         self.synchronized = true;
+        self.refresh_attempts = 0;
+    }
+
+    fn should_request_refresh(&self) -> bool {
+        self.visible && self.pending_request.is_none() && self.refresh_attempts < MARK_OVERLAY_REFRESH_ATTEMPT_LIMIT
+    }
+
+    fn record_refresh_attempt(&mut self, request: RequestId) -> bool {
+        self.refresh_attempts = self.refresh_attempts.saturating_add(1);
+        if request.0 == Source::NO_CORRELATION {
+            return false;
+        }
+        self.pending_request = Some(request);
+        true
+    }
+
+    fn settle_refresh_reply(
+        &mut self,
+        request: RequestId,
+        context: Option<MarkOverlayRefreshContext>,
+        marks: Vec<Mark>,
+    ) -> bool {
+        if self.pending_request != Some(request) {
+            return false;
+        }
+        self.pending_request = None;
+        let Some(context) = context else {
+            return false;
+        };
+        if !self.visible || context.generation != self.generation {
+            return false;
+        }
+        self.replace_snapshot(marks);
+        true
     }
 }
 
 impl WorldView {
     fn request_mark_overlay_refresh<M: ReplyMode>(&mut self, ctx: &WasmCtx<'_, M>) {
-        if !self.mark_overlay.visible || self.mark_overlay.pending_request.is_some() {
+        if !self.mark_overlay.should_request_refresh() {
             return;
         }
-        let context = MarkOverlayRefreshContext {
-            generation: self.mark_overlay.generation,
-        };
+        let context = MarkOverlayRefreshContext { generation: self.mark_overlay.generation };
         let request = ctx
             .actor::<ComponentHostCapability>()
             .loaded::<MarkBook>(MARK_BOOK_COMPONENT)
             .send_with_context(&MarkList, &context);
-        self.mark_overlay.pending_request = Some(request);
+        if !self.mark_overlay.record_refresh_attempt(request)
+            && self.mark_overlay.refresh_attempts == MARK_OVERLAY_REFRESH_ATTEMPT_LIMIT
+        {
+            tracing::warn!(
+                target: "aether_kit",
+                attempts = self.mark_overlay.refresh_attempts,
+                "mark overlay refresh send was dropped; retry budget exhausted",
+            );
+        }
     }
 
     /// Rebuild every chunk's cached mesh from the current world — used
@@ -299,13 +335,23 @@ impl WasmActor for WorldView {
             }
         }
         if self.mark_overlay.visible {
-            let triangles = overlay::mark_overlay_triangles(
-                &self.world,
-                &self.mark_overlay.marks,
-                self.mark_overlay.selected,
-            );
-            if !triangles.is_empty() {
-                ctx.actor::<RenderCapability>().send_many(&triangles);
+            let batch = overlay::mark_overlay_batch(&self.world, &self.mark_overlay.marks, self.mark_overlay.selected);
+            if let Some(overflow) = batch.overflow
+                && !self.mark_overlay.budget_overflowed
+            {
+                tracing::warn!(
+                    target: "aether_kit",
+                    first_omitted_mark = overflow.first_omitted_mark.get(),
+                    emitted_triangles = overflow.emitted_triangles,
+                    emitted_vertices = overflow.emitted_vertices,
+                    triangle_limit = MAX_MARK_OVERLAY_TRIANGLES,
+                    vertex_limit = MAX_MARK_OVERLAY_VERTICES,
+                    "mark overlay frame budget exhausted; later geometry was omitted",
+                );
+            }
+            self.mark_overlay.budget_overflowed = batch.overflow.is_some();
+            if !batch.triangles.is_empty() {
+                ctx.actor::<RenderCapability>().send_many(&batch.triangles);
             }
         }
     }
@@ -323,11 +369,7 @@ impl WasmActor for WorldView {
     /// correlated refresh; the immediate result reports whether a snapshot
     /// was already synchronized.
     #[handler::manual]
-    fn on_set_mark_overlay_visibility(
-        &mut self,
-        ctx: &mut WasmCtx<'_, Manual>,
-        msg: SetMarkOverlayVisibility,
-    ) {
+    fn on_set_mark_overlay_visibility(&mut self, ctx: &mut WasmCtx<'_, Manual>, msg: SetMarkOverlayVisibility) {
         let result = self.mark_overlay.set_visibility(msg.visible);
         if msg.visible {
             self.request_mark_overlay_refresh(ctx);
@@ -340,11 +382,7 @@ impl WasmActor for WorldView {
     /// Select an exact cached mark revision for highlighted rendering.
     /// Missing or ahead revisions request a refresh and remain unchanged.
     #[handler::manual]
-    fn on_set_mark_overlay_selection(
-        &mut self,
-        ctx: &mut WasmCtx<'_, Manual>,
-        msg: SetMarkOverlaySelection,
-    ) {
+    fn on_set_mark_overlay_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, msg: SetMarkOverlaySelection) {
         let result = self.mark_overlay.set_selection(msg.selected);
         if matches!(result, SetMarkOverlaySelectionResult::Unsynchronized { .. }) {
             self.request_mark_overlay_refresh(ctx);
@@ -368,14 +406,8 @@ impl WasmActor for WorldView {
         if self.mark_overlay.pending_request != Some(request) {
             return;
         }
-        let Some(context) = ctx.take_context::<MarkOverlayRefreshContext>() else {
-            return;
-        };
-        self.mark_overlay.pending_request = None;
-        if !self.mark_overlay.visible || context.generation != self.mark_overlay.generation {
-            return;
-        }
-        self.mark_overlay.replace_snapshot(result.marks);
+        let context = ctx.take_context::<MarkOverlayRefreshContext>();
+        self.mark_overlay.settle_refresh_reply(request, context, result.marks);
     }
 
     /// Write one chunk's planes into the world, then remesh that chunk and
@@ -633,55 +665,32 @@ mod tests {
         let mut projection = MarkOverlayProjection::default();
         assert_eq!(
             projection.set_visibility(true),
-            SetMarkOverlayVisibilityResult {
-                visible: true,
-                synchronized: false,
-            }
+            SetMarkOverlayVisibilityResult { visible: true, synchronized: false }
         );
         projection.replace_snapshot(vec![projected_mark(1, 3), projected_mark(2, 1)]);
-        let selected = MarkRef {
-            id: MarkId::new(1),
-            revision: 3,
-        };
+        let selected = MarkRef { id: MarkId::new(1), revision: 3 };
         assert_eq!(
             projection.set_selection(Some(selected)),
-            SetMarkOverlaySelectionResult::Selected {
-                reference: selected,
-            }
+            SetMarkOverlaySelectionResult::Selected { reference: selected }
         );
         assert_eq!(projection.selected, Some(selected));
 
-        let stale = MarkRef {
-            id: MarkId::new(1),
-            revision: 2,
-        };
+        let stale = MarkRef { id: MarkId::new(1), revision: 2 };
         assert_eq!(
             projection.set_selection(Some(stale)),
-            SetMarkOverlaySelectionResult::Stale {
-                requested: stale,
-                current: selected,
-            }
+            SetMarkOverlaySelectionResult::Stale { requested: stale, current: selected }
         );
         assert_eq!(projection.selected, Some(selected));
 
-        let ahead = MarkRef {
-            id: MarkId::new(1),
-            revision: 4,
-        };
+        let ahead = MarkRef { id: MarkId::new(1), revision: 4 };
         assert_eq!(
             projection.set_selection(Some(ahead)),
-            SetMarkOverlaySelectionResult::Unsynchronized {
-                requested: ahead,
-                cached: Some(selected),
-            }
+            SetMarkOverlaySelectionResult::Unsynchronized { requested: ahead, cached: Some(selected) }
         );
         assert_eq!(projection.selected, Some(selected));
 
         projection.replace_snapshot(vec![projected_mark(1, 4), projected_mark(2, 1)]);
-        assert_eq!(
-            projection.selected, None,
-            "a newer atomic snapshot clears the old highlighted revision"
-        );
+        assert_eq!(projection.selected, None, "a newer atomic snapshot clears the old highlighted revision");
     }
 
     #[test]
@@ -697,25 +706,76 @@ mod tests {
 
         assert_eq!(
             projection.set_visibility(false),
-            SetMarkOverlayVisibilityResult {
-                visible: false,
-                synchronized: false,
-            }
+            SetMarkOverlayVisibilityResult { visible: false, synchronized: false }
         );
         assert!(projection.marks.is_empty());
         assert_eq!(projection.selected, None);
         assert_eq!(
-            projection.set_selection(Some(MarkRef {
-                id: MarkId::new(2),
-                revision: 1,
-            })),
+            projection.set_selection(Some(MarkRef { id: MarkId::new(2), revision: 1 })),
             SetMarkOverlaySelectionResult::Unsynchronized {
-                requested: MarkRef {
-                    id: MarkId::new(2),
-                    revision: 1,
-                },
+                requested: MarkRef { id: MarkId::new(2), revision: 1 },
                 cached: None,
             }
         );
+    }
+
+    #[test]
+    fn overlay_projection_bounds_retries_when_refresh_sends_are_dropped() {
+        let mut projection = MarkOverlayProjection::default();
+        projection.set_visibility(true);
+        for expected_attempts in 1..=MARK_OVERLAY_REFRESH_ATTEMPT_LIMIT {
+            assert!(projection.should_request_refresh());
+            assert!(!projection.record_refresh_attempt(RequestId(Source::NO_CORRELATION)));
+            assert_eq!(projection.refresh_attempts, expected_attempts);
+            assert_eq!(projection.pending_request, None);
+        }
+        assert!(
+            !projection.should_request_refresh(),
+            "a missing MarkBook cannot produce an unbounded request every render"
+        );
+
+        projection.set_visibility(false);
+        projection.set_visibility(true);
+        assert_eq!(projection.refresh_attempts, 0);
+        assert!(projection.should_request_refresh());
+    }
+
+    #[test]
+    fn overlay_projection_ignores_late_reply_after_disable_and_clears_missing_context() {
+        let mut projection = MarkOverlayProjection::default();
+        projection.set_visibility(true);
+        let first_generation = projection.generation;
+        assert!(projection.record_refresh_attempt(RequestId(12)));
+
+        projection.set_visibility(false);
+        assert!(!projection.settle_refresh_reply(
+            RequestId(12),
+            Some(MarkOverlayRefreshContext { generation: first_generation }),
+            vec![projected_mark(1, 1)],
+        ));
+        assert!(projection.marks.is_empty());
+
+        projection.set_visibility(true);
+        assert!(projection.record_refresh_attempt(RequestId(13)));
+        assert!(
+            !projection.settle_refresh_reply(
+                RequestId(12),
+                Some(MarkOverlayRefreshContext { generation: first_generation }),
+                vec![projected_mark(1, 1)],
+            ),
+            "the disabled generation's late reply cannot replace the projection"
+        );
+        assert_eq!(projection.pending_request, Some(RequestId(13)));
+        assert!(projection.marks.is_empty());
+
+        assert!(
+            !projection.settle_refresh_reply(RequestId(13), None, vec![projected_mark(2, 1)]),
+            "a matching reply with missing typed context is rejected"
+        );
+        assert_eq!(
+            projection.pending_request, None,
+            "a matching reply with missing context cannot wedge future refreshes"
+        );
+        assert!(projection.should_request_refresh());
     }
 }

--- a/crates/aether-kit/src/world/overlay.rs
+++ b/crates/aether-kit/src/world/overlay.rs
@@ -1,0 +1,374 @@
+#![allow(clippy::cast_precision_loss)]
+
+//! Pure terrain-anchored mark overlay geometry.
+
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+use core::f32::consts::TAU;
+
+use aether_capabilities::render::{DrawTriangle, Vertex};
+use aether_math::Rgb;
+
+use crate::mark::{Mark, MarkGeometry, MarkId, MarkRef};
+
+use super::{World, WorldPoint};
+
+/// Lift over the sampled top surface, preventing ground z-fighting.
+pub const MARK_OVERLAY_LIFT_METERS: f32 = 0.02;
+/// Ordinary point-marker radius.
+pub const MARK_POINT_RADIUS_METERS: f32 = 0.12;
+/// Ordinary path/area ribbon half-width.
+pub const MARK_PATH_HALF_WIDTH_METERS: f32 = 0.05;
+/// Selected path/area outline half-width.
+pub const MARK_SELECTED_HALF_WIDTH_METERS: f32 = 0.09;
+/// Selected vertex-handle radius.
+pub const MARK_SELECTED_HANDLE_RADIUS_METERS: f32 = 0.10;
+/// Stable ordinary overlay color.
+pub const MARK_OVERLAY_COLOR: Rgb = Rgb::from_srgb8(50, 220, 235);
+/// Stable selected overlay color.
+pub const MARK_SELECTED_COLOR: Rgb = Rgb::from_srgb8(255, 190, 48);
+
+const POINT_SEGMENTS: usize = 8;
+const OCTIMETERS_PER_METER: f32 = 256.0;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct GroundPointMeters {
+    x_meters: f32,
+    z_meters: f32,
+}
+
+impl From<WorldPoint> for GroundPointMeters {
+    fn from(point: WorldPoint) -> Self {
+        Self {
+            x_meters: point.x_octimeters as f32 / OCTIMETERS_PER_METER,
+            z_meters: point.z_octimeters as f32 / OCTIMETERS_PER_METER,
+        }
+    }
+}
+
+fn anchored_vertex(world: &World, point: GroundPointMeters, color: Rgb) -> Option<Vertex> {
+    let surface = world.terrain_surface_at(point.x_meters, point.z_meters)?;
+    Some(Vertex {
+        x: point.x_meters,
+        y: surface.height_meters + MARK_OVERLAY_LIFT_METERS,
+        z: point.z_meters,
+        color,
+    })
+}
+
+fn push_triangle(
+    world: &World,
+    triangles: &mut Vec<DrawTriangle>,
+    first: GroundPointMeters,
+    second: GroundPointMeters,
+    third: GroundPointMeters,
+    color: Rgb,
+) {
+    let Some(first) = anchored_vertex(world, first, color) else {
+        return;
+    };
+    let Some(second) = anchored_vertex(world, second, color) else {
+        return;
+    };
+    let Some(third) = anchored_vertex(world, third, color) else {
+        return;
+    };
+    triangles.push(DrawTriangle {
+        verts: [first, second, third],
+    });
+}
+
+fn disc_points(center: GroundPointMeters, radius_meters: f32) -> Vec<GroundPointMeters> {
+    (0..POINT_SEGMENTS)
+        .map(|index| {
+            let angle = index as f32 * TAU / POINT_SEGMENTS as f32;
+            GroundPointMeters {
+                x_meters: angle.cos().mul_add(radius_meters, center.x_meters),
+                z_meters: angle.sin().mul_add(radius_meters, center.z_meters),
+            }
+        })
+        .collect()
+}
+
+fn emit_disc(
+    world: &World,
+    triangles: &mut Vec<DrawTriangle>,
+    center: GroundPointMeters,
+    radius_meters: f32,
+    color: Rgb,
+) {
+    let ring = disc_points(center, radius_meters);
+    for index in 0..ring.len() {
+        push_triangle(
+            world,
+            triangles,
+            center,
+            ring[index],
+            ring[(index + 1) % ring.len()],
+            color,
+        );
+    }
+}
+
+fn emit_segment(
+    world: &World,
+    triangles: &mut Vec<DrawTriangle>,
+    start: GroundPointMeters,
+    end: GroundPointMeters,
+    half_width_meters: f32,
+    color: Rgb,
+) {
+    let delta_x = end.x_meters - start.x_meters;
+    let delta_z = end.z_meters - start.z_meters;
+    let length_squared = delta_x.mul_add(delta_x, delta_z * delta_z);
+    if !length_squared.is_finite() || length_squared == 0.0 {
+        return;
+    }
+    let scale = half_width_meters / length_squared.sqrt();
+    let offset_x = -delta_z * scale;
+    let offset_z = delta_x * scale;
+    let start_left = GroundPointMeters {
+        x_meters: start.x_meters + offset_x,
+        z_meters: start.z_meters + offset_z,
+    };
+    let start_right = GroundPointMeters {
+        x_meters: start.x_meters - offset_x,
+        z_meters: start.z_meters - offset_z,
+    };
+    let end_left = GroundPointMeters {
+        x_meters: end.x_meters + offset_x,
+        z_meters: end.z_meters + offset_z,
+    };
+    let end_right = GroundPointMeters {
+        x_meters: end.x_meters - offset_x,
+        z_meters: end.z_meters - offset_z,
+    };
+    push_triangle(world, triangles, start_left, start_right, end_left, color);
+    push_triangle(world, triangles, end_left, start_right, end_right, color);
+}
+
+fn emit_line(
+    world: &World,
+    triangles: &mut Vec<DrawTriangle>,
+    points: &[WorldPoint],
+    closed: bool,
+    selected: bool,
+) {
+    if points.len() < 2 {
+        return;
+    }
+    let color = if selected {
+        MARK_SELECTED_COLOR
+    } else {
+        MARK_OVERLAY_COLOR
+    };
+    let half_width_meters = if selected {
+        MARK_SELECTED_HALF_WIDTH_METERS
+    } else {
+        MARK_PATH_HALF_WIDTH_METERS
+    };
+    for pair in points.windows(2) {
+        emit_segment(
+            world,
+            triangles,
+            pair[0].into(),
+            pair[1].into(),
+            half_width_meters,
+            color,
+        );
+    }
+    if closed {
+        emit_segment(
+            world,
+            triangles,
+            points[points.len() - 1].into(),
+            points[0].into(),
+            half_width_meters,
+            color,
+        );
+    }
+    let join_radius = if selected {
+        MARK_SELECTED_HANDLE_RADIUS_METERS
+    } else {
+        MARK_PATH_HALF_WIDTH_METERS
+    };
+    for point in points {
+        emit_disc(world, triangles, (*point).into(), join_radius, color);
+    }
+}
+
+fn emit_mark(world: &World, triangles: &mut Vec<DrawTriangle>, mark: &Mark, selected: bool) {
+    match &mark.geometry {
+        MarkGeometry::Point(point) => emit_disc(
+            world,
+            triangles,
+            (*point).into(),
+            if selected {
+                MARK_SELECTED_HANDLE_RADIUS_METERS
+            } else {
+                MARK_POINT_RADIUS_METERS
+            },
+            if selected {
+                MARK_SELECTED_COLOR
+            } else {
+                MARK_OVERLAY_COLOR
+            },
+        ),
+        MarkGeometry::Path(points) => emit_line(world, triangles, points, false, selected),
+        MarkGeometry::Area(points) => emit_line(world, triangles, points, true, selected),
+    }
+}
+
+/// Generate one stable, terrain-anchored overlay batch from the latest
+/// authoritative `MarkBook` projection.
+pub(super) fn mark_overlay_triangles(
+    world: &World,
+    marks: &BTreeMap<MarkId, Mark>,
+    selected: Option<MarkRef>,
+) -> Vec<DrawTriangle> {
+    let mut triangles = Vec::new();
+    for mark in marks.values() {
+        emit_mark(
+            world,
+            &mut triangles,
+            mark,
+            selected.is_some_and(|reference| reference == mark.reference()),
+        );
+    }
+    triangles
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mark::MarkId;
+    use crate::world::{CellPos, Chunk, ChunkPos, Material};
+
+    fn flat_world(height_octimeters: i32) -> World {
+        let mut chunk = Chunk::empty_boxed();
+        chunk.underlay.fill(Material::Stone);
+        chunk.height.fill(height_octimeters);
+        let mut world = World::new();
+        world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
+        world
+    }
+
+    fn mark(id: u32, geometry: MarkGeometry) -> Mark {
+        Mark {
+            id: MarkId::new(id),
+            revision: 1,
+            geometry,
+            label: alloc::format!("mark-{id}"),
+        }
+    }
+
+    fn assert_finite(triangles: &[DrawTriangle]) {
+        assert!(!triangles.is_empty());
+        for vertex in triangles.iter().flat_map(|triangle| triangle.verts) {
+            assert!(vertex.x.is_finite());
+            assert!(vertex.y.is_finite());
+            assert!(vertex.z.is_finite());
+        }
+    }
+
+    #[test]
+    fn point_path_and_area_are_finite_and_area_closes() {
+        let world = flat_world(0);
+        let point = mark(1, MarkGeometry::Point(WorldPoint::new(512, 512)));
+        let path = mark(
+            2,
+            MarkGeometry::Path(vec![
+                WorldPoint::new(768, 512),
+                WorldPoint::new(1024, 512),
+                WorldPoint::new(1024, 512),
+                WorldPoint::new(1024, 768),
+            ]),
+        );
+        let area_points = vec![
+            WorldPoint::new(1280, 512),
+            WorldPoint::new(1536, 512),
+            WorldPoint::new(1536, 768),
+        ];
+        let open_area_path = mark(4, MarkGeometry::Path(area_points.clone()));
+        let area = mark(3, MarkGeometry::Area(area_points));
+
+        let point_triangles = {
+            let marks = BTreeMap::from([(point.id, point)]);
+            mark_overlay_triangles(&world, &marks, None)
+        };
+        assert_eq!(point_triangles.len(), POINT_SEGMENTS);
+        assert_finite(&point_triangles);
+
+        let path_triangles = {
+            let marks = BTreeMap::from([(path.id, path)]);
+            mark_overlay_triangles(&world, &marks, None)
+        };
+        assert_finite(&path_triangles);
+
+        let area_triangles = {
+            let marks = BTreeMap::from([(area.id, area)]);
+            mark_overlay_triangles(&world, &marks, None)
+        };
+        assert_finite(&area_triangles);
+        let open_area_triangles = {
+            let marks = BTreeMap::from([(open_area_path.id, open_area_path)]);
+            mark_overlay_triangles(&world, &marks, None)
+        };
+        assert_eq!(
+            area_triangles.len(),
+            open_area_triangles.len() + 2,
+            "the area adds exactly one two-triangle closing segment"
+        );
+    }
+
+    #[test]
+    fn vertices_reanchor_and_selected_marks_use_wider_named_style() {
+        let world = flat_world(256);
+        let selected_mark = mark(
+            7,
+            MarkGeometry::Path(vec![WorldPoint::new(512, 512), WorldPoint::new(1024, 512)]),
+        );
+        let reference = selected_mark.reference();
+        let marks = BTreeMap::from([(selected_mark.id, selected_mark)]);
+        let ordinary = mark_overlay_triangles(&world, &marks, None);
+        let selected = mark_overlay_triangles(&world, &marks, Some(reference));
+        assert!(selected.len() >= ordinary.len());
+        assert!(
+            ordinary
+                .iter()
+                .flat_map(|triangle| triangle.verts)
+                .all(|vertex| (vertex.y - 1.02).abs() < 0.0001)
+        );
+        assert!(
+            ordinary
+                .iter()
+                .flat_map(|triangle| triangle.verts)
+                .all(|vertex| vertex.color == MARK_OVERLAY_COLOR)
+        );
+        assert!(
+            selected
+                .iter()
+                .flat_map(|triangle| triangle.verts)
+                .all(|vertex| vertex.color == MARK_SELECTED_COLOR)
+        );
+    }
+
+    #[test]
+    fn geometry_over_void_is_omitted() {
+        let marks = BTreeMap::from([(
+            MarkId::new(1),
+            mark(1, MarkGeometry::Point(WorldPoint::new(128, 128))),
+        )]);
+        assert!(mark_overlay_triangles(&World::new(), &marks, None).is_empty());
+
+        let world = flat_world(0);
+        assert!(
+            world
+                .terrain_surface_at(
+                    CellPos { x: 0, z: 0 }.x as f32 + 0.5,
+                    CellPos { x: 0, z: 0 }.z as f32 + 0.5,
+                )
+                .is_some()
+        );
+    }
+}

--- a/crates/aether-kit/src/world/overlay.rs
+++ b/crates/aether-kit/src/world/overlay.rs
@@ -11,7 +11,7 @@ use aether_math::Rgb;
 
 use crate::mark::{Mark, MarkGeometry, MarkId, MarkRef};
 
-use super::{World, WorldPoint};
+use super::{MAX_STAMP_VERTICES, World, WorldPoint};
 
 /// Lift over the sampled top surface, preventing ground z-fighting.
 pub const MARK_OVERLAY_LIFT_METERS: f32 = 0.02;
@@ -30,6 +30,42 @@ pub const MARK_SELECTED_COLOR: Rgb = Rgb::from_srgb8(255, 190, 48);
 
 const POINT_SEGMENTS: usize = 8;
 const OCTIMETERS_PER_METER: f32 = 256.0;
+/// Whole-frame cap that still admits one maximum-size selected area mark.
+pub const MAX_MARK_OVERLAY_TRIANGLES: usize = MAX_STAMP_VERTICES * (POINT_SEGMENTS + 2);
+/// Vertex companion to [`MAX_MARK_OVERLAY_TRIANGLES`].
+pub const MAX_MARK_OVERLAY_VERTICES: usize = MAX_MARK_OVERLAY_TRIANGLES * 3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct MarkOverlayOverflow {
+    pub(super) first_omitted_mark: MarkId,
+    pub(super) emitted_triangles: usize,
+    pub(super) emitted_vertices: usize,
+}
+
+pub(super) struct MarkOverlayBatch {
+    pub(super) triangles: Vec<DrawTriangle>,
+    pub(super) overflow: Option<MarkOverlayOverflow>,
+}
+
+struct OverlayBuilder {
+    triangles: Vec<DrawTriangle>,
+}
+
+impl OverlayBuilder {
+    fn push(&mut self, triangle: DrawTriangle) -> bool {
+        let Some(next_triangles) = self.triangles.len().checked_add(1) else {
+            return false;
+        };
+        let Some(next_vertices) = next_triangles.checked_mul(3) else {
+            return false;
+        };
+        if next_triangles > MAX_MARK_OVERLAY_TRIANGLES || next_vertices > MAX_MARK_OVERLAY_VERTICES {
+            return false;
+        }
+        self.triangles.push(triangle);
+        true
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct GroundPointMeters {
@@ -48,34 +84,27 @@ impl From<WorldPoint> for GroundPointMeters {
 
 fn anchored_vertex(world: &World, point: GroundPointMeters, color: Rgb) -> Option<Vertex> {
     let surface = world.terrain_surface_at(point.x_meters, point.z_meters)?;
-    Some(Vertex {
-        x: point.x_meters,
-        y: surface.height_meters + MARK_OVERLAY_LIFT_METERS,
-        z: point.z_meters,
-        color,
-    })
+    Some(Vertex { x: point.x_meters, y: surface.height_meters + MARK_OVERLAY_LIFT_METERS, z: point.z_meters, color })
 }
 
 fn push_triangle(
     world: &World,
-    triangles: &mut Vec<DrawTriangle>,
+    builder: &mut OverlayBuilder,
     first: GroundPointMeters,
     second: GroundPointMeters,
     third: GroundPointMeters,
     color: Rgb,
-) {
+) -> bool {
     let Some(first) = anchored_vertex(world, first, color) else {
-        return;
+        return true;
     };
     let Some(second) = anchored_vertex(world, second, color) else {
-        return;
+        return true;
     };
     let Some(third) = anchored_vertex(world, third, color) else {
-        return;
+        return true;
     };
-    triangles.push(DrawTriangle {
-        verts: [first, second, third],
-    });
+    builder.push(DrawTriangle { verts: [first, second, third] })
 }
 
 fn disc_points(center: GroundPointMeters, radius_meters: f32) -> Vec<GroundPointMeters> {
@@ -92,150 +121,104 @@ fn disc_points(center: GroundPointMeters, radius_meters: f32) -> Vec<GroundPoint
 
 fn emit_disc(
     world: &World,
-    triangles: &mut Vec<DrawTriangle>,
+    builder: &mut OverlayBuilder,
     center: GroundPointMeters,
     radius_meters: f32,
     color: Rgb,
-) {
+) -> bool {
     let ring = disc_points(center, radius_meters);
     for index in 0..ring.len() {
-        push_triangle(
-            world,
-            triangles,
-            center,
-            ring[index],
-            ring[(index + 1) % ring.len()],
-            color,
-        );
+        if !push_triangle(world, builder, center, ring[index], ring[(index + 1) % ring.len()], color) {
+            return false;
+        }
     }
+    true
 }
 
 fn emit_segment(
     world: &World,
-    triangles: &mut Vec<DrawTriangle>,
+    builder: &mut OverlayBuilder,
     start: GroundPointMeters,
     end: GroundPointMeters,
     half_width_meters: f32,
     color: Rgb,
-) {
+) -> bool {
     let delta_x = end.x_meters - start.x_meters;
     let delta_z = end.z_meters - start.z_meters;
     let length_squared = delta_x.mul_add(delta_x, delta_z * delta_z);
     if !length_squared.is_finite() || length_squared == 0.0 {
-        return;
+        return true;
     }
     let scale = half_width_meters / length_squared.sqrt();
     let offset_x = -delta_z * scale;
     let offset_z = delta_x * scale;
-    let start_left = GroundPointMeters {
-        x_meters: start.x_meters + offset_x,
-        z_meters: start.z_meters + offset_z,
-    };
-    let start_right = GroundPointMeters {
-        x_meters: start.x_meters - offset_x,
-        z_meters: start.z_meters - offset_z,
-    };
-    let end_left = GroundPointMeters {
-        x_meters: end.x_meters + offset_x,
-        z_meters: end.z_meters + offset_z,
-    };
-    let end_right = GroundPointMeters {
-        x_meters: end.x_meters - offset_x,
-        z_meters: end.z_meters - offset_z,
-    };
-    push_triangle(world, triangles, start_left, start_right, end_left, color);
-    push_triangle(world, triangles, end_left, start_right, end_right, color);
+    let start_left = GroundPointMeters { x_meters: start.x_meters + offset_x, z_meters: start.z_meters + offset_z };
+    let start_right = GroundPointMeters { x_meters: start.x_meters - offset_x, z_meters: start.z_meters - offset_z };
+    let end_left = GroundPointMeters { x_meters: end.x_meters + offset_x, z_meters: end.z_meters + offset_z };
+    let end_right = GroundPointMeters { x_meters: end.x_meters - offset_x, z_meters: end.z_meters - offset_z };
+    push_triangle(world, builder, start_left, start_right, end_left, color)
+        && push_triangle(world, builder, end_left, start_right, end_right, color)
 }
 
-fn emit_line(
-    world: &World,
-    triangles: &mut Vec<DrawTriangle>,
-    points: &[WorldPoint],
-    closed: bool,
-    selected: bool,
-) {
+fn emit_line(world: &World, builder: &mut OverlayBuilder, points: &[WorldPoint], closed: bool, selected: bool) -> bool {
     if points.len() < 2 {
-        return;
+        return true;
     }
-    let color = if selected {
-        MARK_SELECTED_COLOR
-    } else {
-        MARK_OVERLAY_COLOR
-    };
-    let half_width_meters = if selected {
-        MARK_SELECTED_HALF_WIDTH_METERS
-    } else {
-        MARK_PATH_HALF_WIDTH_METERS
-    };
+    let color = if selected { MARK_SELECTED_COLOR } else { MARK_OVERLAY_COLOR };
+    let half_width_meters = if selected { MARK_SELECTED_HALF_WIDTH_METERS } else { MARK_PATH_HALF_WIDTH_METERS };
     for pair in points.windows(2) {
-        emit_segment(
-            world,
-            triangles,
-            pair[0].into(),
-            pair[1].into(),
-            half_width_meters,
-            color,
-        );
+        if !emit_segment(world, builder, pair[0].into(), pair[1].into(), half_width_meters, color) {
+            return false;
+        }
     }
-    if closed {
-        emit_segment(
-            world,
-            triangles,
-            points[points.len() - 1].into(),
-            points[0].into(),
-            half_width_meters,
-            color,
-        );
+    if closed
+        && !emit_segment(world, builder, points[points.len() - 1].into(), points[0].into(), half_width_meters, color)
+    {
+        return false;
     }
-    let join_radius = if selected {
-        MARK_SELECTED_HANDLE_RADIUS_METERS
-    } else {
-        MARK_PATH_HALF_WIDTH_METERS
-    };
+    let join_radius = if selected { MARK_SELECTED_HANDLE_RADIUS_METERS } else { MARK_PATH_HALF_WIDTH_METERS };
     for point in points {
-        emit_disc(world, triangles, (*point).into(), join_radius, color);
+        if !emit_disc(world, builder, (*point).into(), join_radius, color) {
+            return false;
+        }
     }
+    true
 }
 
-fn emit_mark(world: &World, triangles: &mut Vec<DrawTriangle>, mark: &Mark, selected: bool) {
+fn emit_mark(world: &World, builder: &mut OverlayBuilder, mark: &Mark, selected: bool) -> bool {
     match &mark.geometry {
         MarkGeometry::Point(point) => emit_disc(
             world,
-            triangles,
+            builder,
             (*point).into(),
-            if selected {
-                MARK_SELECTED_HANDLE_RADIUS_METERS
-            } else {
-                MARK_POINT_RADIUS_METERS
-            },
-            if selected {
-                MARK_SELECTED_COLOR
-            } else {
-                MARK_OVERLAY_COLOR
-            },
+            if selected { MARK_SELECTED_HANDLE_RADIUS_METERS } else { MARK_POINT_RADIUS_METERS },
+            if selected { MARK_SELECTED_COLOR } else { MARK_OVERLAY_COLOR },
         ),
-        MarkGeometry::Path(points) => emit_line(world, triangles, points, false, selected),
-        MarkGeometry::Area(points) => emit_line(world, triangles, points, true, selected),
+        MarkGeometry::Path(points) => emit_line(world, builder, points, false, selected),
+        MarkGeometry::Area(points) => emit_line(world, builder, points, true, selected),
     }
 }
 
 /// Generate one stable, terrain-anchored overlay batch from the latest
 /// authoritative `MarkBook` projection.
-pub(super) fn mark_overlay_triangles(
+pub(super) fn mark_overlay_batch(
     world: &World,
     marks: &BTreeMap<MarkId, Mark>,
     selected: Option<MarkRef>,
-) -> Vec<DrawTriangle> {
-    let mut triangles = Vec::new();
+) -> MarkOverlayBatch {
+    let mut builder = OverlayBuilder { triangles: Vec::new() };
+    let mut overflow = None;
     for mark in marks.values() {
-        emit_mark(
-            world,
-            &mut triangles,
-            mark,
-            selected.is_some_and(|reference| reference == mark.reference()),
-        );
+        if !emit_mark(world, &mut builder, mark, selected.is_some_and(|reference| reference == mark.reference())) {
+            overflow = Some(MarkOverlayOverflow {
+                first_omitted_mark: mark.id,
+                emitted_triangles: builder.triangles.len(),
+                emitted_vertices: builder.triangles.len() * 3,
+            });
+            break;
+        }
     }
-    triangles
+    MarkOverlayBatch { triangles: builder.triangles, overflow }
 }
 
 #[cfg(test)]
@@ -254,12 +237,7 @@ mod tests {
     }
 
     fn mark(id: u32, geometry: MarkGeometry) -> Mark {
-        Mark {
-            id: MarkId::new(id),
-            revision: 1,
-            geometry,
-            label: alloc::format!("mark-{id}"),
-        }
+        Mark { id: MarkId::new(id), revision: 1, geometry, label: alloc::format!("mark-{id}") }
     }
 
     fn assert_finite(triangles: &[DrawTriangle]) {
@@ -284,35 +262,31 @@ mod tests {
                 WorldPoint::new(1024, 768),
             ]),
         );
-        let area_points = vec![
-            WorldPoint::new(1280, 512),
-            WorldPoint::new(1536, 512),
-            WorldPoint::new(1536, 768),
-        ];
+        let area_points = vec![WorldPoint::new(1280, 512), WorldPoint::new(1536, 512), WorldPoint::new(1536, 768)];
         let open_area_path = mark(4, MarkGeometry::Path(area_points.clone()));
         let area = mark(3, MarkGeometry::Area(area_points));
 
         let point_triangles = {
             let marks = BTreeMap::from([(point.id, point)]);
-            mark_overlay_triangles(&world, &marks, None)
+            mark_overlay_batch(&world, &marks, None).triangles
         };
         assert_eq!(point_triangles.len(), POINT_SEGMENTS);
         assert_finite(&point_triangles);
 
         let path_triangles = {
             let marks = BTreeMap::from([(path.id, path)]);
-            mark_overlay_triangles(&world, &marks, None)
+            mark_overlay_batch(&world, &marks, None).triangles
         };
         assert_finite(&path_triangles);
 
         let area_triangles = {
             let marks = BTreeMap::from([(area.id, area)]);
-            mark_overlay_triangles(&world, &marks, None)
+            mark_overlay_batch(&world, &marks, None).triangles
         };
         assert_finite(&area_triangles);
         let open_area_triangles = {
             let marks = BTreeMap::from([(open_area_path.id, open_area_path)]);
-            mark_overlay_triangles(&world, &marks, None)
+            mark_overlay_batch(&world, &marks, None).triangles
         };
         assert_eq!(
             area_triangles.len(),
@@ -323,52 +297,76 @@ mod tests {
 
     #[test]
     fn vertices_reanchor_and_selected_marks_use_wider_named_style() {
-        let world = flat_world(256);
-        let selected_mark = mark(
-            7,
-            MarkGeometry::Path(vec![WorldPoint::new(512, 512), WorldPoint::new(1024, 512)]),
-        );
+        let mut world = flat_world(0);
+        let selected_mark = mark(7, MarkGeometry::Path(vec![WorldPoint::new(512, 512), WorldPoint::new(1024, 512)]));
         let reference = selected_mark.reference();
         let marks = BTreeMap::from([(selected_mark.id, selected_mark)]);
-        let ordinary = mark_overlay_triangles(&world, &marks, None);
-        let selected = mark_overlay_triangles(&world, &marks, Some(reference));
+        let before_edit = mark_overlay_batch(&world, &marks, None).triangles;
+
+        let mut raised_chunk = Chunk::empty_boxed();
+        raised_chunk.underlay.fill(Material::Stone);
+        raised_chunk.height.fill(256);
+        world.insert_chunk(ChunkPos { x: 0, z: 0 }, raised_chunk);
+        let ordinary = mark_overlay_batch(&world, &marks, None).triangles;
+        let selected = mark_overlay_batch(&world, &marks, Some(reference)).triangles;
         assert!(selected.len() >= ordinary.len());
         assert!(
-            ordinary
+            before_edit
                 .iter()
                 .flat_map(|triangle| triangle.verts)
-                .all(|vertex| (vertex.y - 1.02).abs() < 0.0001)
+                .all(|vertex| (vertex.y - MARK_OVERLAY_LIFT_METERS).abs() < 0.0001)
         );
-        assert!(
-            ordinary
-                .iter()
-                .flat_map(|triangle| triangle.verts)
-                .all(|vertex| vertex.color == MARK_OVERLAY_COLOR)
-        );
-        assert!(
-            selected
-                .iter()
-                .flat_map(|triangle| triangle.verts)
-                .all(|vertex| vertex.color == MARK_SELECTED_COLOR)
-        );
+        assert!(ordinary.iter().flat_map(|triangle| triangle.verts).all(|vertex| (vertex.y - 1.02).abs() < 0.0001));
+        assert!(ordinary.iter().flat_map(|triangle| triangle.verts).all(|vertex| vertex.color == MARK_OVERLAY_COLOR));
+        assert!(selected.iter().flat_map(|triangle| triangle.verts).all(|vertex| vertex.color == MARK_SELECTED_COLOR));
     }
 
     #[test]
     fn geometry_over_void_is_omitted() {
-        let marks = BTreeMap::from([(
-            MarkId::new(1),
-            mark(1, MarkGeometry::Point(WorldPoint::new(128, 128))),
-        )]);
-        assert!(mark_overlay_triangles(&World::new(), &marks, None).is_empty());
+        let marks = BTreeMap::from([(MarkId::new(1), mark(1, MarkGeometry::Point(WorldPoint::new(128, 128))))]);
+        assert!(mark_overlay_batch(&World::new(), &marks, None).triangles.is_empty());
 
         let world = flat_world(0);
         assert!(
             world
-                .terrain_surface_at(
-                    CellPos { x: 0, z: 0 }.x as f32 + 0.5,
-                    CellPos { x: 0, z: 0 }.z as f32 + 0.5,
-                )
+                .terrain_surface_at(CellPos { x: 0, z: 0 }.x as f32 + 0.5, CellPos { x: 0, z: 0 }.z as f32 + 0.5,)
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn maximum_path_fits_and_many_marks_report_the_whole_frame_budget() {
+        let world = flat_world(0);
+        let points = (0..MAX_STAMP_VERTICES)
+            .map(|index| {
+                let column = i32::try_from(index % 256).expect("bounded path column");
+                let row = i32::try_from(index / 256).expect("bounded path row");
+                WorldPoint::new(256 + column * 4, 256 + row * 64)
+            })
+            .collect();
+        let maximum_path = mark(1, MarkGeometry::Path(points));
+        let maximum_batch = mark_overlay_batch(&world, &BTreeMap::from([(maximum_path.id, maximum_path)]), None);
+        assert_eq!(maximum_batch.triangles.len(), 2 * (MAX_STAMP_VERTICES - 1) + POINT_SEGMENTS * MAX_STAMP_VERTICES,);
+        assert_eq!(maximum_batch.overflow, None);
+
+        let mark_count = MAX_MARK_OVERLAY_TRIANGLES / POINT_SEGMENTS + 1;
+        let marks = (0..mark_count)
+            .map(|index| {
+                let id = u32::try_from(index + 1).expect("bounded mark id");
+                let mark = mark(id, MarkGeometry::Point(WorldPoint::new(512, 512)));
+                (mark.id, mark)
+            })
+            .collect();
+        let overflowed = mark_overlay_batch(&world, &marks, None);
+        assert_eq!(overflowed.triangles.len(), MAX_MARK_OVERLAY_TRIANGLES);
+        assert_eq!(overflowed.triangles.len() * 3, MAX_MARK_OVERLAY_VERTICES);
+        assert_eq!(
+            overflowed.overflow,
+            Some(MarkOverlayOverflow {
+                first_omitted_mark: MarkId::new(u32::try_from(mark_count).expect("bounded omitted mark id")),
+                emitted_triangles: MAX_MARK_OVERLAY_TRIANGLES,
+                emitted_vertices: MAX_MARK_OVERLAY_VERTICES,
+            })
         );
     }
 }

--- a/crates/aether-kit/src/world/pick.rs
+++ b/crates/aether-kit/src/world/pick.rs
@@ -1,15 +1,18 @@
 //! Bounded terrain top-surface intersection.
 
 use super::{
-    PickTerrainResult, TerrainPickError, TerrainRay, TerrainSurface, TerrainSurfaceHit, World,
-    WorldDirection, WorldPositionMeters,
+    PickTerrainResult, TerrainPickError, TerrainRay, TerrainSurface, TerrainSurfaceHit, World, WorldDirection,
+    WorldPositionMeters,
 };
 
 /// Furthest terrain pick accepted from a caller.
 pub const MAX_TERRAIN_PICK_DISTANCE_METERS: f32 = 512.0;
 /// March at one authored height/material subcell per step.
-pub const TERRAIN_PICK_STEP_METERS: f32 = 0.0625;
-const _: () = assert!(super::SUBCELLS_PER_CELL_EDGE == 16);
+#[allow(clippy::cast_precision_loss)] // the shared resolution is the exactly-representable value 16
+pub const TERRAIN_PICK_STEP_METERS: f32 = 1.0 / super::SUBCELLS_PER_CELL_EDGE as f32;
+/// Height residual both sides of a refined crossing must converge within.
+#[allow(clippy::cast_precision_loss)] // the shared resolution is the exactly-representable value 16
+pub const TERRAIN_PICK_EPSILON_METERS: f32 = TERRAIN_PICK_STEP_METERS / super::SUBCELLS_PER_CELL_EDGE as f32;
 /// Fixed bisection work after the first above-to-surface crossing.
 pub const TERRAIN_PICK_REFINEMENT_STEPS: u32 = 12;
 
@@ -50,10 +53,7 @@ impl SurfaceSample {
 fn normalized(direction: WorldDirection) -> Result<NormalizedDirection, TerrainPickError> {
     let magnitude_squared = direction.x_unitless.mul_add(
         direction.x_unitless,
-        direction.y_unitless.mul_add(
-            direction.y_unitless,
-            direction.z_unitless * direction.z_unitless,
-        ),
+        direction.y_unitless.mul_add(direction.y_unitless, direction.z_unitless * direction.z_unitless),
     );
     if !magnitude_squared.is_finite() {
         return Err(TerrainPickError::NonFiniteRay);
@@ -79,36 +79,31 @@ fn sample(
     let ray_y_meters = direction.y.mul_add(distance_meters, ray.origin.y_meters);
     let z_meters = direction.z.mul_add(distance_meters, ray.origin.z_meters);
     let surface = world.terrain_surface_at(x_meters, z_meters)?;
-    Some(SurfaceSample {
-        distance_meters,
-        x_meters,
-        ray_y_meters,
-        z_meters,
-        surface,
-    })
+    Some(SurfaceSample { distance_meters, x_meters, ray_y_meters, z_meters, surface })
 }
 
 fn refine_crossing(
     world: &World,
     ray: TerrainRay,
     direction: NormalizedDirection,
-    mut above_distance_meters: f32,
-    mut below_distance_meters: f32,
-) -> TerrainSurfaceHit {
+    mut above: SurfaceSample,
+    mut below: SurfaceSample,
+) -> Option<TerrainSurfaceHit> {
     for _ in 0..TERRAIN_PICK_REFINEMENT_STEPS {
-        let middle_distance_meters = (above_distance_meters + below_distance_meters) * 0.5;
-        match sample(world, ray, direction, middle_distance_meters) {
-            Some(middle) if middle.height_delta_meters() <= 0.0 => {
-                below_distance_meters = middle_distance_meters;
-            }
-            _ => {
-                above_distance_meters = middle_distance_meters;
-            }
+        let middle_distance_meters = (above.distance_meters + below.distance_meters) * 0.5;
+        let middle = sample(world, ray, direction, middle_distance_meters)?;
+        if middle.height_delta_meters() <= 0.0 {
+            below = middle;
+        } else {
+            above = middle;
         }
     }
-    sample(world, ray, direction, below_distance_meters)
-        .expect("the lower crossing bracket remains a present terrain sample")
-        .into_hit()
+    let above_error = above.height_delta_meters().abs();
+    let below_error = below.height_delta_meters().abs();
+    if above_error > TERRAIN_PICK_EPSILON_METERS || below_error > TERRAIN_PICK_EPSILON_METERS {
+        return None;
+    }
+    Some(if above_error < below_error { above.into_hit() } else { below.into_hit() })
 }
 
 /// Intersect a validated, bounded world ray with the first markable terrain
@@ -124,15 +119,10 @@ pub(super) fn pick_terrain(world: &World, ray: TerrainRay) -> PickTerrainResult 
         ray.max_distance_meters,
     ];
     if values.iter().any(|value| !value.is_finite()) {
-        return PickTerrainResult::Rejected {
-            error: TerrainPickError::NonFiniteRay,
-        };
+        return PickTerrainResult::Rejected { error: TerrainPickError::NonFiniteRay };
     }
-    if ray.max_distance_meters <= 0.0 || ray.max_distance_meters > MAX_TERRAIN_PICK_DISTANCE_METERS
-    {
-        return PickTerrainResult::Rejected {
-            error: TerrainPickError::InvalidMaxDistance,
-        };
+    if ray.max_distance_meters <= 0.0 || ray.max_distance_meters > MAX_TERRAIN_PICK_DISTANCE_METERS {
+        return PickTerrainResult::Rejected { error: TerrainPickError::InvalidMaxDistance };
     }
     let direction = match normalized(ray.direction) {
         Ok(direction) => direction,
@@ -144,19 +134,12 @@ pub(super) fn pick_terrain(world: &World, ray: TerrainRay) -> PickTerrainResult 
     loop {
         match sample(world, ray, direction, distance_meters) {
             Some(current) if current.height_delta_meters() <= 0.0 => {
-                let hit = previous_above.map_or_else(
-                    || current.into_hit(),
-                    |above| {
-                        refine_crossing(
-                            world,
-                            ray,
-                            direction,
-                            above.distance_meters,
-                            current.distance_meters,
-                        )
-                    },
-                );
-                return PickTerrainResult::Hit { hit };
+                if let Some(above) = previous_above
+                    && let Some(hit) = refine_crossing(world, ray, direction, above, current)
+                {
+                    return PickTerrainResult::Hit { hit };
+                }
+                previous_above = None;
             }
             Some(current) => previous_above = Some(current),
             None => previous_above = None,
@@ -186,16 +169,8 @@ mod tests {
 
     fn downward_ray(x_meters: f32, z_meters: f32, max_distance_meters: f32) -> TerrainRay {
         TerrainRay {
-            origin: WorldPositionMeters {
-                x_meters,
-                y_meters: 5.0,
-                z_meters,
-            },
-            direction: WorldDirection {
-                x_unitless: 0.0,
-                y_unitless: -2.0,
-                z_unitless: 0.0,
-            },
+            origin: WorldPositionMeters { x_meters, y_meters: 5.0, z_meters },
+            direction: WorldDirection { x_unitless: 0.0, y_unitless: -2.0, z_unitless: 0.0 },
             max_distance_meters,
         }
     }
@@ -213,47 +188,51 @@ mod tests {
         let raised_hit = hit(pick_terrain(&raised, downward_ray(0.5, 0.5, 10.0)));
         assert!((raised_hit.position.y_meters - 1.0).abs() < 0.001);
         assert!((raised_hit.ray_distance_meters - 4.0).abs() < TERRAIN_PICK_STEP_METERS);
-        assert_eq!(
-            raised_hit.surface.mark_point,
-            super::super::WorldPoint::new(128, 128)
-        );
+        assert_eq!(raised_hit.surface.mark_point, super::super::WorldPoint::new(128, 128));
 
         let negative = world_with_surface(CellPos { x: -1, z: -1 }, Material::Grass, 128);
         let negative_hit = hit(pick_terrain(&negative, downward_ray(-0.5, -0.5, 10.0)));
         assert_eq!(negative_hit.surface.cell, CellPos { x: -1, z: -1 });
-        assert_eq!(
-            negative_hit.surface.mark_point,
-            super::super::WorldPoint::new(-128, -128)
-        );
+        assert_eq!(negative_hit.surface.mark_point, super::super::WorldPoint::new(-128, -128));
         assert!((negative_hit.position.y_meters - 0.5).abs() < 0.001);
     }
 
     #[test]
     fn water_hits_its_plane_and_void_or_short_rays_miss() {
         let mut water = world_with_surface(CellPos { x: 0, z: 0 }, Material::Water, -256);
-        water.insert_water_plane(
-            1,
-            WaterPlane {
-                level_octimeters: 512,
-            },
-        );
-        let mut chunk = water
-            .chunk(ChunkPos { x: 0, z: 0 })
-            .expect("water chunk")
-            .clone();
+        water.insert_water_plane(1, WaterPlane { level_octimeters: 512 });
+        let mut chunk = water.chunk(ChunkPos { x: 0, z: 0 }).expect("water chunk").clone();
         chunk.water_plane[0] = 1;
         water.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
         let water_hit = hit(pick_terrain(&water, downward_ray(0.5, 0.5, 10.0)));
         assert!((water_hit.position.y_meters - 2.0).abs() < 0.001);
 
-        assert_eq!(
-            pick_terrain(&World::new(), downward_ray(0.5, 0.5, 10.0)),
-            PickTerrainResult::Miss
-        );
-        assert_eq!(
-            pick_terrain(&water, downward_ray(0.5, 0.5, 1.0)),
-            PickTerrainResult::Miss
-        );
+        assert_eq!(pick_terrain(&World::new(), downward_ray(0.5, 0.5, 10.0)), PickTerrainResult::Miss);
+        assert_eq!(pick_terrain(&water, downward_ray(0.5, 0.5, 1.0)), PickTerrainResult::Miss);
+    }
+
+    #[test]
+    fn horizontal_rays_do_not_turn_side_entry_or_a_cliff_step_into_top_hits() {
+        let raised = world_with_surface(CellPos { x: 0, z: 0 }, Material::Stone, 256);
+        let side_entry = TerrainRay {
+            origin: WorldPositionMeters { x_meters: -0.5, y_meters: 0.5, z_meters: 0.5 },
+            direction: WorldDirection { x_unitless: 1.0, y_unitless: 0.0, z_unitless: 0.0 },
+            max_distance_meters: 2.0,
+        };
+        assert_eq!(pick_terrain(&raised, side_entry), PickTerrainResult::Miss);
+
+        let mut cliff = World::new();
+        let mut chunk = Chunk::empty_boxed();
+        chunk.underlay[CellPos { x: 0, z: 0 }.chunk_index()] = Material::Stone;
+        chunk.underlay[CellPos { x: 1, z: 0 }.chunk_index()] = Material::Stone;
+        chunk.height[CellPos { x: 1, z: 0 }.chunk_index()] = 256;
+        cliff.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
+        let cliff_step = TerrainRay {
+            origin: WorldPositionMeters { x_meters: 0.5, y_meters: 0.5, z_meters: 0.5 },
+            direction: side_entry.direction,
+            max_distance_meters: 1.5,
+        };
+        assert_eq!(pick_terrain(&cliff, cliff_step), PickTerrainResult::Miss);
     }
 
     #[test]
@@ -261,39 +240,21 @@ mod tests {
         let world = World::new();
         let mut ray = downward_ray(0.0, 0.0, 1.0);
         ray.origin.x_meters = f32::NAN;
-        assert_eq!(
-            pick_terrain(&world, ray),
-            PickTerrainResult::Rejected {
-                error: TerrainPickError::NonFiniteRay,
-            }
-        );
+        assert_eq!(pick_terrain(&world, ray), PickTerrainResult::Rejected { error: TerrainPickError::NonFiniteRay });
 
         let mut ray = downward_ray(0.0, 0.0, 1.0);
-        ray.direction = WorldDirection {
-            x_unitless: 0.0,
-            y_unitless: 0.0,
-            z_unitless: 0.0,
-        };
-        assert_eq!(
-            pick_terrain(&world, ray),
-            PickTerrainResult::Rejected {
-                error: TerrainPickError::ZeroDirection,
-            }
-        );
+        ray.direction = WorldDirection { x_unitless: 0.0, y_unitless: 0.0, z_unitless: 0.0 };
+        assert_eq!(pick_terrain(&world, ray), PickTerrainResult::Rejected { error: TerrainPickError::ZeroDirection });
 
         let mut ray = downward_ray(0.0, 0.0, 0.0);
         assert_eq!(
             pick_terrain(&world, ray),
-            PickTerrainResult::Rejected {
-                error: TerrainPickError::InvalidMaxDistance,
-            }
+            PickTerrainResult::Rejected { error: TerrainPickError::InvalidMaxDistance }
         );
         ray.max_distance_meters = MAX_TERRAIN_PICK_DISTANCE_METERS + 1.0;
         assert_eq!(
             pick_terrain(&world, ray),
-            PickTerrainResult::Rejected {
-                error: TerrainPickError::InvalidMaxDistance,
-            }
+            PickTerrainResult::Rejected { error: TerrainPickError::InvalidMaxDistance }
         );
     }
 }

--- a/crates/aether-kit/src/world/pick.rs
+++ b/crates/aether-kit/src/world/pick.rs
@@ -1,0 +1,299 @@
+//! Bounded terrain top-surface intersection.
+
+use super::{
+    PickTerrainResult, TerrainPickError, TerrainRay, TerrainSurface, TerrainSurfaceHit, World,
+    WorldDirection, WorldPositionMeters,
+};
+
+/// Furthest terrain pick accepted from a caller.
+pub const MAX_TERRAIN_PICK_DISTANCE_METERS: f32 = 512.0;
+/// March at one authored height/material subcell per step.
+pub const TERRAIN_PICK_STEP_METERS: f32 = 0.0625;
+const _: () = assert!(super::SUBCELLS_PER_CELL_EDGE == 16);
+/// Fixed bisection work after the first above-to-surface crossing.
+pub const TERRAIN_PICK_REFINEMENT_STEPS: u32 = 12;
+
+#[derive(Clone, Copy)]
+struct NormalizedDirection {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+#[derive(Clone, Copy)]
+struct SurfaceSample {
+    distance_meters: f32,
+    x_meters: f32,
+    ray_y_meters: f32,
+    z_meters: f32,
+    surface: TerrainSurface,
+}
+
+impl SurfaceSample {
+    fn height_delta_meters(self) -> f32 {
+        self.ray_y_meters - self.surface.height_meters
+    }
+
+    fn into_hit(self) -> TerrainSurfaceHit {
+        TerrainSurfaceHit {
+            position: WorldPositionMeters {
+                x_meters: self.x_meters,
+                y_meters: self.surface.height_meters,
+                z_meters: self.z_meters,
+            },
+            surface: self.surface,
+            ray_distance_meters: self.distance_meters,
+        }
+    }
+}
+
+fn normalized(direction: WorldDirection) -> Result<NormalizedDirection, TerrainPickError> {
+    let magnitude_squared = direction.x_unitless.mul_add(
+        direction.x_unitless,
+        direction.y_unitless.mul_add(
+            direction.y_unitless,
+            direction.z_unitless * direction.z_unitless,
+        ),
+    );
+    if !magnitude_squared.is_finite() {
+        return Err(TerrainPickError::NonFiniteRay);
+    }
+    if magnitude_squared == 0.0 {
+        return Err(TerrainPickError::ZeroDirection);
+    }
+    let inverse_magnitude = magnitude_squared.sqrt().recip();
+    Ok(NormalizedDirection {
+        x: direction.x_unitless * inverse_magnitude,
+        y: direction.y_unitless * inverse_magnitude,
+        z: direction.z_unitless * inverse_magnitude,
+    })
+}
+
+fn sample(
+    world: &World,
+    ray: TerrainRay,
+    direction: NormalizedDirection,
+    distance_meters: f32,
+) -> Option<SurfaceSample> {
+    let x_meters = direction.x.mul_add(distance_meters, ray.origin.x_meters);
+    let ray_y_meters = direction.y.mul_add(distance_meters, ray.origin.y_meters);
+    let z_meters = direction.z.mul_add(distance_meters, ray.origin.z_meters);
+    let surface = world.terrain_surface_at(x_meters, z_meters)?;
+    Some(SurfaceSample {
+        distance_meters,
+        x_meters,
+        ray_y_meters,
+        z_meters,
+        surface,
+    })
+}
+
+fn refine_crossing(
+    world: &World,
+    ray: TerrainRay,
+    direction: NormalizedDirection,
+    mut above_distance_meters: f32,
+    mut below_distance_meters: f32,
+) -> TerrainSurfaceHit {
+    for _ in 0..TERRAIN_PICK_REFINEMENT_STEPS {
+        let middle_distance_meters = (above_distance_meters + below_distance_meters) * 0.5;
+        match sample(world, ray, direction, middle_distance_meters) {
+            Some(middle) if middle.height_delta_meters() <= 0.0 => {
+                below_distance_meters = middle_distance_meters;
+            }
+            _ => {
+                above_distance_meters = middle_distance_meters;
+            }
+        }
+    }
+    sample(world, ray, direction, below_distance_meters)
+        .expect("the lower crossing bracket remains a present terrain sample")
+        .into_hit()
+}
+
+/// Intersect a validated, bounded world ray with the first markable terrain
+/// top surface. Work is iterative and capped by the public distance ceiling.
+pub(super) fn pick_terrain(world: &World, ray: TerrainRay) -> PickTerrainResult {
+    let values = [
+        ray.origin.x_meters,
+        ray.origin.y_meters,
+        ray.origin.z_meters,
+        ray.direction.x_unitless,
+        ray.direction.y_unitless,
+        ray.direction.z_unitless,
+        ray.max_distance_meters,
+    ];
+    if values.iter().any(|value| !value.is_finite()) {
+        return PickTerrainResult::Rejected {
+            error: TerrainPickError::NonFiniteRay,
+        };
+    }
+    if ray.max_distance_meters <= 0.0 || ray.max_distance_meters > MAX_TERRAIN_PICK_DISTANCE_METERS
+    {
+        return PickTerrainResult::Rejected {
+            error: TerrainPickError::InvalidMaxDistance,
+        };
+    }
+    let direction = match normalized(ray.direction) {
+        Ok(direction) => direction,
+        Err(error) => return PickTerrainResult::Rejected { error },
+    };
+
+    let mut previous_above: Option<SurfaceSample> = None;
+    let mut distance_meters = 0.0;
+    loop {
+        match sample(world, ray, direction, distance_meters) {
+            Some(current) if current.height_delta_meters() <= 0.0 => {
+                let hit = previous_above.map_or_else(
+                    || current.into_hit(),
+                    |above| {
+                        refine_crossing(
+                            world,
+                            ray,
+                            direction,
+                            above.distance_meters,
+                            current.distance_meters,
+                        )
+                    },
+                );
+                return PickTerrainResult::Hit { hit };
+            }
+            Some(current) => previous_above = Some(current),
+            None => previous_above = None,
+        }
+        if distance_meters >= ray.max_distance_meters {
+            break;
+        }
+        distance_meters = (distance_meters + TERRAIN_PICK_STEP_METERS).min(ray.max_distance_meters);
+    }
+    PickTerrainResult::Miss
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::world::{CellPos, Chunk, ChunkPos, Material, WaterPlane};
+
+    fn world_with_surface(cell: CellPos, material: Material, height_octimeters: i32) -> World {
+        let mut world = World::new();
+        let mut chunk = Chunk::empty_boxed();
+        let index = cell.chunk_index();
+        chunk.underlay[index] = material;
+        chunk.height[index] = height_octimeters;
+        world.insert_chunk(cell.chunk(), chunk);
+        world
+    }
+
+    fn downward_ray(x_meters: f32, z_meters: f32, max_distance_meters: f32) -> TerrainRay {
+        TerrainRay {
+            origin: WorldPositionMeters {
+                x_meters,
+                y_meters: 5.0,
+                z_meters,
+            },
+            direction: WorldDirection {
+                x_unitless: 0.0,
+                y_unitless: -2.0,
+                z_unitless: 0.0,
+            },
+            max_distance_meters,
+        }
+    }
+
+    fn hit(result: PickTerrainResult) -> TerrainSurfaceHit {
+        match result {
+            PickTerrainResult::Hit { hit } => hit,
+            other => panic!("expected terrain hit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn raised_and_negative_surfaces_hit_the_drawn_height() {
+        let raised = world_with_surface(CellPos { x: 0, z: 0 }, Material::Stone, 256);
+        let raised_hit = hit(pick_terrain(&raised, downward_ray(0.5, 0.5, 10.0)));
+        assert!((raised_hit.position.y_meters - 1.0).abs() < 0.001);
+        assert!((raised_hit.ray_distance_meters - 4.0).abs() < TERRAIN_PICK_STEP_METERS);
+        assert_eq!(
+            raised_hit.surface.mark_point,
+            super::super::WorldPoint::new(128, 128)
+        );
+
+        let negative = world_with_surface(CellPos { x: -1, z: -1 }, Material::Grass, 128);
+        let negative_hit = hit(pick_terrain(&negative, downward_ray(-0.5, -0.5, 10.0)));
+        assert_eq!(negative_hit.surface.cell, CellPos { x: -1, z: -1 });
+        assert_eq!(
+            negative_hit.surface.mark_point,
+            super::super::WorldPoint::new(-128, -128)
+        );
+        assert!((negative_hit.position.y_meters - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn water_hits_its_plane_and_void_or_short_rays_miss() {
+        let mut water = world_with_surface(CellPos { x: 0, z: 0 }, Material::Water, -256);
+        water.insert_water_plane(
+            1,
+            WaterPlane {
+                level_octimeters: 512,
+            },
+        );
+        let mut chunk = water
+            .chunk(ChunkPos { x: 0, z: 0 })
+            .expect("water chunk")
+            .clone();
+        chunk.water_plane[0] = 1;
+        water.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);
+        let water_hit = hit(pick_terrain(&water, downward_ray(0.5, 0.5, 10.0)));
+        assert!((water_hit.position.y_meters - 2.0).abs() < 0.001);
+
+        assert_eq!(
+            pick_terrain(&World::new(), downward_ray(0.5, 0.5, 10.0)),
+            PickTerrainResult::Miss
+        );
+        assert_eq!(
+            pick_terrain(&water, downward_ray(0.5, 0.5, 1.0)),
+            PickTerrainResult::Miss
+        );
+    }
+
+    #[test]
+    fn invalid_rays_reject_before_marching() {
+        let world = World::new();
+        let mut ray = downward_ray(0.0, 0.0, 1.0);
+        ray.origin.x_meters = f32::NAN;
+        assert_eq!(
+            pick_terrain(&world, ray),
+            PickTerrainResult::Rejected {
+                error: TerrainPickError::NonFiniteRay,
+            }
+        );
+
+        let mut ray = downward_ray(0.0, 0.0, 1.0);
+        ray.direction = WorldDirection {
+            x_unitless: 0.0,
+            y_unitless: 0.0,
+            z_unitless: 0.0,
+        };
+        assert_eq!(
+            pick_terrain(&world, ray),
+            PickTerrainResult::Rejected {
+                error: TerrainPickError::ZeroDirection,
+            }
+        );
+
+        let mut ray = downward_ray(0.0, 0.0, 0.0);
+        assert_eq!(
+            pick_terrain(&world, ray),
+            PickTerrainResult::Rejected {
+                error: TerrainPickError::InvalidMaxDistance,
+            }
+        );
+        ray.max_distance_meters = MAX_TERRAIN_PICK_DISTANCE_METERS + 1.0;
+        assert_eq!(
+            pick_terrain(&world, ray),
+            PickTerrainResult::Rejected {
+                error: TerrainPickError::InvalidMaxDistance,
+            }
+        );
+    }
+}

--- a/crates/aether-kit/tests/terrain_mark_scenario.rs
+++ b/crates/aether-kit/tests/terrain_mark_scenario.rs
@@ -1,0 +1,593 @@
+//! Terrain picking and MarkBook-projected overlays through the real kit wasm.
+
+use std::f32::consts::FRAC_PI_3;
+use std::fs;
+use std::path::Path;
+
+use aether_actor::Addressable;
+use aether_capabilities::render::ViewProjection;
+use aether_data::Kind;
+use aether_kinds::{
+    DescribeComponent, DescribeComponentResult, FrameCheck, FrameCheckResult, FrameReduction,
+    LoadComponent, LoadResult, NamedMail, Render,
+};
+use aether_kit::mark::{
+    MarkCreate, MarkCreateResult, MarkDelete, MarkDeleteResult, MarkGeometry, MarkRef, MarkUpdate,
+    MarkUpdateResult,
+};
+use aether_kit::world::{
+    CELLS_PER_CHUNK_AREA, Material, PickTerrain, PickTerrainResult, SUBCELLS_PER_CELL,
+    SetCellHeights, SetChunk, SetMarkOverlaySelection, SetMarkOverlaySelectionResult,
+    SetMarkOverlayVisibility, SetMarkOverlayVisibilityResult, TerrainRay, WorldDirection,
+    WorldPoint, WorldPositionMeters,
+};
+use aether_math::{Mat4, Vec3};
+use aether_substrate_bundle::test_bench::{
+    ArtifactGuard, BenchOp, TestBench, test_helpers::require_runtime,
+};
+use aether_substrate_bundle::visual::{Rect, decode_png, run_checks, target_color_stats};
+
+#[allow(unused_imports)]
+use aether_kit as _;
+
+const MARK_COMPONENT_NAME: &str = "aether.kit.mark";
+const WORLD_COMPONENT_NAME: &str = "world";
+const WIDTH: u32 = 192;
+const HEIGHT: u32 = 192;
+const WIDTH_F32: f32 = 192.0;
+const HEIGHT_F32: f32 = 192.0;
+const NORMAL_SRGB: [u8; 3] = [50, 220, 235];
+const SELECTED_SRGB: [u8; 3] = [255, 190, 48];
+const COLOR_TOLERANCE: u8 = 24;
+const STONE_SRGB: [u8; 3] = [140, 140, 148];
+const POINT_REGION: Rect = Rect {
+    min_x: 58,
+    min_y: 58,
+    max_x: 78,
+    max_y: 78,
+};
+const PATH_REGION: Rect = Rect {
+    min_x: 88,
+    min_y: 50,
+    max_x: 123,
+    max_y: 67,
+};
+const AREA_REGION: Rect = Rect {
+    min_x: 126,
+    min_y: 69,
+    max_x: 163,
+    max_y: 104,
+};
+
+fn component_address(name: &str) -> String {
+    format!(
+        "aether.component/{}:{name}",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    )
+}
+
+fn envelope<K: Kind>(recipient: &str, mail: &K) -> NamedMail {
+    NamedMail {
+        recipient_name: recipient.to_owned(),
+        kind_name: K::NAME.to_owned(),
+        payload: mail.encode_into_bytes(),
+        count: 1,
+    }
+}
+
+fn load_export(bench: &mut TestBench, wasm_path: &Path, export: &str, name: &str) {
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: fs::read(wasm_path).expect("read kit wasm"),
+                    name: Some(name.to_owned()),
+                    config: Vec::new(),
+                    export: Some(export.to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { name: loaded, .. } => assert_eq!(loaded, component_address(name)),
+        LoadResult::Err { error } => panic!("load {export}: {error}"),
+    }
+}
+
+fn top_down_view_projection() -> ViewProjection {
+    let eye = Vec3::new(4.0, 10.0, 4.0);
+    let target = Vec3::new(4.0, 0.0, 4.0);
+    let view = Mat4::look_at_rh(eye, target, Vec3::new(0.0, 0.0, -1.0));
+    let projection = Mat4::orthographic_rh(-5.0, 5.0, -5.0, 5.0, 0.1, 100.0);
+    ViewProjection {
+        view_proj: (projection * view).to_cols_array(),
+    }
+}
+
+fn terrain_ray_from_screen_pixel(
+    eye: Vec3,
+    target: Vec3,
+    pixel_x: f32,
+    pixel_y: f32,
+) -> TerrainRay {
+    let ndc_x = (pixel_x / WIDTH_F32).mul_add(2.0, -1.0);
+    let ndc_y = (pixel_y / HEIGHT_F32).mul_add(-2.0, 1.0);
+    let forward = (target - eye).normalize();
+    let right = forward.cross(Vec3::Y).normalize();
+    let up = right.cross(forward);
+    let tangent = (FRAC_PI_3 * 0.5).tan();
+    let direction = forward + right * (ndc_x * tangent) + up * (ndc_y * tangent);
+    TerrainRay {
+        origin: WorldPositionMeters {
+            x_meters: eye.x,
+            y_meters: eye.y,
+            z_meters: eye.z,
+        },
+        direction: WorldDirection {
+            x_unitless: direction.x,
+            y_unitless: direction.y,
+            z_unitless: direction.z,
+        },
+        max_distance_meters: 10.0,
+    }
+}
+
+fn capture(bench: &mut TestBench, world: &str, label: &str) -> Vec<u8> {
+    let captured = bench
+        .execute(vec![(
+            label,
+            BenchOp::capture_with_mails(
+                vec![
+                    envelope("aether.render", &top_down_view_projection()),
+                    envelope(world, &Render),
+                ],
+                Vec::new(),
+            ),
+        )])
+        .expect("capture mark overlay");
+    captured.captured(label).expect("capture bytes").to_vec()
+}
+
+fn create_mark(bench: &mut TestBench, marks: &str, label: &str, geometry: MarkGeometry) -> MarkRef {
+    let created = bench
+        .execute(vec![(
+            label,
+            BenchOp::send_and_await(
+                marks,
+                &MarkCreate {
+                    geometry,
+                    label: label.to_owned(),
+                },
+            ),
+        )])
+        .expect("create mark");
+    match created
+        .reply::<MarkCreateResult>(label)
+        .expect("decode MarkCreateResult")
+    {
+        MarkCreateResult::Created { reference } => reference,
+        MarkCreateResult::Rejected { error } => panic!("create {label}: {error:?}"),
+    }
+}
+
+fn overlay_checks() -> Vec<FrameCheck> {
+    [POINT_REGION, PATH_REGION, AREA_REGION]
+        .into_iter()
+        .map(|region| FrameCheck {
+            reduction: FrameReduction::Coverage,
+            tolerance: 20,
+            background: Some(STONE_SRGB),
+            region: Some(region.into()),
+        })
+        .collect()
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn terrain_pick_and_revisioned_mark_overlays_render_through_real_wasm() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(WIDTH, HEIGHT).expect("boot");
+    load_export(
+        &mut bench,
+        &wasm_path,
+        "aether.kit.mark",
+        MARK_COMPONENT_NAME,
+    );
+    load_export(
+        &mut bench,
+        &wasm_path,
+        "aether.kit.world",
+        WORLD_COMPONENT_NAME,
+    );
+    let marks = component_address(MARK_COMPONENT_NAME);
+    let world = component_address(WORLD_COMPONENT_NAME);
+
+    let described = bench
+        .execute(vec![(
+            "describe-world",
+            BenchOp::send_and_await(
+                "aether.component",
+                &DescribeComponent {
+                    name: world.clone(),
+                },
+            ),
+        )])
+        .expect("describe loaded world component");
+    let capabilities = match described
+        .reply::<DescribeComponentResult>("describe-world")
+        .expect("decode DescribeComponentResult")
+    {
+        DescribeComponentResult::Ok { capabilities } => capabilities,
+        DescribeComponentResult::Err { error } => panic!("describe world: {error}"),
+    };
+    let handler_names: Vec<_> = capabilities
+        .handlers
+        .iter()
+        .map(|handler| handler.name.as_str())
+        .collect();
+    for expected in [
+        "aether.kit.world.pick_terrain",
+        "aether.kit.world.set_mark_overlay_visibility",
+        "aether.kit.world.set_mark_overlay_selection",
+    ] {
+        assert!(
+            handler_names.contains(&expected),
+            "world advertises {expected}: {handler_names:?}",
+        );
+    }
+    for mark_crud in [
+        "aether.kit.mark.create",
+        "aether.kit.mark.update",
+        "aether.kit.mark.delete",
+        "aether.kit.mark.get",
+        "aether.kit.mark.list",
+    ] {
+        assert!(
+            !handler_names.contains(&mark_crud),
+            "mark CRUD remains exclusive to MarkBook: {handler_names:?}",
+        );
+    }
+
+    let mut underlay = vec![Material::Stone.to_u8(); CELLS_PER_CHUNK_AREA];
+    underlay[7 * 16] = Material::Water.to_u8();
+
+    bench
+        .execute(vec![
+            (
+                "chunk",
+                BenchOp::send_mail(
+                    &world,
+                    &SetChunk {
+                        chunk_x: 0,
+                        chunk_z: 0,
+                        underlay,
+                        underlay_points: Vec::new(),
+                        height_points: Vec::new(),
+                        overlay: Vec::new(),
+                        overlay_mask: Vec::new(),
+                        height: vec![0; CELLS_PER_CHUNK_AREA],
+                        region: Vec::new(),
+                        water_plane: vec![0; CELLS_PER_CHUNK_AREA],
+                        smoothing: Vec::new(),
+                    },
+                ),
+            ),
+            (
+                "relief",
+                BenchOp::send_mail(
+                    &world,
+                    &SetCellHeights {
+                        x: 2,
+                        z: 2,
+                        deltas: vec![128; SUBCELLS_PER_CELL],
+                    },
+                ),
+            ),
+        ])
+        .expect("author non-flat terrain");
+
+    let pick_eye = Vec3::new(2.5, 5.0, 5.5);
+    let pick_target = Vec3::new(2.5, 0.5, 2.5);
+    let picked = bench
+        .execute(vec![(
+            "pick",
+            BenchOp::send_and_await(
+                &world,
+                &PickTerrain {
+                    ray: terrain_ray_from_screen_pixel(
+                        pick_eye,
+                        pick_target,
+                        WIDTH_F32 * 0.5,
+                        HEIGHT_F32 * 0.5,
+                    ),
+                },
+            ),
+        )])
+        .expect("pick raised terrain");
+    let hit = match picked
+        .reply::<PickTerrainResult>("pick")
+        .expect("decode PickTerrainResult")
+    {
+        PickTerrainResult::Hit { hit } => hit,
+        other => panic!("expected raised terrain hit, got {other:?}"),
+    };
+    assert!(
+        (hit.position.y_meters - 0.5).abs() < 0.001,
+        "pick follows authored relief rather than flat y=0: {hit:?}",
+    );
+    assert_eq!(hit.surface.mark_point, WorldPoint::new(640, 640));
+
+    let point = create_mark(
+        &mut bench,
+        &marks,
+        "point",
+        MarkGeometry::Point(hit.surface.mark_point),
+    );
+    let path = create_mark(
+        &mut bench,
+        &marks,
+        "path",
+        MarkGeometry::Path(vec![WorldPoint::new(1024, 512), WorldPoint::new(1280, 512)]),
+    );
+    let area = create_mark(
+        &mut bench,
+        &marks,
+        "area",
+        MarkGeometry::Area(vec![
+            WorldPoint::new(1536, 768),
+            WorldPoint::new(1792, 768),
+            WorldPoint::new(1664, 1024),
+        ]),
+    );
+
+    let enabled = bench
+        .execute(vec![(
+            "enable",
+            BenchOp::send_and_await(&world, &SetMarkOverlayVisibility { visible: true }),
+        )])
+        .expect("enable overlay");
+    assert_eq!(
+        enabled
+            .reply::<SetMarkOverlayVisibilityResult>("enable")
+            .expect("decode visibility result"),
+        SetMarkOverlayVisibilityResult {
+            visible: true,
+            synchronized: false,
+        }
+    );
+    let mut synchronized_result = None;
+    for _ in 0..16 {
+        let synchronized = bench
+            .execute(vec![(
+                "sync",
+                BenchOp::send_and_await(&world, &SetMarkOverlayVisibility { visible: true }),
+            )])
+            .expect("poll synchronized overlay");
+        let result = synchronized
+            .reply::<SetMarkOverlayVisibilityResult>("sync")
+            .expect("decode synchronized visibility result");
+        if result.synchronized {
+            synchronized_result = Some(result);
+            break;
+        }
+    }
+    assert_eq!(
+        synchronized_result,
+        Some(SetMarkOverlayVisibilityResult {
+            visible: true,
+            synchronized: true,
+        }),
+        "the correlated MarkList reply settles within a bounded poll",
+    );
+    let selected = bench
+        .execute(vec![(
+            "select",
+            BenchOp::send_and_await(
+                &world,
+                &SetMarkOverlaySelection {
+                    selected: Some(point),
+                },
+            ),
+        )])
+        .expect("select exact point revision");
+    assert_eq!(
+        selected
+            .reply::<SetMarkOverlaySelectionResult>("select")
+            .expect("decode selection result"),
+        SetMarkOverlaySelectionResult::Selected { reference: point }
+    );
+
+    let before_png = capture(&mut bench, &world, "before");
+    let before_image = decode_png(&before_png).expect("decode initial overlay");
+    assert_eq!((before_image.width, before_image.height), (WIDTH, HEIGHT));
+    let checks = overlay_checks();
+    let verdict = run_checks(
+        before_image.rgba.clone(),
+        before_image.width,
+        before_image.height,
+        &checks,
+    );
+    let _before_guard = ArtifactGuard::arm(
+        "terrain_mark_overlay_before",
+        before_png,
+        checks,
+        verdict.results.clone(),
+    )
+    .with_expectation(
+        "selected point is amber; path and closed area are cyan and terrain-anchored",
+    );
+    for result in &verdict.results {
+        match result {
+            FrameCheckResult::Coverage { fraction, .. } => assert!(
+                *fraction > 0.005,
+                "each bounded point/path/area region contains visible overlay pixels: {result:?}",
+            ),
+            other => panic!("expected coverage result, got {other:?}"),
+        }
+    }
+    let selected_before = target_color_stats(
+        &before_image,
+        SELECTED_SRGB,
+        COLOR_TOLERANCE,
+        Some(POINT_REGION),
+    );
+    let path_before = target_color_stats(
+        &before_image,
+        NORMAL_SRGB,
+        COLOR_TOLERANCE,
+        Some(PATH_REGION),
+    );
+    let area_before = target_color_stats(
+        &before_image,
+        NORMAL_SRGB,
+        COLOR_TOLERANCE,
+        Some(AREA_REGION),
+    );
+    assert!(
+        selected_before.matching >= 4,
+        "selected point: {selected_before:?}"
+    );
+    assert!(path_before.matching >= 4, "path ribbon: {path_before:?}");
+    assert!(area_before.matching >= 4, "area perimeter: {area_before:?}");
+
+    let mutated = bench
+        .execute(vec![
+            (
+                "update",
+                BenchOp::send_and_await(
+                    &marks,
+                    &MarkUpdate {
+                        id: point.id,
+                        geometry: None,
+                        label: Some("updated".to_owned()),
+                    },
+                ),
+            ),
+            (
+                "delete",
+                BenchOp::send_and_await(&marks, &MarkDelete { id: area.id }),
+            ),
+        ])
+        .expect("update point and delete area");
+    let point_v2 = MarkRef {
+        id: point.id,
+        revision: 2,
+    };
+    assert_eq!(
+        mutated
+            .reply::<MarkUpdateResult>("update")
+            .expect("decode MarkUpdateResult"),
+        MarkUpdateResult::Updated {
+            reference: point_v2,
+        }
+    );
+    assert_eq!(
+        mutated
+            .reply::<MarkDeleteResult>("delete")
+            .expect("decode MarkDeleteResult"),
+        MarkDeleteResult::Deleted { reference: area }
+    );
+
+    bench
+        .execute(vec![(
+            "refresh",
+            BenchOp::send_and_await(&world, &SetMarkOverlayVisibility { visible: true }),
+        )])
+        .expect("refresh mutated MarkBook projection");
+    let mut stale_result = None;
+    for _ in 0..16 {
+        let stale = bench
+            .execute(vec![(
+                "stale",
+                BenchOp::send_and_await(
+                    &world,
+                    &SetMarkOverlaySelection {
+                        selected: Some(point),
+                    },
+                ),
+            )])
+            .expect("poll old selected revision");
+        let result = stale
+            .reply::<SetMarkOverlaySelectionResult>("stale")
+            .expect("decode stale selection result");
+        if matches!(result, SetMarkOverlaySelectionResult::Stale { .. }) {
+            stale_result = Some(result);
+            break;
+        }
+    }
+    assert_eq!(
+        stale_result,
+        Some(SetMarkOverlaySelectionResult::Stale {
+            requested: point,
+            current: point_v2,
+        }),
+        "the refreshed projection classifies the old revision within a bounded poll",
+    );
+
+    let after_png = capture(&mut bench, &world, "after");
+    let after_image = decode_png(&after_png).expect("decode refreshed overlay");
+    let checks = overlay_checks();
+    let verdict = run_checks(
+        after_image.rgba.clone(),
+        after_image.width,
+        after_image.height,
+        &checks,
+    );
+    let _after_guard = ArtifactGuard::arm(
+        "terrain_mark_overlay_after",
+        after_png,
+        checks,
+        verdict.results,
+    )
+    .with_expectation(
+        "updated point remains as ordinary cyan, path remains, deleted area disappears",
+    );
+    let selected_after = target_color_stats(
+        &after_image,
+        SELECTED_SRGB,
+        COLOR_TOLERANCE,
+        Some(POINT_REGION),
+    );
+    let point_after = target_color_stats(
+        &after_image,
+        NORMAL_SRGB,
+        COLOR_TOLERANCE,
+        Some(POINT_REGION),
+    );
+    let path_after = target_color_stats(
+        &after_image,
+        NORMAL_SRGB,
+        COLOR_TOLERANCE,
+        Some(PATH_REGION),
+    );
+    let area_after = target_color_stats(
+        &after_image,
+        NORMAL_SRGB,
+        COLOR_TOLERANCE,
+        Some(AREA_REGION),
+    );
+    assert_eq!(
+        selected_after.matching, 0,
+        "revision advance clears the amber highlight: {selected_after:?}",
+    );
+    assert!(
+        point_after.matching >= 4,
+        "updated point stays visible: {point_after:?}"
+    );
+    assert!(
+        path_after.matching >= 4,
+        "unmodified path stays visible: {path_after:?}"
+    );
+    assert_eq!(
+        area_after.matching, 0,
+        "atomic refresh removes deleted area geometry: {area_after:?}",
+    );
+    assert_ne!(path, area, "separate MarkBook allocations stay distinct");
+}

--- a/crates/aether-kit/tests/terrain_mark_scenario.rs
+++ b/crates/aether-kit/tests/terrain_mark_scenario.rs
@@ -8,22 +8,22 @@ use aether_actor::Addressable;
 use aether_capabilities::render::ViewProjection;
 use aether_data::Kind;
 use aether_kinds::{
-    DescribeComponent, DescribeComponentResult, FrameCheck, FrameCheckResult, FrameReduction,
-    LoadComponent, LoadResult, NamedMail, Render,
+    DescribeComponent, DescribeComponentResult, FrameCheck, FrameCheckResult, FrameReduction, LoadComponent,
+    LoadResult, NamedMail, Render,
 };
 use aether_kit::mark::{
-    MarkCreate, MarkCreateResult, MarkDelete, MarkDeleteResult, MarkGeometry, MarkRef, MarkUpdate,
-    MarkUpdateResult,
+    MarkCreate, MarkCreateResult, MarkDelete, MarkDeleteResult, MarkGeometry, MarkRef, MarkUpdate, MarkUpdateResult,
 };
 use aether_kit::world::{
-    CELLS_PER_CHUNK_AREA, Material, PickTerrain, PickTerrainResult, SUBCELLS_PER_CELL,
-    SetCellHeights, SetChunk, SetMarkOverlaySelection, SetMarkOverlaySelectionResult,
-    SetMarkOverlayVisibility, SetMarkOverlayVisibilityResult, TerrainRay, WorldDirection,
-    WorldPoint, WorldPositionMeters,
+    CELLS_PER_CHUNK_AREA, Chunk, ChunkPos, Material, PickTerrain, PickTerrainResult, SUBCELLS_PER_CELL, SetCellHeights,
+    SetChunk, SetMarkOverlaySelection, SetMarkOverlaySelectionResult, SetMarkOverlayVisibility,
+    SetMarkOverlayVisibilityResult, TerrainRay, WaterPlane, World, WorldDirection, WorldLoad, WorldPoint,
+    WorldPositionMeters,
 };
 use aether_math::{Mat4, Vec3};
 use aether_substrate_bundle::test_bench::{
-    ArtifactGuard, BenchOp, TestBench, test_helpers::require_runtime,
+    ArtifactGuard, BenchOp, TestBench,
+    test_helpers::{init_save_sandbox, require_runtime, test_namespace_roots},
 };
 use aether_substrate_bundle::visual::{Rect, decode_png, run_checks, target_color_stats};
 
@@ -40,30 +40,12 @@ const NORMAL_SRGB: [u8; 3] = [50, 220, 235];
 const SELECTED_SRGB: [u8; 3] = [255, 190, 48];
 const COLOR_TOLERANCE: u8 = 24;
 const STONE_SRGB: [u8; 3] = [140, 140, 148];
-const POINT_REGION: Rect = Rect {
-    min_x: 58,
-    min_y: 58,
-    max_x: 78,
-    max_y: 78,
-};
-const PATH_REGION: Rect = Rect {
-    min_x: 88,
-    min_y: 50,
-    max_x: 123,
-    max_y: 67,
-};
-const AREA_REGION: Rect = Rect {
-    min_x: 126,
-    min_y: 69,
-    max_x: 163,
-    max_y: 104,
-};
+const POINT_REGION: Rect = Rect { min_x: 58, min_y: 58, max_x: 78, max_y: 78 };
+const PATH_REGION: Rect = Rect { min_x: 88, min_y: 50, max_x: 123, max_y: 67 };
+const AREA_REGION: Rect = Rect { min_x: 126, min_y: 69, max_x: 163, max_y: 104 };
 
 fn component_address(name: &str) -> String {
-    format!(
-        "aether.component/{}:{name}",
-        aether_capabilities::WasmTrampoline::NAMESPACE,
-    )
+    format!("aether.component/{}:{name}", aether_capabilities::WasmTrampoline::NAMESPACE)
 }
 
 fn envelope<K: Kind>(recipient: &str, mail: &K) -> NamedMail {
@@ -90,10 +72,7 @@ fn load_export(bench: &mut TestBench, wasm_path: &Path, export: &str, name: &str
             ),
         )])
         .expect("load sequence");
-    match loaded
-        .reply::<LoadResult>("load")
-        .expect("decode LoadResult")
-    {
+    match loaded.reply::<LoadResult>("load").expect("decode LoadResult") {
         LoadResult::Ok { name: loaded, .. } => assert_eq!(loaded, component_address(name)),
         LoadResult::Err { error } => panic!("load {export}: {error}"),
     }
@@ -104,17 +83,10 @@ fn top_down_view_projection() -> ViewProjection {
     let target = Vec3::new(4.0, 0.0, 4.0);
     let view = Mat4::look_at_rh(eye, target, Vec3::new(0.0, 0.0, -1.0));
     let projection = Mat4::orthographic_rh(-5.0, 5.0, -5.0, 5.0, 0.1, 100.0);
-    ViewProjection {
-        view_proj: (projection * view).to_cols_array(),
-    }
+    ViewProjection { view_proj: (projection * view).to_cols_array() }
 }
 
-fn terrain_ray_from_screen_pixel(
-    eye: Vec3,
-    target: Vec3,
-    pixel_x: f32,
-    pixel_y: f32,
-) -> TerrainRay {
+fn terrain_ray_from_screen_pixel(eye: Vec3, target: Vec3, pixel_x: f32, pixel_y: f32) -> TerrainRay {
     let ndc_x = (pixel_x / WIDTH_F32).mul_add(2.0, -1.0);
     let ndc_y = (pixel_y / HEIGHT_F32).mul_add(-2.0, 1.0);
     let forward = (target - eye).normalize();
@@ -123,16 +95,8 @@ fn terrain_ray_from_screen_pixel(
     let tangent = (FRAC_PI_3 * 0.5).tan();
     let direction = forward + right * (ndc_x * tangent) + up * (ndc_y * tangent);
     TerrainRay {
-        origin: WorldPositionMeters {
-            x_meters: eye.x,
-            y_meters: eye.y,
-            z_meters: eye.z,
-        },
-        direction: WorldDirection {
-            x_unitless: direction.x,
-            y_unitless: direction.y,
-            z_unitless: direction.z,
-        },
+        origin: WorldPositionMeters { x_meters: eye.x, y_meters: eye.y, z_meters: eye.z },
+        direction: WorldDirection { x_unitless: direction.x, y_unitless: direction.y, z_unitless: direction.z },
         max_distance_meters: 10.0,
     }
 }
@@ -142,10 +106,7 @@ fn capture(bench: &mut TestBench, world: &str, label: &str) -> Vec<u8> {
         .execute(vec![(
             label,
             BenchOp::capture_with_mails(
-                vec![
-                    envelope("aether.render", &top_down_view_projection()),
-                    envelope(world, &Render),
-                ],
+                vec![envelope("aether.render", &top_down_view_projection()), envelope(world, &Render)],
                 Vec::new(),
             ),
         )])
@@ -155,21 +116,9 @@ fn capture(bench: &mut TestBench, world: &str, label: &str) -> Vec<u8> {
 
 fn create_mark(bench: &mut TestBench, marks: &str, label: &str, geometry: MarkGeometry) -> MarkRef {
     let created = bench
-        .execute(vec![(
-            label,
-            BenchOp::send_and_await(
-                marks,
-                &MarkCreate {
-                    geometry,
-                    label: label.to_owned(),
-                },
-            ),
-        )])
+        .execute(vec![(label, BenchOp::send_and_await(marks, &MarkCreate { geometry, label: label.to_owned() }))])
         .expect("create mark");
-    match created
-        .reply::<MarkCreateResult>(label)
-        .expect("decode MarkCreateResult")
-    {
+    match created.reply::<MarkCreateResult>(label).expect("decode MarkCreateResult") {
         MarkCreateResult::Created { reference } => reference,
         MarkCreateResult::Rejected { error } => panic!("create {label}: {error:?}"),
     }
@@ -193,54 +142,75 @@ fn terrain_pick_and_revisioned_mark_overlays_render_through_real_wasm() {
     let Some(wasm_path) = require_runtime("aether_kit") else {
         return;
     };
-    let mut bench = TestBench::start_with_size(WIDTH, HEIGHT).expect("boot");
-    load_export(
-        &mut bench,
-        &wasm_path,
-        "aether.kit.mark",
-        MARK_COMPONENT_NAME,
-    );
-    load_export(
-        &mut bench,
-        &wasm_path,
-        "aether.kit.world",
-        WORLD_COMPONENT_NAME,
-    );
+    let sandbox = init_save_sandbox("kit-terrain-mark");
+    let water_world_path = "terrain-mark-water.world";
+    let water_cell_index = 7 * 16;
+    let mut authored_water = World::new();
+    authored_water.insert_water_plane(1, WaterPlane { level_octimeters: 384 });
+    let mut water_chunk = Chunk::empty();
+    water_chunk.underlay[water_cell_index] = Material::Water;
+    water_chunk.height[water_cell_index] = -256;
+    water_chunk.water_plane[water_cell_index] = 1;
+    authored_water.insert_chunk(ChunkPos { x: 0, z: 0 }, water_chunk);
+    fs::write(sandbox.join(water_world_path), authored_water.to_bytes()).expect("write authored water world fixture");
+
+    let mut bench =
+        TestBench::builder().size(WIDTH, HEIGHT).namespace_roots(test_namespace_roots(sandbox)).build().expect("boot");
+    load_export(&mut bench, &wasm_path, "aether.kit.mark", MARK_COMPONENT_NAME);
+    load_export(&mut bench, &wasm_path, "aether.kit.world", WORLD_COMPONENT_NAME);
     let marks = component_address(MARK_COMPONENT_NAME);
     let world = component_address(WORLD_COMPONENT_NAME);
+
+    bench
+        .execute(vec![(
+            "load-water-world",
+            BenchOp::send_mail(&world, &WorldLoad { namespace: "save".to_owned(), path: water_world_path.to_owned() }),
+        )])
+        .expect("load authored water world");
+    let water_ray = TerrainRay {
+        origin: WorldPositionMeters { x_meters: 0.5, y_meters: 5.0, z_meters: 7.5 },
+        direction: WorldDirection { x_unitless: 0.0, y_unitless: -1.0, z_unitless: 0.0 },
+        max_distance_meters: 10.0,
+    };
+    let mut water_hit = None;
+    for _ in 0..16 {
+        let picked = bench
+            .execute(vec![("pick-water", BenchOp::send_and_await(&world, &PickTerrain { ray: water_ray }))])
+            .expect("pick authored water plane");
+        if let PickTerrainResult::Hit { hit } =
+            picked.reply::<PickTerrainResult>("pick-water").expect("decode water PickTerrainResult")
+        {
+            water_hit = Some(hit);
+            break;
+        }
+    }
+    let water_hit = water_hit.expect("registered water-plane world settles within bounded polls");
+    assert_eq!(water_hit.surface.cell.x, 0);
+    assert_eq!(water_hit.surface.cell.z, 7);
+    assert_eq!(water_hit.surface.mark_point, WorldPoint::new(128, 1920));
+    assert!(
+        (water_hit.position.y_meters - 1.5).abs() < 0.001,
+        "pick resolves the registered water plane rather than its -1m lakebed: {water_hit:?}",
+    );
 
     let described = bench
         .execute(vec![(
             "describe-world",
-            BenchOp::send_and_await(
-                "aether.component",
-                &DescribeComponent {
-                    name: world.clone(),
-                },
-            ),
+            BenchOp::send_and_await("aether.component", &DescribeComponent { name: world.clone() }),
         )])
         .expect("describe loaded world component");
-    let capabilities = match described
-        .reply::<DescribeComponentResult>("describe-world")
-        .expect("decode DescribeComponentResult")
-    {
-        DescribeComponentResult::Ok { capabilities } => capabilities,
-        DescribeComponentResult::Err { error } => panic!("describe world: {error}"),
-    };
-    let handler_names: Vec<_> = capabilities
-        .handlers
-        .iter()
-        .map(|handler| handler.name.as_str())
-        .collect();
+    let capabilities =
+        match described.reply::<DescribeComponentResult>("describe-world").expect("decode DescribeComponentResult") {
+            DescribeComponentResult::Ok { capabilities } => capabilities,
+            DescribeComponentResult::Err { error } => panic!("describe world: {error}"),
+        };
+    let handler_names: Vec<_> = capabilities.handlers.iter().map(|handler| handler.name.as_str()).collect();
     for expected in [
         "aether.kit.world.pick_terrain",
         "aether.kit.world.set_mark_overlay_visibility",
         "aether.kit.world.set_mark_overlay_selection",
     ] {
-        assert!(
-            handler_names.contains(&expected),
-            "world advertises {expected}: {handler_names:?}",
-        );
+        assert!(handler_names.contains(&expected), "world advertises {expected}: {handler_names:?}");
     }
     for mark_crud in [
         "aether.kit.mark.create",
@@ -249,14 +219,15 @@ fn terrain_pick_and_revisioned_mark_overlays_render_through_real_wasm() {
         "aether.kit.mark.get",
         "aether.kit.mark.list",
     ] {
-        assert!(
-            !handler_names.contains(&mark_crud),
-            "mark CRUD remains exclusive to MarkBook: {handler_names:?}",
-        );
+        assert!(!handler_names.contains(&mark_crud), "mark CRUD remains exclusive to MarkBook: {handler_names:?}");
     }
 
     let mut underlay = vec![Material::Stone.to_u8(); CELLS_PER_CHUNK_AREA];
-    underlay[7 * 16] = Material::Water.to_u8();
+    underlay[water_cell_index] = Material::Water.to_u8();
+    let mut height = vec![0; CELLS_PER_CHUNK_AREA];
+    height[water_cell_index] = -256;
+    let mut water_plane = vec![0; CELLS_PER_CHUNK_AREA];
+    water_plane[water_cell_index] = 1;
 
     bench
         .execute(vec![
@@ -272,23 +243,16 @@ fn terrain_pick_and_revisioned_mark_overlays_render_through_real_wasm() {
                         height_points: Vec::new(),
                         overlay: Vec::new(),
                         overlay_mask: Vec::new(),
-                        height: vec![0; CELLS_PER_CHUNK_AREA],
+                        height,
                         region: Vec::new(),
-                        water_plane: vec![0; CELLS_PER_CHUNK_AREA],
+                        water_plane,
                         smoothing: Vec::new(),
                     },
                 ),
             ),
             (
                 "relief",
-                BenchOp::send_mail(
-                    &world,
-                    &SetCellHeights {
-                        x: 2,
-                        z: 2,
-                        deltas: vec![128; SUBCELLS_PER_CELL],
-                    },
-                ),
+                BenchOp::send_mail(&world, &SetCellHeights { x: 2, z: 2, deltas: vec![128; SUBCELLS_PER_CELL] }),
             ),
         ])
         .expect("author non-flat terrain");
@@ -301,35 +265,19 @@ fn terrain_pick_and_revisioned_mark_overlays_render_through_real_wasm() {
             BenchOp::send_and_await(
                 &world,
                 &PickTerrain {
-                    ray: terrain_ray_from_screen_pixel(
-                        pick_eye,
-                        pick_target,
-                        WIDTH_F32 * 0.5,
-                        HEIGHT_F32 * 0.5,
-                    ),
+                    ray: terrain_ray_from_screen_pixel(pick_eye, pick_target, WIDTH_F32 * 0.5, HEIGHT_F32 * 0.5),
                 },
             ),
         )])
         .expect("pick raised terrain");
-    let hit = match picked
-        .reply::<PickTerrainResult>("pick")
-        .expect("decode PickTerrainResult")
-    {
+    let hit = match picked.reply::<PickTerrainResult>("pick").expect("decode PickTerrainResult") {
         PickTerrainResult::Hit { hit } => hit,
         other => panic!("expected raised terrain hit, got {other:?}"),
     };
-    assert!(
-        (hit.position.y_meters - 0.5).abs() < 0.001,
-        "pick follows authored relief rather than flat y=0: {hit:?}",
-    );
+    assert!((hit.position.y_meters - 0.5).abs() < 0.001, "pick follows authored relief rather than flat y=0: {hit:?}");
     assert_eq!(hit.surface.mark_point, WorldPoint::new(640, 640));
 
-    let point = create_mark(
-        &mut bench,
-        &marks,
-        "point",
-        MarkGeometry::Point(hit.surface.mark_point),
-    );
+    let point = create_mark(&mut bench, &marks, "point", MarkGeometry::Point(hit.surface.mark_point));
     let path = create_mark(
         &mut bench,
         &marks,
@@ -340,35 +288,20 @@ fn terrain_pick_and_revisioned_mark_overlays_render_through_real_wasm() {
         &mut bench,
         &marks,
         "area",
-        MarkGeometry::Area(vec![
-            WorldPoint::new(1536, 768),
-            WorldPoint::new(1792, 768),
-            WorldPoint::new(1664, 1024),
-        ]),
+        MarkGeometry::Area(vec![WorldPoint::new(1536, 768), WorldPoint::new(1792, 768), WorldPoint::new(1664, 1024)]),
     );
 
     let enabled = bench
-        .execute(vec![(
-            "enable",
-            BenchOp::send_and_await(&world, &SetMarkOverlayVisibility { visible: true }),
-        )])
+        .execute(vec![("enable", BenchOp::send_and_await(&world, &SetMarkOverlayVisibility { visible: true }))])
         .expect("enable overlay");
     assert_eq!(
-        enabled
-            .reply::<SetMarkOverlayVisibilityResult>("enable")
-            .expect("decode visibility result"),
-        SetMarkOverlayVisibilityResult {
-            visible: true,
-            synchronized: false,
-        }
+        enabled.reply::<SetMarkOverlayVisibilityResult>("enable").expect("decode visibility result"),
+        SetMarkOverlayVisibilityResult { visible: true, synchronized: false }
     );
     let mut synchronized_result = None;
     for _ in 0..16 {
         let synchronized = bench
-            .execute(vec![(
-                "sync",
-                BenchOp::send_and_await(&world, &SetMarkOverlayVisibility { visible: true }),
-            )])
+            .execute(vec![("sync", BenchOp::send_and_await(&world, &SetMarkOverlayVisibility { visible: true }))])
             .expect("poll synchronized overlay");
         let result = synchronized
             .reply::<SetMarkOverlayVisibilityResult>("sync")
@@ -380,27 +313,14 @@ fn terrain_pick_and_revisioned_mark_overlays_render_through_real_wasm() {
     }
     assert_eq!(
         synchronized_result,
-        Some(SetMarkOverlayVisibilityResult {
-            visible: true,
-            synchronized: true,
-        }),
+        Some(SetMarkOverlayVisibilityResult { visible: true, synchronized: true }),
         "the correlated MarkList reply settles within a bounded poll",
     );
     let selected = bench
-        .execute(vec![(
-            "select",
-            BenchOp::send_and_await(
-                &world,
-                &SetMarkOverlaySelection {
-                    selected: Some(point),
-                },
-            ),
-        )])
+        .execute(vec![("select", BenchOp::send_and_await(&world, &SetMarkOverlaySelection { selected: Some(point) }))])
         .expect("select exact point revision");
     assert_eq!(
-        selected
-            .reply::<SetMarkOverlaySelectionResult>("select")
-            .expect("decode selection result"),
+        selected.reply::<SetMarkOverlaySelectionResult>("select").expect("decode selection result"),
         SetMarkOverlaySelectionResult::Selected { reference: point }
     );
 
@@ -408,21 +328,9 @@ fn terrain_pick_and_revisioned_mark_overlays_render_through_real_wasm() {
     let before_image = decode_png(&before_png).expect("decode initial overlay");
     assert_eq!((before_image.width, before_image.height), (WIDTH, HEIGHT));
     let checks = overlay_checks();
-    let verdict = run_checks(
-        before_image.rgba.clone(),
-        before_image.width,
-        before_image.height,
-        &checks,
-    );
-    let _before_guard = ArtifactGuard::arm(
-        "terrain_mark_overlay_before",
-        before_png,
-        checks,
-        verdict.results.clone(),
-    )
-    .with_expectation(
-        "selected point is amber; path and closed area are cyan and terrain-anchored",
-    );
+    let verdict = run_checks(before_image.rgba.clone(), before_image.width, before_image.height, &checks);
+    let _before_guard = ArtifactGuard::arm("terrain_mark_overlay_before", before_png, checks, verdict.results.clone())
+        .with_expectation("selected point is amber; path and closed area are cyan and terrain-anchored");
     for result in &verdict.results {
         match result {
             FrameCheckResult::Coverage { fraction, .. } => assert!(
@@ -432,28 +340,10 @@ fn terrain_pick_and_revisioned_mark_overlays_render_through_real_wasm() {
             other => panic!("expected coverage result, got {other:?}"),
         }
     }
-    let selected_before = target_color_stats(
-        &before_image,
-        SELECTED_SRGB,
-        COLOR_TOLERANCE,
-        Some(POINT_REGION),
-    );
-    let path_before = target_color_stats(
-        &before_image,
-        NORMAL_SRGB,
-        COLOR_TOLERANCE,
-        Some(PATH_REGION),
-    );
-    let area_before = target_color_stats(
-        &before_image,
-        NORMAL_SRGB,
-        COLOR_TOLERANCE,
-        Some(AREA_REGION),
-    );
-    assert!(
-        selected_before.matching >= 4,
-        "selected point: {selected_before:?}"
-    );
+    let selected_before = target_color_stats(&before_image, SELECTED_SRGB, COLOR_TOLERANCE, Some(POINT_REGION));
+    let path_before = target_color_stats(&before_image, NORMAL_SRGB, COLOR_TOLERANCE, Some(PATH_REGION));
+    let area_before = target_color_stats(&before_image, NORMAL_SRGB, COLOR_TOLERANCE, Some(AREA_REGION));
+    assert!(selected_before.matching >= 4, "selected point: {selected_before:?}");
     assert!(path_before.matching >= 4, "path ribbon: {path_before:?}");
     assert!(area_before.matching >= 4, "area perimeter: {area_before:?}");
 
@@ -463,60 +353,34 @@ fn terrain_pick_and_revisioned_mark_overlays_render_through_real_wasm() {
                 "update",
                 BenchOp::send_and_await(
                     &marks,
-                    &MarkUpdate {
-                        id: point.id,
-                        geometry: None,
-                        label: Some("updated".to_owned()),
-                    },
+                    &MarkUpdate { id: point.id, geometry: None, label: Some("updated".to_owned()) },
                 ),
             ),
-            (
-                "delete",
-                BenchOp::send_and_await(&marks, &MarkDelete { id: area.id }),
-            ),
+            ("delete", BenchOp::send_and_await(&marks, &MarkDelete { id: area.id })),
         ])
         .expect("update point and delete area");
-    let point_v2 = MarkRef {
-        id: point.id,
-        revision: 2,
-    };
+    let point_v2 = MarkRef { id: point.id, revision: 2 };
     assert_eq!(
-        mutated
-            .reply::<MarkUpdateResult>("update")
-            .expect("decode MarkUpdateResult"),
-        MarkUpdateResult::Updated {
-            reference: point_v2,
-        }
+        mutated.reply::<MarkUpdateResult>("update").expect("decode MarkUpdateResult"),
+        MarkUpdateResult::Updated { reference: point_v2 }
     );
     assert_eq!(
-        mutated
-            .reply::<MarkDeleteResult>("delete")
-            .expect("decode MarkDeleteResult"),
+        mutated.reply::<MarkDeleteResult>("delete").expect("decode MarkDeleteResult"),
         MarkDeleteResult::Deleted { reference: area }
     );
 
     bench
-        .execute(vec![(
-            "refresh",
-            BenchOp::send_and_await(&world, &SetMarkOverlayVisibility { visible: true }),
-        )])
+        .execute(vec![("refresh", BenchOp::send_and_await(&world, &SetMarkOverlayVisibility { visible: true }))])
         .expect("refresh mutated MarkBook projection");
     let mut stale_result = None;
     for _ in 0..16 {
         let stale = bench
             .execute(vec![(
                 "stale",
-                BenchOp::send_and_await(
-                    &world,
-                    &SetMarkOverlaySelection {
-                        selected: Some(point),
-                    },
-                ),
+                BenchOp::send_and_await(&world, &SetMarkOverlaySelection { selected: Some(point) }),
             )])
             .expect("poll old selected revision");
-        let result = stale
-            .reply::<SetMarkOverlaySelectionResult>("stale")
-            .expect("decode stale selection result");
+        let result = stale.reply::<SetMarkOverlaySelectionResult>("stale").expect("decode stale selection result");
         if matches!(result, SetMarkOverlaySelectionResult::Stale { .. }) {
             stale_result = Some(result);
             break;
@@ -524,70 +388,23 @@ fn terrain_pick_and_revisioned_mark_overlays_render_through_real_wasm() {
     }
     assert_eq!(
         stale_result,
-        Some(SetMarkOverlaySelectionResult::Stale {
-            requested: point,
-            current: point_v2,
-        }),
+        Some(SetMarkOverlaySelectionResult::Stale { requested: point, current: point_v2 }),
         "the refreshed projection classifies the old revision within a bounded poll",
     );
 
     let after_png = capture(&mut bench, &world, "after");
     let after_image = decode_png(&after_png).expect("decode refreshed overlay");
     let checks = overlay_checks();
-    let verdict = run_checks(
-        after_image.rgba.clone(),
-        after_image.width,
-        after_image.height,
-        &checks,
-    );
-    let _after_guard = ArtifactGuard::arm(
-        "terrain_mark_overlay_after",
-        after_png,
-        checks,
-        verdict.results,
-    )
-    .with_expectation(
-        "updated point remains as ordinary cyan, path remains, deleted area disappears",
-    );
-    let selected_after = target_color_stats(
-        &after_image,
-        SELECTED_SRGB,
-        COLOR_TOLERANCE,
-        Some(POINT_REGION),
-    );
-    let point_after = target_color_stats(
-        &after_image,
-        NORMAL_SRGB,
-        COLOR_TOLERANCE,
-        Some(POINT_REGION),
-    );
-    let path_after = target_color_stats(
-        &after_image,
-        NORMAL_SRGB,
-        COLOR_TOLERANCE,
-        Some(PATH_REGION),
-    );
-    let area_after = target_color_stats(
-        &after_image,
-        NORMAL_SRGB,
-        COLOR_TOLERANCE,
-        Some(AREA_REGION),
-    );
-    assert_eq!(
-        selected_after.matching, 0,
-        "revision advance clears the amber highlight: {selected_after:?}",
-    );
-    assert!(
-        point_after.matching >= 4,
-        "updated point stays visible: {point_after:?}"
-    );
-    assert!(
-        path_after.matching >= 4,
-        "unmodified path stays visible: {path_after:?}"
-    );
-    assert_eq!(
-        area_after.matching, 0,
-        "atomic refresh removes deleted area geometry: {area_after:?}",
-    );
+    let verdict = run_checks(after_image.rgba.clone(), after_image.width, after_image.height, &checks);
+    let _after_guard = ArtifactGuard::arm("terrain_mark_overlay_after", after_png, checks, verdict.results)
+        .with_expectation("updated point remains as ordinary cyan, path remains, deleted area disappears");
+    let selected_after = target_color_stats(&after_image, SELECTED_SRGB, COLOR_TOLERANCE, Some(POINT_REGION));
+    let point_after = target_color_stats(&after_image, NORMAL_SRGB, COLOR_TOLERANCE, Some(POINT_REGION));
+    let path_after = target_color_stats(&after_image, NORMAL_SRGB, COLOR_TOLERANCE, Some(PATH_REGION));
+    let area_after = target_color_stats(&after_image, NORMAL_SRGB, COLOR_TOLERANCE, Some(AREA_REGION));
+    assert_eq!(selected_after.matching, 0, "revision advance clears the amber highlight: {selected_after:?}");
+    assert!(point_after.matching >= 4, "updated point stays visible: {point_after:?}");
+    assert!(path_after.matching >= 4, "unmodified path stays visible: {path_after:?}");
+    assert_eq!(area_after.matching, 0, "atomic refresh removes deleted area geometry: {area_after:?}");
     assert_ne!(path, area, "separate MarkBook allocations stay distinct");
 }

--- a/docs/guide/systems/rendering.md
+++ b/docs/guide/systems/rendering.md
@@ -192,7 +192,7 @@ subcell budget. Coordinates remain named records rather than positional arrays:
 
 ```json
 {
-  "source": { "id": 7, "revision": 3 },
+  "source": { "id": { "0": 7 }, "revision": 3 },
   "path": [
     { "x_octimeters": 512, "z_octimeters": 512 },
     { "x_octimeters": 1536, "z_octimeters": 512 }
@@ -215,6 +215,61 @@ consistent partial world is still remeshed. `RunAutomaton` takes a named
 accepted automaton cell costs one step and all 256 of its material subcells.
 These are live mutation results only: preview/commit/discard state belongs to
 the separate proposal transaction in ADR-0143.
+
+**Pick and project revisioned terrain marks.** Load the MarkBook under its
+default component name (`aether.kit.mark`) alongside the world component.
+`aether.kit.world.pick_terrain` accepts a named meter-space ray rather than a
+screen-space tuple:
+
+```json
+{
+  "ray": {
+    "origin": {
+      "x_meters": 2.0,
+      "y_meters": 8.0,
+      "z_meters": 2.0
+    },
+    "direction": {
+      "x_unitless": 0.0,
+      "y_unitless": -1.0,
+      "z_unitless": 0.0
+    },
+    "max_distance_meters": 16.0
+  }
+}
+```
+
+The typed result is either `Hit`, `Miss`, or `Rejected`. A hit reports
+the continuous meter-space position, the owning `CellPos`, the sampled
+surface height, the ray distance, and a nearest-octimeter `WorldPoint` that
+can be passed directly to `aether.kit.mark.create`. Picking follows the
+rendered top surface, including relief and water; missing/Void terrain is not a
+mark anchor.
+
+The world does not own or mutate marks. Send
+`aether.kit.world.set_mark_overlay_visibility { "visible": true }` to start a
+correlated `MarkList` projection from the default-loaded MarkBook. The reply
+reports whether the first full snapshot has synchronized. While visible, each
+render refreshes at most one snapshot in flight and draws the cached point,
+path, and area geometry after the ground mesh. Every overlay vertex resamples
+terrain height, so an unchanged mark follows a later terrain edit.
+
+Select only an exact cached revision:
+
+```json
+{
+  "selected": {
+    "id": { "0": 7 },
+    "revision": 3
+  }
+}
+```
+
+`set_mark_overlay_selection_result` distinguishes `Selected`, `Cleared`,
+`Stale` (the cache has a newer revision), and `Unsynchronized` (the
+requested revision is ahead or missing and a refresh was requested). A later
+snapshot that edits or deletes the selected mark clears the highlight instead
+of silently moving it to another revision.
 
 **From an agent over MCP — stage, then capture.** Use `capture_frame`: its
 `mails` bundle dispatches before the readback (the state that should appear) and

--- a/docs/guide/systems/rendering.md
+++ b/docs/guide/systems/rendering.md
@@ -244,7 +244,11 @@ the continuous meter-space position, the owning `CellPos`, the sampled
 surface height, the ray distance, and a nearest-octimeter `WorldPoint` that
 can be passed directly to `aether.kit.mark.create`. Picking follows the
 rendered top surface, including relief and water; missing/Void terrain is not a
-mark anchor.
+mark anchor. The bounded march accepts only a present above-to-below bracket
+whose two sides converge on the sampled height; entering terrain from the side
+or crossing a discontinuous cliff with a horizontal ray is not reclassified as
+a top-surface hit. Its step and convergence epsilon are both derived from the
+shared subcell resolution.
 
 The world does not own or mutate marks. Send
 `aether.kit.world.set_mark_overlay_visibility { "visible": true }` to start a
@@ -270,6 +274,14 @@ Select only an exact cached revision:
 requested revision is ahead or missing and a refresh was requested). A later
 snapshot that edits or deletes the selected mark clears the highlight instead
 of silently moving it to another revision.
+
+Scalar overlay-only ground uses the contour library's continuous reconstructed
+coverage at the same 127.5 crossing as the rendered mesh, rather than treating a
+whole subcell as its stored byte. Mark geometry is capped per frame at 10,240
+triangles / 30,720 vertices — enough for one maximum-size selected area. Marks
+are traversed in stable id order; geometry after the cap is omitted and the
+first omitted mark plus the emitted counts are warning-logged once when the
+view enters overflow.
 
 **From an agent over MCP — stage, then capture.** Use `capture_frame`: its
 `mails` bundle dispatches before the readback (the state that should appear) and


### PR DESCRIPTION
## Summary

- Add named terrain-ray picking that follows rendered relief, water, holes, and scalar overlay coverage without introducing positional coordinate aliases.
- Project the authoritative `MarkBook` into `WorldView` with correlated atomic snapshots, revision-exact selection, and terrain-anchored point/path/area geometry.
- Prove the public mail surface, ownership boundary, picking, rendering, refresh, stale revision, and deletion behavior through a strict real-wasm TestBench scenario.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p aether-kit --lib` (268 passed)
- [x] `cargo build --target wasm32-unknown-unknown -p aether-kit --release`
- [x] `AETHER_REQUIRE_RUNTIME=1 cargo test -p aether-kit --test terrain_mark_scenario -- --nocapture`
- [x] `cargo doc -p aether-kit --no-deps`
- [x] Audit new public/wire vocabulary for semantic tuple, fixed-array, and array-alias types; all new domain shapes use named fields.

## Related

- Closes #2930
- ADR: `docs/adr/0142-terrain-mark-identity-and-revisions.md`
