### PR TITLE
feat(workflow): dogfood evidence branch and rollup issue comments

### DIFF
--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -31,6 +31,7 @@ Accept these values from the user or caller:
 3. Attempt: spawn a fresh Codex subagent without forked context. Pass only the approved task and public surface pointers. Do not pass the diff, implementation files, or Author reasoning. Require output with `succeeded`, `summary`, `engineId`, `buildGreen`, and `findings`.
 4. Judge: if `expectedArtifact` is non-null and Attempt leaves an `engineId`, spawn a fresh judge subagent to capture and inspect the frame through the Aether MCP tools, then terminate the substrate.
 5. Rollup: summarize totals, grouped friction, artifact verdict, and soft holds. Do not file follow-up issues from this skill.
+6. Persist and post: stage the run's evidence, commit it to the orphan `dogfood/evidence` branch, and upsert the rollup comment on the feature issue (see Persist and Post).
 
 ## Finding Categories
 
@@ -40,3 +41,27 @@ Accept these values from the user or caller:
 - `blocker`: the task stopped.
 
 Soft-hold on a wrong artifact verdict or any high-severity blocker.
+
+## Persist and Post
+
+The workflow never touches GitHub. This skill makes the run durable after the rollup returns: it persists the evidence to the `dogfood/evidence` branch and posts the rollup as one living issue comment.
+
+Stage a run directory holding this run's evidence:
+
+- `rollup.json`: the workflow return written verbatim. The poster accepts the full `{rollup, task}` object or a bare rollup.
+- `frame.png`: the judged frame, present only when a vision judge ran. The judge captures it to disk through `capture_frame` `save_path`, so the still is a file on the host rather than an image confined to the judge's context.
+- `solution/`: the Attempt's scratch crate, for an `author` or `build-layer` medium. A `drive` medium writes no crate, so this is absent.
+
+Name the run by a UTC timestamp in `YYYYMMDD-HHMMSS` form (`date -u +%Y%m%d-%H%M%S`). With the issue number it forms the `evidence/<issue>/<run-id>/` branch path and the `<issue>/<run-id>` run ref.
+
+Commit the evidence, then post the rollup:
+
+```
+scripts/dogfood-evidence.sh <staged-run-dir> <issue> <run-id>
+
+ISSUE=<issue> PR=<pr-if-any> RUN_REF=<issue>/<run-id> \
+  ROLLUP_PATH=<staged-run-dir>/rollup.json HAS_FRAME=<1-when-frame-staged> \
+  node scripts/post-dogfood-rollup.mjs
+```
+
+`scripts/dogfood-evidence.sh` does its git work in a throwaway worktree, bootstraps the orphan branch on first run, and retries a push rejected by a concurrent run. `scripts/post-dogfood-rollup.mjs` (node >= 20, no npm deps) upserts the marker-anchored comment with verdicts, friction grouped by category, soft-holds, the judged frame inline, and a viewer link, then sets `dogfood:unresolved` when the trial is actionable (attempt did not succeed, artifact verdict `wrong`, any soft-hold, or any `blocker` / `missing-primitive` friction) and clears it otherwise. Pass `PR` when a PR is open, since that is where `/land` reads the label; omit it to carry the label on the issue.

--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -7,7 +7,7 @@ description: Consumer-viewpoint validation of a landed feature — a fresh agent
 
 The Claude entry point to the `dogfood` workflow (`.claude/workflows/dogfood.js`). Where the workflow holds the multi-agent orchestration — Author → Attempt → Judge → Rollup — this skill is the thin invocation surface around it: it resolves the caller-side inputs the workflow sandbox cannot run itself, brings the live MCP harness up when a medium needs it, handles the heavy-medium approval stop-and-resume, and reports the returned rollup. The mirror of the Codex wrapper at `.agents/skills/dogfood/SKILL.md`, invoking the same workflow through the `Workflow` tool.
 
-`/dogfood` never touches GitHub, never gates CI, and files nothing — surfacing the friction it finds as follow-up issues is a separate `/sketch` step.
+The `dogfood` workflow never touches GitHub and never gates CI. This skill is where the run becomes durable: once the rollup returns, the skill persists the run's evidence to the `dogfood/evidence` branch and posts the rollup as one living comment on the feature issue (see [Persist and post](#persist-and-post)). Filing the friction findings as follow-up issues stays a separate `/sketch` step.
 
 ## Invocation
 
@@ -75,9 +75,39 @@ On completion the workflow returns `{rollup, task}`. Report the rollup to the us
 - **friction by category** — the logged friction grouped `papercut` / `missing-primitive` / `doc-gap` / `blocker`, each with where it hit, what it was, and a suggested consumer-side fix.
 - **soft-holds** — a `wrong` artifact verdict or any high-severity `blocker`. Advisory only — `/dogfood` never blocks a land; the soft-hold is a flag for the reviewer.
 
+## Persist and post
+
+The rollup that the workflow returns dies with the conversation, and the judge's captured frame lives only inside the judge agent's vision context. This tail makes the run durable: it stages the evidence into a run directory, commits it to the orphan `dogfood/evidence` branch, and posts the rollup onto the feature issue.
+
+**Stage the run directory.** Assemble one directory holding this run's evidence:
+
+- `rollup.json` — the workflow return written verbatim (`{rollup, task}`; the poster accepts the full object or a bare rollup).
+- `frame.png` — the judged frame, present only when a vision judge ran. The judge captures it to disk through `capture_frame`'s `save_path` (ADR-referenced #2962), so the still is a file on the harness host rather than an image that lived only in the judge's context.
+- `solution/` — the Attempt's scratch crate, for an `author` or `build-layer` medium. Copy the crate the Attempt authored so a later reader can see what the consumer actually built. A `drive` medium writes no crate, so `solution/` is absent.
+
+**Name the run.** The run id is a UTC timestamp in `YYYYMMDD-HHMMSS` form (`date -u +%Y%m%d-%H%M%S`). Paired with the issue number it forms the `evidence/<issue>/<run-id>/` path on the branch and the `<issue>/<run-id>` run ref the poster and viewer share.
+
+**Commit the evidence.** Push the staged directory to the branch:
+
+```
+scripts/dogfood-evidence.sh <staged-run-dir> <issue> <run-id>
+```
+
+The script does all its git work in a throwaway worktree — the invoking checkout is never touched — bootstrapping the orphan branch on first run and retrying a rejected push against a concurrent run.
+
+**Post the rollup.** Upsert the living comment and set or clear the advisory label:
+
+```
+ISSUE=<issue> PR=<pr-if-any> RUN_REF=<issue>/<run-id> \
+  ROLLUP_PATH=<staged-run-dir>/rollup.json HAS_FRAME=<1-when-frame-staged> \
+  node scripts/post-dogfood-rollup.mjs
+```
+
+The comment renders the verdicts, the friction grouped by category, the soft-holds, the judged frame inline (from its evidence-branch raw URL, when a frame was staged), and a viewer link to the full run. `dogfood:unresolved` is set when the trial is actionable — the attempt did not succeed, the artifact verdict is `wrong`, any soft-hold fired, or any friction is a `blocker` or `missing-primitive` — and cleared on a clean re-run. Pass `PR` when a PR is open, since that is where `/land` reads the label; omit it to carry the label on the issue.
+
 ## What `/dogfood` does NOT do
 
 - File follow-up issues. The rollup's friction findings are triaged into `papercut` / missing-primitive / doc-gap issues via a separate `/sketch` step — the user's call which.
-- Touch GitHub or gate CI. The trial is advisory; the rollup is the surface.
+- Gate CI or hard-block a land. The persist-and-post tail writes the evidence branch and the rollup comment, and `dogfood:unresolved` flags an actionable trial for the `/land` gate, but the trial itself never fails CI and never blocks a merge on its own.
 - Show the Attempt agent the implementation. The diff and implementation files go to the Author phase only — a consumer trial that sees the code is not a consumer trial.
 - Reimplement the orchestration. The `dogfood` workflow is the single source of the Author → Attempt → Judge → Rollup logic; this skill only invokes it.

--- a/scripts/dogfood-evidence.sh
+++ b/scripts/dogfood-evidence.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Commit a staged dogfood run directory to the orphan `dogfood/evidence`
+# branch at `evidence/<issue>/<run-id>/` and push it (issue 2967).
+#
+# The branch is orphan so it never bloats a checkout of main and can be
+# history-squashed on a /sweep cadence once issues close. Every git
+# operation runs inside a throwaway worktree checked out into a mktemp
+# dir, so the invoking checkout is never touched; the worktree is removed
+# on exit via a trap. A concurrent push (another run racing to the same
+# branch) is handled by up to three fetch-and-reapply retries.
+#
+# Usage:
+#   scripts/dogfood-evidence.sh <staged-run-dir> <issue> <run-id>
+#
+# <staged-run-dir> is the local directory holding this run's evidence
+# (rollup.json, frame.png, solution/…); <issue> and <run-id> form the
+# `evidence/<issue>/<run-id>/` path on the branch. Bash + git/coreutils
+# only, no external deps.
+
+set -euo pipefail
+
+staged_dir="${1:?usage: dogfood-evidence.sh <staged-run-dir> <issue> <run-id>}"
+issue="${2:?usage: dogfood-evidence.sh <staged-run-dir> <issue> <run-id>}"
+run_id="${3:?usage: dogfood-evidence.sh <staged-run-dir> <issue> <run-id>}"
+
+branch=dogfood/evidence
+remote=origin
+max_retries=3
+
+if [[ ! -d "$staged_dir" ]]; then
+  echo "dogfood-evidence: staged run dir not found: $staged_dir" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+# A detached temp worktree keeps every branch operation off the invoking
+# checkout. The trap removes it (and prunes the registration) whatever the
+# exit path.
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/dogfood-evidence.XXXXXX")"
+cleanup() {
+  git -C "$repo_root" worktree remove --force "$work_dir" 2>/dev/null || true
+  rm -rf "$work_dir" 2>/dev/null || true
+  git -C "$repo_root" worktree prune 2>/dev/null || true
+}
+trap cleanup EXIT
+
+git -C "$repo_root" worktree add --detach "$work_dir" >/dev/null
+
+# Check out the branch if the remote already has it, otherwise bootstrap a
+# fresh orphan with a clean tree.
+git -C "$work_dir" fetch "$remote" "$branch" 2>/dev/null || true
+if git -C "$work_dir" rev-parse --verify --quiet "refs/remotes/$remote/$branch" >/dev/null; then
+  git -C "$work_dir" switch -c "$branch" "$remote/$branch" >/dev/null
+else
+  git -C "$work_dir" switch --orphan "$branch" >/dev/null
+  git -C "$work_dir" rm -rf . >/dev/null 2>&1 || true
+fi
+
+dest="$work_dir/evidence/$issue/$run_id"
+mkdir -p "$dest"
+cp -R "$staged_dir/." "$dest/"
+
+git -C "$work_dir" add "evidence/$issue/$run_id"
+if git -C "$work_dir" diff --cached --quiet; then
+  echo "dogfood-evidence: nothing to commit for evidence/$issue/$run_id (already present and identical)"
+  exit 0
+fi
+
+git -C "$work_dir" commit -q -m "evidence: dogfood run $issue/$run_id"
+
+# Push with fetch-and-reapply retries. A rejected push means another run
+# advanced the branch between our fetch and our push; rebase our single
+# evidence commit onto the fresh tip and try again. Paths are unique per
+# run (issue/run-id), so the rebase never conflicts.
+attempt=0
+while true; do
+  if git -C "$work_dir" push "$remote" "$branch:$branch"; then
+    echo "dogfood-evidence: pushed evidence/$issue/$run_id to $branch"
+    break
+  fi
+  attempt=$((attempt + 1))
+  if [[ "$attempt" -ge "$max_retries" ]]; then
+    echo "dogfood-evidence: push rejected after $max_retries attempts" >&2
+    exit 1
+  fi
+  echo "dogfood-evidence: push rejected, refetching and reapplying (attempt $attempt/$max_retries)" >&2
+  git -C "$work_dir" fetch "$remote" "$branch"
+  git -C "$work_dir" rebase "$remote/$branch"
+done

--- a/scripts/post-dogfood-rollup.mjs
+++ b/scripts/post-dogfood-rollup.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+// Post a dogfood rollup onto its feature issue as one living, marker-
+// anchored comment, and set or clear the advisory `dogfood:unresolved`
+// label (issue 2967). Mirrors scripts/post-review-rollup.mjs — same env
+// contract, fetch wrapper, marker-anchored upsert, and label set/clear.
+//
+// The posture matches the review poster: the comment and label are
+// advisory. The teeth are the /land gate that reads `dogfood:unresolved`
+// (a separate skill-text change), not a CI failure here. A failed API
+// call logs and continues where the review poster does.
+//
+// Inputs (env):
+//   GITHUB_TOKEN        least-privilege token (issues write)
+//   GITHUB_REPOSITORY   owner/repo
+//   ISSUE               the feature issue to comment on (required)
+//   PR                  the PR to carry the label (optional; defaults to ISSUE)
+//   RUN_REF             <issue>/<run-id> — the evidence-branch path segment
+//   ROLLUP_PATH         rollup.json (the workflow's returned rollup)
+//   HAS_FRAME           "1"/"true" when the staged run dir held a frame.png
+//                       (falls back to rollup.artifact != null when unset)
+//
+// No external deps — Node built-ins + global fetch only.
+
+import { readFile } from 'node:fs/promises'
+
+const TOKEN = requireEnv('GITHUB_TOKEN')
+const REPO = requireEnv('GITHUB_REPOSITORY')
+const ISSUE = Number(requireEnv('ISSUE'))
+const PR = process.env.PR ? Number(process.env.PR) : ISSUE
+const RUN_REF = requireEnv('RUN_REF')
+const ROLLUP_PATH = process.env.ROLLUP_PATH || 'rollup.json'
+
+const MARKER = '<!-- aether-dogfood -->'
+const LABEL = 'dogfood:unresolved'
+const API = 'https://api.github.com'
+const RAW_BASE = 'https://raw.githubusercontent.com/iamacoffeepot/aether/dogfood/evidence/evidence'
+const VIEWER_BASE = 'https://iamacoffeepot.github.io/aether/evidence/'
+
+function requireEnv(name) {
+  const v = process.env[name]
+  if (!v) throw new Error(`post-dogfood-rollup: ${name} is required`)
+  return v
+}
+
+async function api(method, path, body) {
+  const res = await fetch(`${API}/${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${TOKEN}`,
+      accept: 'application/vnd.github+json',
+      'x-github-api-version': '2022-11-28',
+      'content-type': 'application/json',
+      'user-agent': 'aether-dogfood-poster',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  const text = await res.text()
+  const data = text ? safeJson(text) : null
+  return { ok: res.ok, status: res.status, data, text }
+}
+
+function safeJson(t) {
+  try { return JSON.parse(t) } catch { return null }
+}
+
+// Paginate a GitHub list endpoint via the Link header.
+async function apiList(path) {
+  const out = []
+  let url = `${API}/${path}${path.includes('?') ? '&' : '?'}per_page=100`
+  while (url) {
+    const res = await fetch(url, {
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        accept: 'application/vnd.github+json',
+        'x-github-api-version': '2022-11-28',
+        'user-agent': 'aether-dogfood-poster',
+      },
+    })
+    if (!res.ok) throw new Error(`GET ${url} -> ${res.status} ${await res.text()}`)
+    const page = await res.json()
+    if (Array.isArray(page)) out.push(...page)
+    url = nextLink(res.headers.get('link'))
+  }
+  return out
+}
+
+function nextLink(link) {
+  if (!link) return null
+  for (const part of link.split(',')) {
+    const m = part.match(/<([^>]+)>;\s*rel="next"/)
+    if (m) return m[1]
+  }
+  return null
+}
+
+function verdictLines(rollup) {
+  const lines = []
+  const succeeded = rollup.succeeded === true
+  lines.push(`- **Attempt:** ${succeeded ? 'succeeded' : 'did not succeed'}`)
+  if (rollup.buildGreen !== null && rollup.buildGreen !== undefined) {
+    lines.push(`- **Build:** ${rollup.buildGreen ? 'green' : 'red'}`)
+  }
+  if (rollup.artifact) {
+    lines.push(`- **Artifact:** ${rollup.artifact.verdict} — ${rollup.artifact.rationale}`)
+  }
+  if (rollup.summary) {
+    lines.push('', rollup.summary)
+  }
+  return lines
+}
+
+const CATEGORIES = ['blocker', 'missing-primitive', 'papercut', 'doc-gap']
+
+function frictionLines(friction) {
+  const lines = []
+  let any = false
+  for (const category of CATEGORIES) {
+    const items = Array.isArray(friction && friction[category]) ? friction[category] : []
+    if (!items.length) continue
+    any = true
+    lines.push('', `#### ${category}`, '', '| severity | where | what | suggested |', '| --- | --- | --- | --- |')
+    for (const f of items) {
+      lines.push(`| ${cell(f.severity)} | ${cell(f.where)} | ${cell(f.what)} | ${cell(f.suggested)} |`)
+    }
+  }
+  if (!any) lines.push('', '_No friction logged — the surface was friction-free._')
+  return lines
+}
+
+// Escape pipes and collapse newlines so a finding never breaks the table.
+function cell(v) {
+  return String(v ?? '').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').trim() || '—'
+}
+
+function softHoldLines(softHolds) {
+  if (!Array.isArray(softHolds) || !softHolds.length) return []
+  const lines = ['', '### Soft-holds', '', '_Advisory: a soft-hold flags something a reviewer should clear; it never gates the land._', '']
+  for (const h of softHolds) {
+    const where = h.where ? ` (${h.where})` : ''
+    lines.push(`- **${h.kind}**${where} — ${h.detail || ''}`)
+  }
+  return lines
+}
+
+function renderComment(rollup, hasFrame) {
+  const lines = [MARKER, '## Dogfood trial', '']
+  lines.push(...verdictLines(rollup))
+  lines.push('', '### Friction')
+  lines.push(...frictionLines(rollup.friction))
+  lines.push(...softHoldLines(rollup.softHolds))
+  if (hasFrame) {
+    lines.push('', '### Judged frame', '', `![judged frame](${RAW_BASE}/${RUN_REF}/frame.png)`)
+  }
+  lines.push('', `[Full run in the evidence viewer](${VIEWER_BASE}?run=${encodeURIComponent(RUN_REF)})`)
+  return lines.join('\n')
+}
+
+function isActionable(rollup) {
+  if (rollup.succeeded === false) return true
+  if (rollup.artifact && rollup.artifact.verdict === 'wrong') return true
+  if (Array.isArray(rollup.softHolds) && rollup.softHolds.length) return true
+  const friction = rollup.friction || {}
+  for (const category of ['blocker', 'missing-primitive']) {
+    if (Array.isArray(friction[category]) && friction[category].length) return true
+  }
+  return false
+}
+
+// Create the label if it does not exist yet. An already-exists 422 is a
+// clean success — the label is present, which is all we need.
+async function ensureLabel() {
+  const res = await api('POST', `repos/${REPO}/labels`, {
+    name: LABEL,
+    color: 'd93f0b',
+    description: 'A dogfood trial surfaced something actionable',
+  })
+  if (res.ok || res.status === 422) return
+  console.error(`ensure label failed: ${res.status} ${res.text}`)
+}
+
+async function main() {
+  const raw = JSON.parse(await readFile(ROLLUP_PATH, 'utf8'))
+  // Accept either the bare rollup or the workflow's full { rollup, task }.
+  const rollup = raw && raw.rollup ? raw.rollup : raw
+
+  const hasFrame = process.env.HAS_FRAME
+    ? /^(1|true)$/i.test(process.env.HAS_FRAME)
+    : rollup.artifact != null
+
+  const body = renderComment(rollup, hasFrame)
+
+  // Upsert the marker-anchored living comment — edit if present, create
+  // otherwise. The evidence branch keeps per-run history, so the comment
+  // shows latest-state.
+  const issueComments = await apiList(`repos/${REPO}/issues/${ISSUE}/comments`)
+  const existing = issueComments.find((c) => String(c.body || '').includes(MARKER))
+  if (existing) {
+    const res = await api('PATCH', `repos/${REPO}/issues/comments/${existing.id}`, { body })
+    if (!res.ok) console.error(`update comment failed: ${res.status} ${res.text}`)
+    else console.log('updated dogfood comment')
+  } else {
+    const res = await api('POST', `repos/${REPO}/issues/${ISSUE}/comments`, { body })
+    if (!res.ok) console.error(`post comment failed: ${res.status} ${res.text}`)
+    else console.log('posted dogfood comment')
+  }
+
+  // Advisory label on the PR when passed (that is where /land reads),
+  // else on the issue. Set when actionable, cleared clean.
+  const target = PR
+  if (isActionable(rollup)) {
+    await ensureLabel()
+    const res = await api('POST', `repos/${REPO}/issues/${target}/labels`, { labels: [LABEL] })
+    if (!res.ok) console.error(`add label failed: ${res.status} ${res.text}`)
+    else console.log(`set ${LABEL} on #${target}`)
+  } else {
+    const res = await api('DELETE', `repos/${REPO}/issues/${target}/labels/${encodeURIComponent(LABEL)}`)
+    // 404 = the label was not present; a clean no-op.
+    if (res.ok || res.status === 404) console.log(`cleared ${LABEL} on #${target}`)
+    else console.error(`remove label failed: ${res.status} ${res.text}`)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes #2967.

## Summary

The durability half of the dogfood arc, mirroring the review arc's caller-side split (the workflow stays GitHub-free; the skill layer persists and posts). `scripts/dogfood-evidence.sh` commits a staged run directory to the orphan `dogfood/evidence` branch at `evidence/<issue>/<run>/` — all inside a temp detached worktree with an EXIT-trap teardown, bootstrapping the branch when absent and pushing with up to three fetch-and-rebase retries under contention. `scripts/post-dogfood-rollup.mjs` mirrors the review poster's skeleton: it renders the rollup (verdict header, friction grouped by category, soft-holds), embeds the judged frame inline via its evidence-branch raw URL, links the full run through the Pages viewer, and upserts one living comment anchored on `<!-- aether-dogfood -->`. The `dogfood:unresolved` label is set when the trial is actionable (failed attempt, wrong artifact verdict, any soft-hold, or a blocker / missing-primitive finding) on the PR when given — where the /land gate reads — else on the issue, and cleared on a clean re-run. Both dogfood skills (Claude and Codex mirrors) gain the persist-and-post tail with the stage-dir and run-id contract, and the boundary sentence moves to its true home: the workflow never touches GitHub; the skill does.

Viewer links 404 until #2974 deploys, then heal retroactively — the viewer is pure indirection, so no ordering is imposed.

## Test plan

Scripts + skill text, no cargo surface; `bash -n` and `node --check` pass. Live verification is the first `/dogfood` run after this lands: evidence appears on the orphan branch, the rollup comment renders with the inline frame, and the label reflects actionability.

## Generated by

`/implement` — [issue #2967](https://github.com/iamacoffeepot/aether/issues/2967), scoped and approved through the pipeline.
