### PR TITLE
feat(ci): dogfood github action on runs-on gated on green ci

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -1,0 +1,694 @@
+name: Dogfood
+
+# Consumer-use half of QA: hand a landed feature's public surface to a fresh
+# agent that never saw the implementation, have it accomplish a realistic
+# task through that surface alone (the dogfood workflow, .claude/workflows/
+# dogfood.js), and grade the friction it hit plus the rendered artifact. The
+# trial runs unattended on a Runs-On ephemeral box; a separate post job pushes
+# the evidence, upserts the PR/issue comment, and enforces the retry cap.
+#
+# GATE STACK (each predicate must hold, in order — this is the terminal stage
+# of the PR gate chain, so it fires only when everything upstream is green):
+#   1. CI green      — the other CI gates passed (structural: Review only runs
+#                      on CI success, and Dogfood only runs on Review success).
+#   2. Review gate   — the `Review gate` commit status stands `success` on the
+#                      current head. That single status encodes "review ran at
+#                      least once" for Rust PRs and the auto-skip for non-Rust
+#                      ones (issue 2996), so requiring it makes dogfood the very
+#                      last thing to run without polling review's own state.
+#   3. Brief present — the closing issue carries a filled `## Dogfood brief`
+#                      (emitted by /scope). An `N/A` brief (or none) skips
+#                      cleanly: no consumer surface to trial, no run.
+#   4. Retry state   — the marker comment the poster upserts carries
+#                      `attempts=<N> verdict=<green|failed>`. A `green` verdict
+#                      is terminal (the feature works — no more auto-runs); an
+#                      `attempts >= DOGFOOD_MAX_ATTEMPTS` count is terminal-
+#                      failed (the post job has bounced the issue). Anything
+#                      else runs as attempt N+1.
+#
+# RETRY CONTRACT: unlike review (run-once per PR), dogfood retries until green —
+# a feature whose trial cannot pass is not done. A failed trial re-runs on the
+# next green event; hitting DOGFOOD_MAX_ATTEMPTS bounces the CLOSING ISSUE to
+# the user (phase:bounced + a persistent-failure comment linking every attempt's
+# evidence) rather than looping forever. A `workflow_dispatch` with a `pr` input
+# is the manual override: it bypasses the retry-state guards (green + cap) for a
+# deliberate re-trial, but still honours the structural gates (open PR, Review
+# gate green, brief present).
+#
+# RUN-ID CONVENTION: `<github.run_id>-<attempt>` — sortable, collision-free
+# across a retrying PR, and the `evidence/<issue>/<run-id>/` path segment on the
+# dogfood/evidence branch and under s3://aether-evidence.
+#
+# SECURITY POSTURE (issue 2967 / the security comment on 2968): secrets never
+# meet untrusted branches. Same-repo head only (a fork PR never sees the OAuth
+# token and skips); NEVER pull_request_target. Least-privilege split — the
+# `trial` job executes branch code (build + headless Claude with
+# --dangerously-skip-permissions on the ephemeral box) and holds `contents:
+# read` and nothing else; only the `post` job, which never runs branch code
+# (it checks out main), carries the write scopes. A default-drop iptables egress
+# firewall inside the trial job closes the arbitrary-exfiltration channel for
+# the inference-scoped OAuth token. Verdicts stay advisory — never a required
+# status check; the teeth are the dogfood:unresolved /land gate (issue 2969).
+
+on:
+  workflow_run:
+    workflows: ["Review"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to dogfood (bypasses the retry-state guards)
+        required: true
+
+# One trial per PR; a newer trigger supersedes an in-flight one. Keyed by the
+# head branch on the workflow_run path (the Review workflow_run event exposes
+# the PR head branch), or the dispatched PR number.
+concurrency:
+  group: dogfood-${{ github.event.workflow_run.head_branch || github.event.inputs.pr }}
+  cancel-in-progress: true
+
+env:
+  # The retry cap (issue 2968). Workflow-level so both the resolve gate and the
+  # post job's cap-bounce read the same number; injected into every run step's
+  # environment as $DOGFOOD_MAX_ATTEMPTS.
+  DOGFOOD_MAX_ATTEMPTS: "3"
+
+jobs:
+  resolve:
+    name: Resolve gate stack
+    runs-on: ubuntu-latest
+    # Pure GitHub API calls — no checkout, no branch code. Read-only.
+    permissions:
+      contents: read
+    # Job-level guard mirroring review.yml: manual dispatch is always allowed
+    # and resolves its own PR; the workflow_run path requires the parent (the
+    # Review workflow) to have succeeded and its head to be this repo — a fork
+    # PR never sees the secret and never runs here.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
+    outputs:
+      proceed: ${{ steps.gate.outputs.proceed }}
+      pr: ${{ steps.gate.outputs.pr }}
+      issue: ${{ steps.gate.outputs.issue }}
+      head_sha: ${{ steps.gate.outputs.head_sha }}
+      attempt: ${{ steps.gate.outputs.attempt }}
+      medium: ${{ steps.gate.outputs.medium }}
+      prompt: ${{ steps.gate.outputs.prompt }}
+      surface: ${{ steps.gate.outputs.surface }}
+      expected_artifact: ${{ steps.gate.outputs.expected_artifact }}
+    steps:
+      - name: Resolve PR, Review gate, brief, and retry state
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          DISPATCH_PR: ${{ github.event.inputs.pr }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # A clean no-op: emit proceed=false and stop. Every gate below routes
+          # here rather than failing the job — a skipped gate is not an error.
+          skip() {
+            echo "$1"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          # Gate 1 (structural) is the trigger chain itself: this workflow only
+          # fires on a successful Review workflow_run, which only fires on a
+          # successful CI run. Resolve the PR from the head branch (dispatch
+          # supplies it directly).
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            pr="$DISPATCH_PR"
+          else
+            pr="$(gh api "repos/${REPO}/pulls?head=iamacoffeepot:${HEAD_BRANCH}&state=open" \
+              --jq '.[0].number // empty')"
+          fi
+          [ -n "${pr:-}" ] || skip "No open PR for branch '${HEAD_BRANCH}' — nothing to dogfood."
+
+          head_sha="$(gh api "repos/${REPO}/pulls/${pr}" --jq '.head.sha')"
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+          # Gate 2 — the `Review gate` commit status must stand `success` on the
+          # current head. This is the "review has gone green" predicate; it also
+          # auto-passes non-Rust PRs (the review action posts success-skip for
+          # them). Applies on the dispatch path too — dispatch overrides only the
+          # retry state, not the structural gate stack.
+          gate="$(gh api "repos/${REPO}/commits/${head_sha}/status" \
+            --jq '[.statuses[] | select(.context == "Review gate")] | .[0].state // "missing"')"
+          [ "$gate" = "success" ] || skip "Review gate is '${gate}', not success — dogfood waits for review to go green."
+
+          # Gate 3 — the closing issue must carry a filled `## Dogfood brief`.
+          # The closing reference is the authoritative link (GraphQL
+          # closingIssuesReferences), not a body regex, so a re-worded PR body
+          # never loses it.
+          issue="$(gh api graphql -f query='
+            query($owner:String!, $repo:String!, $pr:Int!) {
+              repository(owner:$owner, name:$repo) {
+                pullRequest(number:$pr) {
+                  closingIssuesReferences(first:1) { nodes { number } }
+                }
+              }
+            }' -F owner="${REPO%/*}" -F repo="${REPO#*/}" -F pr="$pr" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[0].number // empty')"
+          [ -n "${issue:-}" ] || skip "PR #${pr} closes no issue — no brief to run."
+          echo "issue=$issue" >> "$GITHUB_OUTPUT"
+
+          body="$(gh api "repos/${REPO}/issues/${issue}" --jq '.body')"
+          # The brief section runs from its H2 header to the next H2 (or EOF).
+          brief="$(awk '/^## Dogfood brief/{f=1; next} /^## /{f=0} f' <<<"$body")"
+          [ -n "$brief" ] || skip "Issue #${issue} has no ## Dogfood brief — nothing to trial."
+          if grep -qE '^[[:space:]]*N/A' <<<"$brief"; then
+            skip "Issue #${issue} brief is N/A — no consumer surface to dogfood."
+          fi
+
+          # Parse the four brief fields. Each is a `- **field**: value` bullet
+          # (single line, the /scope format). A missing value routes to skip.
+          field() {
+            grep -m1 -E "^- \*\*$1\*\*:" <<<"$brief" | sed -E "s/^- \*\*$1\*\*:[[:space:]]*//"
+          }
+          medium="$(field medium)"
+          prompt="$(field prompt)"
+          surface="$(field surfaceUnderTest)"
+          artifact="$(field expectedArtifact)"
+          [ -n "$medium" ] && [ -n "$prompt" ] || skip "Issue #${issue} brief is malformed (medium/prompt missing) — skipping."
+
+          # Emit the free-text fields through random-delimiter heredocs so a
+          # brief value (second-order-injection surface) can never smuggle an
+          # extra output line into $GITHUB_OUTPUT.
+          echo "medium=$medium" >> "$GITHUB_OUTPUT"
+          emit() {
+            local delim="ghout_$(openssl rand -hex 12)"
+            { echo "$1<<$delim"; printf '%s\n' "$2"; echo "$delim"; } >> "$GITHUB_OUTPUT"
+          }
+          emit prompt "$prompt"
+          emit surface "$surface"
+          emit expected_artifact "$artifact"
+
+          # Gate 4 — retry state, read back from the marker comment the poster
+          # upserts on the ISSUE (where post-dogfood-rollup.mjs writes it). The
+          # bare `<!-- aether-dogfood` prefix matches both the old and the
+          # extended marker; a missing marker means attempts=0 (a fresh feature).
+          marker="$(gh api "repos/${REPO}/issues/${issue}/comments" --paginate \
+            --jq '.[].body' | grep -m1 -oE '<!-- aether-dogfood[^>]*-->' || true)"
+          attempts="$(grep -oE 'attempts=[0-9]+' <<<"$marker" | grep -oE '[0-9]+' || echo 0)"
+          verdict="$(grep -oE 'verdict=[a-z]+' <<<"$marker" | sed 's/verdict=//' || echo '')"
+          echo "marker so far: attempts=${attempts:-0} verdict=${verdict:-none}"
+
+          # Dispatch is the manual override — it bypasses BOTH retry-state guards
+          # (a deliberate re-trial after a green verdict or past the cap). The
+          # automatic path honours them: a green verdict is terminal, and the cap
+          # is terminal-failed (the post job bounced the issue at that point).
+          if [ "$EVENT" != "workflow_dispatch" ]; then
+            [ "$verdict" != "green" ] || skip "Issue #${issue} dogfood already green — terminal, no re-run (dispatch to force)."
+            if [ "${attempts:-0}" -ge "$DOGFOOD_MAX_ATTEMPTS" ]; then
+              skip "Issue #${issue} dogfood hit the ${DOGFOOD_MAX_ATTEMPTS}-attempt cap — bounced, no re-run (dispatch to force)."
+            fi
+          fi
+
+          echo "attempt=$((attempts + 1))" >> "$GITHUB_OUTPUT"
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+  trial:
+    name: Dogfood trial
+    needs: resolve
+    if: needs.resolve.outputs.proceed == 'true'
+    # Same ephemeral EC2 shape as the spike proved: 8cpu buys the workflow's
+    # agent fan-out headroom, s3-cache warms sccache across a retrying PR's runs.
+    runs-on: runs-on=${{ github.run_id }}/runner=8cpu-linux-x64/extras=s3-cache
+    # The trial executes branch code and drives headless Claude with
+    # --dangerously-skip-permissions; it must never hold a write scope. All
+    # posting is the `post` job's, which never runs branch code.
+    permissions:
+      contents: read
+    # Cold release-profile build of the chassis is the long pole on the first
+    # run; warm runs are minutes. A wedged in-flight workflow must not idle the
+    # EC2 box toward the 6h default.
+    timeout-minutes: 60
+    env:
+      # Mold for the native link, target-scoped so nothing leaks into a wasm
+      # build if one is ever added here (mirrors CI's test job).
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -Clink-arg=-fuse-ld=mold
+      # No audio device on an EC2 runner — keep the desktop chassis off cpal.
+      AETHER_AUDIO_DISABLE: "1"
+      # Job level so step-level `if: env... != ''` gating works. Absent secret =>
+      # the CC steps skip cleanly and no rollup is produced, so `post` no-ops.
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      # <github.run_id>-<attempt> — the evidence path segment for this attempt.
+      DOGFOOD_RUN_ID: ${{ github.run_id }}-${{ needs.resolve.outputs.attempt }}
+      EXPECTED_ARTIFACT: ${{ needs.resolve.outputs.expected_artifact }}
+      ISSUE: ${{ needs.resolve.outputs.issue }}
+    outputs:
+      rollup_produced: ${{ steps.rollup.outputs.produced }}
+    steps:
+      - uses: runs-on/action@v2
+      # Check out the PR head — the branch build is the point (branch-build
+      # fidelity: the harness the consumer drives is this PR's own code).
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.head_sha }}
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux deps (ALSA headers for cpal, Mesa lavapipe for wgpu, Xvfb + xkbcommon-x11 for the desktop chassis, mold, ffmpeg for x11grab)
+        # libxkbcommon-x11-{0,dev}: winit's keyboard layer dlopens
+        # libxkbcommon-x11.so at runtime; the runner image ships neither the
+        # library nor the unversioned dev symlink, and without them the desktop
+        # chassis panics at boot under Xvfb (spike #2961).
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+          mesa-vulkan-drivers xvfb libxkbcommon-x11-0 libxkbcommon-x11-dev mold ffmpeg
+
+      - uses: Swatinem/rust-cache@v2
+      - name: Configure sccache (S3 backend)
+        run: |
+          echo "SCCACHE_BUCKET=$RUNS_ON_S3_BUCKET_CACHE" >> "$GITHUB_ENV"
+          echo "SCCACHE_REGION=$RUNS_ON_AWS_REGION" >> "$GITHUB_ENV"
+          echo "SCCACHE_S3_KEY_PREFIX=cache/sccache" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      # Install Claude Code BEFORE the firewall so the npm registry never needs
+      # an allowlist entry (the simpler of the two options: install-before vs.
+      # allow registry.npmjs.org).
+      - name: Install Claude Code
+        if: env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        run: npm install -g @anthropic-ai/claude-code
+
+      # Egress firewall — default-drop OUTPUT, allowlist the few hosts the trial
+      # legitimately reaches, drop the rest. This closes the arbitrary-
+      # exfiltration channel for the inference-scoped OAuth token (issue 2968's
+      # security requirement). Runs after apt/toolchain + the runs-on cache
+      # setup and after the npm install, but BEFORE the tunnel + Claude come up.
+      # Honest limits: domains resolve to IPs at rule time, so CDN rotation can
+      # break a long job mid-run and IP-pinning is audit-grade, not adversary-
+      # proof — but it kills arbitrary exfiltration, which is the stated bar.
+      - name: Install the egress firewall (default-drop iptables)
+        run: |
+          set -euo pipefail
+          # Hosts the trial reaches: inference, GitHub (checkout is already
+          # done, but cargo/git may still fetch), crates.io, and the two S3
+          # faces (the evidence bucket + the runs-on sccache bucket). S3 is
+          # resolved by hostname at rule time per the scope decision (simpler
+          # than pinning the VPC-endpoint prefix list).
+          domains="api.anthropic.com github.com api.github.com codeload.github.com \
+            objects.githubusercontent.com raw.githubusercontent.com \
+            static.crates.io crates.io index.crates.io \
+            s3.amazonaws.com s3.${RUNS_ON_AWS_REGION}.amazonaws.com \
+            aether-evidence.s3.amazonaws.com aether-evidence.s3.${RUNS_ON_AWS_REGION}.amazonaws.com \
+            ${RUNS_ON_S3_BUCKET_CACHE}.s3.amazonaws.com ${RUNS_ON_S3_BUCKET_CACHE}.s3.${RUNS_ON_AWS_REGION}.amazonaws.com"
+
+          # Flush OUTPUT but leave the policy ACCEPT during setup so the getent
+          # DNS lookups below still resolve; the final rule flips it to DROP.
+          sudo iptables -F OUTPUT
+          sudo iptables -A OUTPUT -o lo -j ACCEPT
+          sudo iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+          # DNS itself (udp + tcp 53) so resolution keeps working post-drop.
+          sudo iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+          sudo iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+          # EC2 instance metadata (IMDS) — the aws CLI needs it for the append-
+          # only instance-profile creds that push evidence to S3. Link-local,
+          # not an internet exfiltration path; consistent with the pre-existing
+          # exposure every Runs-On CI job already has.
+          sudo iptables -A OUTPUT -d 169.254.169.254 -j ACCEPT
+          for d in $domains; do
+            for ip in $(getent ahostsv4 "$d" | awk '{print $1}' | sort -u); do
+              echo "allow 443 -> $ip ($d)"
+              sudo iptables -A OUTPUT -p tcp -d "$ip" --dport 443 -j ACCEPT
+            done
+          done
+          # Log what falls through before dropping it, so a legitimately blocked
+          # domain (a rotated CDN IP) is diagnosable from the run log.
+          sudo iptables -A OUTPUT -j LOG --log-prefix "egress-drop: " --log-level 4
+          sudo iptables -P OUTPUT DROP
+          echo "egress firewall installed:"
+          sudo iptables -L OUTPUT -n --line-numbers
+
+      # The repo's .claude hooks bind interactive sessions into per-session
+      # worktrees and police edits outside them — actively harmful in CI, where
+      # they rebind the session out of $GITHUB_WORKSPACE and delete the live
+      # transcript tee target as untracked scratch (#2986). The runner is
+      # ephemeral and single-purpose, so strip the hooks from this checkout
+      # COPY; the hooks in the repo itself are untouched.
+      - name: Strip interactive-session hooks from the checkout copy
+        run: |
+          jq 'del(.hooks)' .claude/settings.json > /tmp/settings.json
+          mv /tmp/settings.json .claude/settings.json
+
+      # The desktop chassis is not in ensure-tunnel.sh's own build list, but the
+      # script DOES ingest target/release/aether-substrate into the hub's binary
+      # store when it exists — so build it first and a render brief can spawn it
+      # by selector under Xvfb with no extra plumbing.
+      - name: Build the desktop chassis (for render briefs)
+        run: cargo build --release -p aether-substrate-bundle --bin aether-substrate
+
+      # Xvfb up BEFORE the tunnel: the tunnel forks the hub, the hub forks
+      # substrates, and the desktop chassis inherits DISPLAY through that chain.
+      - name: Start Xvfb (virtual display for the desktop chassis)
+        run: |
+          Xvfb :99 -screen 0 1280x800x24 &
+          echo "DISPLAY=:99" >> "$GITHUB_ENV"
+
+      # Bring up the MCP harness from THIS branch's build. ensure-tunnel.sh
+      # builds the fork chain, launches the tunnel detached, and exits 0 best-
+      # effort; the poll below is the actual assertion that the stack came up.
+      - name: Bring up the MCP harness
+        run: scripts/ensure-tunnel.sh
+      - name: Assert tunnel + both children are up
+        run: |
+          # Both children must be alive, not just the tunnel answering — the
+          # tunnel re-forks a crashed child, and the trial must not start
+          # against a mid-restart harness.
+          ok=""
+          for _ in $(seq 1 30); do
+            if curl -fsS --max-time 2 http://127.0.0.1:8890/admin/status -o /tmp/status.json \
+               && grep -q '"aether_mcp":{"alive":true' /tmp/status.json \
+               && grep -q '"hub":{"alive":true' /tmp/status.json; then
+              ok=1
+              break
+            fi
+            sleep 2
+          done
+          echo "admin/status:"
+          cat /tmp/status.json 2>/dev/null || echo "(no response)"
+          echo
+          if [ -z "$ok" ]; then
+            echo "DOGFOOD-HARNESS-FAIL: tunnel + both children never all alive"
+            exit 1
+          fi
+          echo "DOGFOOD-HARNESS-OK"
+
+      - name: Note when the OAuth token secret is absent
+        if: env.CLAUDE_CODE_OAUTH_TOKEN == ''
+        run: |
+          echo "CLAUDE_CODE_OAUTH_TOKEN secret is not set — the trial is skipped."
+          echo "Mint one with 'claude setup-token' and add it: gh secret set CLAUDE_CODE_OAUTH_TOKEN"
+
+      # Pre-trust the checkout so settings.json permissions aren't ignored with
+      # a warning under skip-permissions.
+      - name: Pre-trust the workspace for headless Claude
+        if: env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        run: printf '{"projects":{"%s":{"hasTrustDialogAccepted":true}}}\n' "$PWD" > "$HOME/.claude.json"
+
+      # Auth in isolation before the real run: a one-line prompt, no tools. If
+      # this fails the OAuth token itself is the problem, not the harness.
+      # --max-turns 3 (not 1) because the model occasionally spends a turn
+      # before emitting the reply, and a 1-turn cap reads as a spurious auth
+      # failure (spike #2961).
+      - name: Auth probe (no tools)
+        if: env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        run: |
+          claude -p "Reply with exactly: AUTH-OK" \
+            --model claude-sonnet-5 \
+            --max-turns 3 | tee /tmp/auth.log
+          grep -q "AUTH-OK" /tmp/auth.log
+
+      # Record the virtual display for the whole session — but ONLY when the
+      # brief renders (expectedArtifact != none). A drive/author brief with no
+      # visual content gets no video, matching the design rule.
+      - name: Start display recording (x11grab)
+        if: env.CLAUDE_CODE_OAUTH_TOKEN != '' && env.EXPECTED_ARTIFACT != 'none' && env.EXPECTED_ARTIFACT != ''
+        run: |
+          nohup ffmpeg -y -f x11grab -video_size 1280x800 -framerate 15 -i :99 \
+            -codec:v libx264 -preset veryfast -pix_fmt yuv420p /tmp/trial.mp4 \
+            > /tmp/ffmpeg.log 2>&1 &
+          echo $! > /tmp/ffmpeg.pid
+
+      # The trial itself. Headless Claude invokes the dogfood WORKFLOW with
+      # args.task set from the brief — a supplied task skips the Author phase and
+      # its human approval stop, which is what makes the run unattended. The
+      # stream-json + jq renderer makes the session watchable live in the Actions
+      # log; the tee'd JSONL is the durable transcript (uploaded below). The tee
+      # target lives in /tmp, outside the checkout, so the session can never
+      # mistake it for repo scratch and delete it (#2986). The wait contract is
+      # MECHANICAL, not prose — a headless session ends its process (and kills
+      # the in-flight background workflow) the moment it produces a final reply,
+      # so the prompt forbids that reply until the rollup file exists on disk.
+      - name: Run the dogfood trial
+        if: env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        env:
+          BRIEF_MEDIUM: ${{ needs.resolve.outputs.medium }}
+          BRIEF_PROMPT: ${{ needs.resolve.outputs.prompt }}
+          BRIEF_SURFACE: ${{ needs.resolve.outputs.surface }}
+          BRIEF_ARTIFACT: ${{ needs.resolve.outputs.expected_artifact }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/dogfood-run"
+
+          # Build the args.task JSON with jq so a brief value carrying quotes,
+          # backticks, or $ is escaped correctly. `none` maps to a null
+          # expectedArtifact (the workflow's "nothing renders" sentinel).
+          task_json="$(jq -nc \
+            --arg medium "$BRIEF_MEDIUM" \
+            --arg prompt "$BRIEF_PROMPT" \
+            --arg surface "$BRIEF_SURFACE" \
+            --arg artifact "$BRIEF_ARTIFACT" \
+            '{medium: $medium, prompt: $prompt, surfaceUnderTest: $surface,
+              expectedArtifact: (if $artifact == "none" or $artifact == "" then null else $artifact end)}')"
+
+          # Assemble the prompt in a quoted heredoc so the interpolated JSON is
+          # inserted verbatim (no shell re-parsing of its contents).
+          cat > /tmp/dogfood-prompt.md <<EOF
+          You are running headless in CI on a checkout of PR #${PR_NUMBER}'s head branch, with the
+          aether MCP harness already up (tunnel -> aether-mcp -> hub -> substrate) via .mcp.json.
+
+          Run the repo's DOGFOOD WORKFLOW (.claude/workflows/dogfood.js, the /dogfood entry point) via
+          the Workflow/Skill tooling, passing args set to EXACTLY this JSON object. Supplying args.task
+          SKIPS the Author phase and its human approval stop — that is what makes this run unattended:
+
+          { "task": ${task_json} }
+
+          THE WAIT CONTRACT (load-bearing — headless runs die on this): the Workflow tool runs in the
+          BACKGROUND. In headless mode your final reply exits the process and KILLS the in-flight
+          workflow, so you may NOT produce a final reply until ${GITHUB_WORKSPACE}/dogfood-rollup.json
+          exists on disk. While the workflow runs, poll MECHANICALLY: run the Bash command
+          'sleep 60; ls ${GITHUB_WORKSPACE}/dogfood-rollup.json 2>/dev/null || echo waiting'
+          again and again, as many turns as it takes — the completion notification or the workflow
+          result reaches you between polls. Polling turns are cheap; an early final reply wastes the
+          whole run. The file NEVER appears on its own — the workflow returns { rollup, task } as a
+          VALUE, and YOU write it. When it returns, write the returned ROLLUP object as JSON verbatim
+          to exactly ${GITHUB_WORKSPACE}/dogfood-rollup.json (that absolute path — the rollup object,
+          not the { rollup, task } wrapper).
+
+          EVIDENCE (absolute paths only — ${GITHUB_WORKSPACE}/dogfood-run/ already exists):
+          - If the task's expectedArtifact is not null the run RENDERS. Ensure a live engine is showing
+            the expected state (re-spawn + re-drive it if the workflow's judge already terminated the
+            render engine), then call capture_frame with save_path set to EXACTLY
+            ${GITHUB_WORKSPACE}/dogfood-run/frame.png so the judged frame is persisted for the record.
+          - If the medium was author or build-layer and you can locate the Attempt's scratch crate,
+            copy it into ${GITHUB_WORKSPACE}/dogfood-run/solution/ so the author/build-layer artifact
+            rides in the evidence (best effort — skip if it is not reachable from here).
+
+          Do not push to git or touch GitHub. Print exactly DOGFOOD-DONE once the rollup file is written.
+          EOF
+
+          claude -p "$(cat /tmp/dogfood-prompt.md)" \
+            --mcp-config .mcp.json \
+            --dangerously-skip-permissions \
+            --model claude-sonnet-5 \
+            --max-turns 120 \
+            --output-format stream-json --verbose \
+            | tee /tmp/dogfood-session.jsonl \
+            | jq -rj --unbuffered '
+                if .type == "assistant" then
+                  ([.message.content[]? | if .type == "text" then "\n■ " + .text + "\n"
+                    elif .type == "tool_use" then "▸ " + .name + "\n" else empty end] | join(""))
+                elif .type == "result" then "\n== result (\(.subtype)) ==\n" + (.result // "") + "\n"
+                else empty end' \
+            || true
+
+      # Stop + finalize the recording and push it to the evidence bucket, even
+      # on a failed trial — a failed render trial is exactly when a human wants
+      # to watch. Instance-profile creds are append-only on the bucket.
+      - name: Stop recording, upload to the evidence bucket
+        if: always() && env.CLAUDE_CODE_OAUTH_TOKEN != '' && env.EXPECTED_ARTIFACT != 'none' && env.EXPECTED_ARTIFACT != ''
+        run: |
+          [ -f /tmp/ffmpeg.pid ] || { echo "no recording was started"; exit 0; }
+          kill -INT "$(cat /tmp/ffmpeg.pid)" 2>/dev/null || true
+          for _ in $(seq 1 10); do
+            kill -0 "$(cat /tmp/ffmpeg.pid)" 2>/dev/null || break
+            sleep 1
+          done
+          [ -s /tmp/trial.mp4 ] || { echo "recording empty — nothing to upload"; cat /tmp/ffmpeg.log; exit 0; }
+          ls -la /tmp/trial.mp4
+          KEY="evidence/${ISSUE}/${DOGFOOD_RUN_ID}/trial.mp4"
+          aws s3 cp /tmp/trial.mp4 "s3://aether-evidence/${KEY}" --content-type video/mp4
+          URL="https://aether-evidence.s3.amazonaws.com/${KEY}"
+          echo "trial video: ${URL}"
+          echo "### Dogfood trial video" >> "$GITHUB_STEP_SUMMARY"
+          echo "[watch the trial](${URL})" >> "$GITHUB_STEP_SUMMARY"
+
+      # Stage the evidence the post job consumes: the rollup, the judged frame,
+      # the scratch solution, and the transcript. The rollup lands at the
+      # workspace root (the session writes it there); move it under dogfood-run/.
+      - name: Stage the run directory
+        if: always()
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/dogfood-run"
+          if [ -f "$GITHUB_WORKSPACE/dogfood-rollup.json" ]; then
+            cp "$GITHUB_WORKSPACE/dogfood-rollup.json" "$GITHUB_WORKSPACE/dogfood-run/rollup.json"
+          fi
+          cp /tmp/dogfood-session.jsonl "$GITHUB_WORKSPACE/dogfood-run/transcript.jsonl" 2>/dev/null || true
+          echo "staged run directory:"
+          ls -la "$GITHUB_WORKSPACE/dogfood-run" || true
+
+      # Whether the run produced a rollup gates the `post` job. A missing rollup
+      # after the trial actually ran (token present) is a FAILURE, not a quiet
+      # skip — the session exiting with the workflow still in flight is the exact
+      # bug the mechanical wait contract exists to prevent (#2979/#2986). The
+      # quiet-skip path exists only for the absent-secret case.
+      - name: Note whether a rollup was produced
+        id: rollup
+        if: always()
+        run: |
+          if [ -f "$GITHUB_WORKSPACE/dogfood-run/rollup.json" ]; then
+            echo "produced=true" >> "$GITHUB_OUTPUT"
+          elif [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+            echo "produced=false" >> "$GITHUB_OUTPUT"
+            echo "trial ran but produced no rollup — failing loudly. Session's final events:"
+            if [ -f /tmp/dogfood-session.jsonl ]; then
+              tail -n 5 /tmp/dogfood-session.jsonl | cut -c1-2000
+            else
+              echo "(no session transcript)"
+            fi
+            exit 1
+          else
+            echo "produced=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always() && steps.rollup.outputs.produced == 'true'
+        with:
+          name: dogfood-run
+          path: dogfood-run
+          if-no-files-found: ignore
+
+      # The transcript, uploaded even on failure — a dead run's transcript is
+      # exactly what diagnoses it.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: dogfood-session-transcript
+          path: /tmp/dogfood-session.jsonl
+          if-no-files-found: ignore
+
+      - name: Tunnel log (diagnostics)
+        if: always()
+        run: |
+          LOG="${TMPDIR:-/tmp}/aether-tunnel/tunnel.log"
+          if [ -f "$LOG" ]; then
+            echo "--- tail of $LOG ---"
+            tail -n 200 "$LOG"
+          else
+            echo "no tunnel log at $LOG"
+          fi
+
+  post:
+    name: Post dogfood rollup
+    needs: [resolve, trial]
+    # No-op when the trial produced no rollup (token absent or the trial
+    # failed). Mirrors review.yml's needs-output gate.
+    if: needs.trial.outputs.rollup_produced == 'true'
+    runs-on: ubuntu-latest
+    # The only job with write scopes, and it never executes branch code: the
+    # default checkout is the base repo (main), so the evidence + poster
+    # scripts are the trusted versions — the PR head is only ever read as data.
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      ISSUE: ${{ needs.resolve.outputs.issue }}
+      PR: ${{ needs.resolve.outputs.pr }}
+      ATTEMPT: ${{ needs.resolve.outputs.attempt }}
+      DOGFOOD_RUN_ID: ${{ github.run_id }}-${{ needs.resolve.outputs.attempt }}
+      VIEWER_BASE: https://iamacoffeepot.github.io/aether/evidence/
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dogfood-run
+          path: dogfood-run
+
+      # Commit this attempt's run directory to the orphan dogfood/evidence
+      # branch at evidence/<issue>/<run-id>/ (the script pushes with retries).
+      - name: Push the run to the evidence branch
+        run: scripts/dogfood-evidence.sh dogfood-run "$ISSUE" "$DOGFOOD_RUN_ID"
+
+      # Upsert the living marker comment on the issue and set/clear the advisory
+      # dogfood:unresolved label on the PR. The marker carries attempts/verdict
+      # so the next green event's resolve gate can read the retry state back.
+      - name: Post the rollup comment + label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RUN_REF: ${{ needs.resolve.outputs.issue }}/${{ github.run_id }}-${{ needs.resolve.outputs.attempt }}
+          ROLLUP_PATH: dogfood-run/rollup.json
+        run: |
+          HAS_FRAME=0
+          [ -f dogfood-run/frame.png ] && HAS_FRAME=1
+          HAS_FRAME="$HAS_FRAME" node scripts/post-dogfood-rollup.mjs
+
+      # Cap-bounce: a persistently-failing feature (an actionable trial at the
+      # attempt cap) bounces the CLOSING ISSUE to the user for review rather than
+      # looping forever. The actionability predicate mirrors the poster's — a
+      # failed attempt, a wrong artifact, a soft-hold, or a blocker /
+      # missing-primitive finding. The PR keeps its evidence comment + label;
+      # the issue's phase:bounced is the review surface.
+      - name: Bounce the issue at the attempt cap
+        run: |
+          set -euo pipefail
+          actionable="$(jq -r '(.rollup // .) as $r
+            | (($r.succeeded == false)
+               or ($r.artifact.verdict == "wrong")
+               or ((($r.softHolds // []) | length) > 0)
+               or ((($r.friction.blocker // []) | length) > 0)
+               or ((($r.friction["missing-primitive"] // []) | length) > 0))' \
+            dogfood-run/rollup.json)"
+          echo "attempt=${ATTEMPT} cap=${DOGFOOD_MAX_ATTEMPTS} actionable=${actionable}"
+          if [ "$actionable" != "true" ] || [ "$ATTEMPT" -lt "$DOGFOOD_MAX_ATTEMPTS" ]; then
+            echo "not bouncing (either clean or below the cap)."
+            exit 0
+          fi
+
+          # Swap the phase label to phase:bounced, preserving every non-phase
+          # label. REST PUT replaces the whole set, so build it explicitly.
+          labels="$(gh api "repos/${REPO}/issues/${ISSUE}/labels" \
+            --jq '[.[].name | select(startswith("phase:") | not)] + ["phase:bounced"]')"
+          gh api -X PUT "repos/${REPO}/issues/${ISSUE}/labels" \
+            --input <(jq -nc --argjson l "$labels" '{labels: $l}')
+
+          # Link every recorded attempt's evidence from the dogfood/evidence
+          # branch (each run-id dir under evidence/<issue>/) via the viewer.
+          runs="$(gh api "repos/${REPO}/contents/evidence/${ISSUE}?ref=dogfood/evidence" \
+            --jq '.[].name' 2>/dev/null || true)"
+          links=""
+          for r in $runs; do
+            links="${links}- [attempt evidence \`${r}\`](${VIEWER_BASE}?run=${ISSUE}/${r})
+          "
+          done
+          [ -n "$links" ] || links="- (no evidence directories found on the dogfood/evidence branch)
+          "
+
+          # Write the comment body to a file (a plain heredoc, not wrapped in a
+          # command substitution) and read it back — the wrapping form confuses
+          # the shell parser on the escaped backticks / apostrophes.
+          cat > /tmp/bounce-body.md <<EOF
+          ## Dogfood bounced to you
+
+          The dogfood trial for this feature failed **${DOGFOOD_MAX_ATTEMPTS}** times (the retry cap) without going green, so it is bounced here for your review rather than retrying forever.
+
+          The PR (#${PR}) keeps its living dogfood comment and its \`dogfood:unresolved\` label; this issue now carries \`phase:bounced\`. Every attempt's evidence:
+
+          ${links}
+          Clear it by fixing the feature (or the brief) and re-running the trial via \`workflow_dispatch\` on the Dogfood workflow with this PR number.
+          EOF
+          gh api -X POST "repos/${REPO}/issues/${ISSUE}/comments" -f body="$(cat /tmp/bounce-body.md)"

--- a/scripts/post-dogfood-rollup.mjs
+++ b/scripts/post-dogfood-rollup.mjs
@@ -9,6 +9,18 @@
 // (a separate skill-text change), not a CI failure here. A failed API
 // call logs and continues where the review poster does.
 //
+// The marker line carries the retry state the dogfood action's resolve
+// step reads back on the next green event (issue 2968): it is extended
+// from the bare `<!-- aether-dogfood -->` to
+// `<!-- aether-dogfood attempts=<N> verdict=<green|failed> -->`, where
+// `attempts` is this comment's attempt number (the ATTEMPT env, defaulting
+// to 1) and `verdict` is `green` when the trial is clean and `failed` when
+// the actionability predicate fires or the attempt did not succeed. A
+// `green` verdict is terminal (no more auto-runs); `attempts >= the cap`
+// is terminal-failed. The upsert lookup still matches on the bare
+// `<!-- aether-dogfood` prefix, so an old bare-marker comment migrates to
+// the extended form in place on the first post that carries the state.
+//
 // Inputs (env):
 //   GITHUB_TOKEN        least-privilege token (issues write)
 //   GITHUB_REPOSITORY   owner/repo
@@ -16,6 +28,8 @@
 //   PR                  the PR to carry the label (optional; defaults to ISSUE)
 //   RUN_REF             <issue>/<run-id> — the evidence-branch path segment
 //   ROLLUP_PATH         rollup.json (the workflow's returned rollup)
+//   ATTEMPT             this trial's attempt number, baked into the marker
+//                       (optional; defaults to 1)
 //   HAS_FRAME           "1"/"true" when the staged run dir held a frame.png
 //                       (falls back to rollup.artifact != null when unset)
 //
@@ -29,8 +43,13 @@ const ISSUE = Number(requireEnv('ISSUE'))
 const PR = process.env.PR ? Number(process.env.PR) : ISSUE
 const RUN_REF = requireEnv('RUN_REF')
 const ROLLUP_PATH = process.env.ROLLUP_PATH || 'rollup.json'
+const ATTEMPT = process.env.ATTEMPT ? Number(process.env.ATTEMPT) : 1
 
-const MARKER = '<!-- aether-dogfood -->'
+// The bare prefix is the upsert anchor — it matches both the old
+// `<!-- aether-dogfood -->` comment and the extended
+// `<!-- aether-dogfood attempts=… verdict=… -->` one, so a format change
+// migrates in place rather than stacking a second comment.
+const MARKER_PREFIX = '<!-- aether-dogfood'
 const LABEL = 'dogfood:unresolved'
 const API = 'https://api.github.com'
 const RAW_BASE = 'https://raw.githubusercontent.com/iamacoffeepot/aether/dogfood/evidence/evidence'
@@ -142,8 +161,20 @@ function softHoldLines(softHolds) {
   return lines
 }
 
+// The verdict baked into the marker mirrors the label decision: a trial
+// with anything actionable (a failed attempt, a wrong artifact, a
+// soft-hold, a blocker / missing-primitive finding) is `failed`, else
+// `green`. `green` is terminal for the auto-retry loop.
+function markerVerdict(rollup) {
+  return isActionable(rollup) || rollup.succeeded === false ? 'failed' : 'green'
+}
+
+function markerLine(rollup) {
+  return `${MARKER_PREFIX} attempts=${ATTEMPT} verdict=${markerVerdict(rollup)} -->`
+}
+
 function renderComment(rollup, hasFrame) {
-  const lines = [MARKER, '## Dogfood trial', '']
+  const lines = [markerLine(rollup), '## Dogfood trial', '']
   lines.push(...verdictLines(rollup))
   lines.push('', '### Friction')
   lines.push(...frictionLines(rollup.friction))
@@ -193,7 +224,7 @@ async function main() {
   // otherwise. The evidence branch keeps per-run history, so the comment
   // shows latest-state.
   const issueComments = await apiList(`repos/${REPO}/issues/${ISSUE}/comments`)
-  const existing = issueComments.find((c) => String(c.body || '').includes(MARKER))
+  const existing = issueComments.find((c) => String(c.body || '').includes(MARKER_PREFIX))
   if (existing) {
     const res = await api('PATCH', `repos/${REPO}/issues/comments/${existing.id}`, { body })
     if (!res.ok) console.error(`update comment failed: ${res.status} ${res.text}`)


### PR DESCRIPTION
Closes #2968.

## Summary

The dogfood runner, assembled from the pieces the arc already landed: the spike-proven trial recipe (#2961), the evidence scripts (#2967), the viewer (#2974), and the `Review gate` status (#2996). The workflow chains `workflow_run` on the Review workflow, making dogfood the structural last stage: a run proceeds only when the head's `Review gate` status is `success`, the closing issue carries a filled `## Dogfood brief` (an `N/A` brief skips cleanly), and the retry state allows it. Retry state rides the poster's marker (`<!-- aether-dogfood attempts=N verdict=green|failed -->`): green is terminal, failed retries on subsequent green events up to `DOGFOOD_MAX_ATTEMPTS` (default 3), and a cap-hit bounces the closing issue to `phase:bounced` with a persistent-failure summary linking each attempt's evidence through the viewer. `workflow_dispatch pr=N` bypasses both retry-state guards as the human escape hatch — structural gates still apply.

The trial job (`contents: read`, 60-minute leash, Runs-On 8cpu) executes branch code behind a default-drop egress firewall (rule-time-resolved allowlist: Anthropic API, GitHub, crates.io, the S3 endpoints, IMDS for instance-profile creds; drops logged) and carries every review-action bring-up scar: repo hooks stripped from the checkout, isolated auth probe, stream-json live log with the transcript teed to /tmp, mechanical wait contract with absolute workspace paths, loud-fail when a token was present but no rollup emerged. x11grab records only when the brief's `expectedArtifact` is not `none`, uploading to the append-only evidence bucket. The post job never executes branch code: it checks out main, commits the run to the orphan evidence branch, posts the always-on rollup comment (success included), and sets/clears `dogfood:unresolved` on the PR where the /land gate reads it.

One structural assumption to confirm on the first live PR: push → CI → Review → Dogfood sits exactly at GitHub's three-level `workflow_run` chaining limit.

## Test plan

Workflow YAML + poster marker extension; YAML load, `node --check`, and per-block `bash -n` pass, with the brief parser, marker parsing, bounce predicate, and task-JSON escaping exercised against sample inputs. Live verification is the first Rust PR with a filled brief after this lands — and this PR itself is the first live observation of the `Review gate` status posting (non-Rust auto-skip), the precondition for the branch-protection flip.

## Generated by

`/implement` — [issue #2968](https://github.com/iamacoffeepot/aether/issues/2968), scoped and approved through the pipeline.
