### PR TITLE
feat(mcp): flag on list_engines to filter alive or dead engines

### DIFF
--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -161,6 +161,23 @@ pub struct ListBinariesArgs {
     pub target: Option<String>,
 }
 
+/// `list_engines` arguments (issue 2985). One optional filter deciding
+/// which of the two reported lists come back, so a routine liveness
+/// check doesn't pay the context cost of the whole recently-died fleet
+/// history — and a death-forensics call doesn't enumerate the live
+/// fleet.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListEnginesArgs {
+    /// Which lists to return: `"alive"` renders only the live `engines`,
+    /// `"dead"` renders only the `recently_died` sidecar, and `"all"`
+    /// (the default when omitted) renders both exactly as before. The
+    /// omitted list is absent from the reply JSON, not present-but-empty,
+    /// so the tokens are actually saved. Any other value is a tool error
+    /// naming the three accepted values.
+    #[serde(default)]
+    pub show: Option<String>,
+}
+
 /// `send_mail` arguments — a best-effort batch.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SendMailArgs {
@@ -242,13 +259,23 @@ pub struct DeadEngineInfo {
 /// `list_engines` output: the live fleet plus the recently-died sidecar
 /// (issue 1906). An object rather than a bare array so an observer can
 /// tell a clean shutdown from a failure without grepping host logs.
+/// Each list is optional (issue 2985): the `show` filter renders only
+/// the requested list(s), and the unasked one is `None` — dropped from
+/// the JSON via `skip_serializing_if` rather than serialized empty, so
+/// its absence states the filter and the tokens are saved. The default
+/// (`show` omitted / `"all"`) leaves both `Some`, so an unfiltered call
+/// serializes exactly as before.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ListEnginesResponse {
-    /// Every engine the hub currently supervises.
-    pub engines: Vec<EngineInfo>,
+    /// Every engine the hub currently supervises. `None` (absent from
+    /// the JSON) when `show` was `"dead"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub engines: Option<Vec<EngineInfo>>,
     /// The last few engines that left the fleet, each with why it left
-    /// and how long ago.
-    pub recently_died: Vec<DeadEngineInfo>,
+    /// and how long ago. `None` (absent from the JSON) when `show` was
+    /// `"alive"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recently_died: Option<Vec<DeadEngineInfo>>,
 }
 
 /// Per-item outcome from a `send_mail` batch.

--- a/crates/aether-mcp/src/tools/engine.rs
+++ b/crates/aether-mcp/src/tools/engine.rs
@@ -8,7 +8,9 @@ use aether_kinds::{
 use rmcp::ErrorData as McpError;
 use tokio::time;
 
-use crate::args::{DeadEngineInfo, EngineInfo, ListEnginesResponse, SpawnSubstrateArgs, TerminateSubstrateArgs};
+use crate::args::{
+    DeadEngineInfo, EngineInfo, ListEnginesArgs, ListEnginesResponse, SpawnSubstrateArgs, TerminateSubstrateArgs,
+};
 
 use super::components::components_all_loaded;
 use super::envelope::{engine_envelope, local_envelope};
@@ -16,33 +18,50 @@ use super::ids::parse_engine_id;
 use super::render::{death_reason_parts, internal, internal_msg, json};
 use super::{ENGINE_CAP, Mcp};
 
-pub(super) async fn list_engines(mcp: &Mcp) -> Result<String, McpError> {
+pub(super) async fn list_engines(mcp: &Mcp, args: ListEnginesArgs) -> Result<String, McpError> {
+    // Decide which lists to render before the wire round-trip so a bad
+    // `show` value fails at the tool boundary. The wire call still
+    // fetches both — the fleet is small and the filter is a projection
+    // concern (issue 2985) — but the unasked list is dropped from the
+    // reply as `None` rather than serialized empty.
+    let (want_alive, want_dead) = match args.show.as_deref().unwrap_or("all") {
+        "all" => (true, true),
+        "alive" => (true, false),
+        "dead" => (false, true),
+        other => {
+            return Err(McpError::invalid_params(format!("unknown show {other:?}; expected alive|dead|all"), None));
+        }
+    };
     let reply = mcp.session.call_one(local_envelope(ENGINE_CAP, &ListEngines {})).await.map_err(internal)?;
     let result = ListEnginesResult::decode_from_bytes(&reply.payload)
         .ok_or_else(|| internal_msg("undecodable ListEnginesResult"))?;
-    let engines: Vec<EngineInfo> = result
-        .engines
-        .into_iter()
-        .map(|e| EngineInfo {
-            engine_id: e.engine_id,
-            rpc_port: e.rpc_port,
-            last_heartbeat_age_millis: e.last_heartbeat_age_millis,
-        })
-        .collect();
-    let recently_died: Vec<DeadEngineInfo> = result
-        .recently_died
-        .into_iter()
-        .map(|d| {
-            let (reason, detail) = death_reason_parts(d.reason);
-            DeadEngineInfo {
-                engine_id: d.engine_id,
-                rpc_port: d.rpc_port,
-                reason,
-                detail,
-                died_age_millis: d.died_age_millis,
-            }
-        })
-        .collect();
+    let engines: Option<Vec<EngineInfo>> = want_alive.then(|| {
+        result
+            .engines
+            .into_iter()
+            .map(|e| EngineInfo {
+                engine_id: e.engine_id,
+                rpc_port: e.rpc_port,
+                last_heartbeat_age_millis: e.last_heartbeat_age_millis,
+            })
+            .collect()
+    });
+    let recently_died: Option<Vec<DeadEngineInfo>> = want_dead.then(|| {
+        result
+            .recently_died
+            .into_iter()
+            .map(|d| {
+                let (reason, detail) = death_reason_parts(d.reason);
+                DeadEngineInfo {
+                    engine_id: d.engine_id,
+                    rpc_port: d.rpc_port,
+                    reason,
+                    detail,
+                    died_age_millis: d.died_age_millis,
+                }
+            })
+            .collect()
+    });
     json(&ListEnginesResponse { engines, recently_died })
 }
 

--- a/crates/aether-mcp/src/tools/mod.rs
+++ b/crates/aether-mcp/src/tools/mod.rs
@@ -49,9 +49,9 @@ use crate::args::ActorCostArgs;
 use crate::args::ActorLogsArgs;
 use crate::args::{
     CaptureFrameArgs, CaptureMailSpec, ComponentSpec, DescribeComponentArgs, DescribeHandlersArgs, DescribeKindsArgs,
-    ListBinariesArgs, ListComponentsArgs, LoadComponentArgs, MailIdJson, MailNodeJson, MailSpec, ReplaceComponentArgs,
-    ReplyEventJson, SendMailArgs, SendMailTracedArgs, SpawnSubstrateArgs, TerminateSubstrateArgs, TracedMailSpec,
-    UploadBinaryArgs, UploadComponentArgs,
+    ListBinariesArgs, ListComponentsArgs, ListEnginesArgs, LoadComponentArgs, MailIdJson, MailNodeJson, MailSpec,
+    ReplaceComponentArgs, ReplyEventJson, SendMailArgs, SendMailTracedArgs, SpawnSubstrateArgs, TerminateSubstrateArgs,
+    TracedMailSpec, UploadBinaryArgs, UploadComponentArgs,
 };
 use crate::reverse::EngineNames;
 use crate::rpc::RpcSession;
@@ -234,10 +234,10 @@ impl Mcp {
 #[tool_router]
 impl Mcp {
     #[tool(
-        description = "List every engine the hub currently supervises, plus a recently-died sidecar. Returns an object {engines, recently_died}: each `engines` item reports the engine_id (pass it to send_mail / terminate_substrate) and the localhost RPC port the hub assigned its substrate; each `recently_died` item reports a departed engine with why it left — reason \"terminated\" (a deliberate terminate_substrate), \"crashed\" (the substrate closed its connection), \"evicted\" (a missed-heartbeat eviction), or \"spawn_failed\" (a spawn that never connected — the substrate failed to come up) — plus a detail string and how long ago it left, so a clean shutdown is distinguishable from a failure."
+        description = "List every engine the hub currently supervises, plus a recently-died sidecar. Returns an object {engines, recently_died}: each `engines` item reports the engine_id (pass it to send_mail / terminate_substrate) and the localhost RPC port the hub assigned its substrate; each `recently_died` item reports a departed engine with why it left — reason \"terminated\" (a deliberate terminate_substrate), \"crashed\" (the substrate closed its connection), \"evicted\" (a missed-heartbeat eviction), or \"spawn_failed\" (a spawn that never connected — the substrate failed to come up) — plus a detail string and how long ago it left, so a clean shutdown is distinguishable from a failure. Pass `show` to filter which lists come back so a routine liveness check doesn't pay the context cost of the whole fleet history: \"alive\" returns only {engines}, \"dead\" returns only {recently_died}, and \"all\" (the default when omitted) returns both. The unasked list is absent from the reply JSON, not present-but-empty. Any other `show` value is a tool error naming the three accepted values."
     )]
-    pub async fn list_engines(&self) -> Result<String, McpError> {
-        engine::list_engines(self).await
+    pub async fn list_engines(&self, Parameters(args): Parameters<ListEnginesArgs>) -> Result<String, McpError> {
+        engine::list_engines(self, args).await
     }
 
     #[tool(

--- a/crates/aether-mcp/src/tools/tests/engine.rs
+++ b/crates/aether-mcp/src/tools/tests/engine.rs
@@ -3,18 +3,65 @@ use super::super::test_support::*;
 #[allow(clippy::wildcard_imports)]
 use super::super::*;
 
-/// `list_engines` over the RPC round-trip yields an object with empty
+/// `list_engines` with no `show` argument yields an object with empty
 /// `engines` / `recently_died` arrays on a fresh hub — proves the
 /// whole `RpcSession` demux + the `engine = None` Call path against
-/// the real `aether.engine` cap, and the issue-1906 output shape.
+/// the real `aether.engine` cap, the issue-1906 output shape, and that
+/// the issue-2985 `show` default (`"all"`) preserves the pre-filter
+/// shape byte-for-byte so existing callers see no change.
 #[tokio::test]
 async fn list_engines_on_empty_hub_is_empty() {
     let (_chassis, port) = boot_hub();
     let mcp = connect_mcp(port);
-    let out = mcp.list_engines().await.expect("list_engines ok");
+    let out = mcp.list_engines(Parameters(ListEnginesArgs { show: None })).await.expect("list_engines ok");
     assert_eq!(
         out, "{\"engines\":[],\"recently_died\":[]}",
         "fresh hub supervises no engines and has no recent deaths",
+    );
+}
+
+/// `show: "alive"` renders only `engines`; `recently_died` is dropped
+/// from the JSON entirely (issue 2985). Tripwire: catches an inverted
+/// filter (returning the dead list) or a default that keeps both lists
+/// present-but-empty instead of omitting the unasked one.
+#[tokio::test]
+async fn list_engines_show_alive_omits_recently_died() {
+    let (_chassis, port) = boot_hub();
+    let mcp = connect_mcp(port);
+    let out = mcp
+        .list_engines(Parameters(ListEnginesArgs { show: Some("alive".to_owned()) }))
+        .await
+        .expect("list_engines ok");
+    assert_eq!(out, "{\"engines\":[]}", "show=alive keeps only engines and omits the recently_died key",);
+}
+
+/// `show: "dead"` renders only `recently_died`; the live `engines` list
+/// is dropped from the JSON entirely (issue 2985). Tripwire mirror of
+/// the alive case — catches the same inversion from the other side.
+#[tokio::test]
+async fn list_engines_show_dead_omits_engines() {
+    let (_chassis, port) = boot_hub();
+    let mcp = connect_mcp(port);
+    let out =
+        mcp.list_engines(Parameters(ListEnginesArgs { show: Some("dead".to_owned()) })).await.expect("list_engines ok");
+    assert_eq!(out, "{\"recently_died\":[]}", "show=dead keeps only recently_died and omits the engines key",);
+}
+
+/// An unrecognized `show` value is a tool error naming the three
+/// accepted values, rejected at the tool boundary before the wire
+/// round-trip (issue 2985).
+#[tokio::test]
+async fn list_engines_bad_show_is_tool_error() {
+    let (_chassis, port) = boot_hub();
+    let mcp = connect_mcp(port);
+    let err = mcp
+        .list_engines(Parameters(ListEnginesArgs { show: Some("bogus".to_owned()) }))
+        .await
+        .expect_err("an unknown show value should be a tool error");
+    let message = err.to_string();
+    assert!(
+        message.contains("alive") && message.contains("dead") && message.contains("all"),
+        "the error should name the three accepted show values, got: {message}",
     );
 }
 

--- a/crates/aether-mcp/src/tools/tests/engine.rs
+++ b/crates/aether-mcp/src/tools/tests/engine.rs
@@ -32,7 +32,7 @@ async fn list_engines_show_alive_omits_recently_died() {
         .list_engines(Parameters(ListEnginesArgs { show: Some("alive".to_owned()) }))
         .await
         .expect("list_engines ok");
-    assert_eq!(out, "{\"engines\":[]}", "show=alive keeps only engines and omits the recently_died key",);
+    assert_eq!(out, "{\"engines\":[]}", "show=alive keeps only engines and omits the recently_died key");
 }
 
 /// `show: "dead"` renders only `recently_died`; the live `engines` list
@@ -44,7 +44,7 @@ async fn list_engines_show_dead_omits_engines() {
     let mcp = connect_mcp(port);
     let out =
         mcp.list_engines(Parameters(ListEnginesArgs { show: Some("dead".to_owned()) })).await.expect("list_engines ok");
-    assert_eq!(out, "{\"recently_died\":[]}", "show=dead keeps only recently_died and omits the engines key",);
+    assert_eq!(out, "{\"recently_died\":[]}", "show=dead keeps only recently_died and omits the engines key");
 }
 
 /// An unrecognized `show` value is a tool error naming the three


### PR DESCRIPTION
Closes #2985.

## Summary

`list_engines` always returned the full `{engines, recently_died}` object, so a routine "which engines are alive right now" check paid the context cost of the whole recently-died fleet history on a long-running hub — and a death-forensics call paid to enumerate the live fleet it didn't need.

`list_engines` now accepts an optional `show` argument: `"alive"` returns only `engines`, `"dead"` returns only `recently_died`, and omitted (or `"all"`) returns both exactly as today, so existing callers see no change. The omitted list is absent from the reply JSON — dropped via `skip_serializing_if` rather than serialized empty — so the tokens are actually saved and the reply shape states what was asked. An unrecognized `show` value is an `invalid_params` tool error naming the three accepted values.

Filtering lives in the aether-mcp projection (`fn list_engines`), where reply shaping already lives; the `ListEngines` wire call to the hub is unchanged. No wire kinds, no hub change, no ADR.

## Test plan

`crates/aether-mcp/src/tools/tests/engine.rs`: the empty-hub test now asserts the default (no `show`) shape is byte-for-byte the pre-filter `{"engines":[],"recently_died":[]}`; added one test per filter value asserting the omitted list's key is absent from the rendered JSON and the kept list is present (tripwires against an inverted filter or a present-but-empty default), and one asserting an unknown `show` value errors with a message naming the three accepted values. All four pass; `cargo clippy -p aether-mcp --all-targets -- -D warnings` clean.

## Generated by

`/implement` — agent execution of [scoped issue #2985](https://github.com/iamacoffeepot/aether/issues/2985).
