### PR TITLE
chore(ci): sweep stale advisory-only messaging from the review stack

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -3,9 +3,11 @@ name: Review
 # Producer-side quality check: run the repo's five-pillar review workflow
 # (.claude/workflows/review.js) over a PR's diff via headless Claude Code,
 # and post the rollup as inline PR annotations + a summary comment with an
-# advisory `review:unresolved` label. Never a required status check — the
-# five-pillar verdicts are agent judgment; the teeth are the implement
-# loop's obligation to address the comment, not a merge gate.
+# advisory `review:unresolved` label. The five-pillar verdicts are agent
+# judgment posted as a COMMENT review, never REQUEST_CHANGES — advisory in
+# content. The `gate` job below mirrors the label into a required `Review
+# gate` commit status that blocks merge on a Rust-touching PR; a non-Rust
+# PR is never held.
 #
 # Trigger is first-green, once-only. The workflow fires when a PR's CI run
 # completes successfully (`workflow_run` on "CI"), resolves the PR from the

--- a/scripts/post-review-rollup.mjs
+++ b/scripts/post-review-rollup.mjs
@@ -7,7 +7,9 @@
 // The posture is load-bearing: the review event is ALWAYS `COMMENT`, never
 // `REQUEST_CHANGES` — a bot changes-requested review would hard-gate the
 // merge, and the five-pillar verdicts are agent judgment. The teeth are the
-// label + the implement loop's obligation to address the comment.
+// label: it mirrors into the required `Review gate` commit status on a
+// Rust-touching PR (blocking merge there), plus the implement loop's
+// obligation to address the comment.
 //
 // Inputs (env):
 //   GITHUB_TOKEN        least-privilege token (pull-requests + issues write)
@@ -205,7 +207,7 @@ async function main() {
     if (softHolds.length) {
       bodyLines.push(`**${softHolds.length} soft-hold** finding(s) — clear before un-draft.`, '')
     }
-    bodyLines.push('_Advisory: this review never gates the merge._')
+    bodyLines.push('_Findings are advisory (this is a COMMENT review); on a Rust-touching PR an unresolved verdict blocks merge via the required `Review gate` status._')
 
     const review = { event: 'COMMENT', body: bodyLines.join('\n') }
     if (inline.length && commitId) { review.commit_id = commitId; review.comments = inline }
@@ -289,7 +291,7 @@ function renderSummary(rollup, normalized, fingerprints) {
     lines.push('_No confirmed findings — the change is clean under all five pillars._', '')
   }
 
-  lines.push('_Advisory only: this review never gates the merge._')
+  lines.push('_Findings are advisory (this is a COMMENT review); on a Rust-touching PR an unresolved verdict blocks merge via the required `Review gate` status._')
   // Hidden fingerprints so a dispatched re-run dedups against this comment.
   for (const fp of fingerprints) lines.push(`<!-- aether-review-fp:${fp} -->`)
   return lines.join('\n')


### PR DESCRIPTION
Closes #3022.

## Summary

The review stack still described itself as purely advisory — the review.yml header said "Never a required status check" and the poster footers said the review "never gates the merge" — wording that predates the required `Review gate` commit status on Rust-touching PRs. Rewrites those sites to the accurate framing: findings are advisory in content (a COMMENT review, never REQUEST_CHANGES), but `review:unresolved` on a Rust-touching PR blocks merge via the required `Review gate` status; non-Rust PRs are never held. Comment and messaging text only; no behavior change.

## Test plan

No runtime surface — CI green validates file integrity; the corrected text appears on the next posted review rollup.

## Generated by

`/implement` — agent execution of [scoped issue #3022](https://github.com/iamacoffeepot/aether/issues/3022).
