### PR TITLE
fix(ci): fail the review gate closed when the review job ends without success

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -374,10 +374,16 @@ jobs:
       # failure rather than leaving the required context missing.
       #
       # Verdict table (first match wins):
+      #   review job did not succeed     -> failure  (infra/cancelled; re-run via dispatch)
       #   PR touches no Rust             -> success  (review not required)
-      #   review job failed (infra)      -> failure  (re-run via dispatch)
       #   Rust + review:unresolved set   -> failure  (points at the rollup)
       #   Rust + label absent            -> success
+      #
+      # The infra-failure check runs first so a review job that dies before
+      # computing touches_rust (leaving it empty) fails closed rather than
+      # falling through to the non-Rust success branch — an empty value must
+      # never read as "no Rust changes". Keyed on REVIEW_RESULT != "success"
+      # (not == "failure") so a cancelled run fails closed too.
       #
       # Wedge hazard (issue #2996 rollout is two-phase): branch protection
       # must NOT require this context until the poster is proven live on real
@@ -393,16 +399,20 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          # Non-Rust short-circuits first: such a PR is never required to pass
-          # the review, so it stays green even through a review-job hiccup.
-          if [ "$TOUCHES_RUST" != "true" ]; then
-            state="success"
-            description="no Rust changes — review not required"
-          elif [ "$REVIEW_RESULT" = "failure" ]; then
-            # Rust PR whose review job broke before a verdict — fail closed so
-            # the review can't be bypassed by an infra flake; re-run to clear.
+          # Infra-failure check first: a review job that dies before computing
+          # touches_rust leaves it empty, which must fail closed rather than
+          # fall through to the non-Rust success branch below. Keyed on
+          # != "success" (not == "failure") so a cancelled run fails closed
+          # too — the review can't be bypassed by an infra flake; re-run to
+          # clear.
+          if [ "$REVIEW_RESULT" != "success" ]; then
             state="failure"
             description="review run failed (infra). Re-run via workflow_dispatch."
+          elif [ "$TOUCHES_RUST" != "true" ]; then
+            # Non-Rust PR with a completed review job: never required to pass
+            # the review.
+            state="success"
+            description="no Rust changes — review not required"
           else
             # Rust PR with a verdict: mirror the LIVE label. Capture then match
             # with a here-string (not a pipe) so grep -q can't SIGPIPE gh.


### PR DESCRIPTION
Closes #3018.

## Summary

The Review gate's verdict table evaluated the non-Rust short-circuit before the infra-failure check, so a review job that died before computing `touches_rust` (leaving it empty) posted success "no Rust changes" on a PR that may be all Rust — a fail-open hole in a required check. Reorders the table so the infra check runs first, and widens it from `REVIEW_RESULT = "failure"` to `!= "success"` so a cancelled review run (observed live on #3014) also fails closed instead of falling through to the label mirror.

## Test plan

No runtime surface — CI green validates the workflow YAML; the reordered verdict is exercised by every subsequent review-gate post, and a dispatch re-run clears any fail-closed status.

## Generated by

`/implement` — agent execution of [scoped issue #3018](https://github.com/iamacoffeepot/aether/issues/3018).
