### PR TITLE
fix(workflow): run the correctness lens on out-of-scope files instead of pruning them

### DIFF
--- a/.claude/workflows/review.js
+++ b/.claude/workflows/review.js
@@ -221,6 +221,14 @@ if (FINDER_SHAPE === 'merged') {
   FILE_LENSES = merged
 }
 
+// Lens subset for out-of-scope (drive-by / unrelated) changed files. Phase 0's spec filter keeps
+// these files in the funnel with correctness ALONE — a bug does not become acceptable because the
+// file was out of scope, and correctness is the one soft-hold pillar. The advisory lenses (economy,
+// convention, test-integrity) stay pruned: nitpicking the style of a to-be-reverted edit is noise.
+// Derived from FILE_LENSES (already intersected with SELECTED), so a lens-restricted run that
+// excludes correctness leaves this empty and prunes out-of-scope files entirely, as before.
+const OUT_OF_SCOPE_LENSES = FILE_LENSES.filter(l => l.key === 'correctness')
+
 // Deterministic scope resolution (no agents): one entry per file, carrying the lenses that
 // apply to it (code lenses for files, test-integrity for testFiles) and its diff hunk if any.
 // In the pr profile, small-diff code-only entries are grouped into shared finder calls.
@@ -612,12 +620,25 @@ if (A.issue && SPEC_LENS) {
   spec = await agent(specPrompt(A.issue, scoped), { label: 'spec-fidelity', phase: 'Scope', model: FINDER_MODEL, schema: SPEC_SCHEMA })
   const out = new Set((spec && spec.outOfScope) || [])
   if (out.size) {
-    inScope = scoped.map(e => {
-      if (!e.batch) return out.has(e.file) ? null : e
-      const members = e.members.filter(m => !out.has(m.file))
-      return members.length ? { ...e, members } : null
-    }).filter(Boolean)
-    log(`spec-fidelity: ${out.size} out-of-scope file(s) pruned from the per-file passes`)
+    // Keep out-of-scope files in the funnel with the reduced correctness-only lens set (a demoted
+    // single entry) rather than dropping them, so a drive-by file's bugs are still caught and can
+    // soft-hold. Out-of-scope members of a small-diff batch are lifted out into their own demoted
+    // entries so the batch's uniform FILE_LENSES stays honored. When correctness is not selected,
+    // OUT_OF_SCOPE_LENSES is empty and the file is pruned entirely, as before.
+    inScope = scoped.flatMap(e => {
+      if (!e.batch) {
+        if (!out.has(e.file)) return [e]
+        return OUT_OF_SCOPE_LENSES.length ? [{ ...e, lenses: OUT_OF_SCOPE_LENSES }] : []
+      }
+      const kept = e.members.filter(m => !out.has(m.file))
+      const demoted = OUT_OF_SCOPE_LENSES.length
+        ? e.members.filter(m => out.has(m.file)).map(m => ({ file: m.file, lenses: OUT_OF_SCOPE_LENSES, diff: m.diff }))
+        : []
+      const batch = kept.length ? [{ ...e, members: kept }] : []
+      return [...batch, ...demoted]
+    })
+    const note = OUT_OF_SCOPE_LENSES.length ? 'reduced to the correctness lens (advisory lenses pruned)' : 'pruned from the per-file passes'
+    log(`spec-fidelity: ${out.size} out-of-scope file(s) ${note}`)
   }
 }
 


### PR DESCRIPTION
Closes #3024.

## Summary

Phase 0's spec-fidelity filter pruned out-of-scope files from every per-file pass, so a drive-by change was flagged as scope leakage and then merged with its bugs unexamined — spec-fidelity was the only lens that ever saw the file. Out-of-scope files now stay in the funnel demoted to the correctness lens only: their findings flow through the normal refute path (high-severity keeps the per-finding test-grounded refuter) and can soft-hold, while the advisory lenses (economy, convention, test-integrity) stay pruned so the filter keeps its cost purpose. Out-of-scope members of a small-diff batch are lifted into their own demoted entries so batch lens uniformity holds, and a lens-restricted run that excludes correctness reproduces the old full prune.

## Test plan

node --check passes and a standalone simulation of the scope resolution confirms all four cases (in-scope full lenses, out-of-scope demotion, batch-member lift-out, correctness-excluded full prune). Behavioral validation rides the next live review runs alongside the #3015 compression validation.

## Generated by

`/implement` — agent execution of [scoped issue #3024](https://github.com/iamacoffeepot/aether/issues/3024).
