### PR TITLE
fix(workflow): carry full paths in review rollup rows

### DIFF
--- a/.claude/workflows/review.js
+++ b/.claude/workflows/review.js
@@ -705,7 +705,9 @@ for (const e of clean) {
     for (const fd of (x.r.findings || [])) {
       totals.findings++
       const lens = x.lens
-      const file = base(fd.file || runFile)
+      // Full path, not a basename — the dedup key and grouped map below key on
+      // this, and a basename collides across same-named files (mod.rs, kinds.rs).
+      const file = fd.file || runFile
       const v = fd.verify
       if (ALWAYS_VERIFY.has(lens.key) && fd.confidence === 'high') {
         // ALWAYS_VERIFY consults the refuter even at high confidence: a refuted high-confidence
@@ -728,7 +730,7 @@ for (const e of clean) {
   // profile instead routes its per-PR challenge misses through the refuter, below).
   for (const ch of (e.challenged || [])) {
     const v = ch.challenge
-    const file = base(ch.file || (e.files && e.files[0]))
+    const file = ch.file || (e.files && e.files[0])
     if (v && v.final_verdict === 'missed') {
       for (const m of (v.missed || [])) { totals.challengerMissed++; confirmed.push(rowOf(file, ch.lens, m, 'challenger-missed')) }
     } else if (v && v.final_verdict === 'uncertain') {
@@ -740,7 +742,7 @@ for (const e of clean) {
 // Per-PR challenge misses (pr profile) — refute-gated before confirmed, unlike the backfill path.
 for (const it of prChallengeMissed) {
   const { fd, lens } = it
-  const file = base(it.file)
+  const file = it.file
   const v = fd.verify
   if (v && v.final_verdict === 'confirmed') { totals.challengerMissed++; confirmed.push(rowOf(file, lens, fd, 'challenger-missed')) }
   else if (v && v.final_verdict === 'false-positive') { spared.push({ ...rowOf(file, lens, fd, 'spared'), reason: v.rationale }); totals.falsePositives++ }

--- a/scripts/post-review-rollup.mjs
+++ b/scripts/post-review-rollup.mjs
@@ -109,10 +109,12 @@ function commentableLines(patch) {
   return lines
 }
 
-// The rollup stores each confirmed finding's `file` as a basename (review.js
-// bases it). Resolve it back to a full changed-file path; null when the
-// basename is ambiguous or unknown, in which case the finding degrades to
-// the review body rather than being dropped.
+// The rollup now stores each confirmed finding's `file` as the full changed-file
+// path (review.js only bases at render-time label sites). The changed.has()
+// fast-path below resolves it directly; the basename-match arms are defensive
+// back-compat for a rollup produced before this normalization, degrading to
+// null when a bare basename is ambiguous, in which case the finding drops to
+// the folded review body rather than being dropped outright.
 function resolvePath(fileField, changed) {
   if (!fileField) return null
   if (changed.has(fileField)) return fileField


### PR DESCRIPTION
Closes #3021.

## Summary

Review rollup rows stored basenames only, so the dedup key and grouped map could silently merge distinct findings in same-basename files (mod.rs everywhere, worst in backfill), and the poster had to reverse-engineer paths, degrading ambiguous ones to the folded body. Rows now carry the full path at the three rowOf-feeding sites; base() stays at the display-label sites. No poster code change — its resolvePath already fast-paths a full path — only its stale comment is updated.

## Test plan

node --check passes; the poster's changed.has() fast-path is exercised by the next posted rollup. No runtime surface beyond the workflow script.

## Generated by

`/implement` — agent execution of [scoped issue #3021](https://github.com/iamacoffeepot/aether/issues/3021).
