### PR TITLE
fix(workflow): route high-severity spec findings into review soft-holds

### DIFF
--- a/.claude/workflows/review.js
+++ b/.claude/workflows/review.js
@@ -685,6 +685,8 @@ if (PROFILE === 'pr' && !A.noChallenge && challengeLenses.length && scopeUnits(i
 // flag the refuter overturned, now including a refuted high-confidence correctness finding (issue
 // #3015 item 2 — the Opus refuter's verdict is consulted rather than discarded). gate = soft-hold
 // only for a high-severity finding on a soft-hold pillar (spec/correctness); everything else advisory.
+// Spec-fidelity findings never flow through rowOf/gateFor — they live in the separate Phase 0
+// `spec` channel — so a high-severity spec finding is routed into softHolds directly, below.
 const gateFor = (lens, severity) => (lens.gate === 'soft-hold' && severity === 'high') ? 'soft-hold' : 'advisory'
 const rowOf = (file, lens, fd, source) => ({
   file, pillar: fd.pillar || lens.key, source, category: fd.category, line: fd.line, symbol: fd.symbol,
@@ -762,7 +764,14 @@ const processedFiles = new Set()
 for (const e of clean) if (e.runs && e.runs.length) for (const fl of (e.files || [])) processedFiles.add(fl)
 totals.files = processedFiles.size
 totals.confirmed = deduped.length
-const softHolds = deduped.filter(r => r.gate === 'soft-hold')
+// A high-severity spec finding never enters confirmed/deduped (it would double-render alongside
+// rollup.spec.findings) but still counts as a hold — the poster already gives it label teeth.
+const specSoftHolds = ((spec && spec.findings) || []).filter(f => f.severity === 'high').map(f => ({
+  file: base(f.file), pillar: 'spec-fidelity', source: 'spec', category: f.category, line: null,
+  symbol: f.symbol, severity: f.severity, gate: 'soft-hold', recommendation: undefined,
+  suggested_form: f.description, direction: undefined, char_delta: undefined,
+}))
+const softHolds = [...deduped.filter(r => r.gate === 'soft-hold'), ...specSoftHolds]
 totals.softHolds = softHolds.length
 
 // grouped: by file then pillar, so the rollup drops straight into /sketch.


### PR DESCRIPTION
Closes #3023.

## Summary

The spec-fidelity lens declares soft-hold gating, but Phase 0 spec findings never flowed through the softHolds pipeline — the rollup a human reads under-reported the hold set relative to the review:unresolved label the poster already sets. High-severity spec findings are now normalized into soft-hold rows (line null, suggested_form from the description, source spec) appended to rollup.softHolds, never to confirmed, so nothing double-renders and totals.softHolds counts both sources.

## Test plan

node --check passes; the visible soft-hold count on the next actionable review rollup now matches the label behavior. No runtime surface beyond the workflow script.

## Generated by

`/implement` — agent execution of [scoped issue #3023](https://github.com/iamacoffeepot/aether/issues/3023).
