### PR TITLE
fix(workflow): gate the correctness refuter's cargo-test grounding off in ci

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -29,6 +29,7 @@ The skill assembles the workflow's arg contract (`{issue?, files, testFiles?, di
 - `testFiles` — absolute `.rs` paths for the test-integrity lens.
 - `issue` — the issue or scope text for the spec-fidelity lens. Omit for backfill; its presence is what selects integrated mode.
 - `diffs` — per-file diff hunks keyed by path, so the finders judge the change rather than the whole file (integrated mode).
+- `noBuild` — passed through to the workflow args; set true in CI so the correctness refuter grounds read-only.
 
 ## Caller-side prep
 

--- a/.claude/workflows/review.js
+++ b/.claude/workflows/review.js
@@ -28,6 +28,9 @@ export const meta = {
 //   finderModel,  string              — model for Phase 0 + finders + batched/challenge verify (default 'sonnet').
 //   verifyModel,  string              — model for the high-severity correctness refuter (default 'opus').
 //   noChallenge,  bool                — skip the false-negative challenge (per-PR in pr, per-file in backfill).
+//   noBuild,      bool                — the high-severity correctness refuter grounds read-only (no
+//                                       scratch #[test] write + cargo test run); set true where no
+//                                       toolchain/build cache is provisioned (default false).
 // }
 //
 // returns { rollup, files }. rollup = { totals, spec, softHolds, confirmed, grouped,
@@ -47,6 +50,7 @@ if (!FILES.length && !TEST_FILES.length) throw new Error('review: args.files (an
 
 const FINDER_MODEL = A.finderModel || 'sonnet'
 const VERIFY_MODEL = A.verifyModel || 'opus'
+const NO_BUILD = A.noBuild === true
 const DIFFS = A.diffs || {}
 const HAS_DIFFS = Object.keys(DIFFS).length > 0
 
@@ -486,10 +490,13 @@ Report every site this lens flags as a finding: symbol + approximate line, categ
 
 function refutePrompt(file, fd, lens) {
   const corr = lens.key === 'correctness'
+  const step2 = NO_BUILD
+    ? `2. No test covers the claim and no build is available here — ground by reading the existing #[test]s and the code path; if a high-severity claim has no covering test, state that in the rationale and return final_verdict='uncertain' rather than confirming on inspection alone.`
+    : `2. If no test covers the claim and the finding is high-severity, WRITE one and RUN it: add a focused #[test], run \`cargo test -p <crate> <name>\` from the crate root, let the result decide, then delete the scratch test.`
   const grounding = corr
     ? `\nGROUND THE VERDICT IN TESTS, not inspection — a confident reading of subtle code (math conventions, sign order, edge cases) is exactly where this lens hallucinates a bug.
 1. Read the existing #[test]s for this item. A passing test that pins the claimed-broken behavior REFUTES the finding (final_verdict='false-positive') — cite the test by name.
-2. If no test covers the claim and the finding is high-severity, WRITE one and RUN it: add a focused #[test], run \`cargo test -p <crate> <name>\` from the crate root, let the result decide, then delete the scratch test.
+${step2}
 3. NEVER uphold a finding whose suggested fix would break a currently-passing test — check the fix against the suite before confirming.\n`
     : ''
   return `A code-review finding was raised under the ${lens.name} lens. Decide whether it survives a STRICT bar — do not rescue it with a plausible story, and do not reject a real issue out of conservatism.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -47,7 +47,10 @@ jobs:
     # agents at ~min(16, cores - 2), so the 4-core GitHub-hosted box
     # squeezes the per-file finder fan-out to ~2-wide while every agent
     # just waits on inference. 8 cores buys ~6-wide fan-out; the job's
-    # own compute stays trivial (no cargo build, no s3-cache needed).
+    # own compute stays trivial (no cargo build, no s3-cache needed — the
+    # correctness refuter's write-and-run cargo-test path is gated off here
+    # via the noBuild: true workflow arg, so this premise is enforced, not
+    # just asserted; see the "Run the five-pillar review" step).
     runs-on: runs-on=${{ github.run_id }}/runner=8cpu-linux-x64
     # Bring-up leash: a wedged in-flight workflow (the session now waits
     # for it indefinitely, iamacoffeepot/aether#2979) must not idle an
@@ -249,7 +252,10 @@ jobs:
           Invoke the repo's /review skill in INTEGRATED mode against origin/main...HEAD:
           resolve the changed .rs files and their per-file diffs from git, and read the issue
           text this PR closes (use gh to find the PR's closing reference for issue #${PR_NUMBER}
-          if needed). Let the skill run the review.js workflow in a single pass.
+          if needed). Pass noBuild: true in the /review invocation's workflow args — this
+          runner has no Rust toolchain, so the high-severity correctness refuter must ground
+          read-only rather than write and run a scratch cargo test. Let the skill run the
+          review.js workflow in a single pass.
           THE WAIT CONTRACT (load-bearing — two prior runs died on this): the Workflow tool
           runs in the BACKGROUND. In headless mode your final reply exits the process and
           KILLS the in-flight workflow, so you may not produce a final reply until
@@ -263,7 +269,8 @@ jobs:
           When the workflow returns { rollup, files }, write the returned ROLLUP object as JSON
           verbatim to exactly ${GITHUB_WORKSPACE}/review-rollup.json — that absolute path, not
           a path relative to your working directory (the rollup, not the whole return).
-          Do not edit any source. Print exactly REVIEW-DONE when the file is written." \
+          Do not edit any source (the noBuild flag above keeps the correctness refuter
+          subagent non-editing too). Print exactly REVIEW-DONE when the file is written." \
             --dangerously-skip-permissions \
             --model claude-sonnet-5 \
             --max-turns 80 \


### PR DESCRIPTION
Closes #3025.

## Summary

The correctness refuter's grounding told a high-severity refuter to write and run a scratch cargo test — on a CI runner sized on an explicit "no cargo build" premise, with no toolchain, inside the 45-minute leash, under a top-level "do not edit any source" instruction the subagent never sees. Grounding is now gated on a `noBuild` workflow arg (default false): the CI prompt passes `noBuild: true`, under which the refuter grounds read-only and an unconfirmable high-severity claim returns `uncertain` rather than a confirmation on inspection alone; local and backfill runs keep the full write-and-run grounding where a warm toolchain makes it cheap. The runner-sizing comment now states the enforced invariant, and the `/review` skill documents the input. The original env-var design was amended to a workflow arg on the issue — the sandbox has no env access.

## Test plan

node --check passes. Live verification is a follow-up `workflow_dispatch` review re-run on a Rust PR: no cargo invocation in the session transcript, run inside the leash, and a local backfill run (flag absent) still renders write-and-run grounding.

## Generated by

`/implement` — agent execution of [scoped issue #3025](https://github.com/iamacoffeepot/aether/issues/3025).
