### PR TITLE
refactor(repo): re-chain unrolled method-call sites across the tree

### DIFF
--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -390,9 +390,9 @@ mod tests {
     #[test]
     fn mail_sender_some_for_real_handle() {
         // SAFETY: no pointer is dereferenced; we only inspect `sender`.
-        let mail = unsafe { Mail::__from_ptr(0, 0, 0, 0, 42, 0) };
-        let s = mail.reply_handle().expect("non-sentinel handle yields Some");
-        assert_eq!(s.raw(), 42);
+        let handle =
+            unsafe { Mail::__from_ptr(0, 0, 0, 0, 42, 0) }.reply_handle().expect("non-sentinel handle yields Some");
+        assert_eq!(handle.raw(), 42);
     }
 
     #[test]
@@ -451,8 +451,7 @@ mod tests {
 
     #[test]
     fn mail_decode_kind_wrong_kind_returns_none() {
-        let value = FakeStructured { tag: String::from("x"), ids: alloc::vec![] };
-        let bytes = value.encode_into_bytes();
+        let bytes = FakeStructured { tag: String::from("x"), ids: alloc::vec![] }.encode_into_bytes();
         // SAFETY: `bytes` outlives `mail`; the `(addr, len)` pair is
         // valid for `bytes.len()` bytes for the rest of the body.
         let mail = unsafe {
@@ -463,8 +462,7 @@ mod tests {
 
     #[test]
     fn mail_decode_kind_wrong_count_returns_none() {
-        let value = FakeStructured { tag: String::from("x"), ids: alloc::vec![] };
-        let bytes = value.encode_into_bytes();
+        let bytes = FakeStructured { tag: String::from("x"), ids: alloc::vec![] }.encode_into_bytes();
         // SAFETY: `bytes` outlives `mail`; the `(addr, len)` pair is
         // valid for `bytes.len()` bytes for the rest of the body.
         let mail = unsafe {
@@ -475,8 +473,7 @@ mod tests {
 
     #[test]
     fn mail_decode_kind_truncated_bytes_returns_none() {
-        let value = FakeStructured { tag: String::from("longer"), ids: alloc::vec![1, 2, 3] };
-        let bytes = value.encode_into_bytes();
+        let bytes = FakeStructured { tag: String::from("longer"), ids: alloc::vec![1, 2, 3] }.encode_into_bytes();
         // Pretend the substrate only wrote the first 2 bytes —
         // `decode_from_bytes` gets the truncated slice and surfaces the
         // parse error as `None`.

--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -1442,8 +1442,7 @@ mod tests {
         )
         .expect("install inline child");
 
-        let mailbox = WasmActorMailbox::<SucceedingChild>::__new(child.0, root, &registry);
-        let request = mailbox.send_tracked(&());
+        let request = WasmActorMailbox::<SucceedingChild>::__new(child.0, root, &registry).send_tracked(&());
         assert_eq!(request.0, Source::NO_CORRELATION, "local inline sends have no host-minted request id");
     }
 

--- a/crates/aether-actor/src/wasm/inline/compose.rs
+++ b/crates/aether-actor/src/wasm/inline/compose.rs
@@ -536,8 +536,7 @@ mod tests {
     fn reconstruct_one_child_reinits_typed_config_from_real_bytes() {
         let registry = Registry::new();
         let alias = MailboxId(0x9001);
-        let config = TypedConfig(0xDEAD_BEEF);
-        let config_bytes = config.encode_into_bytes();
+        let config_bytes = TypedConfig(0xDEAD_BEEF).encode_into_bytes();
         let to_reconstruct = InlineChildToReconstruct {
             alias,
             type_tag: 0x1234,

--- a/crates/aether-behavior-derive/tests/ui/pass_behavior.rs
+++ b/crates/aether-behavior-derive/tests/ui/pass_behavior.rs
@@ -54,6 +54,5 @@ fn main() {
         Clamp::__AETHER_BEHAVIOR_EXPORTS.len()
     );
 
-    let clamp = Clamp::default();
-    let _ = clamp.state_save();
+    let _ = Clamp::default().state_save();
 }

--- a/crates/aether-behavior/src/host/slot.rs
+++ b/crates/aether-behavior/src/host/slot.rs
@@ -95,8 +95,7 @@ impl ScriptSlot {
         let manifest = decode_manifest(&module);
 
         let mut store = Store::new(engine, ());
-        let linker: Linker<()> = Linker::new(engine);
-        let instance = linker
+        let instance = Linker::<()>::new(engine)
             .instantiate_and_start(&mut store, &module)
             .map_err(|error| alloc::format!("instantiate: {error}"))?;
 

--- a/crates/aether-capabilities/src/audio/runtime/decode.rs
+++ b/crates/aether-capabilities/src/audio/runtime/decode.rs
@@ -120,8 +120,7 @@ fn downmix_to_mono(interleaved: &[f32], channels: usize) -> Vec<f32> {
 /// header but only returns the resampled PCM. Parses the header chunk
 /// only — the sample data is not read.
 pub fn wav_source_rate(bytes: &[u8]) -> Result<u32, String> {
-    let reader = hound::WavReader::new(Cursor::new(bytes)).map_err(|e| e.to_string())?;
-    let rate = reader.spec().sample_rate;
+    let rate = hound::WavReader::new(Cursor::new(bytes)).map_err(|e| e.to_string())?.spec().sample_rate;
     if rate == 0 {
         return Err("zero sample rate".to_owned());
     }

--- a/crates/aether-capabilities/src/audio/runtime/pipeline.rs
+++ b/crates/aether-capabilities/src/audio/runtime/pipeline.rs
@@ -45,8 +45,7 @@ impl fmt::Display for AudioBuildError {
 }
 
 pub fn try_build_pipeline(requested_sample_rate: Option<u32>) -> Result<AudioPipeline, AudioBuildError> {
-    let host = cpal::default_host();
-    let device = host.default_output_device().ok_or(AudioBuildError::NoDevice)?;
+    let device = cpal::default_host().default_output_device().ok_or(AudioBuildError::NoDevice)?;
 
     let config = match requested_sample_rate {
         Some(rate) => find_config_for_rate(&device, rate).ok_or(AudioBuildError::RateUnsupported(rate))?,

--- a/crates/aether-capabilities/src/fs/runtime.rs
+++ b/crates/aether-capabilities/src/fs/runtime.rs
@@ -944,18 +944,16 @@ mod tests {
         let root = scratch_root("fetch-transform");
         let assets = root.join("assets");
         fs::create_dir_all(&assets).expect("test setup: assets dir creates");
-        let input = TestNumber { value: 7, tag: 0 };
-        let encoded = input.encode_into_bytes();
-        fs::write(assets.join("number.bin"), &encoded).expect("test setup: seed number.bin");
+        fs::write(assets.join("number.bin"), TestNumber { value: 7, tag: 0 }.encode_into_bytes())
+            .expect("test setup: seed number.bin");
 
         let reg = build_two_namespace_registry(&root, Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let double_id = double_fs_transform_id();
 
-        let transform_reg = TransformRegistry::from_inventory();
-        let double_t = transform_reg.lookup(double_id).expect("double_fs registered");
-        let expected_output_kind = double_t.output_kind_id;
+        let expected_output_kind =
+            TransformRegistry::from_inventory().lookup(double_id).expect("double_fs registered").output_kind_id;
 
         let result = FsCapability::on_fetch(
             &mut fix.state,
@@ -1046,9 +1044,8 @@ mod tests {
         let root = scratch_root("fetch-panic");
         let assets = root.join("assets");
         fs::create_dir_all(&assets).expect("test setup: assets dir creates");
-        let input = TestNumber { value: 1, tag: 0 };
-        let encoded = input.encode_into_bytes();
-        fs::write(assets.join("number.bin"), &encoded).expect("test setup: seed number.bin");
+        fs::write(assets.join("number.bin"), TestNumber { value: 1, tag: 0 }.encode_into_bytes())
+            .expect("test setup: seed number.bin");
         let reg = build_two_namespace_registry(&root, Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());

--- a/crates/aether-capabilities/src/gemini/adapter.rs
+++ b/crates/aether-capabilities/src/gemini/adapter.rs
@@ -155,8 +155,10 @@ impl GeminiAdapter for UreqGeminiAdapter {
         });
         let text = self.post_json(&req.model, "predict", &body)?;
 
-        let clips = lyria::parse_clip_response(&text)?;
-        let artifacts = clips.into_iter().map(|bytes| GeminiArtifact { bytes, ext: "wav".to_string() }).collect();
+        let artifacts = lyria::parse_clip_response(&text)?
+            .into_iter()
+            .map(|bytes| GeminiArtifact { bytes, ext: "wav".to_string() })
+            .collect();
         Ok(GeminiResponse {
             artifacts,
             model_used: req.model,

--- a/crates/aether-capabilities/src/http/client/runtime.rs
+++ b/crates/aether-capabilities/src/http/client/runtime.rs
@@ -332,8 +332,7 @@ mod tests {
 
     #[test]
     fn allowlist_empty_rejects_every_host() {
-        let adapter = UreqHttpAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES);
-        let resp = adapter.fetch(FetchRequest {
+        let resp = UreqHttpAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES).fetch(FetchRequest {
             url: "https://api.example.com/".to_string(),
             method: HttpMethod::Get,
             headers: vec![],
@@ -347,8 +346,7 @@ mod tests {
     fn allowlist_miss_returns_denied_without_making_request() {
         let mut allowlist = HashSet::new();
         allowlist.insert("allowed.example.com".to_string());
-        let adapter = UreqHttpAdapter::new(allowlist, false, DEFAULT_MAX_BODY_BYTES);
-        let resp = adapter.fetch(FetchRequest {
+        let resp = UreqHttpAdapter::new(allowlist, false, DEFAULT_MAX_BODY_BYTES).fetch(FetchRequest {
             url: "https://denied.example.com/".to_string(),
             method: HttpMethod::Get,
             headers: vec![],
@@ -360,8 +358,7 @@ mod tests {
 
     #[test]
     fn invalid_url_returns_invalid_url_variant() {
-        let adapter = UreqHttpAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES);
-        let resp = adapter.fetch(FetchRequest {
+        let resp = UreqHttpAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES).fetch(FetchRequest {
             url: "not-a-url".to_string(),
             method: HttpMethod::Get,
             headers: vec![],
@@ -375,8 +372,7 @@ mod tests {
     fn require_https_rejects_http_scheme() {
         let mut allowlist = HashSet::new();
         allowlist.insert("example.com".to_string());
-        let adapter = UreqHttpAdapter::new(allowlist, true, DEFAULT_MAX_BODY_BYTES);
-        let resp = adapter.fetch(FetchRequest {
+        let resp = UreqHttpAdapter::new(allowlist, true, DEFAULT_MAX_BODY_BYTES).fetch(FetchRequest {
             url: "http://example.com/".to_string(),
             method: HttpMethod::Get,
             headers: vec![],
@@ -390,8 +386,7 @@ mod tests {
     fn oversize_request_body_returns_body_too_large() {
         let mut allowlist = HashSet::new();
         allowlist.insert("example.com".to_string());
-        let adapter = UreqHttpAdapter::new(allowlist, false, 10);
-        let resp = adapter.fetch(FetchRequest {
+        let resp = UreqHttpAdapter::new(allowlist, false, 10).fetch(FetchRequest {
             url: "https://example.com/".to_string(),
             method: HttpMethod::Post,
             headers: vec![],
@@ -496,9 +491,7 @@ mod tests {
 
     #[test]
     fn build_http_adapter_with_disable_returns_disabled() {
-        let cfg = HttpConfig { disabled: true, ..HttpConfig::default() };
-        let a = build_http_adapter(cfg);
-        let resp = a.fetch(FetchRequest {
+        let resp = build_http_adapter(HttpConfig { disabled: true, ..HttpConfig::default() }).fetch(FetchRequest {
             url: "https://example.com/".to_string(),
             method: HttpMethod::Get,
             headers: vec![],

--- a/crates/aether-capabilities/src/http/server/runtime/render.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/render.rs
@@ -223,8 +223,7 @@ pub fn reason_phrase(status: u16) -> &'static str {
 pub fn http_date(now: SystemTime) -> String {
     const WEEKDAYS: [&str; 7] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
     const MONTHS: [&str; 12] = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-    let secs = now.duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
-    let total = i64::try_from(secs).unwrap_or(i64::MAX);
+    let total = i64::try_from(now.duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs())).unwrap_or(i64::MAX);
     let days = total.div_euclid(86_400);
     let rem = total.rem_euclid(86_400);
     let hour = rem / 3_600;

--- a/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/unit_tests.rs
@@ -132,8 +132,7 @@ fn sha1_matches_the_rfc_3174_vector() {
     // Tripwire: RFC 3174 §7.3 worked example sha1("abc"). A computed digest
     // that drifts if the block schedule / padding / round logic breaks.
     use std::fmt::Write as _;
-    let digest = sha1(b"abc");
-    let hex = digest.iter().fold(String::new(), |mut acc, byte| {
+    let hex = sha1(b"abc").iter().fold(String::new(), |mut acc, byte| {
         let _ = write!(acc, "{byte:02x}");
         acc
     });

--- a/crates/aether-capabilities/src/render/mod.rs
+++ b/crates/aether-capabilities/src/render/mod.rs
@@ -202,9 +202,12 @@ mod tests {
             textures.entries.insert(texture_id, test_staged_texture(vec![0xAB; 16]));
         }
 
-        let mail = DestroyTexture { texture_id };
-        let payload = mail.encode_into_bytes();
-        deliver(&registry, RenderCapability::NAMESPACE, <DestroyTexture as Kind>::ID, &payload);
+        deliver(
+            &registry,
+            RenderCapability::NAMESPACE,
+            <DestroyTexture as Kind>::ID,
+            &DestroyTexture { texture_id }.encode_into_bytes(),
+        );
 
         thread::sleep(Duration::from_millis(50));
 
@@ -239,9 +242,12 @@ mod tests {
         }
 
         for texture_id in [99, WHITE_TEXTURE_ID] {
-            let mail = DestroyTexture { texture_id };
-            let payload = mail.encode_into_bytes();
-            deliver(&registry, RenderCapability::NAMESPACE, <DestroyTexture as Kind>::ID, &payload);
+            deliver(
+                &registry,
+                RenderCapability::NAMESPACE,
+                <DestroyTexture as Kind>::ID,
+                &DestroyTexture { texture_id }.encode_into_bytes(),
+            );
         }
 
         thread::sleep(Duration::from_millis(50));

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -347,13 +347,16 @@ fn expand_schema(input: &DeriveInput) -> syn::Result<TokenStream2> {
 /// the labels side reports `Anonymous` (no nominal info for a raw
 /// byte buffer).
 fn expand_label_node_struct(type_ident: &str, fields: &[FieldInfo]) -> TokenStream2 {
-    let field_names = fields.iter().enumerate().map(|(idx, f)| match &f.ident {
-        Some(id) => id.to_string(),
-        None => idx.to_string(),
-    });
-    let field_name_entries = field_names.map(|n| {
-        quote! { ::aether_data::__derive_runtime::Cow::Borrowed(#n) }
-    });
+    let field_name_entries = fields
+        .iter()
+        .enumerate()
+        .map(|(idx, f)| match &f.ident {
+            Some(id) => id.to_string(),
+            None => idx.to_string(),
+        })
+        .map(|n| {
+            quote! { ::aether_data::__derive_runtime::Cow::Borrowed(#n) }
+        });
     let field_node_exprs = fields.iter().map(|f| field_label_node_expr(&f.ty));
     quote! {
         ::aether_data::__derive_runtime::LabelNode::Struct {

--- a/crates/aether-data-derive/tests/transform.rs
+++ b/crates/aether-data-derive/tests/transform.rs
@@ -50,8 +50,7 @@ fn transform_determinism() {
         .find(|e| e.name.ends_with("det_double"))
         .expect("det_double transform registered in link-time inventory");
 
-    let input = DetScalar { value: 21 };
-    let input_bytes = input.encode_into_bytes();
+    let input_bytes = DetScalar { value: 21 }.encode_into_bytes();
     let slices: [&[u8]; 1] = [input_bytes.as_slice()];
 
     let out_a = (entry.invoke)(&slices).expect("first invoke succeeds");

--- a/crates/aether-math/src/aabb.rs
+++ b/crates/aether-math/src/aabb.rs
@@ -291,8 +291,7 @@ mod tests {
 
     #[test]
     fn corners_count_and_match_min_max() {
-        let a = Aabb::from_half_extents(1.0, 2.0, 3.0);
-        let cs = a.corners();
+        let cs = Aabb::from_half_extents(1.0, 2.0, 3.0).corners();
         assert_eq!(cs.len(), 8);
         assert!(cs.contains(&Vec3::new(-1.0, -2.0, -3.0)));
         assert!(cs.contains(&Vec3::new(1.0, 2.0, 3.0)));
@@ -364,16 +363,14 @@ mod tests {
 
     #[test]
     fn translate_shifts_both_bounds() {
-        let a = Aabb::from_half_extents(1.0, 1.0, 1.0);
-        let t = a.translate(Vec3::new(10.0, 0.0, -5.0));
+        let t = Aabb::from_half_extents(1.0, 1.0, 1.0).translate(Vec3::new(10.0, 0.0, -5.0));
         assert_eq!(t.min, Vec3::new(9.0, -1.0, -6.0));
         assert_eq!(t.max, Vec3::new(11.0, 1.0, -4.0));
     }
 
     #[test]
     fn scale_negative_factor_swaps_min_max() {
-        let a = Aabb::from_min_max(Vec3::new(1.0, 2.0, 3.0), Vec3::new(4.0, 5.0, 6.0));
-        let s = a.scale(Vec3::new(-1.0, 1.0, 1.0));
+        let s = Aabb::from_min_max(Vec3::new(1.0, 2.0, 3.0), Vec3::new(4.0, 5.0, 6.0)).scale(Vec3::new(-1.0, 1.0, 1.0));
         assert_eq!(s.min, Vec3::new(-4.0, 2.0, 3.0));
         assert_eq!(s.max, Vec3::new(-1.0, 5.0, 6.0));
     }
@@ -387,8 +384,7 @@ mod tests {
 
     #[test]
     fn rotate_offset_box_grows() {
-        let a = Aabb::from_min_max(Vec3::new(1.0, -0.5, -0.5), Vec3::new(2.0, 0.5, 0.5));
-        let r = a.rotate(Vec3::Y, PI * 0.5);
+        let r = Aabb::from_min_max(Vec3::new(1.0, -0.5, -0.5), Vec3::new(2.0, 0.5, 0.5)).rotate(Vec3::Y, PI * 0.5);
         assert!((r.extents().x - 1.0).abs() < EPS);
         assert!((r.extents().z - 1.0).abs() < EPS);
         assert!(approx_eq(r.min.x, -0.5));
@@ -407,8 +403,7 @@ mod tests {
 
     #[test]
     fn mirror_x_flips_x_bounds() {
-        let a = Aabb::from_min_max(Vec3::new(1.0, 2.0, 3.0), Vec3::new(4.0, 5.0, 6.0));
-        let m = a.mirror(Axis::X);
+        let m = Aabb::from_min_max(Vec3::new(1.0, 2.0, 3.0), Vec3::new(4.0, 5.0, 6.0)).mirror(Axis::X);
         assert_eq!(m.min, Vec3::new(-4.0, 2.0, 3.0));
         assert_eq!(m.max, Vec3::new(-1.0, 5.0, 6.0));
     }

--- a/crates/aether-math/src/mat.rs
+++ b/crates/aether-math/src/mat.rs
@@ -341,8 +341,7 @@ mod tests {
 
     #[test]
     fn to_cols_array_is_column_major() {
-        let m = Mat4::from_translation(Vec3::new(7.0, 8.0, 9.0));
-        let arr = m.to_cols_array();
+        let arr = Mat4::from_translation(Vec3::new(7.0, 8.0, 9.0)).to_cols_array();
         assert_eq!(&arr[0..4], &[1.0, 0.0, 0.0, 0.0]);
         assert_eq!(&arr[4..8], &[0.0, 1.0, 0.0, 0.0]);
         assert_eq!(&arr[8..12], &[0.0, 0.0, 1.0, 0.0]);

--- a/crates/aether-mcp/src/bin/aether-tunnel.rs
+++ b/crates/aether-mcp/src/bin/aether-tunnel.rs
@@ -217,8 +217,8 @@ impl Tunnel {
     /// Fork a fresh child for `kind` from its spec and install it.
     /// Replaces any existing entry (the caller has already terminated it).
     async fn fork(&self, kind: ChildKind) -> anyhow::Result<()> {
-        let spec = self.specs.get(&kind).with_context(|| format!("no spec registered for {}", kind.as_str()))?;
-        let child = spec.spawn()?;
+        let child =
+            self.specs.get(&kind).with_context(|| format!("no spec registered for {}", kind.as_str()))?.spawn()?;
         tracing::info!(
             target: "aether_tunnel",
             child = kind.as_str(),

--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -916,9 +916,7 @@ mod tests {
             .expect("connect task")
             .expect("connect");
 
-        let err = session.call_one(probe_envelope()).await.expect_err("zero-reply settle must be an error");
-
-        let msg = err.to_string();
+        let msg = session.call_one(probe_envelope()).await.expect_err("zero-reply settle must be an error").to_string();
         assert!(
             msg.contains("settled without a reply event"),
             "zero-reply error should mention the settled-without-reply condition, got: {msg:?}",
@@ -942,9 +940,8 @@ mod tests {
             .expect("connect task")
             .expect("connect");
 
-        let err = session.call_one(probe_envelope()).await.expect_err("multi-reply settle must be an error");
-
-        let msg = err.to_string();
+        let msg =
+            session.call_one(probe_envelope()).await.expect_err("multi-reply settle must be an error").to_string();
         assert!(
             msg.contains("exactly one reply event") && msg.contains("got 2"),
             "multi-reply error should mention the expected-one / got-N condition, got: {msg:?}",

--- a/crates/aether-mcp/src/tools/tests/engine.rs
+++ b/crates/aether-mcp/src/tools/tests/engine.rs
@@ -10,8 +10,7 @@ use super::super::*;
 #[tokio::test]
 async fn list_engines_on_empty_hub_is_empty() {
     let (_chassis, port) = boot_hub();
-    let mcp = connect_mcp(port);
-    let out = mcp.list_engines().await.expect("list_engines ok");
+    let out = connect_mcp(port).list_engines().await.expect("list_engines ok");
     assert_eq!(
         out, "{\"engines\":[],\"recently_died\":[]}",
         "fresh hub supervises no engines and has no recent deaths",

--- a/crates/aether-mesh/src/cleanup/slivers.rs
+++ b/crates/aether-mesh/src/cleanup/slivers.rs
@@ -178,8 +178,7 @@ mod tests {
             p(5000, 8000, 0), // 3: C
         ];
         let polygons = vec![poly(vec![0, 1, 2, 3])];
-        let mesh = IndexedMesh { vertices, polygons };
-        let cleaned = mesh.remove_slivers();
+        let cleaned = IndexedMesh { vertices, polygons }.remove_slivers();
         assert_eq!(cleaned.polygons.len(), 1);
         // 2 (B') merged into 1 (B); polygon's loop collapses the
         // consecutive duplicate.
@@ -194,8 +193,7 @@ mod tests {
         // don't see a degenerate primitive.
         let vertices = vec![p(0, 0, 0), p(20, 0, 0), p(0, 20, 0)];
         let polygons = vec![poly(vec![0, 1, 2])];
-        let mesh = IndexedMesh { vertices, polygons };
-        let cleaned = mesh.remove_slivers();
+        let cleaned = IndexedMesh { vertices, polygons }.remove_slivers();
         assert!(cleaned.polygons.is_empty());
     }
 
@@ -205,8 +203,7 @@ mod tests {
         // through unchanged.
         let vertices = vec![p(0, 0, 0), p(10000, 0, 0), p(0, 10000, 0)];
         let polygons = vec![poly(vec![0, 1, 2])];
-        let mesh = IndexedMesh { vertices, polygons };
-        let cleaned = mesh.remove_slivers();
+        let cleaned = IndexedMesh { vertices, polygons }.remove_slivers();
         assert_eq!(cleaned.polygons.len(), 1);
         assert_eq!(cleaned.polygons[0].vertices, vec![0, 1, 2]);
     }
@@ -229,8 +226,7 @@ mod tests {
             poly(vec![0, 1, 2, 3, 4]), // top quad walks B → B'
             poly(vec![5, 6, 2, 1]),    // bottom quad walks B' → B
         ];
-        let mesh = IndexedMesh { vertices, polygons };
-        let cleaned = mesh.remove_slivers();
+        let cleaned = IndexedMesh { vertices, polygons }.remove_slivers();
         assert_eq!(cleaned.polygons.len(), 2);
         for poly in &cleaned.polygons {
             assert!(!poly.vertices.contains(&2));
@@ -253,8 +249,7 @@ mod tests {
             p(5000, 8000, 0), // 4: C
         ];
         let polygons = vec![poly(vec![0, 1, 2, 3, 4])];
-        let mesh = IndexedMesh { vertices, polygons };
-        let cleaned = mesh.remove_slivers();
+        let cleaned = IndexedMesh { vertices, polygons }.remove_slivers();
         assert_eq!(cleaned.polygons.len(), 1);
         assert_eq!(cleaned.polygons[0].vertices, vec![0, 1, 4]);
     }
@@ -271,8 +266,7 @@ mod tests {
 
     #[test]
     fn empty_mesh_passes_through_unchanged() {
-        let mesh = IndexedMesh { vertices: vec![], polygons: vec![] };
-        let cleaned = mesh.remove_slivers();
+        let cleaned = IndexedMesh { vertices: vec![], polygons: vec![] }.remove_slivers();
         assert!(cleaned.vertices.is_empty());
         assert!(cleaned.polygons.is_empty());
     }

--- a/crates/aether-mesh/src/cleanup/tjunctions.rs
+++ b/crates/aether-mesh/src/cleanup/tjunctions.rs
@@ -254,8 +254,7 @@ mod tests {
             pt(1.0, -1.0, 0.0), // 4: E
         ];
         let polygons = vec![poly(vec![0, 1, 2], plane, 0), poly(vec![0, 3, 4], plane, 0)];
-        let mesh = IndexedMesh { vertices, polygons };
-        let repaired = mesh.repair_tjunctions();
+        let repaired = IndexedMesh { vertices, polygons }.repair_tjunctions();
         assert_eq!(repaired.polygons[0].vertices, vec![0, 3, 1, 2]);
         assert_eq!(repaired.polygons[1].vertices, vec![0, 3, 4]);
     }
@@ -270,8 +269,7 @@ mod tests {
             poly(vec![1, 0, 2], plane, 0), // walks B → A → C
             poly(vec![0, 3, 4], plane, 0),
         ];
-        let mesh = IndexedMesh { vertices, polygons };
-        let repaired = mesh.repair_tjunctions();
+        let repaired = IndexedMesh { vertices, polygons }.repair_tjunctions();
         // Walking B → A, the subdivision D should slot between B and A.
         assert_eq!(repaired.polygons[0].vertices, vec![1, 3, 0, 2]);
     }
@@ -281,8 +279,7 @@ mod tests {
         let plane = xy_plane();
         let vertices = vec![pt(0.0, 0.0, 0.0), pt(1.0, 0.0, 0.0), pt(0.0, 1.0, 0.0)];
         let polygons = vec![poly(vec![0, 1, 2], plane, 0)];
-        let mesh = IndexedMesh { vertices, polygons };
-        let repaired = mesh.repair_tjunctions();
+        let repaired = IndexedMesh { vertices, polygons }.repair_tjunctions();
         assert_eq!(repaired.polygons.len(), 1);
         assert_eq!(repaired.polygons[0].vertices, vec![0, 1, 2]);
     }
@@ -319,8 +316,7 @@ mod tests {
             // twice — the spike pattern is the bug.
             poly(vec![0, 1, 2, 3], plane, 0),
         ];
-        let mesh = IndexedMesh { vertices, polygons };
-        let repaired = mesh.repair_tjunctions();
+        let repaired = IndexedMesh { vertices, polygons }.repair_tjunctions();
         let target = &repaired.polygons[1].vertices;
         let mut counts = HashMap::new();
         for &v in target {
@@ -349,8 +345,7 @@ mod tests {
             poly(vec![0, 3, 4], plane, 0), // hosts D₁
             poly(vec![1, 5, 6], plane, 0), // hosts D₂
         ];
-        let mesh = IndexedMesh { vertices, polygons };
-        let repaired = mesh.repair_tjunctions();
+        let repaired = IndexedMesh { vertices, polygons }.repair_tjunctions();
         // Polygon 0 has D₁ and D₂ inserted in order along A→B.
         assert_eq!(repaired.polygons[0].vertices, vec![0, 3, 5, 1, 2]);
     }
@@ -422,8 +417,7 @@ mod tests {
             pt(1.0, 0.0, 0.0), // 4: Q (midpoint AM)
         ];
         let polygons = vec![poly(vec![0, 1, 2], plane, 0)];
-        let mesh = IndexedMesh { vertices, polygons };
-        let repaired = mesh.repair_tjunctions();
+        let repaired = IndexedMesh { vertices, polygons }.repair_tjunctions();
         assert_eq!(repaired.polygons[0].vertices, vec![0, 4, 3, 1, 2]);
     }
 
@@ -440,8 +434,7 @@ mod tests {
             pt(1.0, 1.0, 0.0), // 4: N on B→C (midpoint of (2,0)-(0,2))
         ];
         let polygons = vec![poly(vec![0, 1, 2], plane, 0)];
-        let mesh = IndexedMesh { vertices, polygons };
-        let repaired = mesh.repair_tjunctions();
+        let repaired = IndexedMesh { vertices, polygons }.repair_tjunctions();
         assert_eq!(repaired.polygons[0].vertices, vec![0, 3, 1, 4, 2]);
     }
 
@@ -501,8 +494,7 @@ mod tests {
             // Polygon under test.
             poly(vec![0, 1, 2, 3, 4, 5, 6], plane, 0),
         ];
-        let mesh = IndexedMesh { vertices, polygons };
-        let repaired = mesh.repair_tjunctions();
+        let repaired = IndexedMesh { vertices, polygons }.repair_tjunctions();
 
         // Every emitted polygon must be simple (no repeated vertex).
         for p in &repaired.polygons {
@@ -545,8 +537,7 @@ mod tests {
             pt(1.0, 0.0, 0.0), // 3 — referenced by no polygon yet present in pool
         ];
         let polygons = vec![poly(vec![0, 1, 2], plane, 0)];
-        let mesh = IndexedMesh { vertices, polygons };
-        let repaired = mesh.repair_tjunctions();
+        let repaired = IndexedMesh { vertices, polygons }.repair_tjunctions();
         assert_eq!(repaired.polygons[0].vertices, vec![0, 3, 1, 2]);
     }
 }

--- a/crates/aether-mesh/src/debug.rs
+++ b/crates/aether-mesh/src/debug.rs
@@ -423,8 +423,7 @@ pub fn validate_no_t_junctions(polygons: &[Polygon]) -> Vec<GeometryViolation> {
             if *v_key == *a_key || *v_key == *b_key {
                 continue;
             }
-            let av = *v - a;
-            let t = av.dot(ab) / ab_len_sq;
+            let t = (*v - a).dot(ab) / ab_len_sq;
             // Open interior — exclude endpoints by a small parametric margin
             // proportional to the snap tolerance vs. edge length.
             let margin = (tol::T_JUNCTION / ab_len_sq.sqrt()).min(0.5);
@@ -691,8 +690,10 @@ mod tests {
             quad([a, b, e, e], Vec3::new(0.0, 1.0, 1.0)),
         ];
         let violations = validate_manifold(&polys);
-        let singular = violations.iter().filter(|v| matches!(v, ManifoldViolation::SingularEdge { .. })).count();
-        assert!(singular >= 1, "expected at least one SingularEdge, got {violations:#?}");
+        assert!(
+            violations.iter().filter(|v| matches!(v, ManifoldViolation::SingularEdge { .. })).count() >= 1,
+            "expected at least one SingularEdge, got {violations:#?}"
+        );
     }
 
     #[test]

--- a/crates/aether-mesh/src/plane.rs
+++ b/crates/aether-mesh/src/plane.rs
@@ -498,8 +498,7 @@ mod tests {
         // construction should produce a plane that already has the same
         // key. We approximate this by reading the key, building a plane
         // with those fields directly, and re-keying.
-        let plane = Plane3::from_points(p(0.0, 0.0, 0.0), p(2.0, 0.0, 0.0), p(0.0, 3.0, 0.0));
-        let key = plane.canonical_key();
+        let key = Plane3::from_points(p(0.0, 0.0, 0.0), p(2.0, 0.0, 0.0), p(0.0, 3.0, 0.0)).canonical_key();
         let normalized = Plane3 { n_x: key.0, n_y: key.1, n_z: key.2, d: key.3 };
         assert_eq!(normalized.canonical_key(), key);
     }

--- a/crates/aether-mesh/tests/round_trip.rs
+++ b/crates/aether-mesh/tests/round_trip.rs
@@ -87,8 +87,7 @@ fn parse_errors_on_invalid_axis() {
 
 #[test]
 fn parse_errors_on_trailing_top_level_form() {
-    let result = parse("(box 1 1 1 :color 0) (box 2 2 2 :color 1)");
-    let err = result.expect_err("trailing top-level form should fail");
+    let err = parse("(box 1 1 1 :color 0) (box 2 2 2 :color 1)").expect_err("trailing top-level form should fail");
     assert!(matches!(err, aether_mesh::ParseError::TrailingInput { .. }), "expected TrailingInput, got {err:?}");
 }
 

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -506,9 +506,9 @@ impl DesktopChassis {
             .with_actor::<RenderCapability>(render_config)
             .with_actor::<UnsupportedTestBenchCapability>(())
             .with_actor::<LifecycleCapability>(frame_lifecycle_config(lifecycle_advance_timeout_millis));
-        let builder = maybe_with_rpc_server(builder, rpc_addr, "aether-desktop");
-        let builder = maybe_with_http_server(builder, http_server);
-        let built = builder.driver(driver).build()?;
+        let built = maybe_with_http_server(maybe_with_rpc_server(builder, rpc_addr, "aether-desktop"), http_server)
+            .driver(driver)
+            .build()?;
         // Auto-load any bundled components, in order, before the run loop
         // starts. Fire-and-forward: the component host dispatches each load off
         // the worker pool (already up after `build`), so the game is live

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -371,9 +371,9 @@ impl HeadlessChassis {
             .with_actor::<HeadlessWindowCapability>(())
             .with_actor::<UnsupportedTestBenchCapability>(())
             .with_actor::<LifecycleCapability>(tick_only_lifecycle_config(lifecycle_advance_timeout_millis));
-        let builder = maybe_with_rpc_server(builder, rpc_addr, "aether-headless");
-        let builder = maybe_with_http_server(builder, http_server);
-        let built = builder.driver(driver).build()?;
+        let built = maybe_with_http_server(maybe_with_rpc_server(builder, rpc_addr, "aether-headless"), http_server)
+            .driver(driver)
+            .build()?;
         // Auto-load any bundled components, in order, before the run loop
         // starts. Fire-and-forward: the component host dispatches each load
         // off the worker pool (already up after `build`), so the components

--- a/crates/aether-substrate-bundle/src/visual.rs
+++ b/crates/aether-substrate-bundle/src/visual.rs
@@ -1071,8 +1071,8 @@ mod tests {
         let img = solid_with_rect(16, 16, [bg[0], bg[1], bg[2], 255], [200, 32, 32, 255], rect);
         let check =
             FrameCheck { reduction: FrameReduction::Coverage, tolerance: 5, background: Some(bg), region: None };
-        let mask = diagnostic_mask(&img, &check);
-        let lit_count = mask.chunks_exact(4).filter(|pixel| *pixel == [255, 255, 255, 255]).count();
+        let lit_count =
+            diagnostic_mask(&img, &check).chunks_exact(4).filter(|pixel| *pixel == [255, 255, 255, 255]).count();
         let verdict = run_checks(img.rgba.clone(), img.width, img.height, &[check]);
         let FrameCheckResult::Coverage { fraction, .. } = &verdict.results[0] else {
             panic!("expected a Coverage result");

--- a/crates/aether-substrate-bundle/tests/console_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/console_render_interaction.rs
@@ -50,8 +50,7 @@ fn build_bench() -> TestBench {
 }
 
 fn build_bench_without_assets_root() -> TestBench {
-    let sandbox = init_save_sandbox("console-render-interaction-no-assets");
-    let assets = sandbox.join("empty-assets");
+    let assets = init_save_sandbox("console-render-interaction-no-assets").join("empty-assets");
     fs::create_dir_all(&assets).expect("create empty assets root");
     build_bench_with_assets(assets, "console-render-interaction-no-assets")
 }

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario/render.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario/render.rs
@@ -38,11 +38,14 @@ fn capture_frame_round_trip_runs_pre_and_after_mails() {
     // Priming advance subscribes the probe to ticks; the
     // capture-with-mails op then dispatches the pre bundle, reads
     // back, and dispatches the after bundle — all in one frame.
-    let captured = bench
-        .execute(vec![("prime", BenchOp::advance(1)), ("snap", BenchOp::capture_with_mails(pre, after))])
-        .expect("prime + capture-with-mails");
-    let png = captured.captured("snap").expect("snap step ran");
-    let img = decode_png(png).expect("decode capture png");
+    let img = decode_png(
+        bench
+            .execute(vec![("prime", BenchOp::advance(1)), ("snap", BenchOp::capture_with_mails(pre, after))])
+            .expect("prime + capture-with-mails")
+            .captured("snap")
+            .expect("snap step ran"),
+    )
+    .expect("decode capture png");
     let bg = background_top_left(&img);
     let tolerance = 5;
     // The probe draws one large triangle (NDC verts spanning ±0.9),
@@ -72,11 +75,14 @@ fn capture_frame_round_trip_runs_pre_and_after_mails() {
     // Cleanup ran: probe.render is now { visible: 0 }. Advance once
     // and capture again — the next tick won't emit DrawTriangle, so
     // the frame stays at clear color.
-    let cleaned = bench
-        .execute(vec![("cleanup_advance", BenchOp::advance(1)), ("snap2", BenchOp::capture())])
-        .expect("post-cleanup advance + capture");
-    let png2 = cleaned.captured("snap2").expect("snap2 step ran");
-    let img2 = decode_png(png2).expect("decode cleanup png");
+    let img2 = decode_png(
+        bench
+            .execute(vec![("cleanup_advance", BenchOp::advance(1)), ("snap2", BenchOp::capture())])
+            .expect("post-cleanup advance + capture")
+            .captured("snap2")
+            .expect("snap2 step ran"),
+    )
+    .expect("decode cleanup png");
     let cleaned_coverage = coverage(&img2, background_top_left(&img2), 5);
     assert!(
         cleaned_coverage < 0.01,
@@ -240,9 +246,14 @@ fn textured_quad_draws_screen_space_rect() {
         },
     )];
 
-    let captured = bench.execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))]).expect("capture-with-mails");
-    let png = captured.captured("snap").expect("snap step ran");
-    let img = decode_png(png).expect("decode capture png");
+    let img = decode_png(
+        bench
+            .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+            .expect("capture-with-mails")
+            .captured("snap")
+            .expect("snap step ran"),
+    )
+    .expect("decode capture png");
     let bg = background_top_left(&img);
     let tolerance = 5;
 
@@ -270,11 +281,14 @@ fn textured_quad_draws_screen_space_rect() {
     // Immediate-mode contract: with no quad resent, an advance commits
     // the empty accumulator (clearing the cache) and the next capture is
     // back at clear color.
-    let cleared = bench
-        .execute(vec![("clear_advance", BenchOp::advance(1)), ("snap2", BenchOp::capture())])
-        .expect("advance + capture");
-    let png2 = cleared.captured("snap2").expect("snap2 step ran");
-    let img2 = decode_png(png2).expect("decode cleared png");
+    let img2 = decode_png(
+        bench
+            .execute(vec![("clear_advance", BenchOp::advance(1)), ("snap2", BenchOp::capture())])
+            .expect("advance + capture")
+            .captured("snap2")
+            .expect("snap2 step ran"),
+    )
+    .expect("decode cleared png");
     let cleared_coverage = coverage(&img2, background_top_left(&img2), tolerance);
     assert!(
         cleared_coverage < 0.01,
@@ -590,9 +604,14 @@ fn target_color_stats_distinguishes_quadrant_colors_on_real_capture() {
         },
     )];
 
-    let captured = bench.execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))]).expect("capture-with-mails");
-    let png = captured.captured("snap").expect("snap step ran");
-    let img = decode_png(png).expect("decode capture png");
+    let img = decode_png(
+        bench
+            .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+            .expect("capture-with-mails")
+            .captured("snap")
+            .expect("snap step ran"),
+    )
+    .expect("decode capture png");
     let tolerance = 20;
 
     // Inset 8x4 probe rects, one per quadrant, each pulled at least 4px
@@ -670,11 +689,14 @@ fn destroyed_texture_draw_drops_from_frame() {
         )
     };
 
-    let captured = bench
-        .execute(vec![("snap", BenchOp::capture_with_mails(vec![draw()], vec![]))])
-        .expect("capture with live texture");
-    let png = captured.captured("snap").expect("snap step ran");
-    let img = decode_png(png).expect("decode capture png");
+    let img = decode_png(
+        bench
+            .execute(vec![("snap", BenchOp::capture_with_mails(vec![draw()], vec![]))])
+            .expect("capture with live texture")
+            .captured("snap")
+            .expect("snap step ran"),
+    )
+    .expect("decode capture png");
     let bg = background_top_left(&img);
     let drawn = coverage(&img, bg, 5);
     assert!((0.08..0.22).contains(&drawn), "live texture quad coverage {drawn} fell outside the expected band");
@@ -765,9 +787,14 @@ fn r8_texture_updates_and_draws_red_channel_only() {
         ),
     ];
 
-    let captured = bench.execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))]).expect("capture r8 texture");
-    let png = captured.captured("snap").expect("snap step ran");
-    let img = decode_png(png).expect("decode capture png");
+    let img = decode_png(
+        bench
+            .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+            .expect("capture r8 texture")
+            .captured("snap")
+            .expect("snap step ran"),
+    )
+    .expect("decode capture png");
     assert_eq!((img.width, img.height), (frame_width, frame_height));
 
     let sample = |x: u32, y: u32| -> [u8; 4] {
@@ -984,9 +1011,14 @@ fn solid_quad_draws_screen_space_rect() {
         },
     )];
 
-    let captured = bench.execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))]).expect("capture-with-mails");
-    let png = captured.captured("snap").expect("snap step ran");
-    let img = decode_png(png).expect("decode capture png");
+    let img = decode_png(
+        bench
+            .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+            .expect("capture-with-mails")
+            .captured("snap")
+            .expect("snap step ran"),
+    )
+    .expect("decode capture png");
     let bg = background_top_left(&img);
     let tolerance = 5;
 
@@ -1008,11 +1040,14 @@ fn solid_quad_draws_screen_space_rect() {
     );
 
     // Immediate-mode clear: advance with no quad resent, next capture returns to clear color.
-    let cleared = bench
-        .execute(vec![("clear_advance", BenchOp::advance(1)), ("snap2", BenchOp::capture())])
-        .expect("advance + capture");
-    let png2 = cleared.captured("snap2").expect("snap2 step ran");
-    let img2 = decode_png(png2).expect("decode cleared png");
+    let img2 = decode_png(
+        bench
+            .execute(vec![("clear_advance", BenchOp::advance(1)), ("snap2", BenchOp::capture())])
+            .expect("advance + capture")
+            .captured("snap2")
+            .expect("snap2 step ran"),
+    )
+    .expect("decode cleared png");
     let cleared_coverage = coverage(&img2, background_top_left(&img2), tolerance);
     assert!(
         cleared_coverage < 0.01,

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario/text.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario/text.rs
@@ -65,9 +65,14 @@ fn text_draws_a_screen_space_string() {
     // Now the glyphs rasterize and the quad batch reaches the renderer the
     // same tick the capture records.
     let pre = vec![envelope("aether.text", &draw)];
-    let captured = bench.execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))]).expect("capture-with-mails");
-    let png = captured.captured("snap").expect("snap step ran");
-    let img = decode_png(png).expect("decode capture png");
+    let img = decode_png(
+        bench
+            .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+            .expect("capture-with-mails")
+            .captured("snap")
+            .expect("snap step ran"),
+    )
+    .expect("decode capture png");
     let bg = background_top_left(&img);
     let tolerance = 5;
 

--- a/crates/aether-substrate-bundle/tests/typed_config.rs
+++ b/crates/aether-substrate-bundle/tests/typed_config.rs
@@ -93,8 +93,7 @@ fn typed_config_guest_with_config_bytes_round_trips() {
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     let wasm = fs::read::<&Path>(wasm_path.as_ref()).expect("read fixture wasm");
 
-    let config = ProbeConfig { seed: 0xABCD_1234, label: "c2-round-trip".to_owned() };
-    let config_bytes = config.encode_into_bytes();
+    let config_bytes = ProbeConfig { seed: 0xABCD_1234, label: "c2-round-trip".to_owned() }.encode_into_bytes();
 
     let report = bench
         .execute(vec![

--- a/crates/aether-substrate-bundle/tests/widget_compositing.rs
+++ b/crates/aether-substrate-bundle/tests/widget_compositing.rs
@@ -230,11 +230,14 @@ fn flat_panel_is_one_sender_with_chrome_under_children() {
     };
     load_panel(&mut bench, &wasm, &config);
 
-    let captured = bench
-        .execute(vec![("snap", BenchOp::capture_with_mails(vec![tick_to_root()], vec![]))])
-        .expect("capture-with-mails");
-    let png = captured.captured("snap").expect("snap step ran");
-    let img = decode_png(png).expect("decode capture png");
+    let img = decode_png(
+        bench
+            .execute(vec![("snap", BenchOp::capture_with_mails(vec![tick_to_root()], vec![]))])
+            .expect("capture-with-mails")
+            .captured("snap")
+            .expect("snap step ran"),
+    )
+    .expect("decode capture png");
 
     assert_eq!(
         bench.count_observed("aether.render.draw_solid_quads"),
@@ -329,11 +332,14 @@ fn nested_tree_draws_in_depth_first_order() {
     };
     load_panel(&mut bench, &wasm, &config);
 
-    let captured = bench
-        .execute(vec![("snap", BenchOp::capture_with_mails(vec![tick_to_root()], vec![]))])
-        .expect("capture-with-mails");
-    let png = captured.captured("snap").expect("snap step ran");
-    let img = decode_png(png).expect("decode capture png");
+    let img = decode_png(
+        bench
+            .execute(vec![("snap", BenchOp::capture_with_mails(vec![tick_to_root()], vec![]))])
+            .expect("capture-with-mails")
+            .captured("snap")
+            .expect("snap step ran"),
+    )
+    .expect("decode capture png");
 
     assert_eq!(
         bench.count_observed("aether.render.draw_solid_quads"),

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -601,8 +601,7 @@ impl BlobWork {
                     // SAFETY: slot `base + j` was just published (`len`
                     // advanced past it), so it is initialized; `work()` is a
                     // producer-side relaxed load on the slot we wrote.
-                    let group = unsafe { self.groups[base + j].get() };
-                    let w = group.work();
+                    let w = unsafe { self.groups[base + j].get() }.work();
                     total_work = total_work.saturating_add(w);
                     max_group_work = max_group_work.max(w);
                 }

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -1310,9 +1310,8 @@ mod tests {
 
         let (_registry, mailer) = bare_substrate();
         let binding = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0x00BE_EF11)));
-        let mailbox = NativeActorMailbox::<'_, StubActor>::__new_in_flight(0x00FE_ED01, &binding, None, None);
-
-        let mail_id = mailbox.send_with_context(&CastOnly { code: 1 }, &NativeRequestContext { value: 13 });
+        let mail_id = NativeActorMailbox::<'_, StubActor>::__new_in_flight(0x00FE_ED01, &binding, None, None)
+            .send_with_context(&CastOnly { code: 1 }, &NativeRequestContext { value: 13 });
 
         assert_eq!(
             binding.take_request_context::<NativeRequestContext>(RequestId(mail_id.correlation_id)),

--- a/crates/aether-substrate/src/chassis/builder/tests.rs
+++ b/crates/aether-substrate/src/chassis/builder/tests.rs
@@ -442,9 +442,12 @@ fn with_actor_boots_dispatches_and_tears_down() {
         panic!("ProbeCap claim must be a sink entry");
     };
 
-    let payload = Ping { tag: 0xDEAD_BEEF };
-    let bytes = payload.encode_into_bytes();
-    handler.enqueue(registry::test_owned_dispatch(<Ping as Kind>::ID, Ping::NAME, &bytes, 1));
+    handler.enqueue(registry::test_owned_dispatch(
+        <Ping as Kind>::ID,
+        Ping::NAME,
+        &Ping { tag: 0xDEAD_BEEF }.encode_into_bytes(),
+        1,
+    ));
 
     // Wait briefly for the dispatcher thread to dispatch.
     let deadline = Instant::now() + Duration::from_millis(500);
@@ -550,9 +553,12 @@ fn with_actor_stamps_local_for_init_and_handler() {
     // 101, 102, 103 in order. We assert the final 103 with a
     // wait budget to cover dispatcher-thread scheduling.
     for seq in 0..3 {
-        let payload = Tick { seq };
-        let bytes = payload.encode_into_bytes();
-        handler.enqueue(registry::test_owned_dispatch(<Tick as Kind>::ID, Tick::NAME, &bytes, 1));
+        handler.enqueue(registry::test_owned_dispatch(
+            <Tick as Kind>::ID,
+            Tick::NAME,
+            &Tick { seq }.encode_into_bytes(),
+            1,
+        ));
     }
 
     let deadline = Instant::now() + Duration::from_millis(500);

--- a/crates/aether-substrate/src/config.rs
+++ b/crates/aether-substrate/src/config.rs
@@ -784,8 +784,7 @@ mod tests {
 
     #[test]
     fn config_error_display_names_key_and_value() {
-        let e = ConfigError::unparseable("AETHER_BOOT_MANIFEST", "lots", an_int_error());
-        let msg = e.to_string();
+        let msg = ConfigError::unparseable("AETHER_BOOT_MANIFEST", "lots", an_int_error()).to_string();
         assert!(msg.contains("AETHER_BOOT_MANIFEST"));
         assert!(msg.contains("lots"));
     }

--- a/crates/aether-substrate/src/mail/mail_ref.rs
+++ b/crates/aether-substrate/src/mail/mail_ref.rs
@@ -217,9 +217,7 @@ mod tests {
         let ring = Arc::new(MailRing::with_capacity(1024));
         let locs = ring.push_blob(&[OutMail { recipient: 9, kind: 9, payload: &[1, 2, 3, 4, 5] }]).unwrap();
         let live = ring.live_bytes();
-        let r = MailRef::in_ring(Arc::clone(&ring), locs[0]);
-        let v = r.into_vec();
-        assert_eq!(v, vec![1, 2, 3, 4, 5]);
+        assert_eq!(MailRef::in_ring(Arc::clone(&ring), locs[0]).into_vec(), vec![1, 2, 3, 4, 5]);
         // into_vec consumed the ref -> released -> reclaimable
         assert_eq!(ring.reclaim(), live);
     }

--- a/crates/aether-substrate/src/mail/registry/mailbox.rs
+++ b/crates/aether-substrate/src/mail/registry/mailbox.rs
@@ -532,8 +532,7 @@ impl Registry {
     /// ADR-0063.
     pub(crate) fn route_lookup(&self, kind: KindId, recipient: MailboxId) -> RouteLookup {
         let inner = self.inner.read().expect("registry lock poisoned; fail-fast per ADR-0063");
-        let kind_slot = inner.kinds.get(&kind);
-        let kind_name = kind_slot.map(|s| s.name.clone()).unwrap_or_default();
+        let kind_name = inner.kinds.get(&kind).map(|s| s.name.clone()).unwrap_or_default();
         let entry = inner.mailboxes.get(&recipient).map(|m| m.entry.clone());
         // iamacoffeepot/aether#1135: hand the demuxer the recipient's
         // seize handle under the same guard. Cloned out of the deferred

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -127,8 +127,7 @@ fn make_hook(
         // case-scenario; we never want to obscure the original
         // payload by panicking again here.
         let timestamp_unix_ms = now_unix_millis();
-        let thread = thread::current();
-        let thread_name = thread.name().unwrap_or("<unnamed>").to_owned();
+        let thread_name = thread::current().name().unwrap_or("<unnamed>").to_owned();
         let location = info
             .location()
             .map_or_else(|| "<unknown>".to_string(), |l| format!("{}:{}:{}", l.file(), l.line(), l.column()));
@@ -566,8 +565,7 @@ mod tests {
     /// this byte format.
     #[test]
     fn write_jsonl_emits_header_then_entries() {
-        let dir = tempdir("write_jsonl");
-        let path = dir.join("aether.audio.jsonl");
+        let path = tempdir("write_jsonl").join("aether.audio.jsonl");
         let ring = vec![entry(2, 1, "before crash a"), entry(3, 2, "before crash b")];
         write_jsonl(
             &path,
@@ -613,8 +611,7 @@ mod tests {
     fn write_jsonl_with_no_or_empty_ring_emits_header_only() {
         let empty: [LogEntry; 0] = [];
         for (label, ring) in [("none", None), ("empty", Some(&empty[..]))] {
-            let dir = tempdir(&format!("write_jsonl_{label}_ring"));
-            let path = dir.join("scheduler-thread.jsonl");
+            let path = tempdir(&format!("write_jsonl_{label}_ring")).join("scheduler-thread.jsonl");
             write_jsonl(
                 &path,
                 1_700_000_002_000,


### PR DESCRIPTION
Closes #3036.

## Summary

The tree carried unrolled call sequences — single-use `let` intermediates where each binding is consumed exactly once by the next call, and mut-local mutator runs. #3035 codified the chain-first rule in `CLAUDE.md`; this is the retroactive judgment sweep over code already written.

Both finder patterns were re-run against current `main` (post-#3034 reformat, `--pcre2` probed against a synthetic positive first), yielding 288 candidate sites: 221 let-intermediates and 67 mut-local runs. The per-site judgment filter kept 82 rewrites and skipped 206:

- **multi-use (124)** — the binding is consumed more than once (dominant over-match: test fixture bindings reused across asserts)
- **non-fluent mut runs (67)** — `()`-returning mutator receivers (Vec/String builders, test scaffolding); out of scope by explicit user decision, no API redesign
- **guard-or-borrow (11)** — drop-timing or borrow-lifetime does real work (lock guards, `SettlingInbox` settlement-on-drop, RefCell `Ref`s, listener bindings, E0716 temporaries)
- **load-bearing names (3)** and SAFETY-paired / macro-boundary sites — the name or structure documents a domain fact the chain would hide

Every rewrite is behavior-preserving: single-use intermediates collapsed into chains, with borrows completing within their statement and type annotations carried as turbofish where needed.

## Test plan

Strictly no behavior change — coverage is the existing test suite staying green under CI (Clippy, tests, Format). A pure re-chaining diff should keep Qodana quiet.

## Generated by

`/implement` — agent execution of [scoped issue #3036](https://github.com/iamacoffeepot/aether/issues/3036).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
