### PR TITLE
feat(kit): add multiline text area widget

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -89,7 +89,8 @@ pub use widget::theme::{SetTheme, Theme, ThemeState};
 pub use widget::{
     ButtonClicked, ButtonConfig, ChildrenChanged, Collect, FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig,
     ImageFit, LabelConfig, MembershipEntry, PanelConfig, RadioConfig, RadioSelected, SetWidgetState, SliderChanged,
-    SliderConfig, TextCommitted, TextFieldConfig, WidgetChildSpec, WidgetClipRect, WidgetConfig, WidgetControlState,
+    SliderConfig, TextAreaConfig, TextCommitted, TextFieldConfig, WidgetChildSpec, WidgetClipRect, WidgetConfig,
+    WidgetControlState,
     WidgetDrawItem, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged, WidgetValidation,
 };
 pub use world::{
@@ -138,6 +139,7 @@ aether_actor::export!(
     widget::Widget,
     widget::set::SliderWidget,
     widget::set::TextFieldWidget,
+    widget::set::TextAreaWidget,
     widget::set::RadioGroupWidget,
     widget::set::ButtonWidget,
     widget::set::LabelWidget,
@@ -158,6 +160,7 @@ aether_actor::export!(
     widget::Widget,
     widget::set::SliderWidget,
     widget::set::TextFieldWidget,
+    widget::set::TextAreaWidget,
     widget::set::RadioGroupWidget,
     widget::set::ButtonWidget,
     widget::set::LabelWidget,

--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -90,8 +90,7 @@ pub use widget::{
     ButtonClicked, ButtonConfig, ChildrenChanged, Collect, FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig,
     ImageFit, LabelConfig, MembershipEntry, PanelConfig, RadioConfig, RadioSelected, SetWidgetState, SliderChanged,
     SliderConfig, TextAreaConfig, TextCommitted, TextFieldConfig, WidgetChildSpec, WidgetClipRect, WidgetConfig,
-    WidgetControlState,
-    WidgetDrawItem, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged, WidgetValidation,
+    WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged, WidgetValidation,
 };
 pub use world::{
     ApplyBrush, AutomatonRule, BrushParameters, CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk,

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -742,6 +742,15 @@ impl Default for PanelConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aether_data::wire::to_vec;
+    use alloc::vec;
+
+    #[test]
+    fn text_area_appends_after_the_landed_image_wire_discriminant() {
+        assert_eq!(to_vec(&WidgetKind::BehaviorHost).expect("encode BehaviorHost"), vec![6, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::Image).expect("encode Image"), vec![7, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::TextArea).expect("encode TextArea"), vec![8, 0, 0, 0]);
+    }
 
     #[test]
     fn quad_offset_translates_position_and_keeps_size() {

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -307,6 +307,10 @@ pub enum WidgetKind {
     /// A static image — `config` decodes as [`ImageConfig`]. Not focusable.
     /// Appended to preserve the established wire discriminants above.
     Image,
+    /// A multiline text area — `config` decodes as [`TextAreaConfig`]. Kept at
+    /// the end so adding it does not renumber the landed image discriminant or
+    /// any earlier wire discriminant.
+    TextArea,
 }
 
 impl WidgetKind {
@@ -332,6 +336,7 @@ impl WidgetKind {
             Self::Slider => aether_data::mailbox_id_from_name("aether.kit.widget.slider").0,
             Self::Radio => aether_data::mailbox_id_from_name("aether.kit.widget.radio").0,
             Self::TextField => aether_data::mailbox_id_from_name("aether.kit.widget.text_field").0,
+            Self::TextArea => aether_data::mailbox_id_from_name("aether.kit.widget.text_area").0,
             Self::Button => aether_data::mailbox_id_from_name("aether.kit.widget.button").0,
             Self::Composite | Self::BehaviorHost => return None,
         };
@@ -525,6 +530,20 @@ pub struct TextFieldConfig {
     pub state: WidgetControlState,
 }
 
+/// `aether.kit.widget.text_area.config` — a multiline editable string with a
+/// fixed whole-line viewport. `rows` is the number of visible rows (`0` uses
+/// one row); `max_chars` counts Unicode scalar values (`0` = no cap).
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
+#[kind(name = "aether.kit.widget.text_area.config")]
+pub struct TextAreaConfig {
+    pub initial: String,
+    pub max_chars: u32,
+    pub rows: u32,
+    pub theme: Theme,
+    #[serde(default)]
+    pub state: WidgetControlState,
+}
+
 /// `aether.kit.widget.radio.config` — a vertical list of mutually-exclusive
 /// `options`, one selected at a time, starting at `initial_index` (clamped
 /// into range at init). Each option draws as one theme row.
@@ -620,8 +639,8 @@ pub struct SliderChanged {
     pub committed: bool,
 }
 
-/// `aether.kit.widget.text_field.committed` — a text field's value-up event,
-/// emitted when the field's Enter key commits its current contents.
+/// `aether.kit.widget.text_field.committed` — the shared text-control value-up
+/// event. A text field emits it on Enter; a text area emits it on Ctrl+Enter.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.kit.widget.text_field.committed")]
 pub struct TextCommitted {

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -64,8 +64,9 @@ use crate::widget::set::{
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{
     ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig, LabelConfig,
-    PanelConfig, RadioConfig, RadioSelected, SliderChanged, SliderConfig, TextAreaConfig, TextCommitted, TextFieldConfig,
-    WidgetChildSpec, WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged,
+    PanelConfig, RadioConfig, RadioSelected, SliderChanged, SliderConfig, TextAreaConfig, TextCommitted,
+    TextFieldConfig, WidgetChildSpec, WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame, WidgetKind,
+    WidgetStateChanged,
 };
 use crate::widget::{accept_child_list, emit, flush_membership};
 

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -59,12 +59,12 @@ use crate::widget::focus::{
     AvailabilityEffects, Focus, FocusDirection, FocusEligibility, FocusRect, FocusTransition, HoverTransition,
 };
 use crate::widget::set::{
-    ButtonWidget, ImageWidget, LabelWidget, RadioGroupWidget, SliderWidget, TextFieldWidget, quad,
+    ButtonWidget, ImageWidget, LabelWidget, RadioGroupWidget, SliderWidget, TextAreaWidget, TextFieldWidget, quad,
 };
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{
     ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig, LabelConfig,
-    PanelConfig, RadioConfig, RadioSelected, SliderChanged, SliderConfig, TextCommitted, TextFieldConfig,
+    PanelConfig, RadioConfig, RadioSelected, SliderChanged, SliderConfig, TextAreaConfig, TextCommitted, TextFieldConfig,
     WidgetChildSpec, WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged,
 };
 use crate::widget::{accept_child_list, emit, flush_membership};
@@ -257,6 +257,18 @@ fn spawn_panel_child(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, row:
                 focusable: true,
                 state,
                 type_namespace: <TextFieldWidget as Addressable>::NAMESPACE,
+            })
+        }),
+        WidgetKind::TextArea => decode_child::<TextAreaConfig>(spec).and_then(|config| {
+            let height = row * config.rows.max(1) as f32;
+            let state = config.state.clone();
+            spawn::<TextAreaWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
+                id,
+                height,
+                pointer_eligible: true,
+                focusable: true,
+                state,
+                type_namespace: <TextAreaWidget as Addressable>::NAMESPACE,
             })
         }),
         WidgetKind::Button => decode_child::<ButtonConfig>(spec).and_then(|config| {
@@ -467,6 +479,10 @@ fn spawn_behavior_host(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, ro
             let config = decode_named::<TextFieldConfig>(&spec.subname, &host_spec.wrapped_config)?;
             (row, true, true, config.state)
         }
+        WidgetKind::TextArea => {
+            let config = decode_named::<TextAreaConfig>(&spec.subname, &host_spec.wrapped_config)?;
+            (row * config.rows.max(1) as f32, true, true, config.state)
+        }
         WidgetKind::Button => {
             let config = decode_named::<ButtonConfig>(&spec.subname, &host_spec.wrapped_config)?;
             (row, true, true, config.state)
@@ -505,6 +521,7 @@ fn spawn_behavior_host(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, ro
             ImageConfig::ID.0,
             SliderConfig::ID.0,
             TextFieldConfig::ID.0,
+            TextAreaConfig::ID.0,
             ButtonConfig::ID.0,
             RadioConfig::ID.0,
             SliderChanged::ID.0,
@@ -857,6 +874,7 @@ mod behavior_tests {
         assert_eq!(WidgetKind::Image.type_tag(), Some(ActorTypeTag::of::<ImageWidget>().0));
         assert_eq!(WidgetKind::Radio.type_tag(), Some(ActorTypeTag::of::<RadioGroupWidget>().0));
         assert_eq!(WidgetKind::TextField.type_tag(), Some(ActorTypeTag::of::<TextFieldWidget>().0));
+        assert_eq!(WidgetKind::TextArea.type_tag(), Some(ActorTypeTag::of::<TextAreaWidget>().0));
         assert_eq!(WidgetKind::Composite.type_tag(), None);
         assert_eq!(WidgetKind::BehaviorHost.type_tag(), None);
     }

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -6,6 +6,7 @@
 //! - [`SliderWidget`] — a horizontal value slider, dragged or
 //!   arrow-nudged.
 //! - [`TextFieldWidget`] — a single-line editable string.
+//! - [`TextAreaWidget`] — a multiline measured editor with line scrolling.
 //! - [`RadioGroupWidget`] — a vertical list of exclusive options.
 //! - [`ButtonWidget`] — a momentary push button.
 //! - [`LabelWidget`] — static, non-interactive text.
@@ -29,6 +30,7 @@ pub mod image;
 pub mod label;
 pub mod radio;
 pub mod slider;
+pub mod text_area;
 pub mod text_field;
 
 pub use button::ButtonWidget;
@@ -36,6 +38,7 @@ pub use image::ImageWidget;
 pub use label::LabelWidget;
 pub use radio::RadioGroupWidget;
 pub use slider::SliderWidget;
+pub use text_area::TextAreaWidget;
 pub use text_field::TextFieldWidget;
 
 use alloc::vec::Vec;

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -44,11 +44,61 @@ pub use text_field::TextFieldWidget;
 use alloc::vec::Vec;
 
 use aether_actor::WasmCtx;
+use aether_capabilities::TextCapability;
+use aether_capabilities::text::{FontMetricsRequest, FontRef};
+use aether_kinds::{Modifiers, MouseButtonRelease, mouse_button};
 use aether_math::Rgba;
 
-use crate::widget::state::InteractionState;
-use crate::widget::theme::Theme;
-use crate::widget::{WidgetDrawItem, WidgetDrawList};
+use crate::widget::state::{InteractionState, emit_state_changed};
+use crate::widget::text_edit::{FontMetricsAdapter, TextEditState};
+use crate::widget::theme::{Theme, ThemeState};
+use crate::widget::{WidgetControlState, WidgetDrawItem, WidgetDrawList};
+
+fn text_control_theme_state(state: &InteractionState, dragging: bool) -> ThemeState {
+    if state.focused() { state.supporting_theme_state(dragging) } else { state.theme_state(dragging) }
+}
+
+fn apply_text_control_state(
+    ctx: &WasmCtx<'_>,
+    state: &mut InteractionState,
+    edit: &mut TextEditState,
+    dragging: &mut bool,
+    next: WidgetControlState,
+) {
+    if state.replace(next) {
+        if !state.can_mutate() {
+            edit.clear_composition();
+        }
+        if !state.is_available() {
+            *dragging = false;
+        }
+        emit_state_changed(ctx, state);
+    }
+}
+
+fn pump_text_font_metrics(ctx: &mut WasmCtx<'_>, font_metrics: &mut FontMetricsAdapter) {
+    if let Some(id) = font_metrics.take_pending_request() {
+        ctx.actor::<TextCapability>().send(&FontMetricsRequest { font: FontRef::Id(id) });
+    }
+}
+
+fn apply_text_theme(ctx: &mut WasmCtx<'_>, font_metrics: &mut FontMetricsAdapter, theme: &mut Theme, next: Theme) {
+    font_metrics.set_desired(next.font_id);
+    *theme = next;
+    pump_text_font_metrics(ctx, font_metrics);
+}
+
+fn release_text_drag(dragging: &mut bool, release: MouseButtonRelease) {
+    if release.button == mouse_button::LEFT {
+        *dragging = false;
+    }
+}
+
+fn update_text_modifiers(state: &InteractionState, modifiers: &mut Modifiers, next: Modifiers) {
+    if state.is_available() {
+        *modifiers = next;
+    }
+}
 
 /// Discharge the hidden-widget branch of the always-reply compositing
 /// protocol. Hidden controls retain their slot, so every `Collect` must still

--- a/crates/aether-kit/src/widget/set/text_area.rs
+++ b/crates/aether-kit/src/widget/set/text_area.rs
@@ -138,7 +138,7 @@ impl TextAreaWidget {
     }
 
     fn move_vertical(&mut self, direction: VerticalDirection, extend: bool) {
-        let target = {
+        let (target_byte, desired_x) = {
             let Some(metrics) = self.font_metrics.resolved() else {
                 return;
             };
@@ -167,11 +167,11 @@ impl TextAreaWidget {
         };
 
         if extend {
-            self.edit.extend_to(target.0);
+            self.edit.extend_to(target_byte);
         } else {
-            self.edit.place_caret(target.0);
+            self.edit.place_caret(target_byte);
         }
-        self.preferred_x_pixels = Some(target.1);
+        self.preferred_x_pixels = Some(desired_x);
         self.reconcile_scroll();
     }
 
@@ -486,10 +486,10 @@ impl WasmActor for TextAreaWidget {
         if !self.state.can_mutate() {
             return;
         }
-        let cursor = match (preedit.cursor_begin, preedit.cursor_end) {
-            (Some(begin), Some(end)) => Some(TextSpan::new(begin as usize, end as usize)),
-            _ => None,
-        };
+        let cursor = preedit
+            .cursor_begin
+            .zip(preedit.cursor_end)
+            .map(|(begin, end)| TextSpan::new(begin as usize, end as usize));
         self.edit.set_composition(preedit.text, cursor);
         self.preferred_x_pixels = None;
     }

--- a/crates/aether-kit/src/widget/set/text_area.rs
+++ b/crates/aether-kit/src/widget/set/text_area.rs
@@ -8,15 +8,17 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
-use aether_capabilities::TextCapability;
-use aether_capabilities::text::{FontMetricsRequest, FontMetricsResult, FontRef};
+use aether_capabilities::text::FontMetricsResult;
 use aether_kinds::keycode::{KEY_BACKSPACE, KEY_DOWN, KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_UP};
 use aether_kinds::{
     CachedFontMetrics, ImePreedit, Key, Modifiers, MouseButton, MouseButtonRelease, MouseMove, TextInput, mouse_button,
 };
 
-use crate::widget::set::{push_control_outlines, quad, reply_if_hidden, text_origin_y};
-use crate::widget::state::{InteractionState, emit_state_changed};
+use crate::widget::set::{
+    apply_text_control_state, apply_text_theme, pump_text_font_metrics, push_control_outlines, quad, release_text_drag,
+    reply_if_hidden, text_control_theme_state, text_origin_y, update_text_modifiers,
+};
+use crate::widget::state::InteractionState;
 use crate::widget::text_edit::{EditPolicy, FontMetricsAdapter, SingleLineLayout, TextEditState, TextSpan};
 use crate::widget::theme::{SetTheme, Theme, ThemeState};
 use crate::widget::{
@@ -97,29 +99,15 @@ impl TextAreaWidget {
     }
 
     fn theme_state(&self) -> ThemeState {
-        if self.state.focused() {
-            self.state.supporting_theme_state(self.dragging)
-        } else {
-            self.state.theme_state(self.dragging)
-        }
+        text_control_theme_state(&self.state, self.dragging)
     }
 
     fn apply_control_state(&mut self, ctx: &WasmCtx<'_>, next: WidgetControlState) {
-        if self.state.replace(next) {
-            if !self.state.can_mutate() {
-                self.edit.clear_composition();
-            }
-            if !self.state.is_available() {
-                self.dragging = false;
-            }
-            emit_state_changed(ctx, &self.state);
-        }
+        apply_text_control_state(ctx, &mut self.state, &mut self.edit, &mut self.dragging, next);
     }
 
     fn pump_font_metrics(&mut self, ctx: &mut WasmCtx<'_>) {
-        if let Some(id) = self.font_metrics.take_pending_request() {
-            ctx.actor::<TextCapability>().send(&FontMetricsRequest { font: FontRef::Id(id) });
-        }
+        pump_text_font_metrics(ctx, &mut self.font_metrics);
     }
 
     fn reconcile_scroll(&mut self) {
@@ -376,9 +364,7 @@ impl WasmActor for TextAreaWidget {
 
     #[handler::single]
     fn on_set_theme(&mut self, ctx: &mut WasmCtx<'_>, set: SetTheme) {
-        self.font_metrics.set_desired(set.theme.font_id);
-        self.theme = set.theme;
-        self.pump_font_metrics(ctx);
+        apply_text_theme(ctx, &mut self.font_metrics, &mut self.theme, set.theme);
     }
 
     #[handler::single]
@@ -487,16 +473,12 @@ impl WasmActor for TextAreaWidget {
 
     #[handler::single]
     fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
-        if release.button == mouse_button::LEFT {
-            self.dragging = false;
-        }
+        release_text_drag(&mut self.dragging, release);
     }
 
     #[handler::single]
     fn on_modifiers(&mut self, _ctx: &mut WasmCtx<'_>, modifiers: Modifiers) {
-        if self.state.is_available() {
-            self.modifiers = modifiers;
-        }
+        update_text_modifiers(&self.state, &mut self.modifiers, modifiers);
     }
 
     #[handler::single]

--- a/crates/aether-kit/src/widget/set/text_area.rs
+++ b/crates/aether-kit/src/widget/set/text_area.rs
@@ -1,0 +1,674 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `widget/mod.rs`).
+#![allow(clippy::needless_pass_by_value)]
+
+//! Multiline measured text editing with a fixed whole-line viewport.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::TextCapability;
+use aether_capabilities::text::{FontMetricsRequest, FontMetricsResult, FontRef};
+use aether_kinds::keycode::{KEY_BACKSPACE, KEY_DOWN, KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_UP};
+use aether_kinds::{
+    CachedFontMetrics, ImePreedit, Key, Modifiers, MouseButton, MouseButtonRelease, MouseMove, TextInput, mouse_button,
+};
+
+use crate::widget::set::{push_control_outlines, quad, reply_if_hidden, text_origin_y};
+use crate::widget::state::{InteractionState, emit_state_changed};
+use crate::widget::text_edit::{EditPolicy, FontMetricsAdapter, SingleLineLayout, TextEditState, TextSpan};
+use crate::widget::theme::{SetTheme, Theme, ThemeState};
+use crate::widget::{
+    Collect, FocusGained, FocusLost, HoverGained, HoverLost, SetWidgetState, TextAreaConfig, TextCommitted,
+    WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TextLine {
+    start_byte: usize,
+    end_byte: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VerticalDirection {
+    Up,
+    Down,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnterAction {
+    Ignore,
+    InsertNewline,
+    Commit,
+}
+
+fn text_lines(text: &str) -> Vec<TextLine> {
+    let mut lines = Vec::new();
+    let mut start_byte = 0;
+    for (byte, ch) in text.char_indices() {
+        if ch == '\n' {
+            lines.push(TextLine { start_byte, end_byte: byte });
+            start_byte = byte + ch.len_utf8();
+        }
+    }
+    lines.push(TextLine { start_byte, end_byte: text.len() });
+    lines
+}
+
+fn line_index_for_byte(lines: &[TextLine], byte: usize) -> usize {
+    lines.iter().position(|line| byte <= line.end_byte).unwrap_or_else(|| lines.len().saturating_sub(1))
+}
+
+fn span_on_line(span: TextSpan, line: TextLine, text_len: usize) -> Option<TextSpan> {
+    let start_byte = span.start_byte.max(line.start_byte).min(line.end_byte);
+    let end_byte = span.end_byte.min(line.end_byte).max(start_byte);
+    if start_byte < end_byte {
+        return Some(TextSpan::new(start_byte - line.start_byte, end_byte - line.start_byte));
+    }
+    let selects_newline = line.end_byte < text_len && span.start_byte <= line.end_byte && span.end_byte > line.end_byte;
+    selects_newline.then_some(TextSpan::new(line.end_byte - line.start_byte, line.end_byte - line.start_byte))
+}
+
+/// A multiline text editor. It delegates UTF-8-safe mutation, selection, and
+/// IME state to [`TextEditState`] and owns only line layout, vertical motion,
+/// whole-line scrolling, and the Enter/Ctrl+Enter policy.
+pub struct TextAreaWidget {
+    edit: TextEditState,
+    max_chars: u32,
+    rows: u32,
+    theme: Theme,
+    frame: WidgetFrame,
+    state: InteractionState,
+    modifiers: Modifiers,
+    dragging: bool,
+    preferred_x_pixels: Option<f32>,
+    scroll_top: usize,
+    font_metrics: FontMetricsAdapter,
+}
+
+impl TextAreaWidget {
+    fn policy(&self) -> EditPolicy {
+        EditPolicy { single_line: false, max_chars: self.max_chars }
+    }
+
+    fn visible_rows(&self) -> usize {
+        usize::try_from(self.rows.max(1)).unwrap_or(usize::MAX)
+    }
+
+    fn theme_state(&self) -> ThemeState {
+        if self.state.focused() {
+            self.state.supporting_theme_state(self.dragging)
+        } else {
+            self.state.theme_state(self.dragging)
+        }
+    }
+
+    fn apply_control_state(&mut self, ctx: &WasmCtx<'_>, next: WidgetControlState) {
+        if self.state.replace(next) {
+            if !self.state.can_mutate() {
+                self.edit.clear_composition();
+            }
+            if !self.state.is_available() {
+                self.dragging = false;
+            }
+            emit_state_changed(ctx, &self.state);
+        }
+    }
+
+    fn pump_font_metrics(&mut self, ctx: &mut WasmCtx<'_>) {
+        if let Some(id) = self.font_metrics.take_pending_request() {
+            ctx.actor::<TextCapability>().send(&FontMetricsRequest { font: FontRef::Id(id) });
+        }
+    }
+
+    fn reconcile_scroll(&mut self) {
+        let lines = text_lines(self.edit.value());
+        let caret_line = line_index_for_byte(&lines, self.edit.caret());
+        let visible = self.visible_rows();
+        if caret_line < self.scroll_top {
+            self.scroll_top = caret_line;
+        } else if caret_line >= self.scroll_top.saturating_add(visible) {
+            self.scroll_top = caret_line.saturating_add(1).saturating_sub(visible);
+        }
+        self.scroll_top = self.scroll_top.min(lines.len().saturating_sub(visible.min(lines.len())));
+    }
+
+    fn after_horizontal_or_edit(&mut self) {
+        self.preferred_x_pixels = None;
+        self.reconcile_scroll();
+    }
+
+    fn enter_action(&self) -> EnterAction {
+        if !self.state.can_mutate() {
+            EnterAction::Ignore
+        } else if self.modifiers.ctrl {
+            EnterAction::Commit
+        } else {
+            EnterAction::InsertNewline
+        }
+    }
+
+    fn move_vertical(&mut self, direction: VerticalDirection, extend: bool) {
+        let target = {
+            let Some(metrics) = self.font_metrics.resolved() else {
+                return;
+            };
+            let text = self.edit.value();
+            let lines = text_lines(text);
+            let current_index = line_index_for_byte(&lines, self.edit.caret());
+            let target_index = match direction {
+                VerticalDirection::Up => current_index.checked_sub(1),
+                VerticalDirection::Down => current_index.checked_add(1).filter(|index| *index < lines.len()),
+            };
+            let Some(target_index) = target_index else {
+                return;
+            };
+            let current = lines[current_index];
+            let current_text = &text[current.start_byte..current.end_byte];
+            let current_layout = SingleLineLayout::build(current_text, metrics, self.theme.value_size_pixels);
+            let local_caret = self.edit.caret().min(current.end_byte) - current.start_byte;
+            let desired_x = self.preferred_x_pixels.unwrap_or_else(|| current_layout.caret_x(local_caret));
+            let target_line = lines[target_index];
+            let target_layout = SingleLineLayout::build(
+                &text[target_line.start_byte..target_line.end_byte],
+                metrics,
+                self.theme.value_size_pixels,
+            );
+            (target_line.start_byte + target_layout.hit_test(desired_x), desired_x)
+        };
+
+        if extend {
+            self.edit.extend_to(target.0);
+        } else {
+            self.edit.place_caret(target.0);
+        }
+        self.preferred_x_pixels = Some(target.1);
+        self.reconcile_scroll();
+    }
+
+    fn scroll_drag_edge(&mut self, event_y: f32) {
+        let lines = text_lines(self.edit.value());
+        let max_first = lines.len().saturating_sub(self.visible_rows().min(lines.len()));
+        if event_y < self.frame.y {
+            self.scroll_top = self.scroll_top.saturating_sub(1);
+        } else if event_y >= self.frame.y + self.frame.height {
+            self.scroll_top = self.scroll_top.saturating_add(1).min(max_first);
+        }
+    }
+
+    fn hit_byte(&self, event_x: f32, event_y: f32) -> Option<usize> {
+        let metrics = self.font_metrics.resolved()?;
+        let lines = text_lines(self.edit.value());
+        let visible = self.visible_rows();
+        let local_y = event_y - self.frame.y;
+        let row_height = self.theme.row_height.max(1.0);
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let row = if local_y <= 0.0 { 0 } else { (local_y / row_height) as usize }.min(visible.saturating_sub(1));
+        let line_index = self.scroll_top.saturating_add(row).min(lines.len().saturating_sub(1));
+        let line = lines[line_index];
+        let local_x = event_x - self.frame.x - self.theme.pad;
+        let layout = SingleLineLayout::build(
+            &self.edit.value()[line.start_byte..line.end_byte],
+            metrics,
+            self.theme.value_size_pixels,
+        );
+        Some(line.start_byte + layout.hit_test(local_x))
+    }
+
+    fn push_line_band(&self, items: &mut Vec<WidgetDrawItem>, layout: &SingleLineLayout, span: TextSpan, row_top: f32) {
+        let x0 = self.theme.pad + layout.caret_x(span.start_byte);
+        let x1 = self.theme.pad + layout.caret_x(span.end_byte);
+        let height = self.theme.pad.mul_add(-2.0, self.theme.row_height).max(1.0);
+        items.push(quad(x0, row_top + self.theme.pad, (x1 - x0).max(1.0), height, self.theme.accent));
+    }
+
+    fn line_layout(&self, text: &str) -> Option<SingleLineLayout> {
+        self.font_metrics.resolved().map(|metrics| SingleLineLayout::build(text, metrics, self.theme.value_size_pixels))
+    }
+
+    fn draw_items(&self) -> Vec<WidgetDrawItem> {
+        let width = self.frame.width;
+        let height = self.frame.height;
+        let size = self.theme.value_size_pixels;
+        let row_height = self.theme.row_height;
+        let theme_state = self.theme_state();
+        let displayed = self.edit.displayed();
+        let lines = text_lines(&displayed.text);
+        let first = self.scroll_top.min(lines.len().saturating_sub(1));
+        let end = first.saturating_add(self.visible_rows()).min(lines.len());
+        let mut items = vec![quad(0.0, 0.0, width, height, self.theme.fill(self.theme.surface_raised, theme_state))];
+
+        for (visible_index, line) in lines[first..end].iter().copied().enumerate() {
+            #[allow(clippy::cast_precision_loss)]
+            let row_top = visible_index as f32 * row_height;
+            let line_text = &displayed.text[line.start_byte..line.end_byte];
+            let layout = self.line_layout(line_text);
+
+            if let Some(layout) = &layout {
+                if let Some(span) =
+                    displayed.selection_span.and_then(|span| span_on_line(span, line, displayed.text.len()))
+                {
+                    self.push_line_band(&mut items, layout, span, row_top);
+                }
+                if let Some(span) = displayed
+                    .preedit_cursor_span
+                    .filter(|span| !span.is_collapsed())
+                    .and_then(|span| span_on_line(span, line, displayed.text.len()))
+                {
+                    self.push_line_band(&mut items, layout, span, row_top);
+                }
+            }
+
+            if !line_text.is_empty() {
+                items.push(WidgetDrawItem::Text {
+                    x: self.theme.pad,
+                    y: text_origin_y(row_top, row_height, size),
+                    font_id: self.theme.font_id,
+                    text: String::from(line_text),
+                    size_pixels: size,
+                    color: self.theme.fill(self.theme.text_primary, theme_state),
+                    clip: None,
+                });
+            }
+
+            let Some(layout) = &layout else {
+                continue;
+            };
+            if let Some(span) = displayed.preedit_span.and_then(|span| span_on_line(span, line, displayed.text.len())) {
+                let x0 = self.theme.pad + layout.caret_x(span.start_byte);
+                let x1 = self.theme.pad + layout.caret_x(span.end_byte);
+                items.push(quad(
+                    x0,
+                    text_origin_y(row_top, row_height, size) + size,
+                    (x1 - x0).max(1.0),
+                    1.0,
+                    self.theme.accent,
+                ));
+                if let Some(cursor) = displayed
+                    .preedit_cursor_span
+                    .filter(|cursor| cursor.is_collapsed())
+                    .filter(|cursor| cursor.start_byte >= line.start_byte && cursor.end_byte <= line.end_byte)
+                {
+                    let local = cursor.end_byte - line.start_byte;
+                    let cursor_x = self.theme.pad + layout.caret_x(local);
+                    items.push(quad(
+                        cursor_x,
+                        row_top + self.theme.pad,
+                        1.0,
+                        self.theme.pad.mul_add(-2.0, row_height).max(1.0),
+                        self.theme.accent,
+                    ));
+                }
+            }
+            if self.state.focused()
+                && !displayed.composing
+                && displayed.caret_byte >= line.start_byte
+                && displayed.caret_byte <= line.end_byte
+            {
+                let local = displayed.caret_byte - line.start_byte;
+                let caret_x = self.theme.pad + layout.caret_x(local);
+                items.push(quad(
+                    caret_x,
+                    row_top + self.theme.pad,
+                    1.0,
+                    self.theme.pad.mul_add(-2.0, row_height).max(1.0),
+                    self.theme.accent,
+                ));
+            }
+        }
+        push_control_outlines(&mut items, width, height, &self.state, &self.theme);
+        items
+    }
+}
+
+/// Multiline text area with a fixed whole-line viewport.
+///
+/// # Agent
+/// Not loaded directly — a panel spawns it from [`TextAreaConfig`]. Plain
+/// Enter inserts a newline; Ctrl+Enter emits [`TextCommitted`] to the parent.
+#[actor(instanced)]
+impl WasmActor for TextAreaWidget {
+    type Config = TextAreaConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.text_area";
+
+    fn init(config: TextAreaConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        let mut area = Self {
+            edit: TextEditState::new(config.initial),
+            max_chars: config.max_chars,
+            rows: config.rows,
+            font_metrics: FontMetricsAdapter::new(config.theme.font_id),
+            theme: config.theme,
+            frame: WidgetFrame { x: 0.0, y: 0.0, width: 0.0, height: 0.0 },
+            state: InteractionState::new(config.state),
+            modifiers: Modifiers::default(),
+            dragging: false,
+            preferred_x_pixels: None,
+            scroll_top: 0,
+        };
+        area.reconcile_scroll();
+        Ok(area)
+    }
+
+    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+        self.pump_font_metrics(ctx);
+    }
+
+    #[handler::single]
+    fn on_config(&mut self, ctx: &mut WasmCtx<'_>, config: TextAreaConfig) {
+        self.edit = TextEditState::new(config.initial);
+        self.max_chars = config.max_chars;
+        self.rows = config.rows;
+        self.font_metrics.set_desired(config.theme.font_id);
+        self.theme = config.theme;
+        self.dragging = false;
+        self.preferred_x_pixels = None;
+        self.scroll_top = 0;
+        self.apply_control_state(ctx, config.state);
+        self.reconcile_scroll();
+        self.pump_font_metrics(ctx);
+    }
+
+    #[handler::single]
+    fn on_set_widget_state(&mut self, ctx: &mut WasmCtx<'_>, set: SetWidgetState) {
+        self.apply_control_state(ctx, set.state);
+    }
+
+    #[handler::single]
+    fn on_set_theme(&mut self, ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.font_metrics.set_desired(set.theme.font_id);
+        self.theme = set.theme;
+        self.pump_font_metrics(ctx);
+    }
+
+    #[handler::single]
+    fn on_frame(&mut self, _ctx: &mut WasmCtx<'_>, frame: WidgetFrame) {
+        self.frame = frame;
+    }
+
+    #[handler::single]
+    fn on_focus_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: FocusGained) {
+        self.state.gain_focus();
+        self.reconcile_scroll();
+    }
+
+    #[handler::single]
+    fn on_focus_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: FocusLost) {
+        self.state.lose_focus();
+        self.dragging = false;
+        self.preferred_x_pixels = None;
+        self.edit.clear_composition();
+    }
+
+    #[handler::single]
+    fn on_hover_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: HoverGained) {
+        self.state.set_hovered(true);
+    }
+
+    #[handler::single]
+    fn on_hover_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: HoverLost) {
+        self.state.set_hovered(false);
+    }
+
+    #[handler::single]
+    fn on_text_input(&mut self, _ctx: &mut WasmCtx<'_>, input: TextInput) {
+        if !self.state.can_mutate() {
+            return;
+        }
+        self.edit.clear_composition();
+        if self.edit.insert(&input.text, self.policy()) {
+            self.after_horizontal_or_edit();
+        }
+    }
+
+    #[handler::single]
+    fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
+        if !self.state.is_available() {
+            return;
+        }
+        let extend = self.modifiers.shift;
+        match key.code {
+            KEY_BACKSPACE if self.state.can_mutate() => {
+                self.edit.delete_backward();
+                self.after_horizontal_or_edit();
+            }
+            KEY_LEFT => {
+                self.edit.move_left(extend);
+                self.after_horizontal_or_edit();
+            }
+            KEY_RIGHT => {
+                self.edit.move_right(extend);
+                self.after_horizontal_or_edit();
+            }
+            KEY_UP => self.move_vertical(VerticalDirection::Up, extend),
+            KEY_DOWN => self.move_vertical(VerticalDirection::Down, extend),
+            KEY_ENTER => match self.enter_action() {
+                EnterAction::Ignore => {}
+                EnterAction::Commit => {
+                    if let Some(parent) = ctx.parent() {
+                        parent.send(&TextCommitted { text: String::from(self.edit.value()) });
+                    }
+                }
+                EnterAction::InsertNewline => {
+                    if self.edit.insert("\n", self.policy()) {
+                        self.after_horizontal_or_edit();
+                    }
+                }
+            },
+            _ => {}
+        }
+    }
+
+    #[handler::single]
+    fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        if press.button != mouse_button::LEFT || !self.state.is_available() {
+            return;
+        }
+        let Some(byte) = self.hit_byte(press.x, press.y) else {
+            return;
+        };
+        self.dragging = true;
+        self.preferred_x_pixels = None;
+        self.edit.place_caret(byte);
+        self.reconcile_scroll();
+    }
+
+    #[handler::single]
+    fn on_mouse_move(&mut self, _ctx: &mut WasmCtx<'_>, moved: MouseMove) {
+        if !self.dragging || !self.state.is_available() {
+            return;
+        }
+        self.scroll_drag_edge(moved.y);
+        if let Some(byte) = self.hit_byte(moved.x, moved.y) {
+            self.edit.extend_to(byte);
+            self.preferred_x_pixels = None;
+        }
+    }
+
+    #[handler::single]
+    fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
+        if release.button == mouse_button::LEFT {
+            self.dragging = false;
+        }
+    }
+
+    #[handler::single]
+    fn on_modifiers(&mut self, _ctx: &mut WasmCtx<'_>, modifiers: Modifiers) {
+        if self.state.is_available() {
+            self.modifiers = modifiers;
+        }
+    }
+
+    #[handler::single]
+    fn on_ime_preedit(&mut self, _ctx: &mut WasmCtx<'_>, preedit: ImePreedit) {
+        if !self.state.can_mutate() {
+            return;
+        }
+        let cursor = match (preedit.cursor_begin, preedit.cursor_end) {
+            (Some(begin), Some(end)) => Some(TextSpan::new(begin as usize, end as usize)),
+            _ => None,
+        };
+        self.edit.set_composition(preedit.text, cursor);
+        self.preferred_x_pixels = None;
+    }
+
+    #[handler::single]
+    fn on_font_metrics_result(&mut self, ctx: &mut WasmCtx<'_>, result: FontMetricsResult) {
+        let pump_deferred = match result {
+            FontMetricsResult::Ok { metrics } => self.font_metrics.accept_reply(Some(CachedFontMetrics::new(&metrics))),
+            FontMetricsResult::Err { error } => {
+                tracing::warn!(target: "aether_kit", %error, "text area font metrics failed");
+                self.font_metrics.accept_reply(None)
+            }
+        };
+        if pump_deferred {
+            self.pump_font_metrics(ctx);
+        }
+    }
+
+    #[handler::single]
+    fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
+        if reply_if_hidden(ctx, &self.state) {
+            return;
+        }
+        if let Some(parent) = ctx.parent() {
+            parent.send(&WidgetDrawList { intrinsic: None, items: self.draw_items() });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_kinds::{FontMetrics, GlyphAdvance};
+
+    fn variable_metrics() -> CachedFontMetrics {
+        CachedFontMetrics::new(&FontMetrics {
+            units_per_em: 1000.0,
+            ascent: 800.0,
+            descent: -200.0,
+            line_gap: 0.0,
+            default_advance: 500.0,
+            advances: vec![
+                GlyphAdvance { codepoint: u32::from('i'), advance_units: 200.0 },
+                GlyphAdvance { codepoint: u32::from('m'), advance_units: 800.0 },
+            ],
+        })
+    }
+
+    #[allow(clippy::cast_precision_loss)] // test rows are tiny exact integers
+    fn area(text: &str, rows: u32) -> TextAreaWidget {
+        let mut font_metrics = FontMetricsAdapter::new(7);
+        assert_eq!(font_metrics.take_pending_request(), Some(7));
+        assert!(!font_metrics.accept_reply(Some(variable_metrics())));
+        let mut area = TextAreaWidget {
+            edit: TextEditState::new(String::from(text)),
+            max_chars: 0,
+            rows,
+            theme: Theme { value_size_pixels: 100.0, ..Theme::DEFAULT },
+            frame: WidgetFrame {
+                x: 10.0,
+                y: 20.0,
+                width: 400.0,
+                height: Theme::DEFAULT.row_height * rows.max(1) as f32,
+            },
+            state: InteractionState::new(WidgetControlState::default()),
+            modifiers: Modifiers::default(),
+            dragging: false,
+            preferred_x_pixels: None,
+            scroll_top: 0,
+            font_metrics,
+        };
+        area.state.gain_focus();
+        area.reconcile_scroll();
+        area
+    }
+
+    #[test]
+    fn line_indexing_preserves_empty_and_trailing_rows() {
+        assert_eq!(
+            text_lines("a\n\n"),
+            vec![
+                TextLine { start_byte: 0, end_byte: 1 },
+                TextLine { start_byte: 2, end_byte: 2 },
+                TextLine { start_byte: 3, end_byte: 3 },
+            ]
+        );
+    }
+
+    #[test]
+    fn enter_policy_inserts_newlines_and_reserves_ctrl_enter_for_commit() {
+        let mut area = area("terrain", 2);
+        assert_eq!(area.enter_action(), EnterAction::InsertNewline);
+        assert!(area.edit.insert("\n", area.policy()));
+        assert_eq!(area.edit.value(), "terrain\n");
+
+        area.modifiers.ctrl = true;
+        assert_eq!(area.enter_action(), EnterAction::Commit);
+
+        let read_only = WidgetControlState { read_only: true, ..WidgetControlState::default() };
+        area.state.replace(read_only);
+        assert_eq!(area.enter_action(), EnterAction::Ignore);
+    }
+
+    #[test]
+    fn vertical_motion_preserves_measured_x_across_a_short_line() {
+        let mut area = area("imx\ni\nimx", 3);
+        area.edit.place_caret(3);
+        area.move_vertical(VerticalDirection::Down, false);
+        assert_eq!(area.edit.caret(), 5, "short middle line clamps at its end");
+        area.move_vertical(VerticalDirection::Down, false);
+        assert_eq!(
+            area.edit.caret(),
+            area.edit.value().len(),
+            "the original measured x recovers on the longer third line"
+        );
+    }
+
+    #[test]
+    fn shift_vertical_selection_replaces_on_type_without_splitting_utf8() {
+        let mut area = area("éx\nmi", 2);
+        area.edit.place_caret(2);
+        area.move_vertical(VerticalDirection::Down, true);
+        let selected = area.edit.selection();
+        assert_eq!(selected.start_byte, 2);
+        assert!(selected.end_byte > selected.start_byte);
+        assert!(area.edit.value().is_char_boundary(selected.end_byte));
+        assert!(area.edit.insert("Q", area.policy()));
+        assert_eq!(area.edit.value(), "éQi");
+    }
+
+    #[test]
+    fn scroll_window_tracks_caret_in_both_directions() {
+        let mut area = area("zero\none\ntwo\nthree", 2);
+        assert_eq!(area.scroll_top, 2, "end caret reveals the final two rows");
+        area.edit.move_to_start(false);
+        area.reconcile_scroll();
+        assert_eq!(area.scroll_top, 0, "document start reveals the first rows");
+    }
+
+    #[test]
+    fn multiline_selection_draws_one_measured_band_per_covered_row() {
+        let mut area = area("im\ni", 2);
+        area.edit.move_to_start(false);
+        area.edit.extend_to(area.edit.value().len());
+        let items = area.draw_items();
+        let accent_bands: Vec<_> = items
+            .iter()
+            .filter_map(|item| match item {
+                WidgetDrawItem::Quad { x, y, width, color, .. } if *color == Theme::DEFAULT.accent && *width > 1.0 => {
+                    Some((*x, *y, *width))
+                }
+                _ => None,
+            })
+            .collect();
+        assert!(
+            accent_bands.iter().any(|(_, y, width)| *y == 8.0 && *width == 100.0),
+            "first row uses measured i+m width"
+        );
+        assert!(
+            accent_bands.iter().any(|(_, y, width)| *y == 32.0 && *width == 20.0),
+            "second row uses measured i width"
+        );
+    }
+}

--- a/crates/aether-kit/src/widget/set/text_field.rs
+++ b/crates/aether-kit/src/widget/set/text_field.rs
@@ -39,7 +39,7 @@ use crate::widget::set::{
     APPROX_ADVANCE_RATIO, approx_text_width, push_control_outlines, quad, reply_if_hidden, text_origin_y,
 };
 use crate::widget::state::{InteractionState, emit_state_changed};
-use crate::widget::text_edit::{EditPolicy, SingleLineLayout, TextEditState, TextSpan};
+use crate::widget::text_edit::{EditPolicy, FontMetricsAdapter, SingleLineLayout, TextEditState, TextSpan};
 use crate::widget::theme::{SetTheme, Theme, ThemeState};
 use crate::widget::{
     Collect, FocusGained, FocusLost, HoverGained, HoverLost, SetWidgetState, TextCommitted, TextFieldConfig,
@@ -60,26 +60,8 @@ pub struct TextFieldWidget {
     /// Whether a left-button drag is in progress (a pointer move only extends
     /// the selection while the button is held, never on a bare hover).
     dragging: bool,
-    /// The latest font id the theme asks metrics for.
-    desired_font_id: u32,
-    /// The font id whose metrics are currently installed.
-    current_font_id: Option<u32>,
-    /// The font id of the one outstanding `FontMetricsRequest`, if any.
-    inflight_font_id: Option<u32>,
-    /// The resolved metrics for `current_font_id`, `None` until the first reply
-    /// installs.
-    metrics: Option<CachedFontMetrics>,
-}
-
-/// The committed editor state projected into the one string rendered this
-/// frame, with every owned span remapped into that string's byte offsets.
-struct DisplayedEdit {
-    text: String,
-    caret_byte: usize,
-    selection_span: Option<TextSpan>,
-    preedit_span: Option<TextSpan>,
-    preedit_cursor_span: Option<TextSpan>,
-    composing: bool,
+    /// Single-flight exact metrics for the active theme font.
+    font_metrics: FontMetricsAdapter,
 }
 
 impl TextFieldWidget {
@@ -89,109 +71,11 @@ impl TextFieldWidget {
         EditPolicy { single_line: true, max_chars: self.max_chars }
     }
 
-    /// Adopt a desired font id. Metrics are only usable for the id that
-    /// produced them, so a change returns placement to the warm-up fallback
-    /// until the replacement request resolves.
-    fn set_desired_font_id(&mut self, desired_font_id: u32) {
-        if self.desired_font_id == desired_font_id {
-            return;
-        }
-        self.desired_font_id = desired_font_id;
-        self.current_font_id = None;
-        self.metrics = None;
-    }
-
-    /// Metrics are exact only while their installed font is still the theme's
-    /// desired font. The id check keeps stale tables out of hit testing and all
-    /// selection / composition / caret geometry.
-    fn resolved_metrics(&self) -> Option<&CachedFontMetrics> {
-        (self.current_font_id == Some(self.desired_font_id)).then_some(self.metrics.as_ref()).flatten()
-    }
-
-    /// The font id a pump should request now, or `None` to stay put: only when
-    /// no request is outstanding and the desired id lacks current metrics.
-    /// Font id zero is valid; absence is represented by `Option` instead of a
-    /// numeric sentinel. Pure over the adapter fields.
-    fn pending_request(&self) -> Option<u32> {
-        if self.inflight_font_id.is_some() {
-            return None;
-        }
-        if self.current_font_id == Some(self.desired_font_id) && self.metrics.is_some() {
-            return None;
-        }
-        Some(self.desired_font_id)
-    }
-
-    /// Reserve the next request — the id to fetch (marking it in-flight) or
-    /// `None` if none is due. Pure over the adapter fields; the caller sends the
-    /// wire request.
-    fn take_pending_request(&mut self) -> Option<u32> {
-        let id = self.pending_request()?;
-        self.inflight_font_id = Some(id);
-        Some(id)
-    }
-
-    /// Attribute a metrics reply to the outstanding flight (`Some` for `Ok`,
-    /// `None` for `Err`), install it only when its id is still the desired id,
-    /// and always clear the flight. Returns whether the settled flight was
-    /// superseded and the caller should pump the deferred newer id. A current
-    /// id's error deliberately returns `false`: retrying it immediately would
-    /// form an unbounded request/reply loop.
-    fn accept_reply(&mut self, metrics: Option<CachedFontMetrics>) -> bool {
-        let Some(id) = self.inflight_font_id.take() else {
-            return false;
-        };
-        if id != self.desired_font_id {
-            return true;
-        }
-        if let Some(metrics) = metrics {
-            self.current_font_id = Some(id);
-            self.metrics = Some(metrics);
-        }
-        false
-    }
-
     /// Start a font-metrics request when one is due (single-flight; a duplicate
     /// desired id coalesces onto the outstanding flight).
     fn pump_font_metrics(&mut self, ctx: &mut WasmCtx<'_>) {
-        if let Some(id) = self.take_pending_request() {
+        if let Some(id) = self.font_metrics.take_pending_request() {
             ctx.actor::<TextCapability>().send(&FontMetricsRequest { font: FontRef::Id(id) });
-        }
-    }
-
-    /// Project committed text, selection, and preedit into one render string.
-    /// While composing, the preedit replaces the active selection and its
-    /// cursor span is translated from preedit-local into display byte offsets.
-    fn displayed_edit(&self) -> DisplayedEdit {
-        let selection = self.edit.selection();
-        if self.edit.preedit().is_empty() {
-            return DisplayedEdit {
-                text: String::from(self.edit.value()),
-                caret_byte: self.edit.caret(),
-                selection_span: (!selection.is_collapsed()).then_some(selection),
-                preedit_span: None,
-                preedit_cursor_span: None,
-                composing: false,
-            };
-        }
-
-        let preedit = self.edit.preedit();
-        let mut text = String::with_capacity(self.edit.value().len() + preedit.len());
-        text.push_str(&self.edit.value()[..selection.start_byte]);
-        text.push_str(preedit);
-        text.push_str(&self.edit.value()[selection.end_byte..]);
-        let span_end = selection.start_byte + preedit.len();
-        let cursor = self.edit.preedit_cursor().unwrap_or_else(|| TextSpan::new(preedit.len(), preedit.len()));
-        DisplayedEdit {
-            text,
-            caret_byte: span_end,
-            selection_span: None,
-            preedit_span: Some(TextSpan::new(selection.start_byte, span_end)),
-            preedit_cursor_span: Some(TextSpan::new(
-                selection.start_byte + cursor.start_byte,
-                selection.start_byte + cursor.end_byte,
-            )),
-            composing: true,
         }
     }
 
@@ -202,7 +86,7 @@ impl TextFieldWidget {
         let size = self.theme.value_size_pixels;
         let local_x = event_x - self.frame.x - self.theme.pad;
         let text = self.edit.value();
-        if let Some(metrics) = self.resolved_metrics() {
+        if let Some(metrics) = self.font_metrics.resolved() {
             return SingleLineLayout::build(text, metrics, size).hit_test(local_x);
         }
         let advance = (size * APPROX_ADVANCE_RATIO).max(1.0);
@@ -258,10 +142,7 @@ impl WasmActor for TextFieldWidget {
             frame: WidgetFrame { x: 0.0, y: 0.0, width: 0.0, height: 0.0 },
             modifiers: Modifiers::default(),
             dragging: false,
-            desired_font_id,
-            current_font_id: None,
-            inflight_font_id: None,
-            metrics: None,
+            font_metrics: FontMetricsAdapter::new(desired_font_id),
         })
     }
 
@@ -277,7 +158,7 @@ impl WasmActor for TextFieldWidget {
     fn on_config(&mut self, ctx: &mut WasmCtx<'_>, config: TextFieldConfig) {
         self.edit = TextEditState::new(config.initial);
         self.max_chars = config.max_chars;
-        self.set_desired_font_id(config.theme.font_id);
+        self.font_metrics.set_desired(config.theme.font_id);
         self.theme = config.theme;
         self.apply_control_state(ctx, config.state);
         self.pump_font_metrics(ctx);
@@ -291,7 +172,7 @@ impl WasmActor for TextFieldWidget {
     /// Restyle: adopt the fanned theme and request metrics for its font.
     #[handler::single]
     fn on_set_theme(&mut self, ctx: &mut WasmCtx<'_>, set: SetTheme) {
-        self.set_desired_font_id(set.theme.font_id);
+        self.font_metrics.set_desired(set.theme.font_id);
         self.theme = set.theme;
         self.pump_font_metrics(ctx);
     }
@@ -417,10 +298,10 @@ impl WasmActor for TextFieldWidget {
     #[handler::single]
     fn on_font_metrics_result(&mut self, ctx: &mut WasmCtx<'_>, result: FontMetricsResult) {
         let pump_deferred = match result {
-            FontMetricsResult::Ok { metrics } => self.accept_reply(Some(CachedFontMetrics::new(&metrics))),
+            FontMetricsResult::Ok { metrics } => self.font_metrics.accept_reply(Some(CachedFontMetrics::new(&metrics))),
             FontMetricsResult::Err { error } => {
                 tracing::warn!(target: "aether_kit", %error, "text field font metrics failed");
-                self.accept_reply(None)
+                self.font_metrics.accept_reply(None)
             }
         };
         if pump_deferred {
@@ -450,12 +331,13 @@ impl WasmActor for TextFieldWidget {
         let caret_height = pad.mul_add(-2.0, height).max(1.0);
         let theme_state = self.theme_state();
 
-        let displayed = self.displayed_edit();
+        let displayed = self.edit.displayed();
 
         // One measured layout per rendered string. Every geometry lookup below
         // reads this table; the warm-up fallback remains character-count based
         // only until the desired font's metrics settle.
-        let layout = self.resolved_metrics().map(|metrics| SingleLineLayout::build(&displayed.text, metrics, size));
+        let layout =
+            self.font_metrics.resolved().map(|metrics| SingleLineLayout::build(&displayed.text, metrics, size));
         let prefix_width = |byte: usize| {
             layout.as_ref().map_or_else(
                 || approx_text_width(displayed.text[..byte].chars().count(), size),
@@ -508,11 +390,8 @@ impl WasmActor for TextFieldWidget {
 mod tests {
     use super::*;
     use crate::widget::WidgetControlState;
-    use aether_kinds::FontMetrics;
 
-    /// A field with the given desired font id, no metrics resolved yet — the
-    /// adapter's cold start.
-    fn adapter_field(desired_font_id: u32) -> TextFieldWidget {
+    fn field() -> TextFieldWidget {
         TextFieldWidget {
             edit: TextEditState::new(String::new()),
             max_chars: 0,
@@ -521,123 +400,24 @@ mod tests {
             frame: WidgetFrame { x: 0.0, y: 0.0, width: 100.0, height: 24.0 },
             modifiers: Modifiers::default(),
             dragging: false,
-            desired_font_id,
-            current_font_id: None,
-            inflight_font_id: None,
-            metrics: None,
+            font_metrics: FontMetricsAdapter::new(7),
         }
-    }
-
-    /// A minimal resolved metric table — enough to stand in for an installed
-    /// font in the adapter transition tests.
-    fn some_metrics() -> CachedFontMetrics {
-        CachedFontMetrics::new(&FontMetrics {
-            units_per_em: 1000.0,
-            ascent: 800.0,
-            descent: -200.0,
-            line_gap: 0.0,
-            default_advance: 500.0,
-            advances: Vec::new(),
-        })
     }
 
     #[test]
     fn composition_projection_preserves_the_full_multibyte_cursor_span() {
-        let mut field = adapter_field(7);
+        let mut field = field();
         field.edit = TextEditState::new(String::from("abécd"));
         field.edit.move_left(true);
         field.edit.move_left(true); // select `cd` at bytes 4..6
         field.edit.set_composition(String::from("üx"), Some(TextSpan::new(0, 2)));
 
-        let displayed = field.displayed_edit();
+        let displayed = field.edit.displayed();
         assert_eq!(displayed.text, "abéüx");
         assert_eq!(displayed.selection_span, None);
         assert_eq!(displayed.preedit_span, Some(TextSpan::new(4, 7)));
         assert_eq!(displayed.preedit_cursor_span, Some(TextSpan::new(4, 6)));
         assert_eq!(displayed.caret_byte, 7);
         assert!(displayed.composing);
-    }
-
-    #[test]
-    fn initial_load_requests_desired_once_then_coalesces() {
-        let mut field = adapter_field(7);
-        assert_eq!(field.take_pending_request(), Some(7));
-        // The flight is outstanding, so a second pump requests nothing.
-        assert_eq!(field.take_pending_request(), None);
-    }
-
-    #[test]
-    fn a_resolved_reply_installs_and_stops_requesting() {
-        let mut field = adapter_field(7);
-        assert_eq!(field.take_pending_request(), Some(7));
-        assert!(!field.accept_reply(Some(some_metrics())));
-        assert_eq!(field.current_font_id, Some(7));
-        assert!(field.metrics.is_some());
-        // Desired is satisfied, so nothing more is requested.
-        assert_eq!(field.take_pending_request(), None);
-    }
-
-    #[test]
-    fn an_error_for_the_current_font_does_not_immediately_retry() {
-        let mut field = adapter_field(7);
-        assert_eq!(field.take_pending_request(), Some(7));
-        assert!(!field.accept_reply(None), "the result handler must not pump the just-failed id");
-        assert_eq!(field.current_font_id, None);
-        assert!(field.metrics.is_none());
-        assert_eq!(field.inflight_font_id, None);
-        // A later config/theme event may retry the id explicitly.
-        assert_eq!(field.take_pending_request(), Some(7));
-    }
-
-    #[test]
-    fn a_font_change_mid_flight_drops_the_stale_reply_and_defers_the_new_one() {
-        let mut field = adapter_field(7);
-        assert_eq!(field.take_pending_request(), Some(7));
-        // The theme font changes while the request for 7 is outstanding.
-        field.set_desired_font_id(9);
-        // Still single-flight: no new request until the outstanding one settles.
-        assert_eq!(field.take_pending_request(), None);
-        // The reply for the superseded font 7 must not install as current.
-        assert!(field.accept_reply(Some(some_metrics())));
-        assert_eq!(field.current_font_id, None);
-        assert!(field.metrics.is_none());
-        // Now the deferred request for the latest desired id goes out and
-        // installs.
-        assert_eq!(field.take_pending_request(), Some(9));
-        assert!(!field.accept_reply(Some(some_metrics())));
-        assert_eq!(field.current_font_id, Some(9));
-        assert!(field.metrics.is_some());
-    }
-
-    #[test]
-    fn a_stale_error_pumps_the_deferred_newer_font() {
-        let mut field = adapter_field(7);
-        assert_eq!(field.take_pending_request(), Some(7));
-        field.set_desired_font_id(9);
-        assert!(field.accept_reply(None));
-        assert_eq!(field.take_pending_request(), Some(9));
-    }
-
-    #[test]
-    fn a_font_change_clears_installed_metrics_before_new_geometry() {
-        let mut field = adapter_field(7);
-        assert_eq!(field.take_pending_request(), Some(7));
-        assert!(!field.accept_reply(Some(some_metrics())));
-        assert!(field.resolved_metrics().is_some());
-
-        field.set_desired_font_id(9);
-        assert_eq!(field.current_font_id, None);
-        assert!(field.metrics.is_none());
-        assert!(field.resolved_metrics().is_none());
-        assert_eq!(field.take_pending_request(), Some(9));
-    }
-
-    #[test]
-    fn zero_is_a_valid_font_id_and_requests_metrics() {
-        let mut field = adapter_field(0);
-        assert_eq!(field.take_pending_request(), Some(0));
-        assert!(!field.accept_reply(Some(some_metrics())));
-        assert_eq!(field.current_font_id, Some(0));
-        assert!(field.resolved_metrics().is_some());
     }
 }

--- a/crates/aether-kit/src/widget/set/text_field.rs
+++ b/crates/aether-kit/src/widget/set/text_field.rs
@@ -28,17 +28,18 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
-use aether_capabilities::TextCapability;
-use aether_capabilities::text::{FontMetricsRequest, FontMetricsResult, FontRef};
+use aether_capabilities::text::FontMetricsResult;
 use aether_kinds::keycode::{KEY_BACKSPACE, KEY_ENTER, KEY_LEFT, KEY_RIGHT};
 use aether_kinds::{
     CachedFontMetrics, ImePreedit, Key, Modifiers, MouseButton, MouseButtonRelease, MouseMove, TextInput, mouse_button,
 };
 
 use crate::widget::set::{
-    APPROX_ADVANCE_RATIO, approx_text_width, push_control_outlines, quad, reply_if_hidden, text_origin_y,
+    APPROX_ADVANCE_RATIO, apply_text_control_state, apply_text_theme, approx_text_width, pump_text_font_metrics,
+    push_control_outlines, quad, release_text_drag, reply_if_hidden, text_control_theme_state, text_origin_y,
+    update_text_modifiers,
 };
-use crate::widget::state::{InteractionState, emit_state_changed};
+use crate::widget::state::InteractionState;
 use crate::widget::text_edit::{EditPolicy, FontMetricsAdapter, SingleLineLayout, TextEditState, TextSpan};
 use crate::widget::theme::{SetTheme, Theme, ThemeState};
 use crate::widget::{
@@ -74,9 +75,7 @@ impl TextFieldWidget {
     /// Start a font-metrics request when one is due (single-flight; a duplicate
     /// desired id coalesces onto the outstanding flight).
     fn pump_font_metrics(&mut self, ctx: &mut WasmCtx<'_>) {
-        if let Some(id) = self.font_metrics.take_pending_request() {
-            ctx.actor::<TextCapability>().send(&FontMetricsRequest { font: FontRef::Id(id) });
-        }
+        pump_text_font_metrics(ctx, &mut self.font_metrics);
     }
 
     /// The `char`-boundary byte offset a pointer at window `event_x` lands on —
@@ -101,23 +100,11 @@ impl TextFieldWidget {
     }
 
     fn theme_state(&self) -> ThemeState {
-        if self.state.focused() {
-            self.state.supporting_theme_state(self.dragging)
-        } else {
-            self.state.theme_state(self.dragging)
-        }
+        text_control_theme_state(&self.state, self.dragging)
     }
 
     fn apply_control_state(&mut self, ctx: &WasmCtx<'_>, next: WidgetControlState) {
-        if self.state.replace(next) {
-            if !self.state.can_mutate() {
-                self.edit.clear_composition();
-            }
-            if !self.state.is_available() {
-                self.dragging = false;
-            }
-            emit_state_changed(ctx, &self.state);
-        }
+        apply_text_control_state(ctx, &mut self.state, &mut self.edit, &mut self.dragging, next);
     }
 }
 
@@ -172,9 +159,7 @@ impl WasmActor for TextFieldWidget {
     /// Restyle: adopt the fanned theme and request metrics for its font.
     #[handler::single]
     fn on_set_theme(&mut self, ctx: &mut WasmCtx<'_>, set: SetTheme) {
-        self.font_metrics.set_desired(set.theme.font_id);
-        self.theme = set.theme;
-        self.pump_font_metrics(ctx);
+        apply_text_theme(ctx, &mut self.font_metrics, &mut self.theme, set.theme);
     }
 
     /// Cache the layout rect the root assigned.
@@ -265,18 +250,14 @@ impl WasmActor for TextFieldWidget {
     /// A left release ends the drag.
     #[handler::single]
     fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
-        if release.button == mouse_button::LEFT {
-            self.dragging = false;
-        }
+        release_text_drag(&mut self.dragging, release);
     }
 
     /// Cache the latest modifier state (Ctrl / Shift / …) so Shift-extended
     /// movement and future chord-aware edits can consult it.
     #[handler::single]
     fn on_modifiers(&mut self, _ctx: &mut WasmCtx<'_>, modifiers: Modifiers) {
-        if self.state.is_available() {
-            self.modifiers = modifiers;
-        }
+        update_text_modifiers(&self.state, &mut self.modifiers, modifiers);
     }
 
     /// Track the in-flight IME composition at the active selection. Empty text

--- a/crates/aether-kit/src/widget/set/text_field.rs
+++ b/crates/aether-kit/src/widget/set/text_field.rs
@@ -15,7 +15,8 @@
 //! `char` boundary, so a multi-byte character is never split.
 //!
 //! Caret placement and pointer hit-testing are exact once the font's metrics
-//! settle: the field drives a single-flight [`FontMetricsRequest`] for its
+//! settle: the field drives a single-flight
+//! [`FontMetricsRequest`](aether_capabilities::text::FontMetricsRequest) for its
 //! theme's font and measures against the resolved
 //! [`CachedFontMetrics`]. Until then it falls
 //! back to the proportional approximation as a bounded font-warm-up placement.

--- a/crates/aether-kit/src/widget/text_edit.rs
+++ b/crates/aether-kit/src/widget/text_edit.rs
@@ -1,4 +1,4 @@
-//! Reusable single-line plain-text editing state (issue 2924).
+//! Reusable plain-text editing state and measured line layout (issue 2924).
 //!
 //! [`TextEditState`] owns a committed `String`, a selection expressed as an
 //! `anchor` and an active `caret` (both byte offsets), and an in-flight IME
@@ -69,8 +69,9 @@ impl Default for EditPolicy {
     }
 }
 
-/// A single-line plain-text editing core: committed text, a selection, and an
-/// IME composition, all on `char` boundaries.
+/// A plain-text editing core: committed text, a selection, and an IME
+/// composition, all on `char` boundaries. [`EditPolicy`] decides whether an
+/// individual consumer accepts line breaks.
 #[derive(Debug, Clone, Default)]
 pub struct TextEditState {
     text: String,
@@ -84,6 +85,18 @@ pub struct TextEditState {
     /// The IME's reported cursor/selection span as byte offsets into `preedit`,
     /// `None` when the IME gives no span.
     preedit_cursor: Option<TextSpan>,
+}
+
+/// The committed editor state projected into the string rendered this frame,
+/// with every owned span remapped into that string's byte offsets. While an
+/// IME composition is active, its preedit replaces the committed selection.
+pub(super) struct DisplayedEdit {
+    pub(super) text: String,
+    pub(super) caret_byte: usize,
+    pub(super) selection_span: Option<TextSpan>,
+    pub(super) preedit_span: Option<TextSpan>,
+    pub(super) preedit_cursor_span: Option<TextSpan>,
+    pub(super) composing: bool,
 }
 
 /// Floor `byte` to a `char` boundary of `text`, clamping to `text.len()` first.
@@ -145,6 +158,42 @@ impl TextEditState {
     #[must_use]
     pub fn preedit_cursor(&self) -> Option<TextSpan> {
         self.preedit_cursor
+    }
+
+    /// Project committed text, selection, and preedit into one render string.
+    /// The projection is line-agnostic: single-line and multiline widgets can
+    /// split the returned text however their own layout policy requires.
+    #[must_use]
+    pub(super) fn displayed(&self) -> DisplayedEdit {
+        let selection = self.selection();
+        if self.preedit.is_empty() {
+            return DisplayedEdit {
+                text: self.text.clone(),
+                caret_byte: self.caret,
+                selection_span: (!selection.is_collapsed()).then_some(selection),
+                preedit_span: None,
+                preedit_cursor_span: None,
+                composing: false,
+            };
+        }
+
+        let mut text = String::with_capacity(self.text.len() + self.preedit.len());
+        text.push_str(&self.text[..selection.start_byte]);
+        text.push_str(&self.preedit);
+        text.push_str(&self.text[selection.end_byte..]);
+        let span_end = selection.start_byte + self.preedit.len();
+        let cursor = self.preedit_cursor.unwrap_or_else(|| TextSpan::new(self.preedit.len(), self.preedit.len()));
+        DisplayedEdit {
+            text,
+            caret_byte: span_end,
+            selection_span: None,
+            preedit_span: Some(TextSpan::new(selection.start_byte, span_end)),
+            preedit_cursor_span: Some(TextSpan::new(
+                selection.start_byte + cursor.start_byte,
+                selection.start_byte + cursor.end_byte,
+            )),
+            composing: true,
+        }
     }
 
     /// The filtered form of `s` under `policy` — line breaks dropped for a
@@ -341,6 +390,67 @@ struct CaretStop {
 #[derive(Debug, Clone)]
 pub struct SingleLineLayout {
     stops: Vec<CaretStop>,
+}
+
+/// Single-flight cache for the font metrics a measured text control needs.
+/// It owns only request attribution and cache freshness; actors still send the
+/// actual capability mail so this helper remains independent of dispatch.
+pub(super) struct FontMetricsAdapter {
+    desired_font_id: u32,
+    current_font_id: Option<u32>,
+    inflight_font_id: Option<u32>,
+    metrics: Option<CachedFontMetrics>,
+}
+
+impl FontMetricsAdapter {
+    pub(super) const fn new(desired_font_id: u32) -> Self {
+        Self { desired_font_id, current_font_id: None, inflight_font_id: None, metrics: None }
+    }
+
+    /// Adopt a desired font. Metrics from the old id stop being readable
+    /// immediately, while an outstanding request remains attributed until its
+    /// reply settles.
+    pub(super) fn set_desired(&mut self, desired_font_id: u32) {
+        if self.desired_font_id == desired_font_id {
+            return;
+        }
+        self.desired_font_id = desired_font_id;
+        self.current_font_id = None;
+        self.metrics = None;
+    }
+
+    /// Exact metrics only while the installed id is still desired.
+    pub(super) fn resolved(&self) -> Option<&CachedFontMetrics> {
+        (self.current_font_id == Some(self.desired_font_id)).then_some(self.metrics.as_ref()).flatten()
+    }
+
+    /// Reserve the next request, coalescing while one is outstanding.
+    pub(super) fn take_pending_request(&mut self) -> Option<u32> {
+        if self.inflight_font_id.is_some()
+            || (self.current_font_id == Some(self.desired_font_id) && self.metrics.is_some())
+        {
+            return None;
+        }
+        self.inflight_font_id = Some(self.desired_font_id);
+        Some(self.desired_font_id)
+    }
+
+    /// Settle the outstanding request. Install successful metrics only when
+    /// their id is still desired. Returns `true` when a newer desired id was
+    /// deferred behind this flight and should now be pumped.
+    pub(super) fn accept_reply(&mut self, metrics: Option<CachedFontMetrics>) -> bool {
+        let Some(id) = self.inflight_font_id.take() else {
+            return false;
+        };
+        if id != self.desired_font_id {
+            return true;
+        }
+        if let Some(metrics) = metrics {
+            self.current_font_id = Some(id);
+            self.metrics = Some(metrics);
+        }
+        false
+    }
 }
 
 impl SingleLineLayout {
@@ -648,5 +758,37 @@ mod tests {
         assert_eq!(layout.hit_test(124.0), 2);
         assert_eq!(layout.hit_test(126.0), 3);
         assert_eq!(layout.hit_test(999.0), 3, "past the end clamps to the last stop");
+    }
+
+    #[test]
+    fn font_metrics_adapter_coalesces_and_installs_zero_id() {
+        let mut adapter = FontMetricsAdapter::new(0);
+        assert_eq!(adapter.take_pending_request(), Some(0));
+        assert_eq!(adapter.take_pending_request(), None, "one flight at a time");
+        assert!(!adapter.accept_reply(Some(variable_metrics())));
+        assert!(adapter.resolved().is_some());
+        assert_eq!(adapter.take_pending_request(), None, "desired id is cached");
+    }
+
+    #[test]
+    fn font_metrics_adapter_drops_stale_reply_then_pumps_latest() {
+        let mut adapter = FontMetricsAdapter::new(7);
+        assert_eq!(adapter.take_pending_request(), Some(7));
+        adapter.set_desired(9);
+        assert_eq!(adapter.take_pending_request(), None, "old flight still owns the slot");
+        assert!(adapter.accept_reply(Some(variable_metrics())));
+        assert!(adapter.resolved().is_none(), "stale metrics never install");
+        assert_eq!(adapter.take_pending_request(), Some(9));
+        assert!(!adapter.accept_reply(Some(variable_metrics())));
+        assert!(adapter.resolved().is_some());
+    }
+
+    #[test]
+    fn font_metrics_adapter_current_error_waits_for_a_later_pump() {
+        let mut adapter = FontMetricsAdapter::new(7);
+        assert_eq!(adapter.take_pending_request(), Some(7));
+        assert!(!adapter.accept_reply(None), "a current error must not request again from its own reply handler");
+        assert!(adapter.resolved().is_none());
+        assert_eq!(adapter.take_pending_request(), Some(7), "a later config or theme event may retry");
     }
 }

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -45,7 +45,7 @@ use aether_capabilities::fs::NamespaceRoots;
 use aether_capabilities::render::{DrawTexturedQuads, WHITE_TEXTURE_ID};
 use aether_capabilities::text::{FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontResult};
 use aether_data::Kind;
-use aether_kinds::keycode::{KEY_BACKSPACE, KEY_ENTER, KEY_RIGHT, KEY_TAB};
+use aether_kinds::keycode::{KEY_BACKSPACE, KEY_DOWN, KEY_ENTER, KEY_RIGHT, KEY_TAB, KEY_UP};
 use aether_kinds::mouse_button::LEFT;
 use aether_kinds::{
     CachedFontMetrics, CaptureFrame, CaptureFrameResult, ClipRect, FrameCheck, FrameCheckResult, FrameRect,
@@ -53,11 +53,11 @@ use aether_kinds::{
     MouseButtonRelease, MouseMove, NamedMail, TextInput, Tick,
 };
 use aether_kit::{
-    ButtonConfig, PanelConfig, SetWidgetState, SliderConfig, Theme, ThemeState, WidgetChildSpec, WidgetControlState,
-    WidgetKind, WidgetValidation,
+    ButtonConfig, PanelConfig, SetWidgetState, SliderConfig, TextAreaConfig, Theme, ThemeState, WidgetChildSpec,
+    WidgetControlState, WidgetKind, WidgetValidation,
 };
 use aether_substrate_bundle::test_bench::{
-    BenchOp, TestBench,
+    ArtifactGuard, BenchOp, TestBench,
     test_helpers::{init_save_sandbox, require_runtime},
 };
 
@@ -279,6 +279,23 @@ fn slider_child(subname: &str, state: WidgetControlState) -> WidgetChildSpec {
     }
 }
 
+fn text_area_child(subname: &str, rows: u32, font_id: u32) -> WidgetChildSpec {
+    WidgetChildSpec {
+        subname: subname.to_owned(),
+        kind: WidgetKind::TextArea,
+        origin: [0.0, 0.0],
+        clip: None,
+        config: TextAreaConfig {
+            initial: String::new(),
+            max_chars: 0,
+            rows,
+            theme: Theme { font_id, ..Theme::DEFAULT },
+            state: WidgetControlState::default(),
+        }
+        .encode_into_bytes(),
+    }
+}
+
 fn control_state_children() -> Vec<WidgetChildSpec> {
     let hidden = WidgetControlState { visible: false, ..WidgetControlState::default() };
     let disabled = WidgetControlState { enabled: false, ..WidgetControlState::default() };
@@ -402,6 +419,40 @@ fn capture(bench: &mut TestBench, checks: Vec<FrameCheck>) -> FrameVerdict {
     match captured.reply::<CaptureFrameResult>("snap").expect("decode CaptureFrameResult") {
         CaptureFrameResult::Ok { verdict, .. } => verdict.expect("checks requested → verdict"),
         CaptureFrameResult::Err { error } => panic!("capture failed: {error}"),
+    }
+}
+
+struct GuardedCapture {
+    verdict: FrameVerdict,
+    _artifacts: ArtifactGuard,
+}
+
+/// Capture a scored frame while keeping its exact PNG and check masks alive
+/// as failure-only diagnostics for every assertion in the caller's scope.
+fn capture_guarded(bench: &mut TestBench, id: &str, expectation: &str, checks: Vec<FrameCheck>) -> GuardedCapture {
+    let captured = bench
+        .execute(vec![(
+            "snap",
+            BenchOp::send_and_await(
+                RenderCapability::NAMESPACE,
+                &CaptureFrame {
+                    mails: vec![tick_to_panel()],
+                    after_mails: Vec::new(),
+                    checks: checks.clone(),
+                    similarity: None,
+                },
+            ),
+        )])
+        .expect("guarded capture with region checks");
+    match captured.reply::<CaptureFrameResult>("snap").expect("decode guarded CaptureFrameResult") {
+        CaptureFrameResult::Ok { png, verdict: Some(verdict), .. } => {
+            let artifacts = ArtifactGuard::arm(id, png, checks, verdict.results.clone()).with_expectation(expectation);
+            GuardedCapture { verdict, _artifacts: artifacts }
+        }
+        CaptureFrameResult::Ok { verdict: None, .. } => {
+            panic!("guarded capture requested checks but returned no verdict")
+        }
+        CaptureFrameResult::Err { error } => panic!("guarded capture failed: {error}"),
     }
 }
 
@@ -1107,6 +1158,251 @@ fn text_field_selection_and_ime_render_measured_bands_and_commit() {
         log.iter().any(|m| m.contains("widget text committed") && m.contains("text=abéZ")),
         "clicking after `abé`, extending over `cd`, and committing `Z` must leave the non-ASCII \
          value `abéZ`; log was:\n{joined}",
+    );
+}
+
+/// **Bug class: multiline editing state and its measured render projection
+/// diverge across a scrolled viewport.** This drives plain Enter insertion,
+/// measured Up/Down selection through unequal UTF-8 lines, whole-line scroll,
+/// IME replacement across a newline, and Ctrl+Enter commit through the real
+/// panel. Exact overlay batches pin the two row-local selection bands and the
+/// preedit cursor/underline geometry; raster checks prove those authored
+/// quads survive the GPU path. Failure-only guards retain both scored frames.
+#[test]
+#[allow(clippy::too_many_lines)] // one cohesive multiline edit/render/commit acceptance run
+fn text_area_scrolls_selects_composes_and_commits_measured_lines() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = build_bench();
+
+    let font_id = load_font(&mut bench);
+    let metrics = load_metrics(&mut bench, font_id);
+    load_panel_with_children(&mut bench, &wasm, font_id, vec![text_area_child("notes", 2, font_id)]);
+    let panel = panel_address();
+    bench
+        .execute(vec![
+            ("spawn", BenchOp::send_mail(&panel, &Tick)),
+            ("prime", BenchOp::send_mail(&panel, &Tick)),
+            ("settle", BenchOp::advance(4)),
+        ])
+        .expect("warm text area and measured font");
+
+    let row_height = Theme::DEFAULT.row_height;
+    let size = Theme::DEFAULT.value_size_pixels;
+    let content_x = PANEL_X + Theme::DEFAULT.pad;
+    let area_height = row_height * 2.0;
+    let area_clip = ClipRect { x: PANEL_X, y: PANEL_Y, width: PANEL_WIDTH, height: area_height };
+
+    // Build five lines with the control's plain-Enter policy. The final caret
+    // forces a two-row viewport to show only `last` and `tail`.
+    bench
+        .execute(vec![
+            ("focus", BenchOp::send_mail(&panel, &press(content_x, PANEL_Y + 10.0))),
+            ("focus_up", BenchOp::send_mail(&panel, &release(content_x, PANEL_Y + 10.0))),
+            ("line0", BenchOp::send_mail(&panel, &TextInput { text: "imx".to_owned() })),
+            ("enter0", BenchOp::send_mail(&panel, &Key { code: KEY_ENTER })),
+            ("line1", BenchOp::send_mail(&panel, &TextInput { text: "é".to_owned() })),
+            ("enter1", BenchOp::send_mail(&panel, &Key { code: KEY_ENTER })),
+            ("line2", BenchOp::send_mail(&panel, &TextInput { text: "short".to_owned() })),
+            ("enter2", BenchOp::send_mail(&panel, &Key { code: KEY_ENTER })),
+            ("line3", BenchOp::send_mail(&panel, &TextInput { text: "last".to_owned() })),
+            ("enter3", BenchOp::send_mail(&panel, &Key { code: KEY_ENTER })),
+            ("line4", BenchOp::send_mail(&panel, &TextInput { text: "tail".to_owned() })),
+            ("rasterize", BenchOp::send_mail(&panel, &Tick)),
+            ("settle_glyphs", BenchOp::advance(2)),
+        ])
+        .expect("type five text-area lines");
+
+    // Place after `tai` on the second visible row. Shift+Up selects from that
+    // point back to the same measured x on `last`; Down and Up again exercise
+    // both directions while leaving the same cross-newline selection active.
+    let after_three_x = content_x + metrics.caret_x("tail", 3, size);
+    bench
+        .execute(vec![
+            ("place", BenchOp::send_mail(&panel, &press(after_three_x, PANEL_Y + row_height + 10.0))),
+            ("place_up", BenchOp::send_mail(&panel, &release(after_three_x, PANEL_Y + row_height + 10.0))),
+            ("shift", BenchOp::send_mail(&panel, &Modifiers { shift: true, ..Modifiers::default() })),
+            ("up", BenchOp::send_mail(&panel, &Key { code: KEY_UP })),
+            ("down", BenchOp::send_mail(&panel, &Key { code: KEY_DOWN })),
+            ("up_again", BenchOp::send_mail(&panel, &Key { code: KEY_UP })),
+        ])
+        .expect("measured multiline selection");
+
+    let last_selection_x = content_x + metrics.caret_x("last", 3, size);
+    let last_selection_end_x = content_x + metrics.caret_x("last", 4, size);
+    let tail_selection_end_x = content_x + metrics.caret_x("tail", 3, size);
+    let selection_top = PANEL_Y + Theme::DEFAULT.pad;
+    let selection_height = row_height - Theme::DEFAULT.pad * 2.0;
+    let selection_checks = vec![
+        check(
+            FrameReduction::Coverage,
+            rect(
+                last_selection_x + 1.0,
+                selection_top + 1.0,
+                last_selection_end_x - 1.0,
+                selection_top + selection_height - 1.0,
+            ),
+            SURFACE_RAISED_SRGB,
+            PARTITION_TOLERANCE,
+        ),
+        check(
+            FrameReduction::Coverage,
+            rect(
+                content_x + 1.0,
+                selection_top + row_height + 1.0,
+                tail_selection_end_x - 1.0,
+                selection_top + row_height + selection_height - 1.0,
+            ),
+            SURFACE_RAISED_SRGB,
+            PARTITION_TOLERANCE,
+        ),
+    ];
+    let selected = capture_guarded(
+        &mut bench,
+        "text-area-multiline-selection",
+        "the selected final character of `last` and first three characters of `tail` fill two measured row bands",
+        selection_checks,
+    );
+    assert!(
+        selected.verdict.results.iter().all(|result| coverage(result) > 0.75),
+        "both measured row-local selection bands must survive rasterization; verdict: {:?}",
+        selected.verdict,
+    );
+
+    {
+        let snapshot = bench.committed_overlay_snapshot();
+        let solid = solid_for(&snapshot, &area_clip);
+        assert_eq!(
+            solid.quads.len(),
+            8,
+            "background + two selection bands + caret + four focus edges; snapshot: {snapshot:?}",
+        );
+        assert_eq!(solid.quads[0].x, PANEL_X);
+        assert_eq!(solid.quads[0].y, PANEL_Y);
+        assert_eq!(solid.quads[0].width, PANEL_WIDTH);
+        assert_eq!(solid.quads[0].height, area_height);
+        assert_eq!(solid.quads[0].tint, Theme::DEFAULT.surface_raised);
+        assert_eq!(solid.quads[1].x, last_selection_x);
+        assert_eq!(solid.quads[1].y, selection_top);
+        assert_eq!(solid.quads[1].width, metrics.caret_x("last", 4, size) - metrics.caret_x("last", 3, size),);
+        assert_eq!(solid.quads[1].height, selection_height);
+        assert_eq!(solid.quads[1].tint, Theme::DEFAULT.accent);
+        assert_eq!(solid.quads[2].x, last_selection_x);
+        assert_eq!(solid.quads[2].y, selection_top);
+        assert_eq!(solid.quads[2].width, 1.0);
+        assert_eq!(solid.quads[2].height, selection_height);
+        assert_eq!(solid.quads[2].tint, Theme::DEFAULT.accent);
+        assert_eq!(solid.quads[3].x, content_x);
+        assert_eq!(solid.quads[3].y, selection_top + row_height);
+        assert_eq!(solid.quads[3].width, metrics.caret_x("tail", 3, size));
+        assert_eq!(solid.quads[3].height, selection_height);
+        assert_eq!(solid.quads[3].tint, Theme::DEFAULT.accent);
+        let area_glyphs: Vec<_> = snapshot
+            .iter()
+            .filter(|batch| batch.texture_id != WHITE_TEXTURE_ID && batch.clip.as_ref() == Some(&area_clip))
+            .flat_map(|batch| &batch.quads)
+            .collect();
+        assert!(
+            area_glyphs.iter().any(|quad| { quad.y >= PANEL_Y && quad.y + quad.height <= PANEL_Y + row_height }),
+            "the first visible line's glyphs must stay in row zero; snapshot: {snapshot:?}",
+        );
+        assert!(
+            area_glyphs
+                .iter()
+                .any(|quad| { quad.y >= PANEL_Y + row_height && quad.y + quad.height <= PANEL_Y + area_height }),
+            "the second visible line's glyphs must stay in row one; snapshot: {snapshot:?}",
+        );
+    }
+
+    // Replace the cross-newline selection visually with a non-ASCII preedit.
+    // The displayed document now has one final line, so its measured cursor
+    // span and underline occupy row zero of the retained whole-line viewport.
+    bench
+        .execute(vec![
+            (
+                "preedit",
+                BenchOp::send_mail(
+                    &panel,
+                    &ImePreedit { text: "üx".to_owned(), cursor_begin: Some(0), cursor_end: Some(2) },
+                ),
+            ),
+            ("rasterize_preedit", BenchOp::send_mail(&panel, &Tick)),
+            ("settle_preedit", BenchOp::advance(2)),
+        ])
+        .expect("multiline IME preedit");
+
+    let preedit_x = content_x + metrics.caret_x("las", 3, size);
+    let preedit_cursor_end_x = preedit_x + metrics.caret_x("üx", 1, size);
+    let preedit_end_x = preedit_x + metrics.caret_x("üx", 2, size);
+    let underline_y = PANEL_Y + (row_height - size) * 0.5 + size;
+    let composition_checks = vec![
+        check(
+            FrameReduction::Coverage,
+            rect(
+                preedit_x + 1.0,
+                selection_top + 1.0,
+                preedit_cursor_end_x - 1.0,
+                selection_top + selection_height - 1.0,
+            ),
+            SURFACE_RAISED_SRGB,
+            PARTITION_TOLERANCE,
+        ),
+        check(
+            FrameReduction::Coverage,
+            rect(preedit_x + 1.0, underline_y, preedit_end_x - 1.0, underline_y + 1.0),
+            SURFACE_RAISED_SRGB,
+            PARTITION_TOLERANCE,
+        ),
+    ];
+    let composed = capture_guarded(
+        &mut bench,
+        "text-area-multiline-preedit",
+        "the non-collapsed IME cursor fills `ü` and the underline spans measured `üx`",
+        composition_checks,
+    );
+    assert!(
+        composed.verdict.results.iter().all(|result| coverage(result) > 0.6),
+        "the measured preedit cursor and underline must survive rasterization; verdict: {:?}",
+        composed.verdict,
+    );
+
+    {
+        let snapshot = bench.committed_overlay_snapshot();
+        let solid = solid_for(&snapshot, &area_clip);
+        assert_eq!(
+            solid.quads.len(),
+            7,
+            "background + IME cursor band + underline + four focus edges; snapshot: {snapshot:?}",
+        );
+        assert_eq!(solid.quads[1].x, preedit_x);
+        assert_eq!(solid.quads[1].y, selection_top);
+        assert_eq!(solid.quads[1].width, metrics.caret_x("üx", 1, size));
+        assert_eq!(solid.quads[1].height, selection_height);
+        assert_eq!(solid.quads[1].tint, Theme::DEFAULT.accent);
+        assert_eq!(solid.quads[2].x, preedit_x);
+        assert_eq!(solid.quads[2].y, underline_y);
+        assert_eq!(solid.quads[2].width, metrics.caret_x("üx", 2, size));
+        assert_eq!(solid.quads[2].height, 1.0);
+        assert_eq!(solid.quads[2].tint, Theme::DEFAULT.accent);
+    }
+
+    // Committed input replaces the selected `t\ntai`; Ctrl+Enter emits the
+    // value upward without inserting another newline.
+    bench
+        .execute(vec![
+            ("commit_preedit", BenchOp::send_mail(&panel, &TextInput { text: "Z".to_owned() })),
+            ("ctrl", BenchOp::send_mail(&panel, &Modifiers { ctrl: true, ..Modifiers::default() })),
+            ("commit_area", BenchOp::send_mail(&panel, &Key { code: KEY_ENTER })),
+        ])
+        .expect("commit multiline replacement");
+
+    let log = panel_log_messages(&mut bench);
+    let joined = log.join("\n");
+    assert!(
+        log.iter().any(|message| { message.contains("widget text committed") && message.contains("lasZl") }),
+        "Ctrl+Enter must commit `imx\\né\\nshort\\nlasZl` without inserting a newline; log was:\n{joined}",
     );
 }
 

--- a/docs/guide/systems/widgets.md
+++ b/docs/guide/systems/widgets.md
@@ -1,7 +1,7 @@
 # The widget set & focus model
 
 `aether-kit` ships a set of guest-side widgets — a slider, a text field, a
-radio group, a button, a label, and an image — as ordinary
+multiline text area, a radio group, a button, a label, and an image — as ordinary
 `#[actor(instanced)]` types.
 A panel root spawns them as inline children (ADR-0114) and drives them entirely
 by mail, so composing an editor panel is a matter of laying out widgets and
@@ -26,9 +26,9 @@ recorded at spawn, so a widget's identity is its inline subname and nothing a
 widget sends can misreport it.
 
 - **Config, down.** One `Config` kind per widget — `SliderConfig`,
-  `TextFieldConfig`, `RadioConfig`, `ButtonConfig`, `LabelConfig`,
-  `ImageConfig` — each
-  embedding a `theme: Theme`. The config is both the value
+  `TextFieldConfig`, `TextAreaConfig`, `RadioConfig`, `ButtonConfig`,
+  `LabelConfig`, `ImageConfig` — each embedding a `theme: Theme`. The config is
+  both the value
   `spawn_inline_child::<W>(subname, &config)` boots the widget with and a
   re-sendable mail: send a widget its config kind again to reconfigure it in
   place (a slider's range, a field's cap, a button's label).
@@ -50,9 +50,9 @@ widget sends can misreport it.
   value; a changed config or state mail emits source-attributed
   `WidgetStateChanged` so panel routing cannot drift. Hidden widgets keep their
   slot and answer `Collect` with an empty `WidgetDrawList`; disabled widgets
-  draw muted but leave input routing; read-only Slider, Radio, and TextField
-  remain focusable but reject mutation. Button and Label ignore read-only and
-  validation.
+  draw muted but leave input routing; read-only Slider, Radio, TextField, and
+  TextArea remain focusable but reject mutation. Button and Label ignore
+  read-only and validation.
 - **Interaction, down.** The root sends `FocusGained` / `FocusLost` and
   `HoverGained` / `HoverLost`. Hover comes from explicit edges, not from a child
   inferring absence from raw motion. Pressed and hover select an exclusive fill
@@ -125,6 +125,17 @@ A focused Button activates once on Enter press (repeat presses are suppressed
 until release) and once on Space release after a matching Space press. Focus
 loss or unavailability cancels the keyboard arm.
 
+TextField and TextArea share the same UTF-8-safe edit, selection, and IME
+state. Once the configured font resolves, pointer placement, caret motion,
+selection fills, preedit cursor bands, and preedit underlines all use its exact
+glyph advances. `TextAreaConfig { initial, max_chars, rows, theme, state }`
+adds a fixed whole-line viewport: `rows` is the number of visible theme rows
+(`0` means one), vertical motion preserves the caret's preferred measured x
+across shorter lines, and the viewport scrolls by complete lines to keep the
+caret visible. Plain Enter inserts a newline; Ctrl+Enter sends
+`TextCommitted` without changing the value. A multiline selection can cross
+newlines and renders one measured band in each covered visible row.
+
 ## The reference panel
 
 `WidgetPanel` (export `aether.kit.widget.panel`) is the worked example — the
@@ -132,10 +143,11 @@ test vehicle and the template a real editor forks. It embeds `Composite` and
 `Focus`, spawns the vertical stack its `PanelConfig` declares on its first
 frame (each `WidgetChildSpec` names a `WidgetKind` and carries that widget's
 pre-encoded config; an empty child list falls back to the built-in reference
-original reference stack), loads a font through `aether.text` and stamps the
+stack), loads a font through `aether.text` and stamps the
 session `font_id` into its theme when `load_font_result` arrives, drives the
 collect/emit loop each frame, and routes input through `Focus`. Row height,
 initial state, and static eligibility derive from each child's decoded config.
+TextArea slots derive their height from `theme.row_height * rows.max(1)`.
 A `WidgetKind::BehaviorHost` derives the same metadata from both its `wrapped`
 discriminator and opaque `wrapped_config`; wrapping does not make every child
 focusable. The vertical order follows the declared order, so what a panel


### PR DESCRIPTION
Closes #2925.

## Summary

- Add a stock `TextAreaWidget` with named configuration, fixed whole-line scrolling, UTF-8-safe multiline editing, measured vertical caret motion, selection, and IME composition.
- Share the line-agnostic edit projection and single-flight font-metrics adapter with `TextFieldWidget`, preserving exact measured geometry for both controls.
- Wire TextArea through panel spawning, behavior-host dispatch, public exports, control state, and Ctrl+Enter value-up commits without introducing positional semantic types.

## Test plan

- `cargo test -p aether-kit text_area`
- `cargo test -p aether-kit --lib`
- `cargo test -p aether-kit --features behavior wrapped_tag_maps_each_stock_widget_and_rejects_unwrappable`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --target wasm32-unknown-unknown --release -p aether-kit`
- `AETHER_REQUIRE_RUNTIME=1 cargo test -p aether-substrate-bundle --test widget_render_interaction text_area_scrolls_selects_composes_and_commits_measured_lines -- --nocapture`

## Generated by

`/implement` — agent execution of [scoped issue #2925](https://github.com/iamacoffeepot/aether/issues/2925).
