### PR TITLE
fix(ci): hand the PR from review to dogfood via a review-context artifact

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -60,11 +60,15 @@ on:
         description: PR number to dogfood (bypasses the retry-state guards)
         required: true
 
-# One trial per PR; a newer trigger supersedes an in-flight one. Keyed by the
-# head branch on the workflow_run path (the Review workflow_run event exposes
-# the PR head branch), or the dispatched PR number.
+# The PR is not knowable at workflow level on the workflow_run path — the
+# triggering Review run is itself workflow_run-triggered, so its run object
+# attaches to the latest MAIN commit (head_branch is always "main"); the real
+# PR arrives via the review-context artifact the resolve job downloads. So the
+# workflow-level group only dedupes per trigger (and per PR on the dispatch
+# path); the one-trial-per-PR supersede lives on the `trial` job, keyed by the
+# resolved PR number.
 concurrency:
-  group: dogfood-${{ github.event.workflow_run.head_branch || github.event.inputs.pr }}
+  group: dogfood-${{ github.event.workflow_run.id || github.event.inputs.pr }}
   cancel-in-progress: true
 
 env:
@@ -78,8 +82,11 @@ jobs:
     name: Resolve gate stack
     runs-on: ubuntu-latest
     # Pure GitHub API calls — no checkout, no branch code. Read-only.
+    # actions: read is for downloading the triggering Review run's
+    # review-context artifact (the PR hand-off).
     permissions:
       contents: read
+      actions: read
     # Job-level guard mirroring review.yml: manual dispatch is always allowed
     # and resolves its own PR; the workflow_run path requires the parent (the
     # Review workflow) to have succeeded and its head to be this repo — a fork
@@ -105,7 +112,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT: ${{ github.event_name }}
           DISPATCH_PR: ${{ github.event.inputs.pr }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REVIEW_RUN_ID: ${{ github.event.workflow_run.id }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -120,15 +127,28 @@ jobs:
 
           # Gate 1 (structural) is the trigger chain itself: this workflow only
           # fires on a successful Review workflow_run, which only fires on a
-          # successful CI run. Resolve the PR from the head branch (dispatch
-          # supplies it directly).
+          # successful CI run. The PR comes from the review-context artifact
+          # the Review run uploaded when its own resolve found an open PR
+          # (dispatch supplies it directly). The Review run's head_branch is
+          # useless here: a workflow_run-triggered run object attaches to the
+          # latest MAIN commit, so it always reads "main" — review can resolve
+          # the branch from CI's push-triggered run, but one chain level down
+          # the event no longer carries it.
           if [ "$EVENT" = "workflow_dispatch" ]; then
             pr="$DISPATCH_PR"
           else
-            pr="$(gh api "repos/${REPO}/pulls?head=iamacoffeepot:${HEAD_BRANCH}&state=open" \
-              --jq '.[0].number // empty')"
+            artifact_id="$(gh api "repos/${REPO}/actions/runs/${REVIEW_RUN_ID}/artifacts" \
+              --jq '[.artifacts[] | select(.name == "review-context")][0].id // empty')"
+            [ -n "${artifact_id:-}" ] || skip "Review run ${REVIEW_RUN_ID} uploaded no review-context artifact — it resolved no open PR, nothing to dogfood."
+            gh api "repos/${REPO}/actions/artifacts/${artifact_id}/zip" > /tmp/review-context.zip
+            unzip -o -d /tmp/review-context /tmp/review-context.zip
+            pr="$(jq -r '.pr // empty' /tmp/review-context/review-context.json)"
           fi
-          [ -n "${pr:-}" ] || skip "No open PR for branch '${HEAD_BRANCH}' — nothing to dogfood."
+          # Belt-and-braces shape check: the artifact is main-code-produced but
+          # still data — a non-numeric value must not reach the API paths below.
+          case "${pr:-}" in
+            ''|*[!0-9]*) skip "Resolved PR '${pr:-}' is not a number — nothing to dogfood." ;;
+          esac
 
           head_sha="$(gh api "repos/${REPO}/pulls/${pr}" --jq '.head.sha')"
           echo "pr=$pr" >> "$GITHUB_OUTPUT"
@@ -218,6 +238,14 @@ jobs:
     name: Dogfood trial
     needs: resolve
     if: needs.resolve.outputs.proceed == 'true'
+    # One trial per PR; a newer green event supersedes an in-flight trial of
+    # the same PR. Job-level because the PR number only exists after resolve
+    # (see the workflow-level concurrency comment). Cancelling a superseded
+    # trial is safe for the bookkeeping: its `post` no-ops (rollup_produced
+    # never turns true), so attempts/verdict state is untouched.
+    concurrency:
+      group: dogfood-trial-${{ needs.resolve.outputs.pr }}
+      cancel-in-progress: true
     # Same ephemeral EC2 shape as the spike proved: 8cpu buys the workflow's
     # agent fan-out headroom, s3-cache warms sccache across a retrying PR's runs.
     runs-on: runs-on=${{ github.run_id }}/runner=8cpu-linux-x64/extras=s3-cache

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -222,6 +222,33 @@ jobs:
 
           echo "proceed=true" >> "$GITHUB_OUTPUT"
 
+      # Hand the resolved PR to the chained Dogfood workflow. Dogfood triggers
+      # on this workflow's completion, but a workflow_run-triggered run object
+      # attaches to the latest MAIN commit — its head_branch is always "main" —
+      # so a downstream chain can never re-derive the PR from the event the way
+      # this workflow does from CI's push-triggered run. This artifact is the
+      # explicit hand-off. It is written on EVERY path that resolves a PR
+      # (label/cap/non-Rust/marker skips included), matching the `gate` job's
+      # coverage, so dogfood can apply its own gate stack (the live `Review
+      # gate` status among them) to the right PR.
+      - name: Write the review-context hand-off for Dogfood
+        if: steps.resolve.outputs.pr_number != ''
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+        run: |
+          jq -nc --argjson pr "$PR_NUMBER" --arg head_sha "$HEAD_SHA" \
+            '{pr: $pr, head_sha: $head_sha}' > "$RUNNER_TEMP/review-context.json"
+          cat "$RUNNER_TEMP/review-context.json"
+      - uses: actions/upload-artifact@v4
+        if: steps.resolve.outputs.pr_number != ''
+        with:
+          name: review-context
+          path: ${{ runner.temp }}/review-context.json
+          # Consumed by the Dogfood run that fires minutes later; nothing
+          # reads it after that.
+          retention-days: 1
+
       # Check out the PR head with full history so the /review skill's
       # `git diff origin/main...HEAD` prep resolves. The base ref is not
       # present after a single-ref checkout, so fetch it explicitly.


### PR DESCRIPTION
The Dogfood resolve gate derived the PR from `github.event.workflow_run.head_branch`. That works one chain level up — review reads CI's push-triggered run, whose run object carries the real branch — but the Review run dogfood chains on is itself `workflow_run`-triggered, so its run object attaches to the latest **main** commit and `head_branch` is always `main`. Every automatic Dogfood run has skipped at the very first predicate (`No open PR for branch 'main'` — e.g. runs 29110410014, 29109767570); only the `workflow_dispatch` escape hatch ever ran a trial.

The fix is an explicit hand-off:

- **review.yml** uploads a `review-context` artifact (`{pr, head_sha}`, 1-day retention) the moment its resolve step finds an open PR — on every path, the label/cap/non-Rust/marker skips included, matching the `gate` job's coverage.
- **dogfood.yml**'s resolve downloads that artifact from the triggering run (resolve gains `actions: read`) instead of querying by branch, with a numeric shape check on the value. Dispatch still supplies the PR directly. A Review run with no artifact (it resolved no open PR) skips cleanly.

The same root poisoned the concurrency key: the workflow-level group was `dogfood-main` for **every** PR with `cancel-in-progress`, so once trials actually ran, any PR's review completing would cancel any other PR's in-flight 60-minute trial. The workflow-level group now dedupes per trigger only; one-trial-per-PR supersede moves to a job-level group on `trial` keyed by the resolved PR number, where cancelling a superseded trial is bookkeeping-safe (its `post` job no-ops on the missing rollup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)