### PR TITLE
feat(kit): add a fixed-row virtual list widget

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -90,8 +90,9 @@ pub use widget::{
     ButtonClicked, ButtonConfig, ChildrenChanged, Collect, FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig,
     ImageFit, LabelConfig, MembershipEntry, PanelConfig, RadioConfig, RadioSelected, ScrollConfig, ScrollDelta,
     ScrollExtent, ScrollOffset, ScrollOutcome, ScrollResidual, SetWidgetState, SliderChanged, SliderConfig,
-    TextAreaConfig, TextCommitted, TextFieldConfig, WidgetChildSpec, WidgetClipRect, WidgetConfig, WidgetControlState,
-    WidgetDrawItem, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged, WidgetValidation,
+    TextAreaConfig, TextCommitted, TextFieldConfig, VirtualListConfig, VirtualListSelected, WidgetChildSpec,
+    WidgetClipRect, WidgetConfig, WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame, WidgetKind,
+    WidgetStateChanged, WidgetValidation,
 };
 pub use world::{
     ApplyBrush, AutomatonRule, BrushParameters, CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk,
@@ -145,6 +146,7 @@ aether_actor::export!(
     widget::set::ButtonWidget,
     widget::set::LabelWidget,
     widget::set::ImageWidget,
+    widget::set::VirtualListWidget,
     widget::WidgetPanel
 );
 
@@ -167,6 +169,7 @@ aether_actor::export!(
     widget::set::ButtonWidget,
     widget::set::LabelWidget,
     widget::set::ImageWidget,
+    widget::set::VirtualListWidget,
     widget::WidgetPanel,
     aether_behavior::BehaviorHost
 );

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -860,36 +860,6 @@ mod tests {
     use alloc::vec;
 
     #[test]
-    fn virtual_list_wire_vocabulary_uses_named_records_not_positional_storage() {
-        let source = include_str!("kinds.rs");
-        let config = source
-            .split("/// `aether.kit.widget.virtual_list.config`")
-            .nth(1)
-            .and_then(|rest| rest.split("/// `aether.kit.widget.button.config`").next())
-            .expect("virtual-list config source section");
-        assert!(config.contains("pub struct VirtualListConfig {"));
-        assert!(!config.contains("pub struct VirtualListConfig("));
-        assert!(!config.contains("pub type VirtualListConfig"));
-        assert!(
-            config.lines().filter(|line| line.trim_start().starts_with("pub ")).all(|line| !line.contains('[')),
-            "virtual-list config fields must not smuggle semantic values through fixed arrays",
-        );
-
-        let selected = source
-            .split("/// `aether.kit.widget.virtual_list.selected`")
-            .nth(1)
-            .and_then(|rest| rest.split("/// `aether.kit.widget.button.clicked`").next())
-            .expect("virtual-list selected source section");
-        assert!(selected.contains("pub struct VirtualListSelected {"));
-        assert!(!selected.contains("pub struct VirtualListSelected("));
-        assert!(!selected.contains("pub type VirtualListSelected"));
-        assert!(
-            selected.lines().filter(|line| line.trim_start().starts_with("pub ")).all(|line| !line.contains('[')),
-            "virtual-list event fields must not use fixed positional storage",
-        );
-    }
-
-    #[test]
     fn virtual_list_appends_without_renumbering_established_widget_kinds() {
         assert_eq!(to_vec(&WidgetKind::Composite).expect("encode Composite"), vec![0, 0, 0, 0]);
         assert_eq!(to_vec(&WidgetKind::Label).expect("encode Label"), vec![1, 0, 0, 0]);

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -856,27 +856,52 @@ impl Default for PanelConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aether_data::wire;
+    use aether_data::wire::{self, to_vec};
+    use alloc::vec;
 
     #[test]
     fn virtual_list_wire_vocabulary_uses_named_records_not_positional_storage() {
         let source = include_str!("kinds.rs");
-        assert!(source.contains("pub struct VirtualListConfig {"));
-        assert!(source.contains("pub struct VirtualListSelected {"));
-        assert!(!source.contains("pub struct VirtualListConfig("));
-        assert!(!source.contains("pub struct VirtualListSelected("));
-        assert!(!source.contains("pub type VirtualListConfig"));
-        assert!(!source.contains("pub type VirtualListSelected"));
-
         let config = source
-            .split("pub struct VirtualListConfig {")
+            .split("/// `aether.kit.widget.virtual_list.config`")
             .nth(1)
-            .and_then(|rest| rest.split("pub struct ButtonConfig").next())
+            .and_then(|rest| rest.split("/// `aether.kit.widget.button.config`").next())
             .expect("virtual-list config source section");
+        assert!(config.contains("pub struct VirtualListConfig {"));
+        assert!(!config.contains("pub struct VirtualListConfig("));
+        assert!(!config.contains("pub type VirtualListConfig"));
         assert!(
-            !config.contains('['),
-            "virtual-list config must not smuggle semantic values through fixed arrays",
+            config.lines().filter(|line| line.trim_start().starts_with("pub ")).all(|line| !line.contains('[')),
+            "virtual-list config fields must not smuggle semantic values through fixed arrays",
         );
+
+        let selected = source
+            .split("/// `aether.kit.widget.virtual_list.selected`")
+            .nth(1)
+            .and_then(|rest| rest.split("/// `aether.kit.widget.button.clicked`").next())
+            .expect("virtual-list selected source section");
+        assert!(selected.contains("pub struct VirtualListSelected {"));
+        assert!(!selected.contains("pub struct VirtualListSelected("));
+        assert!(!selected.contains("pub type VirtualListSelected"));
+        assert!(
+            selected.lines().filter(|line| line.trim_start().starts_with("pub ")).all(|line| !line.contains('[')),
+            "virtual-list event fields must not use fixed positional storage",
+        );
+    }
+
+    #[test]
+    fn virtual_list_appends_without_renumbering_established_widget_kinds() {
+        assert_eq!(to_vec(&WidgetKind::Composite).expect("encode Composite"), vec![0, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::Label).expect("encode Label"), vec![1, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::Slider).expect("encode Slider"), vec![2, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::Radio).expect("encode Radio"), vec![3, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::TextField).expect("encode TextField"), vec![4, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::Button).expect("encode Button"), vec![5, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::BehaviorHost).expect("encode BehaviorHost"), vec![6, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::Image).expect("encode Image"), vec![7, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::TextArea).expect("encode TextArea"), vec![8, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::Scroll).expect("encode Scroll"), vec![9, 0, 0, 0]);
+        assert_eq!(to_vec(&WidgetKind::VirtualList).expect("encode VirtualList"), vec![10, 0, 0, 0]);
     }
 
     #[test]

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -905,10 +905,12 @@ mod tests {
         let image = wire::to_vec(&WidgetKind::Image).expect("encode Image");
         let text_area = wire::to_vec(&WidgetKind::TextArea).expect("encode TextArea");
         let scroll = wire::to_vec(&WidgetKind::Scroll).expect("encode Scroll");
+        let virtual_list = wire::to_vec(&WidgetKind::VirtualList).expect("encode VirtualList");
         assert_eq!(behavior_host.as_slice(), 6_u32.to_le_bytes());
         assert_eq!(image.as_slice(), 7_u32.to_le_bytes());
         assert_eq!(text_area.as_slice(), 8_u32.to_le_bytes());
         assert_eq!(scroll.as_slice(), 9_u32.to_le_bytes());
+        assert_eq!(virtual_list.as_slice(), 10_u32.to_le_bytes());
     }
 
     #[test]

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -397,6 +397,10 @@ pub enum WidgetKind {
     /// The actor owns its offset and recursively routes wheel residuals.
     /// Appended to preserve every established wire discriminant above.
     Scroll,
+    /// A fixed-row virtual list — `config` decodes as [`VirtualListConfig`].
+    /// Appended after `Scroll` to preserve every established wire discriminant
+    /// above.
+    VirtualList,
 }
 
 impl WidgetKind {
@@ -424,6 +428,7 @@ impl WidgetKind {
             Self::TextField => aether_data::mailbox_id_from_name("aether.kit.widget.text_field").0,
             Self::TextArea => aether_data::mailbox_id_from_name("aether.kit.widget.text_area").0,
             Self::Button => aether_data::mailbox_id_from_name("aether.kit.widget.button").0,
+            Self::VirtualList => aether_data::mailbox_id_from_name("aether.kit.widget.virtual_list").0,
             Self::Composite | Self::Scroll | Self::BehaviorHost => return None,
         };
         Some(tag)
@@ -643,6 +648,20 @@ pub struct RadioConfig {
     pub state: WidgetControlState,
 }
 
+/// `aether.kit.widget.virtual_list.config` — a fixed-row viewport over a
+/// potentially large item vector. The panel fixes the viewport height from
+/// `visible_row_count`; the actor realizes only that bounded row window.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
+#[kind(name = "aether.kit.widget.virtual_list.config")]
+pub struct VirtualListConfig {
+    pub items: Vec<String>,
+    pub initial_selected_index: u32,
+    pub visible_row_count: u32,
+    pub theme: Theme,
+    #[serde(default)]
+    pub state: WidgetControlState,
+}
+
 /// `aether.kit.widget.button.config` — a momentary push button showing
 /// `label`, firing [`ButtonClicked`] on a press-then-release-inside.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
@@ -741,6 +760,14 @@ pub struct RadioSelected {
     pub index: u32,
 }
 
+/// `aether.kit.widget.virtual_list.selected` — a virtual list's changed
+/// selection, attributed by the parent from the sending child's mailbox.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.virtual_list.selected")]
+pub struct VirtualListSelected {
+    pub selected_index: u32,
+}
+
 /// `aether.kit.widget.button.clicked` — a button's value-up event, fired once
 /// per completed press-then-release-inside. Fieldless: the click carries no
 /// data, and which button clicked is the root's `source_mailbox` attribution.
@@ -830,6 +857,27 @@ impl Default for PanelConfig {
 mod tests {
     use super::*;
     use aether_data::wire;
+
+    #[test]
+    fn virtual_list_wire_vocabulary_uses_named_records_not_positional_storage() {
+        let source = include_str!("kinds.rs");
+        assert!(source.contains("pub struct VirtualListConfig {"));
+        assert!(source.contains("pub struct VirtualListSelected {"));
+        assert!(!source.contains("pub struct VirtualListConfig("));
+        assert!(!source.contains("pub struct VirtualListSelected("));
+        assert!(!source.contains("pub type VirtualListConfig"));
+        assert!(!source.contains("pub type VirtualListSelected"));
+
+        let config = source
+            .split("pub struct VirtualListConfig {")
+            .nth(1)
+            .and_then(|rest| rest.split("pub struct ButtonConfig").next())
+            .expect("virtual-list config source section");
+        assert!(
+            !config.contains('['),
+            "virtual-list config must not smuggle semantic values through fixed arrays",
+        );
+    }
 
     #[test]
     fn scroll_wire_vocabulary_uses_named_semantic_records() {

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -856,23 +856,7 @@ impl Default for PanelConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aether_data::wire::{self, to_vec};
-    use alloc::vec;
-
-    #[test]
-    fn virtual_list_appends_without_renumbering_established_widget_kinds() {
-        assert_eq!(to_vec(&WidgetKind::Composite).expect("encode Composite"), vec![0, 0, 0, 0]);
-        assert_eq!(to_vec(&WidgetKind::Label).expect("encode Label"), vec![1, 0, 0, 0]);
-        assert_eq!(to_vec(&WidgetKind::Slider).expect("encode Slider"), vec![2, 0, 0, 0]);
-        assert_eq!(to_vec(&WidgetKind::Radio).expect("encode Radio"), vec![3, 0, 0, 0]);
-        assert_eq!(to_vec(&WidgetKind::TextField).expect("encode TextField"), vec![4, 0, 0, 0]);
-        assert_eq!(to_vec(&WidgetKind::Button).expect("encode Button"), vec![5, 0, 0, 0]);
-        assert_eq!(to_vec(&WidgetKind::BehaviorHost).expect("encode BehaviorHost"), vec![6, 0, 0, 0]);
-        assert_eq!(to_vec(&WidgetKind::Image).expect("encode Image"), vec![7, 0, 0, 0]);
-        assert_eq!(to_vec(&WidgetKind::TextArea).expect("encode TextArea"), vec![8, 0, 0, 0]);
-        assert_eq!(to_vec(&WidgetKind::Scroll).expect("encode Scroll"), vec![9, 0, 0, 0]);
-        assert_eq!(to_vec(&WidgetKind::VirtualList).expect("encode VirtualList"), vec![10, 0, 0, 0]);
-    }
+    use aether_data::wire;
 
     #[test]
     fn scroll_wire_vocabulary_uses_named_semantic_records() {

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -114,6 +114,11 @@ pub struct SpawnedChild {
     pub scroll_viewport: Option<ScrollExtent>,
 }
 
+struct VirtualListProfile {
+    height: f32,
+    eligible: bool,
+}
+
 #[cfg(feature = "behavior")]
 struct ChildProfile {
     height: f32,
@@ -369,28 +374,32 @@ pub fn spawn_widget_child(
 
 fn spawn_virtual_list_child(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, row: f32) -> Option<SpawnedChild> {
     let config = decode_child::<VirtualListConfig>(spec)?;
-    let Some(height) = virtual_list_height(row, config.visible_row_count) else {
+    let profile = virtual_list_profile(&spec.subname, row, &config)?;
+    let state = config.state.clone();
+    spawn::<VirtualListWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
+        id,
+        width_pixels: None,
+        height_pixels: profile.height,
+        pointer_eligible: profile.eligible,
+        focusable: profile.eligible,
+        state,
+        type_namespace: <VirtualListWidget as Addressable>::NAMESPACE,
+        scroll_viewport: None,
+    })
+}
+
+fn virtual_list_profile(subname: &str, row_height: f32, config: &VirtualListConfig) -> Option<VirtualListProfile> {
+    let Some(height) = virtual_list_height(row_height, config.visible_row_count) else {
         tracing::warn!(
             target: "aether_kit",
-            subname = %spec.subname,
-            row_height = row,
+            subname,
+            row_height,
             visible_row_count = config.visible_row_count,
             "virtual-list viewport height is invalid; slot skipped",
         );
         return None;
     };
-    let eligible = !config.items.is_empty() && config.visible_row_count > 0;
-    let state = config.state.clone();
-    spawn::<VirtualListWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
-        id,
-        width_pixels: None,
-        height_pixels: height,
-        pointer_eligible: eligible,
-        focusable: eligible,
-        state,
-        type_namespace: <VirtualListWidget as Addressable>::NAMESPACE,
-        scroll_viewport: None,
-    })
+    Some(VirtualListProfile { height, eligible: !config.items.is_empty() && config.visible_row_count > 0 })
 }
 
 fn virtual_list_height(row_height: f32, visible_row_count: u32) -> Option<f32> {
@@ -697,18 +706,13 @@ fn spawn_behavior_host(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, ro
         }
         WidgetKind::VirtualList => {
             let config = decode_named::<VirtualListConfig>(&spec.subname, &host_spec.wrapped_config)?;
-            let Some(height) = virtual_list_height(row, config.visible_row_count) else {
-                tracing::warn!(
-                    target: "aether_kit",
-                    subname = %spec.subname,
-                    row_height = row,
-                    visible_row_count = config.visible_row_count,
-                    "wrapped virtual-list viewport height is invalid; slot skipped",
-                );
-                return None;
-            };
-            let eligible = !config.items.is_empty() && config.visible_row_count > 0;
-            ChildProfile { height, pointer_eligible: eligible, focusable: eligible, state: config.state }
+            let profile = virtual_list_profile(&spec.subname, row, &config)?;
+            ChildProfile {
+                height: profile.height,
+                pointer_eligible: profile.eligible,
+                focusable: profile.eligible,
+                state: config.state,
+            }
         }
         WidgetKind::Composite | WidgetKind::Scroll | WidgetKind::BehaviorHost => return None,
     };

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -33,9 +33,9 @@
 //!   up — and emits the whole panel as contiguous equal-clip solid batches
 //!   (plus text) from one root render sender.
 //! - **Value.** Each value-up event (`SliderChanged` / `TextCommitted` /
-//!   `RadioSelected` / `ButtonClicked`), attributed by `ctx.source_mailbox()`,
-//!   is the seam a real editor translates into world-knob driver mail; the
-//!   reference logs it.
+//!   `RadioSelected` / `VirtualListSelected` / `ButtonClicked`), attributed
+//!   by `ctx.source_mailbox()`, is the seam a real editor translates into
+//!   world-knob driver mail; the reference logs it.
 
 use alloc::string::String;
 use alloc::vec;
@@ -59,14 +59,16 @@ use crate::widget::focus::{
     AvailabilityEffects, Focus, FocusDirection, FocusEligibility, FocusRect, FocusTransition, HoverTransition,
 };
 use crate::widget::set::{
-    ButtonWidget, ImageWidget, LabelWidget, RadioGroupWidget, SliderWidget, TextAreaWidget, TextFieldWidget, quad,
+    ButtonWidget, ImageWidget, LabelWidget, RadioGroupWidget, SliderWidget, TextAreaWidget, TextFieldWidget,
+    VirtualListWidget, quad,
 };
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{
     ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig, LabelConfig,
     PanelConfig, RadioConfig, RadioSelected, ScrollConfig, ScrollExtent, ScrollOutcome, ScrollResidual, ScrollWidget,
-    SliderChanged, SliderConfig, TextAreaConfig, TextCommitted, TextFieldConfig, Widget, WidgetChildSpec,
-    WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged,
+    SliderChanged, SliderConfig, TextAreaConfig, TextCommitted, TextFieldConfig, VirtualListConfig,
+    VirtualListSelected, Widget, WidgetChildSpec, WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame,
+    WidgetKind, WidgetStateChanged,
 };
 use crate::widget::{FrameDischarge, decode_nested_widget_config};
 use crate::widget::{accept_child_list, emit, flush_membership};
@@ -110,6 +112,14 @@ pub struct SpawnedChild {
     pub state: WidgetControlState,
     pub type_namespace: &'static str,
     pub scroll_viewport: Option<ScrollExtent>,
+}
+
+#[cfg(feature = "behavior")]
+struct ChildProfile {
+    height: f32,
+    pointer_eligible: bool,
+    focusable: bool,
+    state: WidgetControlState,
 }
 
 /// The reference panel root. Loaded as a component with a [`PanelConfig`]; its
@@ -350,10 +360,42 @@ pub fn spawn_widget_child(
                 scroll_viewport: None,
             })
         }),
+        WidgetKind::VirtualList => decode_child::<VirtualListConfig>(spec).and_then(|config| {
+            let Some(height) = virtual_list_height(row, config.visible_row_count) else {
+                tracing::warn!(
+                    target: "aether_kit",
+                    subname = %spec.subname,
+                    row_height = row,
+                    visible_row_count = config.visible_row_count,
+                    "virtual-list viewport height is invalid; slot skipped",
+                );
+                return None;
+            };
+            let eligible = !config.items.is_empty() && config.visible_row_count > 0;
+            let state = config.state.clone();
+            spawn::<VirtualListWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
+                id,
+                width_pixels: None,
+                height_pixels: height,
+                pointer_eligible: eligible,
+                focusable: eligible,
+                state,
+                type_namespace: <VirtualListWidget as Addressable>::NAMESPACE,
+                scroll_viewport: None,
+            })
+        }),
         WidgetKind::BehaviorHost => spawn_behavior_host(ctx, spec, row),
         WidgetKind::Composite => spawn_composite_child(ctx, spec, layout, row),
         WidgetKind::Scroll => spawn_scroll_child(ctx, spec, layout),
     }
+}
+
+fn virtual_list_height(row_height: f32, visible_row_count: u32) -> Option<f32> {
+    if !row_height.is_finite() || row_height <= 0.0 {
+        return None;
+    }
+    let height = row_height * visible_row_count as f32;
+    (height.is_finite() && height >= 0.0).then_some(height)
 }
 
 fn spawn_composite_child(
@@ -567,10 +609,12 @@ fn behavior_mirror_kinds() -> Vec<u64> {
         TextAreaConfig::ID.0,
         ButtonConfig::ID.0,
         RadioConfig::ID.0,
+        VirtualListConfig::ID.0,
         SliderChanged::ID.0,
         TextCommitted::ID.0,
         ButtonClicked::ID.0,
         RadioSelected::ID.0,
+        VirtualListSelected::ID.0,
         FocusGained::ID.0,
         FocusLost::ID.0,
         HoverGained::ID.0,
@@ -609,34 +653,59 @@ fn spawn_behavior_host(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, ro
         );
         return None;
     };
-    let (height, pointer_eligible, focusable, state) = match host_spec.wrapped {
+    let profile = match host_spec.wrapped {
         WidgetKind::Label => {
             let config = decode_named::<LabelConfig>(&spec.subname, &host_spec.wrapped_config)?;
-            (row, false, false, config.state)
+            ChildProfile { height: row, pointer_eligible: false, focusable: false, state: config.state }
         }
         WidgetKind::Image => {
             let config = decode_named::<ImageConfig>(&spec.subname, &host_spec.wrapped_config)?;
-            (row, false, false, config.state)
+            ChildProfile { height: row, pointer_eligible: false, focusable: false, state: config.state }
         }
         WidgetKind::Slider => {
             let config = decode_named::<SliderConfig>(&spec.subname, &host_spec.wrapped_config)?;
-            (row, true, true, config.state)
+            ChildProfile { height: row, pointer_eligible: true, focusable: true, state: config.state }
         }
         WidgetKind::Radio => {
             let config = decode_named::<RadioConfig>(&spec.subname, &host_spec.wrapped_config)?;
-            (row * config.options.len() as f32, true, true, config.state)
+            ChildProfile {
+                height: row * config.options.len() as f32,
+                pointer_eligible: true,
+                focusable: true,
+                state: config.state,
+            }
         }
         WidgetKind::TextField => {
             let config = decode_named::<TextFieldConfig>(&spec.subname, &host_spec.wrapped_config)?;
-            (row, true, true, config.state)
+            ChildProfile { height: row, pointer_eligible: true, focusable: true, state: config.state }
         }
         WidgetKind::TextArea => {
             let config = decode_named::<TextAreaConfig>(&spec.subname, &host_spec.wrapped_config)?;
-            (row * config.rows.max(1) as f32, true, true, config.state)
+            ChildProfile {
+                height: row * config.rows.max(1) as f32,
+                pointer_eligible: true,
+                focusable: true,
+                state: config.state,
+            }
         }
         WidgetKind::Button => {
             let config = decode_named::<ButtonConfig>(&spec.subname, &host_spec.wrapped_config)?;
-            (row, true, true, config.state)
+            ChildProfile { height: row, pointer_eligible: true, focusable: true, state: config.state }
+        }
+        WidgetKind::VirtualList => {
+            let config = decode_named::<VirtualListConfig>(&spec.subname, &host_spec.wrapped_config)?;
+            let Some(height) = virtual_list_height(row, config.visible_row_count) else {
+                tracing::warn!(
+                    target: "aether_kit",
+                    subname = %spec.subname,
+                    row_height = row,
+                    visible_row_count = config.visible_row_count,
+                    "wrapped virtual-list viewport height is invalid; slot skipped",
+                );
+                return None;
+            };
+            let eligible = !config.items.is_empty() && config.visible_row_count > 0;
+            ChildProfile { height, pointer_eligible: eligible, focusable: eligible, state: config.state }
         }
         WidgetKind::Composite | WidgetKind::Scroll | WidgetKind::BehaviorHost => return None,
     };
@@ -678,10 +747,10 @@ fn spawn_behavior_host(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, ro
         Ok(id) => Some(SpawnedChild {
             id,
             width_pixels: None,
-            height_pixels: height,
-            pointer_eligible,
-            focusable,
-            state,
+            height_pixels: profile.height,
+            pointer_eligible: profile.pointer_eligible,
+            focusable: profile.focusable,
+            state: profile.state,
             type_namespace: <aether_behavior::BehaviorHost as Addressable>::NAMESPACE,
             scroll_viewport: None,
         }),
@@ -993,6 +1062,20 @@ impl WasmActor for WidgetPanel {
         );
     }
 
+    /// A virtual-list selection. The map-editor seam; the reference logs it.
+    ///
+    /// # Agent
+    /// A child's reply; not useful to send manually.
+    #[handler::manual]
+    fn on_virtual_list_selected(&mut self, ctx: &mut WasmCtx<'_, Manual>, selected: VirtualListSelected) {
+        tracing::info!(
+            target: "aether_kit",
+            widget = self.child_name(ctx.source_mailbox()),
+            selected_index = selected.selected_index,
+            "widget virtual list selected",
+        );
+    }
+
     /// A button click. The map-editor seam; the reference logs it.
     ///
     /// # Agent
@@ -1100,6 +1183,7 @@ mod behavior_tests {
         assert_eq!(WidgetKind::Radio.type_tag(), Some(ActorTypeTag::of::<RadioGroupWidget>().0));
         assert_eq!(WidgetKind::TextField.type_tag(), Some(ActorTypeTag::of::<TextFieldWidget>().0));
         assert_eq!(WidgetKind::TextArea.type_tag(), Some(ActorTypeTag::of::<TextAreaWidget>().0));
+        assert_eq!(WidgetKind::VirtualList.type_tag(), Some(ActorTypeTag::of::<VirtualListWidget>().0));
         assert_eq!(WidgetKind::Composite.type_tag(), None);
         assert_eq!(WidgetKind::Scroll.type_tag(), None);
         assert_eq!(WidgetKind::BehaviorHost.type_tag(), None);

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -360,34 +360,37 @@ pub fn spawn_widget_child(
                 scroll_viewport: None,
             })
         }),
-        WidgetKind::VirtualList => decode_child::<VirtualListConfig>(spec).and_then(|config| {
-            let Some(height) = virtual_list_height(row, config.visible_row_count) else {
-                tracing::warn!(
-                    target: "aether_kit",
-                    subname = %spec.subname,
-                    row_height = row,
-                    visible_row_count = config.visible_row_count,
-                    "virtual-list viewport height is invalid; slot skipped",
-                );
-                return None;
-            };
-            let eligible = !config.items.is_empty() && config.visible_row_count > 0;
-            let state = config.state.clone();
-            spawn::<VirtualListWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
-                id,
-                width_pixels: None,
-                height_pixels: height,
-                pointer_eligible: eligible,
-                focusable: eligible,
-                state,
-                type_namespace: <VirtualListWidget as Addressable>::NAMESPACE,
-                scroll_viewport: None,
-            })
-        }),
+        WidgetKind::VirtualList => spawn_virtual_list_child(ctx, spec, row),
         WidgetKind::BehaviorHost => spawn_behavior_host(ctx, spec, row),
         WidgetKind::Composite => spawn_composite_child(ctx, spec, layout, row),
         WidgetKind::Scroll => spawn_scroll_child(ctx, spec, layout),
     }
+}
+
+fn spawn_virtual_list_child(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, row: f32) -> Option<SpawnedChild> {
+    let config = decode_child::<VirtualListConfig>(spec)?;
+    let Some(height) = virtual_list_height(row, config.visible_row_count) else {
+        tracing::warn!(
+            target: "aether_kit",
+            subname = %spec.subname,
+            row_height = row,
+            visible_row_count = config.visible_row_count,
+            "virtual-list viewport height is invalid; slot skipped",
+        );
+        return None;
+    };
+    let eligible = !config.items.is_empty() && config.visible_row_count > 0;
+    let state = config.state.clone();
+    spawn::<VirtualListWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
+        id,
+        width_pixels: None,
+        height_pixels: height,
+        pointer_eligible: eligible,
+        focusable: eligible,
+        state,
+        type_namespace: <VirtualListWidget as Addressable>::NAMESPACE,
+        scroll_viewport: None,
+    })
 }
 
 fn virtual_list_height(row_height: f32, visible_row_count: u32) -> Option<f32> {
@@ -1159,6 +1162,16 @@ mod dispatch_tests {
     fn feature_off_keeps_behavior_host_and_scroll_unwrappable() {
         assert_eq!(WidgetKind::BehaviorHost.type_tag(), None);
         assert_eq!(WidgetKind::Scroll.type_tag(), None);
+    }
+
+    #[test]
+    fn virtual_list_height_is_finite_and_preserves_zero_viewports() {
+        assert_eq!(virtual_list_height(24.0, 5), Some(120.0));
+        assert_eq!(virtual_list_height(24.0, 0), Some(0.0));
+        assert_eq!(virtual_list_height(0.0, 5), None);
+        assert_eq!(virtual_list_height(-1.0, 5), None);
+        assert_eq!(virtual_list_height(f32::NAN, 5), None);
+        assert_eq!(virtual_list_height(f32::MAX, 2), None);
     }
 }
 

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -11,6 +11,7 @@
 //! - [`ButtonWidget`] — a momentary push button.
 //! - [`LabelWidget`] — static, non-interactive text.
 //! - [`ImageWidget`] — a static, non-interactive borrowed texture.
+//! - [`VirtualListWidget`] — a fixed-row virtualized item list.
 //!
 //! Each caches its assigned [`WidgetFrame`](crate::widget::WidgetFrame) rect
 //! and its [`Theme`], answers every
@@ -32,6 +33,7 @@ pub mod radio;
 pub mod slider;
 pub mod text_area;
 pub mod text_field;
+pub mod virtual_list;
 
 pub use button::ButtonWidget;
 pub use image::ImageWidget;
@@ -40,6 +42,7 @@ pub use radio::RadioGroupWidget;
 pub use slider::SliderWidget;
 pub use text_area::TextAreaWidget;
 pub use text_field::TextFieldWidget;
+pub use virtual_list::VirtualListWidget;
 
 use alloc::vec::Vec;
 

--- a/crates/aether-kit/src/widget/set/virtual_list.rs
+++ b/crates/aether-kit/src/widget/set/virtual_list.rs
@@ -21,8 +21,8 @@ use crate::widget::set::{push_control_outlines, quad, reply_if_hidden, text_orig
 use crate::widget::state::{InteractionState, emit_state_changed};
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{
-    Collect, FocusGained, FocusLost, HoverGained, HoverLost, SetWidgetState, VirtualListConfig,
-    VirtualListSelected, WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+    Collect, FocusGained, FocusLost, HoverGained, HoverLost, SetWidgetState, VirtualListConfig, VirtualListSelected,
+    WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -68,13 +68,8 @@ impl VirtualListWidget {
             self.first_index = 0;
             return;
         };
-        self.first_index = reveal_window(
-            selected_index,
-            self.first_index,
-            self.visible_row_count,
-            self.items.len(),
-        )
-        .first_index;
+        self.first_index =
+            reveal_window(selected_index, self.first_index, self.visible_row_count, self.items.len()).first_index;
     }
 
     fn select(&mut self, selected_index: usize) -> Option<u32> {
@@ -86,14 +81,19 @@ impl VirtualListWidget {
         u32::try_from(selected_index).ok()
     }
 
+    fn select_if_mutable(&mut self, selected_index: usize) -> Option<u32> {
+        self.state.can_mutate().then_some(())?;
+        self.select(selected_index)
+    }
+
     fn move_selection(&mut self, movement: SelectionMove) -> Option<u32> {
-        let next = moved_selection(
-            self.selected_index,
-            movement,
-            self.visible_row_count,
-            self.items.len(),
-        )?;
+        let next = moved_selection(self.selected_index, movement, self.visible_row_count, self.items.len())?;
         self.select(next)
+    }
+
+    fn move_selection_if_mutable(&mut self, movement: SelectionMove) -> Option<u32> {
+        self.state.can_mutate().then_some(())?;
+        self.move_selection(movement)
     }
 
     fn emit(ctx: &WasmCtx<'_>, selected_index: u32) {
@@ -139,6 +139,9 @@ impl VirtualListWidget {
     }
 
     fn draw_items(&self) -> Vec<WidgetDrawItem> {
+        if !self.state.is_visible() {
+            return Vec::new();
+        }
         let window = self.window();
         let visible_row_count = window.len();
         if visible_row_count == 0 || !valid_frame(&self.frame) {
@@ -152,55 +155,27 @@ impl VirtualListWidget {
         }
 
         let mut items = Vec::with_capacity(visible_row_count.saturating_mul(2).saturating_add(8));
-        for (row_offset, item) in self.items[window.first_index..window.end_exclusive_index]
-            .iter()
-            .enumerate()
-        {
+        for (row_offset, item) in self.items[window.first_index..window.end_exclusive_index].iter().enumerate() {
             #[allow(clippy::cast_precision_loss)]
             let row_y = row_offset as f32 * row_height;
             let item_index = window.first_index + row_offset;
             let selected = self.selected_index == Some(item_index);
-            let base = if selected {
-                self.theme.accent
-            } else {
-                self.theme.surface_raised
-            };
-            let row_state = if selected {
-                self.state.theme_state(self.pressed)
-            } else {
-                self.state.supporting_theme_state(false)
-            };
-            items.push(quad(
-                0.0,
-                row_y,
-                self.frame.width,
-                row_height,
-                self.theme.fill(base, row_state),
-            ));
-            let text_base = if selected {
-                self.theme.accent_text
-            } else {
-                self.theme.text_primary
-            };
+            let base = if selected { self.theme.accent } else { self.theme.surface_raised };
+            let row_state =
+                if selected { self.state.theme_state(self.pressed) } else { self.state.supporting_theme_state(false) };
+            items.push(quad(0.0, row_y, self.frame.width, row_height, self.theme.fill(base, row_state)));
+            let text_base = if selected { self.theme.accent_text } else { self.theme.text_primary };
             items.push(WidgetDrawItem::Text {
                 x: self.theme.pad,
                 y: text_origin_y(row_y, row_height, self.theme.label_size_pixels),
                 font_id: self.theme.font_id,
                 text: item.clone(),
                 size_pixels: self.theme.label_size_pixels,
-                color: self
-                    .theme
-                    .fill(text_base, self.state.supporting_theme_state(false)),
+                color: self.theme.fill(text_base, self.state.supporting_theme_state(false)),
                 clip: None,
             });
         }
-        push_control_outlines(
-            &mut items,
-            self.frame.width,
-            self.frame.height,
-            &self.state,
-            &self.theme,
-        );
+        push_control_outlines(&mut items, self.frame.width, self.frame.height, &self.state, &self.theme);
         items
     }
 }
@@ -229,12 +204,7 @@ impl WasmActor for VirtualListWidget {
             first_index,
             visible_row_count,
             theme: config.theme,
-            frame: WidgetFrame {
-                x: 0.0,
-                y: 0.0,
-                width: 0.0,
-                height: 0.0,
-            },
+            frame: WidgetFrame { x: 0.0, y: 0.0, width: 0.0, height: 0.0 },
             state: InteractionState::new(config.state),
             pressed: false,
         })
@@ -294,7 +264,7 @@ impl WasmActor for VirtualListWidget {
         }
         self.pressed = true;
         if let Some(selected_index) = self.row_at_local_y(press.y - self.frame.y)
-            && let Some(selected_index) = self.select(selected_index)
+            && let Some(selected_index) = self.select_if_mutable(selected_index)
         {
             Self::emit(ctx, selected_index);
         }
@@ -319,7 +289,7 @@ impl WasmActor for VirtualListWidget {
             KEY_PAGE_DOWN => SelectionMove::PageDown,
             _ => return,
         };
-        if let Some(selected_index) = self.move_selection(movement) {
+        if let Some(selected_index) = self.move_selection_if_mutable(movement) {
             Self::emit(ctx, selected_index);
         }
     }
@@ -330,10 +300,7 @@ impl WasmActor for VirtualListWidget {
             return;
         }
         if let Some(parent) = ctx.parent() {
-            parent.send(&WidgetDrawList {
-                intrinsic: None,
-                items: self.draw_items(),
-            });
+            parent.send(&WidgetDrawList { intrinsic: None, items: self.draw_items() });
         }
     }
 }
@@ -349,20 +316,11 @@ fn initial_selection(initial_selected_index: u32, item_count: usize) -> Option<u
     Some(usize_from_u32(initial_selected_index).min(item_count - 1))
 }
 
-fn clamped_window(
-    first_index: usize,
-    requested_visible_row_count: usize,
-    item_count: usize,
-) -> VisibleRowWindow {
+fn clamped_window(first_index: usize, requested_visible_row_count: usize, item_count: usize) -> VisibleRowWindow {
     let visible_row_count = requested_visible_row_count.min(item_count);
     let max_first_index = item_count.saturating_sub(visible_row_count);
     let first_index = first_index.min(max_first_index);
-    VisibleRowWindow {
-        first_index,
-        end_exclusive_index: first_index
-            .saturating_add(visible_row_count)
-            .min(item_count),
-    }
+    VisibleRowWindow { first_index, end_exclusive_index: first_index.saturating_add(visible_row_count).min(item_count) }
 }
 
 fn reveal_window(
@@ -379,9 +337,7 @@ fn reveal_window(
     if selected_index < window.first_index {
         window = clamped_window(selected_index, visible_row_count, item_count);
     } else if selected_index >= window.end_exclusive_index {
-        let first_index = selected_index
-            .saturating_add(1)
-            .saturating_sub(visible_row_count);
+        let first_index = selected_index.saturating_add(1).saturating_sub(visible_row_count);
         window = clamped_window(first_index, visible_row_count, item_count);
     }
     window
@@ -402,9 +358,7 @@ fn moved_selection(
         SelectionMove::Up => selected_index.saturating_sub(1),
         SelectionMove::Down => selected_index.saturating_add(1).min(last_index),
         SelectionMove::PageUp => selected_index.saturating_sub(visible_row_count),
-        SelectionMove::PageDown => selected_index
-            .saturating_add(visible_row_count)
-            .min(last_index),
+        SelectionMove::PageDown => selected_index.saturating_add(visible_row_count).min(last_index),
     })
 }
 
@@ -420,32 +374,21 @@ fn valid_frame(frame: &WidgetFrame) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::widget::theme::ThemeState;
     use crate::widget::{WidgetDrawItem, WidgetValidation};
     use alloc::format;
     use alloc::vec;
 
-    fn list(
-        item_count: usize,
-        visible_row_count: usize,
-        selected_index: usize,
-    ) -> VirtualListWidget {
-        let items = (0..item_count)
-            .map(|index| format!("row {index}"))
-            .collect();
-        let selected_index =
-            (item_count > 0).then_some(selected_index.min(item_count.saturating_sub(1)));
+    fn list(item_count: usize, visible_row_count: usize, selected_index: usize) -> VirtualListWidget {
+        let items = (0..item_count).map(|index| format!("row {index}")).collect();
+        let selected_index = (item_count > 0).then_some(selected_index.min(item_count.saturating_sub(1)));
         VirtualListWidget {
             items,
             selected_index,
             first_index: 0,
             visible_row_count,
             theme: Theme::DEFAULT,
-            frame: WidgetFrame {
-                x: 10.0,
-                y: 20.0,
-                width: 100.0,
-                height: 120.0,
-            },
+            frame: WidgetFrame { x: 10.0, y: 20.0, width: 100.0, height: 120.0 },
             state: InteractionState::new(WidgetControlState::default()),
             pressed: false,
         }
@@ -453,54 +396,15 @@ mod tests {
 
     #[test]
     fn window_clamps_zero_one_beginning_middle_and_tail() {
-        assert_eq!(
-            clamped_window(0, 5, 0),
-            VisibleRowWindow {
-                first_index: 0,
-                end_exclusive_index: 0
-            }
-        );
-        assert_eq!(
-            clamped_window(8, 0, 10),
-            VisibleRowWindow {
-                first_index: 8,
-                end_exclusive_index: 8
-            }
-        );
-        assert_eq!(
-            clamped_window(8, 1, 10),
-            VisibleRowWindow {
-                first_index: 8,
-                end_exclusive_index: 9
-            }
-        );
-        assert_eq!(
-            clamped_window(0, 5, 100),
-            VisibleRowWindow {
-                first_index: 0,
-                end_exclusive_index: 5
-            }
-        );
-        assert_eq!(
-            clamped_window(40, 5, 100),
-            VisibleRowWindow {
-                first_index: 40,
-                end_exclusive_index: 45
-            }
-        );
-        assert_eq!(
-            clamped_window(99, 5, 100),
-            VisibleRowWindow {
-                first_index: 95,
-                end_exclusive_index: 100
-            }
-        );
+        assert_eq!(clamped_window(0, 5, 0), VisibleRowWindow { first_index: 0, end_exclusive_index: 0 });
+        assert_eq!(clamped_window(8, 0, 10), VisibleRowWindow { first_index: 8, end_exclusive_index: 8 });
+        assert_eq!(clamped_window(8, 1, 10), VisibleRowWindow { first_index: 8, end_exclusive_index: 9 });
+        assert_eq!(clamped_window(0, 5, 100), VisibleRowWindow { first_index: 0, end_exclusive_index: 5 });
+        assert_eq!(clamped_window(40, 5, 100), VisibleRowWindow { first_index: 40, end_exclusive_index: 45 });
+        assert_eq!(clamped_window(99, 5, 100), VisibleRowWindow { first_index: 95, end_exclusive_index: 100 });
         assert_eq!(
             clamped_window(usize::MAX, usize::MAX, 100),
-            VisibleRowWindow {
-                first_index: 0,
-                end_exclusive_index: 100
-            }
+            VisibleRowWindow { first_index: 0, end_exclusive_index: 100 }
         );
     }
 
@@ -524,70 +428,25 @@ mod tests {
         assert_eq!(initial_selection(0, 0), None);
         assert_eq!(initial_selection(0, 1), Some(0));
         assert_eq!(initial_selection(99, 5), Some(4));
-        assert_eq!(
-            initial_selection(u32::MAX, usize::MAX),
-            Some(usize_from_u32(u32::MAX))
-        );
+        assert_eq!(initial_selection(u32::MAX, usize::MAX), Some(usize_from_u32(u32::MAX)));
     }
 
     #[test]
     fn reveal_moves_only_enough_to_include_selection() {
-        assert_eq!(
-            reveal_window(4, 0, 5, 100),
-            VisibleRowWindow {
-                first_index: 0,
-                end_exclusive_index: 5
-            }
-        );
-        assert_eq!(
-            reveal_window(5, 0, 5, 100),
-            VisibleRowWindow {
-                first_index: 1,
-                end_exclusive_index: 6
-            }
-        );
-        assert_eq!(
-            reveal_window(2, 10, 5, 100),
-            VisibleRowWindow {
-                first_index: 2,
-                end_exclusive_index: 7
-            }
-        );
-        assert_eq!(
-            reveal_window(99, 90, 5, 100),
-            VisibleRowWindow {
-                first_index: 95,
-                end_exclusive_index: 100
-            }
-        );
-        assert_eq!(
-            reveal_window(0, 0, 0, 100),
-            VisibleRowWindow {
-                first_index: 0,
-                end_exclusive_index: 0
-            }
-        );
+        assert_eq!(reveal_window(4, 0, 5, 100), VisibleRowWindow { first_index: 0, end_exclusive_index: 5 });
+        assert_eq!(reveal_window(5, 0, 5, 100), VisibleRowWindow { first_index: 1, end_exclusive_index: 6 });
+        assert_eq!(reveal_window(2, 10, 5, 100), VisibleRowWindow { first_index: 2, end_exclusive_index: 7 });
+        assert_eq!(reveal_window(99, 90, 5, 100), VisibleRowWindow { first_index: 95, end_exclusive_index: 100 });
+        assert_eq!(reveal_window(0, 0, 0, 100), VisibleRowWindow { first_index: 0, end_exclusive_index: 0 });
     }
 
     #[test]
     fn arrow_and_page_movement_clamp_and_require_a_nonzero_viewport() {
         assert_eq!(moved_selection(Some(0), SelectionMove::Up, 5, 100), Some(0));
-        assert_eq!(
-            moved_selection(Some(0), SelectionMove::Down, 5, 100),
-            Some(1)
-        );
-        assert_eq!(
-            moved_selection(Some(5), SelectionMove::PageUp, 5, 100),
-            Some(0)
-        );
-        assert_eq!(
-            moved_selection(Some(5), SelectionMove::PageDown, 5, 100),
-            Some(10)
-        );
-        assert_eq!(
-            moved_selection(Some(99), SelectionMove::PageDown, 5, 100),
-            Some(99)
-        );
+        assert_eq!(moved_selection(Some(0), SelectionMove::Down, 5, 100), Some(1));
+        assert_eq!(moved_selection(Some(5), SelectionMove::PageUp, 5, 100), Some(0));
+        assert_eq!(moved_selection(Some(5), SelectionMove::PageDown, 5, 100), Some(10));
+        assert_eq!(moved_selection(Some(99), SelectionMove::PageDown, 5, 100), Some(99));
         assert_eq!(moved_selection(Some(0), SelectionMove::Down, 0, 100), None);
         assert_eq!(moved_selection(None, SelectionMove::Down, 5, 0), None);
     }
@@ -619,7 +478,7 @@ mod tests {
             .iter()
             .filter_map(|item| match item {
                 WidgetDrawItem::Text { text, .. } => Some(text.as_str()),
-                WidgetDrawItem::Quad { .. } => None,
+                WidgetDrawItem::Quad { .. } | WidgetDrawItem::TexturedQuad { .. } => None,
             })
             .collect();
         assert_eq!(text, vec!["row 2", "row 3", "row 4", "row 5", "row 6"]);
@@ -631,45 +490,42 @@ mod tests {
         let mut widget = list(200, 5, 0);
         assert_eq!(widget.select(0), None);
         assert_eq!(widget.move_selection(SelectionMove::PageDown), Some(5));
-        assert_eq!(
-            widget.window(),
-            VisibleRowWindow {
-                first_index: 1,
-                end_exclusive_index: 6
-            }
-        );
+        assert_eq!(widget.window(), VisibleRowWindow { first_index: 1, end_exclusive_index: 6 });
         assert_eq!(widget.move_selection(SelectionMove::Down), Some(6));
-        assert_eq!(
-            widget.window(),
-            VisibleRowWindow {
-                first_index: 2,
-                end_exclusive_index: 7
-            }
-        );
+        assert_eq!(widget.window(), VisibleRowWindow { first_index: 2, end_exclusive_index: 7 });
         assert_eq!(widget.select(200), None);
     }
 
     #[test]
     fn disabled_and_read_only_state_block_selection_mutation() {
-        for mut control in [WidgetControlState::default(), WidgetControlState::default()] {
-            if control == WidgetControlState::default() {
-                control.enabled = false;
-            }
+        let disabled = WidgetControlState { enabled: false, ..WidgetControlState::default() };
+        let read_only = WidgetControlState { read_only: true, ..WidgetControlState::default() };
+        for control in [disabled, read_only] {
             let mut widget = list(20, 5, 0);
             widget.replace_control_state(control);
             assert!(!widget.state.can_mutate());
+            assert_eq!(widget.move_selection_if_mutable(SelectionMove::PageDown), None);
+            assert_eq!(widget.select_if_mutable(4), None);
             assert_eq!(widget.selected_index, Some(0));
         }
 
         let mut widget = list(20, 5, 0);
-        let mut read_only = WidgetControlState::default();
-        read_only.read_only = true;
+        let read_only = WidgetControlState { read_only: true, ..WidgetControlState::default() };
         assert!(widget.replace_control_state(read_only.clone()));
-        assert!(
-            !widget.replace_control_state(read_only),
-            "same state emits no second change"
-        );
+        assert!(!widget.replace_control_state(read_only), "same state emits no second change");
         assert!(!widget.state.can_mutate());
+        widget.state.gain_focus();
+        assert!(widget.state.focused(), "read-only remains keyboard-focusable");
+    }
+
+    #[test]
+    fn hidden_draw_is_empty_while_retaining_the_bounded_window() {
+        let mut widget = list(200, 5, 6);
+        widget.first_index = 2;
+        let hidden = WidgetControlState { visible: false, ..WidgetControlState::default() };
+        widget.replace_control_state(hidden);
+        assert!(widget.draw_items().is_empty());
+        assert_eq!(widget.window(), VisibleRowWindow { first_index: 2, end_exclusive_index: 7 });
     }
 
     #[test]
@@ -677,46 +533,32 @@ mod tests {
         let mut widget = list(20, 5, 0);
         widget.state.set_hovered(true);
         widget.state.gain_focus();
-        assert_eq!(
-            widget.state.theme_state(false),
-            crate::widget::theme::ThemeState::Hover
-        );
+        assert_eq!(widget.state.theme_state(false), ThemeState::Hover);
         assert!(widget.state.focused());
         widget.state.lose_focus();
-        assert_eq!(
-            widget.state.theme_state(false),
-            crate::widget::theme::ThemeState::Hover
-        );
-        let mut disabled = WidgetControlState::default();
-        disabled.enabled = false;
+        assert_eq!(widget.state.theme_state(false), ThemeState::Hover);
+        let disabled = WidgetControlState { enabled: false, ..WidgetControlState::default() };
         assert!(widget.replace_control_state(disabled));
         assert!(!widget.state.focused());
-        assert_eq!(
-            widget.state.theme_state(false),
-            crate::widget::theme::ThemeState::Disabled
-        );
+        assert_eq!(widget.state.theme_state(false), ThemeState::Disabled);
     }
 
     #[test]
     fn validation_outline_precedes_the_inset_focus_outline() {
         let mut widget = list(20, 5, 0);
-        let mut control = WidgetControlState::default();
-        control.validation = WidgetValidation::Warning {
-            message: String::from("warning"),
+        let control = WidgetControlState {
+            validation: WidgetValidation::Warning { message: String::from("warning") },
+            ..WidgetControlState::default()
         };
         widget.replace_control_state(control);
         widget.state.gain_focus();
         let items = widget.draw_items();
         assert_eq!(items.len(), 18, "ten row items plus two four-quad outlines");
         for item in &items[10..14] {
-            assert!(
-                matches!(item, WidgetDrawItem::Quad { color, .. } if *color == widget.theme.warning)
-            );
+            assert!(matches!(item, WidgetDrawItem::Quad { color, .. } if *color == widget.theme.warning));
         }
         for item in &items[14..18] {
-            assert!(
-                matches!(item, WidgetDrawItem::Quad { color, .. } if *color == widget.theme.accent)
-            );
+            assert!(matches!(item, WidgetDrawItem::Quad { color, .. } if *color == widget.theme.accent));
         }
     }
 }

--- a/crates/aether-kit/src/widget/set/virtual_list.rs
+++ b/crates/aether-kit/src/widget/set/virtual_list.rs
@@ -1,0 +1,722 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `widget/mod.rs`).
+#![allow(clippy::needless_pass_by_value)]
+
+//! A fixed-row virtual list (issue 2921).
+//!
+//! The actor owns the complete item vector but realizes only the bounded row
+//! window visible in its assigned frame. Selection is retained independently
+//! from realization and keyboard movement reveals it without drawing the
+//! offscreen rows.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_kinds::keycode::{KEY_DOWN, KEY_PAGE_DOWN, KEY_PAGE_UP, KEY_UP};
+use aether_kinds::mouse_button;
+use aether_kinds::{Key, MouseButton, MouseButtonRelease};
+
+use crate::widget::set::{push_control_outlines, quad, reply_if_hidden, text_origin_y};
+use crate::widget::state::{InteractionState, emit_state_changed};
+use crate::widget::theme::{SetTheme, Theme};
+use crate::widget::{
+    Collect, FocusGained, FocusLost, HoverGained, HoverLost, SetWidgetState, VirtualListConfig,
+    VirtualListSelected, WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct VisibleRowWindow {
+    first_index: usize,
+    end_exclusive_index: usize,
+}
+
+impl VisibleRowWindow {
+    fn len(self) -> usize {
+        self.end_exclusive_index.saturating_sub(self.first_index)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SelectionMove {
+    Up,
+    Down,
+    PageUp,
+    PageDown,
+}
+
+/// A fixed-row virtual list. The item vector is retained, but every collect
+/// allocates draw items for only [`VisibleRowWindow`].
+pub struct VirtualListWidget {
+    items: Vec<String>,
+    selected_index: Option<usize>,
+    first_index: usize,
+    visible_row_count: usize,
+    theme: Theme,
+    frame: WidgetFrame,
+    state: InteractionState,
+    pressed: bool,
+}
+
+impl VirtualListWidget {
+    fn window(&self) -> VisibleRowWindow {
+        clamped_window(self.first_index, self.visible_row_count, self.items.len())
+    }
+
+    fn reveal_selection(&mut self) {
+        let Some(selected_index) = self.selected_index else {
+            self.first_index = 0;
+            return;
+        };
+        self.first_index = reveal_window(
+            selected_index,
+            self.first_index,
+            self.visible_row_count,
+            self.items.len(),
+        )
+        .first_index;
+    }
+
+    fn select(&mut self, selected_index: usize) -> Option<u32> {
+        if selected_index >= self.items.len() || self.selected_index == Some(selected_index) {
+            return None;
+        }
+        self.selected_index = Some(selected_index);
+        self.reveal_selection();
+        u32::try_from(selected_index).ok()
+    }
+
+    fn move_selection(&mut self, movement: SelectionMove) -> Option<u32> {
+        let next = moved_selection(
+            self.selected_index,
+            movement,
+            self.visible_row_count,
+            self.items.len(),
+        )?;
+        self.select(next)
+    }
+
+    fn emit(ctx: &WasmCtx<'_>, selected_index: u32) {
+        if let Some(parent) = ctx.parent() {
+            parent.send(&VirtualListSelected { selected_index });
+        }
+    }
+
+    fn replace_control_state(&mut self, next: WidgetControlState) -> bool {
+        let changed = self.state.replace(next);
+        if changed && !self.state.can_mutate() {
+            self.pressed = false;
+        }
+        changed
+    }
+
+    fn apply_control_state(&mut self, ctx: &WasmCtx<'_>, next: WidgetControlState) {
+        if self.replace_control_state(next) {
+            emit_state_changed(ctx, &self.state);
+        }
+    }
+
+    fn row_at_local_y(&self, local_y: f32) -> Option<usize> {
+        let window = self.window();
+        let visible_row_count = window.len();
+        if visible_row_count == 0
+            || !local_y.is_finite()
+            || local_y < 0.0
+            || !valid_frame(&self.frame)
+            || local_y >= self.frame.height
+        {
+            return None;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let divisor = visible_row_count as f32;
+        let row_height = self.frame.height / divisor;
+        if !row_height.is_finite() || row_height <= 0.0 {
+            return None;
+        }
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let row_offset = (local_y / row_height).floor() as usize;
+        (row_offset < visible_row_count).then(|| window.first_index + row_offset)
+    }
+
+    fn draw_items(&self) -> Vec<WidgetDrawItem> {
+        let window = self.window();
+        let visible_row_count = window.len();
+        if visible_row_count == 0 || !valid_frame(&self.frame) {
+            return Vec::new();
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let divisor = visible_row_count as f32;
+        let row_height = self.frame.height / divisor;
+        if !row_height.is_finite() || row_height <= 0.0 {
+            return Vec::new();
+        }
+
+        let mut items = Vec::with_capacity(visible_row_count.saturating_mul(2).saturating_add(8));
+        for (row_offset, item) in self.items[window.first_index..window.end_exclusive_index]
+            .iter()
+            .enumerate()
+        {
+            #[allow(clippy::cast_precision_loss)]
+            let row_y = row_offset as f32 * row_height;
+            let item_index = window.first_index + row_offset;
+            let selected = self.selected_index == Some(item_index);
+            let base = if selected {
+                self.theme.accent
+            } else {
+                self.theme.surface_raised
+            };
+            let row_state = if selected {
+                self.state.theme_state(self.pressed)
+            } else {
+                self.state.supporting_theme_state(false)
+            };
+            items.push(quad(
+                0.0,
+                row_y,
+                self.frame.width,
+                row_height,
+                self.theme.fill(base, row_state),
+            ));
+            let text_base = if selected {
+                self.theme.accent_text
+            } else {
+                self.theme.text_primary
+            };
+            items.push(WidgetDrawItem::Text {
+                x: self.theme.pad,
+                y: text_origin_y(row_y, row_height, self.theme.label_size_pixels),
+                font_id: self.theme.font_id,
+                text: item.clone(),
+                size_pixels: self.theme.label_size_pixels,
+                color: self
+                    .theme
+                    .fill(text_base, self.state.supporting_theme_state(false)),
+                clip: None,
+            });
+        }
+        push_control_outlines(
+            &mut items,
+            self.frame.width,
+            self.frame.height,
+            &self.state,
+            &self.theme,
+        );
+        items
+    }
+}
+
+/// A fixed-row virtual list. Spawned inline by a panel root with a
+/// [`VirtualListConfig`]; reports [`VirtualListSelected`] when selection
+/// changes.
+///
+/// # Agent
+/// Not loaded directly — the panel root spawns it as an inline child. Send it
+/// its `VirtualListConfig` again to replace the item vector or viewport.
+#[actor(instanced)]
+impl WasmActor for VirtualListWidget {
+    type Config = VirtualListConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.virtual_list";
+
+    fn init(config: VirtualListConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        let visible_row_count = usize_from_u32(config.visible_row_count);
+        let selected_index = initial_selection(config.initial_selected_index, config.items.len());
+        let first_index = selected_index.map_or(0, |selected_index| {
+            reveal_window(selected_index, 0, visible_row_count, config.items.len()).first_index
+        });
+        Ok(Self {
+            items: config.items,
+            selected_index,
+            first_index,
+            visible_row_count,
+            theme: config.theme,
+            frame: WidgetFrame {
+                x: 0.0,
+                y: 0.0,
+                width: 0.0,
+                height: 0.0,
+            },
+            state: InteractionState::new(config.state),
+            pressed: false,
+        })
+    }
+
+    #[handler::single]
+    fn on_config(&mut self, ctx: &mut WasmCtx<'_>, config: VirtualListConfig) {
+        self.items = config.items;
+        self.visible_row_count = usize_from_u32(config.visible_row_count);
+        self.selected_index = initial_selection(config.initial_selected_index, self.items.len());
+        self.first_index = 0;
+        self.reveal_selection();
+        self.theme = config.theme;
+        self.apply_control_state(ctx, config.state);
+    }
+
+    #[handler::single]
+    fn on_set_widget_state(&mut self, ctx: &mut WasmCtx<'_>, set: SetWidgetState) {
+        self.apply_control_state(ctx, set.state);
+    }
+
+    #[handler::single]
+    fn on_set_theme(&mut self, _ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.theme = set.theme;
+    }
+
+    #[handler::single]
+    fn on_frame(&mut self, _ctx: &mut WasmCtx<'_>, frame: WidgetFrame) {
+        self.frame = frame;
+    }
+
+    #[handler::single]
+    fn on_focus_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: FocusGained) {
+        self.state.gain_focus();
+    }
+
+    #[handler::single]
+    fn on_focus_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: FocusLost) {
+        self.state.lose_focus();
+        self.pressed = false;
+    }
+
+    #[handler::single]
+    fn on_hover_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: HoverGained) {
+        self.state.set_hovered(true);
+    }
+
+    #[handler::single]
+    fn on_hover_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: HoverLost) {
+        self.state.set_hovered(false);
+    }
+
+    #[handler::single]
+    fn on_mouse_button(&mut self, ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        if press.button != mouse_button::LEFT || !self.state.can_mutate() {
+            return;
+        }
+        self.pressed = true;
+        if let Some(selected_index) = self.row_at_local_y(press.y - self.frame.y)
+            && let Some(selected_index) = self.select(selected_index)
+        {
+            Self::emit(ctx, selected_index);
+        }
+    }
+
+    #[handler::single]
+    fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
+        if release.button == mouse_button::LEFT {
+            self.pressed = false;
+        }
+    }
+
+    #[handler::single]
+    fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
+        if !self.state.can_mutate() {
+            return;
+        }
+        let movement = match key.code {
+            KEY_UP => SelectionMove::Up,
+            KEY_DOWN => SelectionMove::Down,
+            KEY_PAGE_UP => SelectionMove::PageUp,
+            KEY_PAGE_DOWN => SelectionMove::PageDown,
+            _ => return,
+        };
+        if let Some(selected_index) = self.move_selection(movement) {
+            Self::emit(ctx, selected_index);
+        }
+    }
+
+    #[handler::single]
+    fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
+        if reply_if_hidden(ctx, &self.state) {
+            return;
+        }
+        if let Some(parent) = ctx.parent() {
+            parent.send(&WidgetDrawList {
+                intrinsic: None,
+                items: self.draw_items(),
+            });
+        }
+    }
+}
+
+fn usize_from_u32(value: u32) -> usize {
+    usize::try_from(value).unwrap_or(usize::MAX)
+}
+
+fn initial_selection(initial_selected_index: u32, item_count: usize) -> Option<usize> {
+    if item_count == 0 {
+        return None;
+    }
+    Some(usize_from_u32(initial_selected_index).min(item_count - 1))
+}
+
+fn clamped_window(
+    first_index: usize,
+    requested_visible_row_count: usize,
+    item_count: usize,
+) -> VisibleRowWindow {
+    let visible_row_count = requested_visible_row_count.min(item_count);
+    let max_first_index = item_count.saturating_sub(visible_row_count);
+    let first_index = first_index.min(max_first_index);
+    VisibleRowWindow {
+        first_index,
+        end_exclusive_index: first_index
+            .saturating_add(visible_row_count)
+            .min(item_count),
+    }
+}
+
+fn reveal_window(
+    selected_index: usize,
+    first_index: usize,
+    requested_visible_row_count: usize,
+    item_count: usize,
+) -> VisibleRowWindow {
+    let mut window = clamped_window(first_index, requested_visible_row_count, item_count);
+    let visible_row_count = window.len();
+    if visible_row_count == 0 || selected_index >= item_count {
+        return window;
+    }
+    if selected_index < window.first_index {
+        window = clamped_window(selected_index, visible_row_count, item_count);
+    } else if selected_index >= window.end_exclusive_index {
+        let first_index = selected_index
+            .saturating_add(1)
+            .saturating_sub(visible_row_count);
+        window = clamped_window(first_index, visible_row_count, item_count);
+    }
+    window
+}
+
+fn moved_selection(
+    selected_index: Option<usize>,
+    movement: SelectionMove,
+    visible_row_count: usize,
+    item_count: usize,
+) -> Option<usize> {
+    let selected_index = selected_index?;
+    if item_count == 0 || visible_row_count == 0 {
+        return None;
+    }
+    let last_index = item_count - 1;
+    Some(match movement {
+        SelectionMove::Up => selected_index.saturating_sub(1),
+        SelectionMove::Down => selected_index.saturating_add(1).min(last_index),
+        SelectionMove::PageUp => selected_index.saturating_sub(visible_row_count),
+        SelectionMove::PageDown => selected_index
+            .saturating_add(visible_row_count)
+            .min(last_index),
+    })
+}
+
+fn valid_frame(frame: &WidgetFrame) -> bool {
+    frame.x.is_finite()
+        && frame.y.is_finite()
+        && frame.width.is_finite()
+        && frame.height.is_finite()
+        && frame.width > 0.0
+        && frame.height > 0.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widget::{WidgetDrawItem, WidgetValidation};
+    use alloc::format;
+    use alloc::vec;
+
+    fn list(
+        item_count: usize,
+        visible_row_count: usize,
+        selected_index: usize,
+    ) -> VirtualListWidget {
+        let items = (0..item_count)
+            .map(|index| format!("row {index}"))
+            .collect();
+        let selected_index =
+            (item_count > 0).then_some(selected_index.min(item_count.saturating_sub(1)));
+        VirtualListWidget {
+            items,
+            selected_index,
+            first_index: 0,
+            visible_row_count,
+            theme: Theme::DEFAULT,
+            frame: WidgetFrame {
+                x: 10.0,
+                y: 20.0,
+                width: 100.0,
+                height: 120.0,
+            },
+            state: InteractionState::new(WidgetControlState::default()),
+            pressed: false,
+        }
+    }
+
+    #[test]
+    fn window_clamps_zero_one_beginning_middle_and_tail() {
+        assert_eq!(
+            clamped_window(0, 5, 0),
+            VisibleRowWindow {
+                first_index: 0,
+                end_exclusive_index: 0
+            }
+        );
+        assert_eq!(
+            clamped_window(8, 0, 10),
+            VisibleRowWindow {
+                first_index: 8,
+                end_exclusive_index: 8
+            }
+        );
+        assert_eq!(
+            clamped_window(8, 1, 10),
+            VisibleRowWindow {
+                first_index: 8,
+                end_exclusive_index: 9
+            }
+        );
+        assert_eq!(
+            clamped_window(0, 5, 100),
+            VisibleRowWindow {
+                first_index: 0,
+                end_exclusive_index: 5
+            }
+        );
+        assert_eq!(
+            clamped_window(40, 5, 100),
+            VisibleRowWindow {
+                first_index: 40,
+                end_exclusive_index: 45
+            }
+        );
+        assert_eq!(
+            clamped_window(99, 5, 100),
+            VisibleRowWindow {
+                first_index: 95,
+                end_exclusive_index: 100
+            }
+        );
+        assert_eq!(
+            clamped_window(usize::MAX, usize::MAX, 100),
+            VisibleRowWindow {
+                first_index: 0,
+                end_exclusive_index: 100
+            }
+        );
+    }
+
+    #[test]
+    fn every_window_is_bounded_and_has_at_most_the_requested_rows() {
+        for item_count in 0..32 {
+            for requested in 0..12 {
+                for first_index in 0..40 {
+                    let window = clamped_window(first_index, requested, item_count);
+                    assert!(window.first_index <= window.end_exclusive_index);
+                    assert!(window.end_exclusive_index <= item_count);
+                    assert!(window.len() <= requested);
+                    assert_eq!(window.len(), requested.min(item_count));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn initial_selection_is_none_for_empty_and_clamped_for_nonempty() {
+        assert_eq!(initial_selection(0, 0), None);
+        assert_eq!(initial_selection(0, 1), Some(0));
+        assert_eq!(initial_selection(99, 5), Some(4));
+        assert_eq!(
+            initial_selection(u32::MAX, usize::MAX),
+            Some(usize_from_u32(u32::MAX))
+        );
+    }
+
+    #[test]
+    fn reveal_moves_only_enough_to_include_selection() {
+        assert_eq!(
+            reveal_window(4, 0, 5, 100),
+            VisibleRowWindow {
+                first_index: 0,
+                end_exclusive_index: 5
+            }
+        );
+        assert_eq!(
+            reveal_window(5, 0, 5, 100),
+            VisibleRowWindow {
+                first_index: 1,
+                end_exclusive_index: 6
+            }
+        );
+        assert_eq!(
+            reveal_window(2, 10, 5, 100),
+            VisibleRowWindow {
+                first_index: 2,
+                end_exclusive_index: 7
+            }
+        );
+        assert_eq!(
+            reveal_window(99, 90, 5, 100),
+            VisibleRowWindow {
+                first_index: 95,
+                end_exclusive_index: 100
+            }
+        );
+        assert_eq!(
+            reveal_window(0, 0, 0, 100),
+            VisibleRowWindow {
+                first_index: 0,
+                end_exclusive_index: 0
+            }
+        );
+    }
+
+    #[test]
+    fn arrow_and_page_movement_clamp_and_require_a_nonzero_viewport() {
+        assert_eq!(moved_selection(Some(0), SelectionMove::Up, 5, 100), Some(0));
+        assert_eq!(
+            moved_selection(Some(0), SelectionMove::Down, 5, 100),
+            Some(1)
+        );
+        assert_eq!(
+            moved_selection(Some(5), SelectionMove::PageUp, 5, 100),
+            Some(0)
+        );
+        assert_eq!(
+            moved_selection(Some(5), SelectionMove::PageDown, 5, 100),
+            Some(10)
+        );
+        assert_eq!(
+            moved_selection(Some(99), SelectionMove::PageDown, 5, 100),
+            Some(99)
+        );
+        assert_eq!(moved_selection(Some(0), SelectionMove::Down, 0, 100), None);
+        assert_eq!(moved_selection(None, SelectionMove::Down, 5, 0), None);
+    }
+
+    #[test]
+    fn row_hit_uses_realized_rows_and_rejects_invalid_or_exclusive_bottom() {
+        let mut widget = list(200, 5, 0);
+        assert_eq!(widget.row_at_local_y(0.0), Some(0));
+        assert_eq!(widget.row_at_local_y(23.999), Some(0));
+        assert_eq!(widget.row_at_local_y(24.0), Some(1));
+        assert_eq!(widget.row_at_local_y(119.999), Some(4));
+        assert_eq!(widget.row_at_local_y(120.0), None);
+        assert_eq!(widget.row_at_local_y(-0.1), None);
+        assert_eq!(widget.row_at_local_y(f32::NAN), None);
+        widget.frame.height = f32::INFINITY;
+        assert_eq!(widget.row_at_local_y(0.0), None);
+
+        let short = list(2, 5, 0);
+        assert_eq!(short.row_at_local_y(59.999), Some(0));
+        assert_eq!(short.row_at_local_y(60.0), Some(1));
+    }
+
+    #[test]
+    fn draw_realizes_exactly_the_current_window_text() {
+        let mut widget = list(200, 5, 6);
+        widget.first_index = 2;
+        let items = widget.draw_items();
+        let text: Vec<&str> = items
+            .iter()
+            .filter_map(|item| match item {
+                WidgetDrawItem::Text { text, .. } => Some(text.as_str()),
+                WidgetDrawItem::Quad { .. } => None,
+            })
+            .collect();
+        assert_eq!(text, vec!["row 2", "row 3", "row 4", "row 5", "row 6"]);
+        assert_eq!(items.len(), 10, "five row quads and five labels only");
+    }
+
+    #[test]
+    fn selection_reports_only_actual_changes_and_reveals_them() {
+        let mut widget = list(200, 5, 0);
+        assert_eq!(widget.select(0), None);
+        assert_eq!(widget.move_selection(SelectionMove::PageDown), Some(5));
+        assert_eq!(
+            widget.window(),
+            VisibleRowWindow {
+                first_index: 1,
+                end_exclusive_index: 6
+            }
+        );
+        assert_eq!(widget.move_selection(SelectionMove::Down), Some(6));
+        assert_eq!(
+            widget.window(),
+            VisibleRowWindow {
+                first_index: 2,
+                end_exclusive_index: 7
+            }
+        );
+        assert_eq!(widget.select(200), None);
+    }
+
+    #[test]
+    fn disabled_and_read_only_state_block_selection_mutation() {
+        for mut control in [WidgetControlState::default(), WidgetControlState::default()] {
+            if control == WidgetControlState::default() {
+                control.enabled = false;
+            }
+            let mut widget = list(20, 5, 0);
+            widget.replace_control_state(control);
+            assert!(!widget.state.can_mutate());
+            assert_eq!(widget.selected_index, Some(0));
+        }
+
+        let mut widget = list(20, 5, 0);
+        let mut read_only = WidgetControlState::default();
+        read_only.read_only = true;
+        assert!(widget.replace_control_state(read_only.clone()));
+        assert!(
+            !widget.replace_control_state(read_only),
+            "same state emits no second change"
+        );
+        assert!(!widget.state.can_mutate());
+    }
+
+    #[test]
+    fn hover_focus_and_control_state_follow_shared_interaction_rules() {
+        let mut widget = list(20, 5, 0);
+        widget.state.set_hovered(true);
+        widget.state.gain_focus();
+        assert_eq!(
+            widget.state.theme_state(false),
+            crate::widget::theme::ThemeState::Hover
+        );
+        assert!(widget.state.focused());
+        widget.state.lose_focus();
+        assert_eq!(
+            widget.state.theme_state(false),
+            crate::widget::theme::ThemeState::Hover
+        );
+        let mut disabled = WidgetControlState::default();
+        disabled.enabled = false;
+        assert!(widget.replace_control_state(disabled));
+        assert!(!widget.state.focused());
+        assert_eq!(
+            widget.state.theme_state(false),
+            crate::widget::theme::ThemeState::Disabled
+        );
+    }
+
+    #[test]
+    fn validation_outline_precedes_the_inset_focus_outline() {
+        let mut widget = list(20, 5, 0);
+        let mut control = WidgetControlState::default();
+        control.validation = WidgetValidation::Warning {
+            message: String::from("warning"),
+        };
+        widget.replace_control_state(control);
+        widget.state.gain_focus();
+        let items = widget.draw_items();
+        assert_eq!(items.len(), 18, "ten row items plus two four-quad outlines");
+        for item in &items[10..14] {
+            assert!(
+                matches!(item, WidgetDrawItem::Quad { color, .. } if *color == widget.theme.warning)
+            );
+        }
+        for item in &items[14..18] {
+            assert!(
+                matches!(item, WidgetDrawItem::Quad { color, .. } if *color == widget.theme.accent)
+            );
+        }
+    }
+}

--- a/crates/aether-kit/src/widget/set/virtual_list.rs
+++ b/crates/aether-kit/src/widget/set/virtual_list.rs
@@ -116,26 +116,26 @@ impl VirtualListWidget {
         }
     }
 
-    fn row_at_local_y(&self, local_y: f32) -> Option<usize> {
-        let window = self.window();
+    fn window_row_height(&self, window: VisibleRowWindow) -> Option<f32> {
         let visible_row_count = window.len();
-        if visible_row_count == 0
-            || !local_y.is_finite()
-            || local_y < 0.0
-            || !valid_frame(&self.frame)
-            || local_y >= self.frame.height
-        {
+        if visible_row_count == 0 || !valid_frame(&self.frame) {
             return None;
         }
         #[allow(clippy::cast_precision_loss)]
         let divisor = visible_row_count as f32;
         let row_height = self.frame.height / divisor;
-        if !row_height.is_finite() || row_height <= 0.0 {
+        (row_height.is_finite() && row_height > 0.0).then_some(row_height)
+    }
+
+    fn row_at_local_y(&self, local_y: f32) -> Option<usize> {
+        let window = self.window();
+        if !local_y.is_finite() || local_y < 0.0 || local_y >= self.frame.height {
             return None;
         }
+        let row_height = self.window_row_height(window)?;
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let row_offset = (local_y / row_height).floor() as usize;
-        (row_offset < visible_row_count).then(|| window.first_index + row_offset)
+        (row_offset < window.len()).then(|| window.first_index + row_offset)
     }
 
     fn draw_items(&self) -> Vec<WidgetDrawItem> {
@@ -144,15 +144,9 @@ impl VirtualListWidget {
         }
         let window = self.window();
         let visible_row_count = window.len();
-        if visible_row_count == 0 || !valid_frame(&self.frame) {
+        let Some(row_height) = self.window_row_height(window) else {
             return Vec::new();
-        }
-        #[allow(clippy::cast_precision_loss)]
-        let divisor = visible_row_count as f32;
-        let row_height = self.frame.height / divisor;
-        if !row_height.is_finite() || row_height <= 0.0 {
-            return Vec::new();
-        }
+        };
 
         let mut items = Vec::with_capacity(visible_row_count.saturating_mul(2).saturating_add(8));
         for (row_offset, item) in self.items[window.first_index..window.end_exclusive_index].iter().enumerate() {

--- a/crates/aether-kit/src/widget/set/virtual_list.rs
+++ b/crates/aether-kit/src/widget/set/virtual_list.rs
@@ -82,7 +82,9 @@ impl VirtualListWidget {
     }
 
     fn select_if_mutable(&mut self, selected_index: usize) -> Option<u32> {
-        self.state.can_mutate().then_some(())?;
+        if !self.state.can_mutate() {
+            return None;
+        }
         self.select(selected_index)
     }
 
@@ -92,7 +94,9 @@ impl VirtualListWidget {
     }
 
     fn move_selection_if_mutable(&mut self, movement: SelectionMove) -> Option<u32> {
-        self.state.can_mutate().then_some(())?;
+        if !self.state.can_mutate() {
+            return None;
+        }
         self.move_selection(movement)
     }
 

--- a/crates/aether-kit/src/widget/set/virtual_list.rs
+++ b/crates/aether-kit/src/widget/set/virtual_list.rs
@@ -46,7 +46,7 @@ enum SelectionMove {
 }
 
 /// A fixed-row virtual list. The item vector is retained, but every collect
-/// allocates draw items for only [`VisibleRowWindow`].
+/// allocates draw items for only the current `VisibleRowWindow`.
 pub struct VirtualListWidget {
     items: Vec<String>,
     selected_index: Option<usize>,

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -392,7 +392,7 @@ fn virtual_list_clip() -> ClipRect {
 fn assert_virtual_list_rows(
     snapshot: &[DrawTexturedQuads],
     selected_row_offset: usize,
-    selected_tint: aether_math::Rgba,
+    selected_tint: Rgba,
     outline_quad_count: usize,
 ) {
     let clip = virtual_list_clip();

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -54,8 +54,8 @@ use aether_kinds::{
 };
 use aether_kit::{
     ButtonConfig, LabelConfig, PanelConfig, ScrollConfig, ScrollExtent, ScrollOffset, SetTheme, SetWidgetState,
-    SliderConfig, TextAreaConfig, Theme, ThemeState, WidgetChildSpec, WidgetConfig, WidgetControlState, WidgetDrawItem,
-    VirtualListConfig, WidgetKind, WidgetValidation,
+    SliderConfig, TextAreaConfig, Theme, ThemeState, VirtualListConfig, WidgetChildSpec, WidgetConfig,
+    WidgetControlState, WidgetDrawItem, WidgetKind, WidgetValidation,
 };
 use aether_math::Rgba;
 use aether_substrate_bundle::test_bench::{

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -45,7 +45,7 @@ use aether_capabilities::fs::NamespaceRoots;
 use aether_capabilities::render::{DrawTexturedQuads, WHITE_TEXTURE_ID};
 use aether_capabilities::text::{FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontResult};
 use aether_data::{Kind, mailbox_id_from_path};
-use aether_kinds::keycode::{KEY_BACKSPACE, KEY_DOWN, KEY_ENTER, KEY_RIGHT, KEY_TAB, KEY_UP};
+use aether_kinds::keycode::{KEY_BACKSPACE, KEY_DOWN, KEY_ENTER, KEY_PAGE_DOWN, KEY_RIGHT, KEY_TAB, KEY_UP};
 use aether_kinds::mouse_button::LEFT;
 use aether_kinds::{
     CachedFontMetrics, CaptureFrame, CaptureFrameResult, ClipRect, FrameCheck, FrameCheckResult, FrameRect,
@@ -55,7 +55,7 @@ use aether_kinds::{
 use aether_kit::{
     ButtonConfig, LabelConfig, PanelConfig, ScrollConfig, ScrollExtent, ScrollOffset, SetTheme, SetWidgetState,
     SliderConfig, TextAreaConfig, Theme, ThemeState, WidgetChildSpec, WidgetConfig, WidgetControlState, WidgetDrawItem,
-    WidgetKind, WidgetValidation,
+    VirtualListConfig, WidgetKind, WidgetValidation,
 };
 use aether_math::Rgba;
 use aether_substrate_bundle::test_bench::{
@@ -342,6 +342,23 @@ fn scroll_child(
     }
 }
 
+fn virtual_list_child(subname: &str, state: WidgetControlState) -> WidgetChildSpec {
+    WidgetChildSpec {
+        subname: subname.to_owned(),
+        kind: WidgetKind::VirtualList,
+        origin: [0.0, 0.0],
+        clip: None,
+        config: VirtualListConfig {
+            items: (0..200).map(|index| format!("{index:03}")).collect(),
+            initial_selected_index: 0,
+            visible_row_count: 5,
+            theme: Theme::DEFAULT,
+            state,
+        }
+        .encode_into_bytes(),
+    }
+}
+
 fn control_state_children() -> Vec<WidgetChildSpec> {
     let hidden = WidgetControlState { visible: false, ..WidgetControlState::default() };
     let disabled = WidgetControlState { enabled: false, ..WidgetControlState::default() };
@@ -366,6 +383,61 @@ fn solid_for<'a>(snapshot: &'a [DrawTexturedQuads], clip: &ClipRect) -> &'a Draw
         .iter()
         .find(|batch| batch.texture_id == WHITE_TEXTURE_ID && batch.clip.as_ref() == Some(clip))
         .unwrap_or_else(|| panic!("missing solid batch for {clip:?}; snapshot: {snapshot:?}"))
+}
+
+fn virtual_list_clip() -> ClipRect {
+    ClipRect { x: PANEL_X, y: PANEL_Y, width: PANEL_WIDTH, height: ROW_HEIGHT * 5.0 }
+}
+
+fn assert_virtual_list_rows(
+    snapshot: &[DrawTexturedQuads],
+    selected_row_offset: usize,
+    selected_tint: aether_math::Rgba,
+    outline_quad_count: usize,
+) {
+    let clip = virtual_list_clip();
+    let batch = solid_for(snapshot, &clip);
+    assert_eq!(
+        batch.quads.len(),
+        5 + outline_quad_count,
+        "five realized row quads plus the requested outlines only; snapshot: {snapshot:?}",
+    );
+    for (row_offset, quad) in batch.quads[..5].iter().enumerate() {
+        assert_eq!(quad.x, PANEL_X);
+        assert_eq!(quad.y, PANEL_Y + row_offset as f32 * ROW_HEIGHT);
+        assert_eq!(quad.width, PANEL_WIDTH);
+        assert_eq!(quad.height, ROW_HEIGHT);
+        let expected_tint =
+            if row_offset == selected_row_offset { selected_tint } else { Theme::DEFAULT.surface_raised };
+        assert_eq!(quad.tint, expected_tint, "row offset {row_offset} has the wrong selection/state fill");
+    }
+}
+
+fn assert_five_virtual_list_glyph_rows(snapshot: &[DrawTexturedQuads]) {
+    let clip = virtual_list_clip();
+    let glyph_quads: Vec<_> = snapshot
+        .iter()
+        .filter(|batch| batch.texture_id != WHITE_TEXTURE_ID && batch.clip.as_ref() == Some(&clip))
+        .flat_map(|batch| &batch.quads)
+        .collect();
+    assert_eq!(glyph_quads.len(), 15, "five three-digit labels, and no off-window labels, should be resident");
+    for row_offset in 0..5usize {
+        let row_top = PANEL_Y + row_offset as f32 * ROW_HEIGHT;
+        let row_bottom = row_top + ROW_HEIGHT;
+        assert!(
+            glyph_quads.iter().any(|quad| quad.y >= row_top && quad.y + quad.height <= row_bottom),
+            "realized row offset {row_offset} should carry resident glyph geometry",
+        );
+    }
+    for quad in glyph_quads {
+        assert!(
+            quad.x >= clip.x
+                && quad.y >= clip.y
+                && quad.x + quad.width <= clip.x + clip.width
+                && quad.y + quad.height <= clip.y + clip.height,
+            "virtual-list glyph {quad:?} should remain inside its exact panel-owned clip {clip:?}",
+        );
+    }
 }
 
 fn assert_initial_control_snapshot(snapshot: &[DrawTexturedQuads], slider_y: f32, hover_y: f32) {
@@ -1799,4 +1871,140 @@ fn nested_scroll_routes_residuals_independently_and_clips_pixels_under_capture()
     assert_eq!(final_terminals.len(), 3);
     assert_eq!(log_f32(final_terminals[1], "residual_y_pixels"), Some(-20.0),);
     assert_eq!(log_f32(final_terminals[2], "residual_x_pixels"), Some(10.0),);
+}
+
+/// A real panel carrying 200 items must keep the committed overlay bounded to
+/// five fixed rows while paging, tail clamping, shared state overlays, and
+/// hidden absence all remain observable through the current `TestBench` APIs.
+#[test]
+#[allow(clippy::too_many_lines)] // one cohesive bounded-window/state/render acceptance run
+fn virtual_list_bounds_realization_and_renders_selection_state() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = build_bench();
+    boot_panel_with_children(&mut bench, &wasm, vec![virtual_list_child("inventory", WidgetControlState::default())]);
+
+    bench
+        .execute(vec![("initial", BenchOp::capture_with_mails(vec![tick_to_panel()], Vec::new()))])
+        .expect("initial virtual-list capture");
+    let initial = bench.committed_overlay_snapshot();
+    assert_virtual_list_rows(&initial, 0, Theme::DEFAULT.accent, 0);
+    assert_five_virtual_list_glyph_rows(&initial);
+
+    let panel = panel_address();
+    let list = child_address("inventory");
+    let warning = WidgetControlState {
+        validation: WidgetValidation::Warning { message: "check selection".to_owned() },
+        ..WidgetControlState::default()
+    };
+    bench
+        .execute(vec![
+            ("focus", BenchOp::send_mail(&panel, &Key { code: KEY_TAB })),
+            ("page", BenchOp::send_mail(&panel, &Key { code: KEY_PAGE_DOWN })),
+            (
+                "hover_selected",
+                BenchOp::send_mail(&panel, &MouseMove { x: PANEL_X + 20.0, y: PANEL_Y + ROW_HEIGHT * 4.5 }),
+            ),
+            ("warn", BenchOp::send_mail(&list, &SetWidgetState { state: warning })),
+        ])
+        .expect("page and shared-state session");
+
+    let selected_interior = rect(
+        PANEL_X + BORDER + 1.0,
+        PANEL_Y + ROW_HEIGHT * 4.0 + BORDER + 1.0,
+        PANEL_X + PANEL_WIDTH - BORDER - 1.0,
+        PANEL_Y + ROW_HEIGHT * 5.0 - BORDER - 1.0,
+    );
+    let outside_below =
+        rect(PANEL_X, PANEL_Y + ROW_HEIGHT * 5.0 + 2.0, PANEL_X + PANEL_WIDTH, PANEL_Y + ROW_HEIGHT * 5.0 + 12.0);
+    let paged_verdict = capture(
+        &mut bench,
+        vec![
+            check(FrameReduction::Coverage, selected_interior, SURFACE_RAISED_SRGB, PARTITION_TOLERANCE),
+            check(FrameReduction::Coverage, outside_below, CLEAR_SRGB, PARTITION_TOLERANCE),
+        ],
+    );
+    assert!(
+        coverage(&paged_verdict.results[0]) > 0.95,
+        "the revealed selected bottom row should raster as a full accent interior",
+    );
+    assert!(
+        coverage(&paged_verdict.results[1]) < 0.02,
+        "no virtual-list row may raster below the fixed five-row viewport",
+    );
+
+    let paged = bench.committed_overlay_snapshot();
+    assert_virtual_list_rows(&paged, 4, Theme::DEFAULT.fill(Theme::DEFAULT.accent, ThemeState::Hover), 8);
+    assert_five_virtual_list_glyph_rows(&paged);
+    let paged_solids = solid_for(&paged, &virtual_list_clip());
+    assert!(
+        paged_solids.quads[5..9].iter().all(|quad| quad.tint == Theme::DEFAULT.warning),
+        "the outer validation outline must precede focus",
+    );
+    assert!(
+        paged_solids.quads[9..13].iter().all(|quad| quad.tint == Theme::DEFAULT.accent),
+        "the focus outline must remain visible inset after validation",
+    );
+
+    for _ in 0..45 {
+        bench
+            .execute(vec![("tail_page", BenchOp::send_mail(&panel, &Key { code: KEY_PAGE_DOWN }))])
+            .expect("page toward virtual-list tail");
+    }
+    let selection_events_before_noop = panel_log_messages(&mut bench)
+        .iter()
+        .filter(|message| message.contains("widget virtual list selected"))
+        .count();
+    bench
+        .execute(vec![
+            ("tail_noop_one", BenchOp::send_mail(&panel, &Key { code: KEY_PAGE_DOWN })),
+            ("tail_noop_two", BenchOp::send_mail(&panel, &Key { code: KEY_PAGE_DOWN })),
+            ("tail_capture", BenchOp::capture_with_mails(vec![tick_to_panel()], Vec::new())),
+        ])
+        .expect("tail clamp and capture");
+    let tail_log = panel_log_messages(&mut bench);
+    let selection_events_after_noop =
+        tail_log.iter().filter(|message| message.contains("widget virtual list selected")).count();
+    assert_eq!(
+        selection_events_after_noop, selection_events_before_noop,
+        "clamped PageDown at the last item must emit no event",
+    );
+    assert!(
+        tail_log.iter().any(|message| {
+            message.contains("widget virtual list selected")
+                && message.contains("widget=inventory")
+                && message.contains("selected_index=199")
+        }),
+        "paging must reach and attribute the final item; log was:\n{}",
+        tail_log.join("\n"),
+    );
+    let tail = bench.committed_overlay_snapshot();
+    assert_virtual_list_rows(&tail, 4, Theme::DEFAULT.fill(Theme::DEFAULT.accent, ThemeState::Hover), 8);
+    assert_five_virtual_list_glyph_rows(&tail);
+
+    let hidden = WidgetControlState { visible: false, ..WidgetControlState::default() };
+    bench
+        .execute(vec![("hide", BenchOp::send_mail(&list, &SetWidgetState { state: hidden }))])
+        .expect("hide virtual list");
+    let hidden_verdict = capture(
+        &mut bench,
+        vec![check(
+            FrameReduction::Coverage,
+            rect(PANEL_X, PANEL_Y, PANEL_X + PANEL_WIDTH, PANEL_Y + ROW_HEIGHT * 5.0),
+            SURFACE_SRGB,
+            PARTITION_TOLERANCE,
+        )],
+    );
+    assert!(
+        coverage(&hidden_verdict.results[0]) < 0.02,
+        "hidden collect should leave only the panel's surface backdrop",
+    );
+    let hidden_snapshot = bench.committed_overlay_snapshot();
+    let clip = virtual_list_clip();
+    assert!(
+        hidden_snapshot.iter().all(|batch| batch.clip.as_ref() != Some(&clip)),
+        "hidden virtual list must contribute no row or glyph batch; snapshot: {hidden_snapshot:?}",
+    );
 }

--- a/crates/aether-substrate-bundle/tests/widget_set.rs
+++ b/crates/aether-substrate-bundle/tests/widget_set.rs
@@ -29,15 +29,15 @@ use std::fs;
 
 use aether_actor::Addressable;
 use aether_data::Kind;
-use aether_kinds::keycode::{KEY_DOWN, KEY_ENTER, KEY_SPACE, KEY_TAB, KEY_UP};
+use aether_kinds::keycode::{KEY_DOWN, KEY_ENTER, KEY_PAGE_DOWN, KEY_SPACE, KEY_TAB, KEY_UP};
 use aether_kinds::mouse_button::LEFT;
 use aether_kinds::{
     Key, KeyRelease, LoadComponent, LoadResult, LogTailResult, Modifiers, MouseButton, MouseButtonRelease, MouseMove,
     TextInput, Tick,
 };
 use aether_kit::{
-    ButtonConfig, PanelConfig, RadioConfig, SetWidgetState, SliderConfig, TextFieldConfig, Theme, WidgetChildSpec,
-    WidgetControlState, WidgetKind,
+    ButtonConfig, PanelConfig, RadioConfig, SetWidgetState, SliderConfig, TextFieldConfig, Theme, VirtualListConfig,
+    WidgetChildSpec, WidgetControlState, WidgetKind,
 };
 use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
 
@@ -324,6 +324,30 @@ fn radio_selected_index(message: &str) -> Option<u32> {
     message.split("index=").nth(1)?.split_whitespace().next()?.parse().ok()
 }
 
+fn virtual_list_selected_index(message: &str) -> Option<u32> {
+    if !message.contains("widget virtual list selected") {
+        return None;
+    }
+    message.split("selected_index=").nth(1)?.split_whitespace().next()?.parse().ok()
+}
+
+fn virtual_list_spec(subname: &str, state: WidgetControlState) -> WidgetChildSpec {
+    WidgetChildSpec {
+        subname: subname.to_owned(),
+        kind: WidgetKind::VirtualList,
+        origin: [0.0, 0.0],
+        clip: None,
+        config: VirtualListConfig {
+            items: (0..200).map(|index| format!("Row {index:03}")).collect(),
+            initial_selected_index: 0,
+            visible_row_count: 5,
+            theme: Theme::DEFAULT,
+            state,
+        }
+        .encode_into_bytes(),
+    }
+}
+
 /// A panel handed an explicit `children` list stacks exactly those widgets in
 /// the declared order, and that order drives the focus (Tab) cycle — the
 /// declarative-composition path the built-in reference stack can never
@@ -370,6 +394,62 @@ fn panel_stacks_declared_children_in_order() {
         vec!["first".to_owned(), "second".to_owned()],
         "the declared child order must drive both the vertical stack and the Tab \
          focus cycle; committed slider events arrived as {order:?}; log was:\n{joined}",
+    );
+}
+
+/// A five-row virtual viewport over 200 items must page and reveal through the
+/// real panel routing path while read-only and disabled state block both input
+/// lanes. The top-row click after two keyboard changes also proves hit testing
+/// is relative to the realized window rather than the full item vector.
+#[test]
+fn virtual_list_pages_clicks_and_blocks_read_only_disabled_changes() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = TestBench::start_with_size(240, 150).expect("boot");
+    let read_only = WidgetControlState { read_only: true, ..WidgetControlState::default() };
+    load_panel_with(&mut bench, &wasm, vec![virtual_list_spec("inventory", read_only)]);
+
+    let panel = panel_address();
+    let list = child_address("inventory");
+    let disabled = WidgetControlState { enabled: false, ..WidgetControlState::default() };
+    bench
+        .execute(vec![
+            ("spawn", BenchOp::send_mail(&panel, &Tick)),
+            ("focus_read_only", BenchOp::send_mail(&panel, &Key { code: KEY_TAB })),
+            ("blocked_read_only_page", BenchOp::send_mail(&panel, &Key { code: KEY_PAGE_DOWN })),
+            ("blocked_read_only_press", BenchOp::send_mail(&panel, &press(30.0, 118.0))),
+            ("blocked_read_only_release", BenchOp::send_mail(&panel, &release(30.0, 118.0))),
+            ("make_mutable", BenchOp::send_mail(&list, &SetWidgetState { state: WidgetControlState::default() })),
+            ("page_to_five", BenchOp::send_mail(&panel, &Key { code: KEY_PAGE_DOWN })),
+            ("down_to_six", BenchOp::send_mail(&panel, &Key { code: KEY_DOWN })),
+            ("click_realized_top", BenchOp::send_mail(&panel, &press(30.0, 22.0))),
+            ("release_realized_top", BenchOp::send_mail(&panel, &release(30.0, 22.0))),
+            ("disable", BenchOp::send_mail(&list, &SetWidgetState { state: disabled })),
+            ("blocked_disabled_page", BenchOp::send_mail(&panel, &Key { code: KEY_PAGE_DOWN })),
+            ("blocked_disabled_press", BenchOp::send_mail(&panel, &press(30.0, 94.0))),
+            ("blocked_disabled_release", BenchOp::send_mail(&panel, &release(30.0, 94.0))),
+            ("enable", BenchOp::send_mail(&list, &SetWidgetState { state: WidgetControlState::default() })),
+            ("refocus", BenchOp::send_mail(&panel, &Key { code: KEY_TAB })),
+            ("page_to_seven", BenchOp::send_mail(&panel, &Key { code: KEY_PAGE_DOWN })),
+        ])
+        .expect("virtual-list state and selection session");
+
+    let log = panel_log_messages(&mut bench);
+    let selected_indices: Vec<u32> = log.iter().filter_map(|message| virtual_list_selected_index(message)).collect();
+    assert_eq!(
+        selected_indices,
+        vec![5, 6, 2, 7],
+        "only allowed actual changes should reach the attributed panel log; log was:\n{}",
+        log.join("\n"),
+    );
+    assert!(
+        log.iter()
+            .filter(|message| message.contains("widget virtual list selected"))
+            .all(|message| message.contains("widget=inventory")),
+        "every virtual-list event must retain source attribution; log was:\n{}",
+        log.join("\n"),
     );
 }
 

--- a/docs/guide/systems/widgets.md
+++ b/docs/guide/systems/widgets.md
@@ -1,8 +1,8 @@
 # The widget set & focus model
 
 `aether-kit` ships a set of guest-side widgets — a slider, a text field, a
-multiline text area, a radio group, a button, a label, and an image — as ordinary
-`#[actor(instanced)]` types.
+multiline text area, a radio group, a fixed-row virtual list, a button, a label,
+and an image — as ordinary `#[actor(instanced)]` types.
 A panel root spawns them as inline children (ADR-0114) and drives them entirely
 by mail, so composing an editor panel is a matter of laying out widgets and
 translating their value events, never re-deriving hit rects, focus, or per-row
@@ -26,9 +26,9 @@ recorded at spawn, so a widget's identity is its inline subname and nothing a
 widget sends can misreport it.
 
 - **Config, down.** One `Config` kind per widget — `SliderConfig`,
-  `TextFieldConfig`, `TextAreaConfig`, `RadioConfig`, `ButtonConfig`,
-  `LabelConfig`, `ImageConfig` — each embedding a `theme: Theme`. The config is
-  both the value
+  `TextFieldConfig`, `TextAreaConfig`, `RadioConfig`, `VirtualListConfig`,
+  `ButtonConfig`, `LabelConfig`, `ImageConfig` — each embedding a
+  `theme: Theme`. The config is both the value
   `spawn_inline_child::<W>(subname, &config)` boots the widget with and a
   re-sendable mail: send a widget its config kind again to reconfigure it in
   place (a slider's range, a field's cap, a button's label).
@@ -50,19 +50,38 @@ widget sends can misreport it.
   value; a changed config or state mail emits source-attributed
   `WidgetStateChanged` so panel routing cannot drift. Hidden widgets keep their
   slot and answer `Collect` with an empty `WidgetDrawList`; disabled widgets
-  draw muted but leave input routing; read-only Slider, Radio, TextField, and
-  TextArea remain focusable but reject mutation. Button and Label ignore
-  read-only and validation.
+  draw muted but leave input routing; read-only Slider, Radio, TextField,
+  TextArea, and VirtualList remain focusable but reject mutation. Button and
+  Label ignore read-only and validation.
 - **Interaction, down.** The root sends `FocusGained` / `FocusLost` and
   `HoverGained` / `HoverLost`. Hover comes from explicit edges, not from a child
   inferring absence from raw motion. Pressed and hover select an exclusive fill
   (Disabled → Pressed → Hover → Normal); focus and validation are separate
   outlines, so both remain visible together.
 - **Value, up.** `SliderChanged { value, committed }`, `TextCommitted { text }`,
-  `RadioSelected { index }`, and `ButtonClicked` flow to the parent through
-  `ctx.parent()`. A slider streams `committed: false` values through a drag and
-  a final `committed: true` on release, so a consumer previews the drag and
-  commits the expensive work once.
+  `RadioSelected { index }`, `VirtualListSelected { selected_index }`, and
+  `ButtonClicked` flow to the parent through `ctx.parent()`. A slider streams
+  `committed: false` values through a drag and a final `committed: true` on
+  release, so a consumer previews the drag and commits the expensive work
+  once.
+
+## Fixed-row virtual lists
+
+`VirtualListConfig { items, initial_selected_index, visible_row_count, theme,
+state }` retains the complete string vector while realizing at most
+`visible_row_count` rows. The panel fixes the slot height at
+`theme.row_height * visible_row_count` and clips the slot to that viewport;
+an empty item vector or zero-row viewport is not pointer- or focus-eligible.
+This bounded realization is the intended path for hundreds or thousands of
+uniform-height choices.
+
+Up and Down move selection by one. PageUp and PageDown move by the configured
+nonzero visible-row count. Movement clamps at the item-vector ends and shifts
+the realized window only enough to reveal the selected row. A click divides
+the assigned frame height by the number of rows actually realized, so a short
+list fills its viewport and the frame's bottom edge remains exclusive. Hidden
+lists answer every `Collect` with an empty draw list; disabled and read-only
+lists reject both pointer and keyboard selection changes.
 
 ## Image widget
 


### PR DESCRIPTION
Closes #2921.

## Summary

- add a named fixed-row VirtualList config/event surface whose draw work is bounded by the visible row count rather than total items
- integrate VirtualListWidget with shared interaction state, panel dispatch, BehaviorHost wrapping, exports, and stable WidgetKind wire ordering
- prove paging, selection, hidden/read-only/disabled behavior, bounded committed rendering, and landed ImageWidget compatibility through unit and strict real-wasm TestBench coverage

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] 15 focused virtual-list unit tests
- [x] 2 BehaviorHost mapping tests
- [x] `cargo build --target wasm32-unknown-unknown -p aether-kit`
- [x] strict real-wasm virtual-list state scenario
- [x] strict real-wasm virtual-list render scenario
- [x] strict real-wasm ImageWidget regression
- [x] public/wire semantic-type audit

## Generated by

`/implement` — agent execution of scoped issue #2921.