### PR TITLE
chore(repo): rustfmt config — 120 width, always-vertical if-else

### DIFF
--- a/crates/aether-actor-derive/src/diagnostics.rs
+++ b/crates/aether-actor-derive/src/diagnostics.rs
@@ -52,7 +52,11 @@ pub fn extract_agent_doc(attrs: &[Attribute]) -> Option<String> {
 
     if found_agent {
         let s = agent_lines.join("\n").trim().to_string();
-        if s.is_empty() { None } else { Some(s) }
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
     } else {
         Some(full_trimmed.to_string())
     }

--- a/crates/aether-actor-derive/src/native_expand.rs
+++ b/crates/aether-actor-derive/src/native_expand.rs
@@ -905,7 +905,11 @@ fn harvest_runtime_identity(
     let dir = decl_path.parent().unwrap_or_else(|| Path::new("."));
     let flat = dir.join(format!("{module_name}.rs"));
     let nested = dir.join(module_name).join("mod.rs");
-    let target = if flat.exists() { flat } else { nested };
+    let target = if flat.exists() {
+        flat
+    } else {
+        nested
+    };
 
     let src = fs::read_to_string(&target).map_err(|e| {
         syn::Error::new(

--- a/crates/aether-actor/src/local.rs
+++ b/crates/aether-actor/src/local.rs
@@ -293,7 +293,11 @@ mod tests {
             unsafe {
                 install_slots_provider(|| {
                     let p = TEST_CURRENT.get();
-                    if p.is_null() { None } else { Some(p) }
+                    if p.is_null() {
+                        None
+                    } else {
+                        Some(p)
+                    }
                 });
             }
         });

--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -190,7 +190,11 @@ impl ActorLogRing {
 /// function so the framework dispatch arm reads cleanly and unit
 /// tests can pin the boundaries without materialising a ring.
 fn resolve_max(max: u32) -> u32 {
-    if max == 0 { DEFAULT_TAIL_MAX } else { max.min(MAX_TAIL_MAX) }
+    if max == 0 {
+        DEFAULT_TAIL_MAX
+    } else {
+        max.min(MAX_TAIL_MAX)
+    }
 }
 
 pub(crate) fn level_to_u8(level: Level) -> u8 {

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -183,7 +183,11 @@ impl Mail<'_> {
     /// is answerable via `Ctx::reply`).
     #[must_use]
     pub fn reply_handle(&self) -> Option<ReplyHandle> {
-        if self.sender == NO_REPLY_HANDLE { None } else { Some(ReplyHandle { raw: self.sender }) }
+        if self.sender == NO_REPLY_HANDLE {
+            None
+        } else {
+            Some(ReplyHandle { raw: self.sender })
+        }
     }
 
     /// Mailbox this mail was routed to (ADR-0114 decision #1). The

--- a/crates/aether-actor/src/trace.rs
+++ b/crates/aether-actor/src/trace.rs
@@ -213,7 +213,11 @@ impl ActorTraceRing {
 /// Clamp `max == 0` to [`DEFAULT_TAIL_MAX`] and any value over
 /// [`MAX_TAIL_MAX`] down to the ceiling.
 fn resolve_max(max: u32) -> u32 {
-    if max == 0 { DEFAULT_TAIL_MAX } else { max.min(MAX_TAIL_MAX) }
+    if max == 0 {
+        DEFAULT_TAIL_MAX
+    } else {
+        max.min(MAX_TAIL_MAX)
+    }
 }
 
 #[cfg(test)]

--- a/crates/aether-actor/src/wasm/inline/mod.rs
+++ b/crates/aether-actor/src/wasm/inline/mod.rs
@@ -473,7 +473,11 @@ impl Registry {
         }
         // SAFETY: see [`Self::insert_child`].
         let map = unsafe { &*self.inner.get() };
-        if map.contains_key(&MailboxId(recipient)) { RouteDecision::Local } else { RouteDecision::Remote }
+        if map.contains_key(&MailboxId(recipient)) {
+            RouteDecision::Local
+        } else {
+            RouteDecision::Remote
+        }
     }
 
     /// Route an outbound send. If `recipient` is a cluster member (the
@@ -815,7 +819,9 @@ mod tests {
         registry.insert_child(id, tag, String::from("widget"), false, 0, Vec::new(), Box::new(RecordingChild::new().0));
 
         let metas = registry.child_metas();
-        let [meta] = metas.as_slice() else { panic!("expected exactly one child meta, got {}", metas.len()) };
+        let [meta] = metas.as_slice() else {
+            panic!("expected exactly one child meta, got {}", metas.len())
+        };
         assert_eq!(meta.id, id, "the meta carries the alias id");
         assert_eq!(meta.type_tag, tag, "the meta carries the actor-type tag");
         assert_eq!(meta.full_subname, "widget", "the meta carries the subname");

--- a/crates/aether-behavior/src/host/actor.rs
+++ b/crates/aether-behavior/src/host/actor.rs
@@ -452,7 +452,11 @@ impl BehaviorHost {
     /// Forward the in-flight mail raw (no interpreter call) along its lane —
     /// up to the parent, or down to the wrapped child.
     fn forward_raw(&self, ctx: &WasmCtx<'_>, is_up: bool, kind: KindId, bytes: &[u8]) {
-        let relative = if is_up { ctx.parent() } else { ctx.child(&self.config.child.subname) };
+        let relative = if is_up {
+            ctx.parent()
+        } else {
+            ctx.child(&self.config.child.subname)
+        };
         if let Some(target) = relative {
             target.send_bytes(kind, bytes);
         } else {
@@ -508,7 +512,11 @@ impl DrainSink for LaneSink<'_, '_> {
     fn record(&mut self, event: DrainEvent) {
         let (relative, kind_id, bytes) = match event {
             DrainEvent::Forward { kind_id, bytes } => {
-                let relative = if self.is_up { self.ctx.parent() } else { self.ctx.child(self.wrapped_subname) };
+                let relative = if self.is_up {
+                    self.ctx.parent()
+                } else {
+                    self.ctx.child(self.wrapped_subname)
+                };
                 (relative, kind_id, bytes)
             }
             DrainEvent::Effect { target, kind_id, bytes } => {
@@ -535,12 +543,13 @@ impl DrainSink for LaneSink<'_, '_> {
 fn resolve_child_path<'a>(ctx: &WasmCtx<'a>, path: &str) -> Option<aether_actor::RelativeMailbox<'a>> {
     let mut segments = path.split('/');
     let first = segments.next().filter(|segment| !segment.is_empty())?;
-    segments.try_fold(
-        ctx.child(first)?,
-        |relative, segment| {
-            if segment.is_empty() { None } else { relative.child(segment) }
-        },
-    )
+    segments.try_fold(ctx.child(first)?, |relative, segment| {
+        if segment.is_empty() {
+            None
+        } else {
+            relative.child(segment)
+        }
+    })
 }
 
 #[cfg(test)]

--- a/crates/aether-capabilities/src/audio/runtime/sample.rs
+++ b/crates/aether-capabilities/src/audio/runtime/sample.rs
@@ -222,7 +222,11 @@ impl SampleVoice {
         // The interpolation neighbour is the next frame — but if that
         // frame reaches or crosses `loop_end`, the loop wraps, so read
         // `loop_start` instead (the seam neighbour).
-        let next_index = if (i + 1) as f32 >= lp.end { (lp.start.floor() as usize).min(len - 1) } else { i + 1 };
+        let next_index = if (i + 1) as f32 >= lp.end {
+            (lp.start.floor() as usize).min(len - 1)
+        } else {
+            i + 1
+        };
         let b = self.pcm[next_index];
         let frac = self.pos - i as f32;
         let s = (b - a).mul_add(frac, a) * self.amplitude * ramp;
@@ -364,7 +368,11 @@ pub fn sfz_dir(path: &str) -> &str {
 /// Join a sample path onto the `.sfz`'s directory. An empty directory
 /// leaves the sample as-is.
 pub fn join_fs(dir: &str, rel: &str) -> String {
-    if dir.is_empty() { rel.to_owned() } else { format!("{dir}/{rel}") }
+    if dir.is_empty() {
+        rel.to_owned()
+    } else {
+        format!("{dir}/{rel}")
+    }
 }
 
 /// Derive a bank name from the `.sfz` filename stem (the last path
@@ -373,5 +381,9 @@ pub fn join_fs(dir: &str, rel: &str) -> String {
 pub fn bank_name_from_path(path: &str) -> String {
     let file = path.rsplit('/').next().unwrap_or(path);
     let stem = file.rsplit_once('.').map_or(file, |(stem, _)| stem);
-    if stem.is_empty() { "instrument".to_owned() } else { stem.to_owned() }
+    if stem.is_empty() {
+        "instrument".to_owned()
+    } else {
+        stem.to_owned()
+    }
 }

--- a/crates/aether-capabilities/src/audio/runtime/tests/synth_voice.rs
+++ b/crates/aether-capabilities/src/audio/runtime/tests/synth_voice.rs
@@ -664,7 +664,11 @@ fn voice_steal_evicts_quietest_note() {
 
     for pitch in 0..MAX_VOICES {
         let pitch = u8::try_from(pitch).unwrap();
-        let velocity = if pitch == QUIET_PITCH { 1 } else { 127 };
+        let velocity = if pitch == QUIET_PITCH {
+            1
+        } else {
+            127
+        };
         sender
             .push(AudioEvent::NoteOn { sender_mailbox: MailboxId(1), pitch, velocity, instrument_id: 0, pan: 0 })
             .unwrap();

--- a/crates/aether-capabilities/src/audio/runtime/voice.rs
+++ b/crates/aether-capabilities/src/audio/runtime/voice.rs
@@ -439,7 +439,11 @@ impl PartialBankVoice {
             let i_f = i as f32;
             let n = i_f + 1.0;
             let stretch = (def.inharmonicity * n).mul_add(n, 1.0).sqrt();
-            let detune = if i % 2 == 0 { 1.0 + def.detune } else { 1.0 - def.detune };
+            let detune = if i % 2 == 0 {
+                1.0 + def.detune
+            } else {
+                1.0 - def.detune
+            };
             p.phase_step = (n * f0 * stretch * detune) / sample_rate;
             let rate = def.decay_base * i_f.mul_add(def.decay_spread, 1.0) * pitch_scale;
             p.decay_mul = (-rate * dt).exp();

--- a/crates/aether-capabilities/src/engine/store/manifest.rs
+++ b/crates/aether-capabilities/src/engine/store/manifest.rs
@@ -140,7 +140,11 @@ pub fn component_manifest(wasm: &[u8]) -> Result<ComponentManifest, String> {
     // marker and omits `aether.namespace`, so it has no bare-load entry.
     // Otherwise the entry is the module's `aether.namespace` value (the
     // single-actor namespace or the `export!(entry = …)` opt-in).
-    let default_entry = if kind_manifest::read_no_entry_marker(wasm) { None } else { module_namespace.clone() };
+    let default_entry = if kind_manifest::read_no_entry_marker(wasm) {
+        None
+    } else {
+        module_namespace.clone()
+    };
 
     let mut actors: Vec<ComponentActor> = Vec::with_capacity(groups.len());
     for group in groups {

--- a/crates/aether-capabilities/src/fs/config.rs
+++ b/crates/aether-capabilities/src/fs/config.rs
@@ -108,7 +108,11 @@ impl aether_substrate::FromArgvThenEnv for NamespaceRoots {
 /// `Ok(s) if !s.is_empty()` guard); any non-empty value is a path.
 #[cfg(feature = "runtime")]
 fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
-    if s.is_empty() { Err(EmptyDir) } else { Ok(PathBuf::from(s)) }
+    if s.is_empty() {
+        Err(EmptyDir)
+    } else {
+        Ok(PathBuf::from(s))
+    }
 }
 
 /// Sentinel error: an empty `AETHER_*_DIR` value, treated as unset by

--- a/crates/aether-capabilities/src/gemini/adapter.rs
+++ b/crates/aether-capabilities/src/gemini/adapter.rs
@@ -179,8 +179,16 @@ fn base64_encode(bytes: &[u8]) -> String {
         let n = (b0 << 16) | (b1 << 8) | b2;
         out.push(ALPHABET[((n >> 18) & 0x3F) as usize] as char);
         out.push(ALPHABET[((n >> 12) & 0x3F) as usize] as char);
-        out.push(if chunk.len() > 1 { ALPHABET[((n >> 6) & 0x3F) as usize] as char } else { '=' });
-        out.push(if chunk.len() > 2 { ALPHABET[(n & 0x3F) as usize] as char } else { '=' });
+        out.push(if chunk.len() > 1 {
+            ALPHABET[((n >> 6) & 0x3F) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHABET[(n & 0x3F) as usize] as char
+        } else {
+            '='
+        });
     }
     out
 }

--- a/crates/aether-capabilities/src/gemini/runtime.rs
+++ b/crates/aether-capabilities/src/gemini/runtime.rs
@@ -283,7 +283,11 @@ pub fn nanobanana_reply(
             // caller asked to retain it for a multi-turn continuation
             // (a signature can run to multiple MB and dominate the
             // reply). Parse stays unconditional; the gate is here.
-            let thought_signature = if include_sig { resp.thought_signature } else { None };
+            let thought_signature = if include_sig {
+                resp.thought_signature
+            } else {
+                None
+            };
             let grounding =
                 resp.grounding.map(|(search_queries, source_urls)| GroundingMetadata { search_queries, source_urls });
             let Some(artifact) = resp.artifacts.into_iter().next() else {

--- a/crates/aether-capabilities/src/http/client/runtime.rs
+++ b/crates/aether-capabilities/src/http/client/runtime.rs
@@ -155,7 +155,11 @@ impl UreqHttpAdapter {
     }
 
     fn check_allowlist(&self, host: &str) -> Result<(), HttpError> {
-        if self.allowlist.contains(host) { Ok(()) } else { Err(HttpError::AllowlistDenied) }
+        if self.allowlist.contains(host) {
+            Ok(())
+        } else {
+            Err(HttpError::AllowlistDenied)
+        }
     }
 }
 

--- a/crates/aether-capabilities/src/http/server/runtime/reader.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/reader.rs
@@ -401,14 +401,22 @@ pub fn run_reader_loop(
                 }
                 HeadParse::NeedMore => {}
             }
-            let want_timeout = if buf.is_empty() { idle_timeout } else { request_timeout };
+            let want_timeout = if buf.is_empty() {
+                idle_timeout
+            } else {
+                request_timeout
+            };
             if !ensure_read_timeout(&mut stream, sink, conn_id, &mut current_timeout, want_timeout) {
                 return;
             }
             match read_more(&mut stream, &mut chunk) {
                 ReadStep::Filled(n) => buf.extend_from_slice(&chunk[..n]),
                 ReadStep::Eof => {
-                    let reason = if buf.is_empty() { "eof between requests" } else { "eof before request head" };
+                    let reason = if buf.is_empty() {
+                        "eof between requests"
+                    } else {
+                        "eof before request head"
+                    };
                     sink.post(InboundEvent::ReaderClosed { conn_id, reason: reason.to_string() });
                     return;
                 }
@@ -416,7 +424,11 @@ pub fn run_reader_loop(
                     // An idle-timeout expiry with no partial request buffered
                     // is a silent close of a kept-alive / fresh idle
                     // connection; a timeout mid-head is the slow-loris guard.
-                    let reason = if buf.is_empty() { "idle" } else { "read timeout (head)" };
+                    let reason = if buf.is_empty() {
+                        "idle"
+                    } else {
+                        "read timeout (head)"
+                    };
                     sink.post(InboundEvent::ReaderClosed { conn_id, reason: reason.to_string() });
                     return;
                 }

--- a/crates/aether-capabilities/src/http/server/runtime/render.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/render.rs
@@ -240,8 +240,16 @@ pub fn http_date(now: SystemTime) -> String {
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
     let mp = (5 * doy + 2) / 153;
     let day = doy - (153 * mp + 2) / 5 + 1;
-    let month = if mp < 10 { mp + 3 } else { mp - 9 };
-    let year = if month <= 2 { year + 1 } else { year };
+    let month = if mp < 10 {
+        mp + 3
+    } else {
+        mp - 9
+    };
+    let year = if month <= 2 {
+        year + 1
+    } else {
+        year
+    };
     let weekday_name = WEEKDAYS[usize::try_from(weekday).unwrap_or(0)];
     let month_name = MONTHS[usize::try_from(month - 1).unwrap_or(0)];
     format!("{weekday_name}, {day:02} {month_name} {year:04} {hour:02}:{minute:02}:{second:02} GMT")

--- a/crates/aether-capabilities/src/http/server/runtime/routing.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/routing.rs
@@ -57,7 +57,11 @@ pub fn normalize_prefix(raw: &str) -> Result<String, String> {
         return Err(format!("route prefix {raw:?} must start with '/'"));
     }
     let trimmed = raw.trim_end_matches('/');
-    Ok(if trimmed.is_empty() { "/".to_string() } else { trimmed.to_string() })
+    Ok(if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        trimmed.to_string()
+    })
 }
 
 /// Registrant-mailbox validation for the explicit-`mailbox`
@@ -119,8 +123,16 @@ pub fn register_route(
                 error: format!(
                     "route ({prefix:?}, {method:?}) is {}; a {} registration cannot \
                      join it (ADR-0136: spreading is a joint opt-in)",
-                    if existing.shared { "a shared member set" } else { "exclusively claimed" },
-                    if shared { "shared" } else { "exclusive" },
+                    if existing.shared {
+                        "a shared member set"
+                    } else {
+                        "exclusively claimed"
+                    },
+                    if shared {
+                        "shared"
+                    } else {
+                        "exclusive"
+                    },
                 ),
             };
         }

--- a/crates/aether-capabilities/src/http/server/runtime/websocket.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/websocket.rs
@@ -94,7 +94,11 @@ pub fn sha1(data: &[u8]) -> [u8; 20] {
 pub fn serialize_ws_frame(opcode: u8, payload: &[u8], mask: Option<[u8; 4]>) -> Vec<u8> {
     let mut out = Vec::with_capacity(payload.len() + 14);
     out.push(0x80 | (opcode & 0x0F));
-    let masked_bit: u8 = if mask.is_some() { 0x80 } else { 0x00 };
+    let masked_bit: u8 = if mask.is_some() {
+        0x80
+    } else {
+        0x00
+    };
     let len = payload.len();
     if len < 126 {
         out.push(masked_bit | u8::try_from(len).unwrap_or(0));
@@ -571,7 +575,11 @@ impl HttpShardState {
         let Some((_, stream_id)) = self.ws_target(conn_id) else {
             return;
         };
-        let opcode = if binary { OPCODE_BINARY } else { OPCODE_TEXT };
+        let opcode = if binary {
+            OPCODE_BINARY
+        } else {
+            OPCODE_TEXT
+        };
         let frame = serialize_ws_frame(opcode, data, None);
         let Some(has_credit) = self.streams.get(&stream_id).map(|stream| stream.credit_outstanding > 0) else {
             return;

--- a/crates/aether-capabilities/src/lifecycle/runtime/settlement.rs
+++ b/crates/aether-capabilities/src/lifecycle/runtime/settlement.rs
@@ -95,7 +95,11 @@ impl LifecycleCapabilityState {
         let next_nanos = self.settlement_latency_ewma.map_or(latency.as_nanos(), |prev| {
             let prev = prev.as_nanos();
             let sample = latency.as_nanos();
-            if sample >= prev { prev + (sample - prev) * alpha / 1000 } else { prev - (prev - sample) * alpha / 1000 }
+            if sample >= prev {
+                prev + (sample - prev) * alpha / 1000
+            } else {
+                prev - (prev - sample) * alpha / 1000
+            }
         });
         let ewma = Duration::from_nanos(u64::try_from(next_nanos).unwrap_or(u64::MAX));
         self.settlement_latency_ewma = Some(ewma);

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -439,7 +439,11 @@ fn decode_enum_body(cur: &mut Cursor<'_>, variant: &EnumVariant, path: &str) -> 
 fn render_map_key(key_value: &Value, key_schema: &SchemaType, path: &str) -> Result<String, DecodeError> {
     match (key_schema, key_value) {
         (SchemaType::String, Value::String(s)) => Ok(s.clone()),
-        (SchemaType::Bool, Value::Bool(b)) => Ok(if *b { "true".into() } else { "false".into() }),
+        (SchemaType::Bool, Value::Bool(b)) => Ok(if *b {
+            "true".into()
+        } else {
+            "false".into()
+        }),
         (SchemaType::Scalar(p), Value::Number(n)) => match p {
             Primitive::U8 | Primitive::U16 | Primitive::U32 | Primitive::U64 => Ok(n
                 .as_u64()

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -551,7 +551,9 @@ fn field_type_schema_expr(ty: &Type) -> TokenStream2 {
 /// syntactic — a type alias (`type Blob = Vec<u8>`) is not resolved by the
 /// proc macro and falls through to the generic `Vec` schema.
 fn is_vec_u8(ty: &Type) -> bool {
-    let Type::Path(tp) = ty else { return false };
+    let Type::Path(tp) = ty else {
+        return false;
+    };
     let Some(seg) = tp.path.segments.last() else {
         return false;
     };

--- a/crates/aether-data/src/canonical/schema.rs
+++ b/crates/aether-data/src/canonical/schema.rs
@@ -309,7 +309,11 @@ const fn write_schema(schema: &SchemaType, out: &mut [u8], cursor: usize) -> usi
                 pos = write_schema(&slice[i].ty, out, pos);
                 i += 1;
             }
-            out[pos] = if *repr_c { 1 } else { 0 };
+            out[pos] = if *repr_c {
+                1
+            } else {
+                0
+            };
             pos += 1;
         }
         SchemaType::Enum { variants } => {

--- a/crates/aether-data/src/ids.rs
+++ b/crates/aether-data/src/ids.rs
@@ -82,7 +82,11 @@ fn deserialize_id<'de, D: Deserializer<'de>>(d: D, expected: Tag) -> Result<u64,
         }
     }
 
-    if d.is_human_readable() { d.deserialize_any(IdVisitor { expected }) } else { u64::deserialize(d) }
+    if d.is_human_readable() {
+        d.deserialize_any(IdVisitor { expected })
+    } else {
+        u64::deserialize(d)
+    }
 }
 
 /// Resolve a `SchemaType::TypeId(id)` payload to the `Tag` the

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -188,7 +188,11 @@ impl Kind for () {
     const ID: KindId = KindId(with_tag(Tag::Kind, fnv1a_64_prefixed(KIND_DOMAIN, Self::NAME.as_bytes())));
 
     fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.is_empty() { Some(()) } else { None }
+        if bytes.is_empty() {
+            Some(())
+        } else {
+            None
+        }
     }
 
     fn encode_into_bytes(&self) -> Vec<u8> {

--- a/crates/aether-data/src/wire/mod.rs
+++ b/crates/aether-data/src/wire/mod.rs
@@ -103,7 +103,11 @@ pub fn to_vec<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, Error> {
 pub fn from_bytes<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<T, Error> {
     let mut deserializer = de::Deserializer::new(bytes);
     let value = T::deserialize(&mut deserializer)?;
-    if deserializer.is_empty() { Ok(value) } else { Err(Error::TrailingBytes) }
+    if deserializer.is_empty() {
+        Ok(value)
+    } else {
+        Err(Error::TrailingBytes)
+    }
 }
 
 /// Decode a value from the front of a wire payload, returning the value and the

--- a/crates/aether-derive/src/config.rs
+++ b/crates/aether-derive/src/config.rs
@@ -450,7 +450,11 @@ fn build_from_layer_expr(
             quote! {
                 #domain_ident: {
                     let resolved = layer.#layer_ident;
-                    if resolved == 0 { #default } else { resolved }
+                    if resolved == 0 {
+                        #default
+                    } else {
+                        resolved
+                    }
                 }
             }
         }

--- a/crates/aether-kit/src/console/markdown.rs
+++ b/crates/aether-kit/src/console/markdown.rs
@@ -78,7 +78,11 @@ impl MarkdownBlockState {
                 code_block: true,
                 thematic_break: false,
                 runs: vec![MarkdownRun {
-                    text: if was_open { String::from("```") } else { text.trim().to_string() },
+                    text: if was_open {
+                        String::from("```")
+                    } else {
+                        text.trim().to_string()
+                    },
                     tone: MarkdownTone::MutedMarker,
                 }],
             };
@@ -294,7 +298,11 @@ fn table_separator(text: &str) -> bool {
 }
 
 fn table_runs(text: &str, header: bool) -> Vec<MarkdownRun> {
-    let cell_tone = if header { MarkdownTone::TableHeader } else { MarkdownTone::TableText };
+    let cell_tone = if header {
+        MarkdownTone::TableHeader
+    } else {
+        MarkdownTone::TableText
+    };
     let mut runs = Vec::new();
     let mut cell = String::new();
     for ch in text.chars() {
@@ -364,7 +372,11 @@ fn image_at(text: &str) -> Option<(usize, String, MarkdownTone)> {
     let target_end = body.get(target_start..)?.find(')')? + target_start;
     let alt = sanitize_text(&body[..alt_end]);
     let target = sanitize_text(&body[target_start..target_end]);
-    let rendered = if target.is_empty() { format!("[image: {alt}]") } else { format!("[image: {alt}] ({target})") };
+    let rendered = if target.is_empty() {
+        format!("[image: {alt}]")
+    } else {
+        format!("[image: {alt}] ({target})")
+    };
     Some((2 + target_end + 1, rendered, MarkdownTone::Image))
 }
 
@@ -378,7 +390,11 @@ fn link_at(text: &str) -> Option<(usize, String, MarkdownTone)> {
         return None;
     }
     let target = sanitize_text(&body[target_start..target_end]);
-    let rendered = if target.is_empty() { label } else { format!("{label} ({target})") };
+    let rendered = if target.is_empty() {
+        label
+    } else {
+        format!("{label} ({target})")
+    };
     Some((1 + target_end + 1, rendered, MarkdownTone::Link))
 }
 

--- a/crates/aether-kit/src/console/state.rs
+++ b/crates/aether-kit/src/console/state.rs
@@ -133,7 +133,11 @@ impl ConsoleState {
     }
 
     pub fn append_command_output(&mut self, lines: Vec<String>, error: bool) {
-        let style = if error { LineStyle::Error } else { LineStyle::Output };
+        let style = if error {
+            LineStyle::Error
+        } else {
+            LineStyle::Output
+        };
         for text in lines {
             self.push_line(ConsoleLine { text, style });
         }

--- a/crates/aether-kit/src/mover/mod.rs
+++ b/crates/aether-kit/src/mover/mod.rs
@@ -329,7 +329,11 @@ impl WorldMover {
     /// `WindowSize`.
     fn aspect(&self) -> f32 {
         let (w, h) = self.window;
-        if w == 0 || h == 0 { DEFAULT_ASPECT } else { w as f32 / h as f32 }
+        if w == 0 || h == 0 {
+            DEFAULT_ASPECT
+        } else {
+            w as f32 / h as f32
+        }
     }
 
     /// World-space eye and target for the follow camera: it looks at a point
@@ -425,7 +429,11 @@ fn step_toward(cur: (i32, i32), target: (i32, i32), speed: i32) -> (i32, i32) {
     // Round speed·d / dist to nearest, away from zero on a tie.
     let round_div = |num: i64| {
         let half = dist / 2;
-        if num >= 0 { (num + half) / dist } else { (num - half) / dist }
+        if num >= 0 {
+            (num + half) / dist
+        } else {
+            (num - half) / dist
+        }
     };
     // |speed·d / dist| ≤ speed, so the result fits an i32 axis step.
     (cur.0 + round_div(speed * dx) as i32, cur.1 + round_div(speed * dz) as i32)

--- a/crates/aether-kit/src/terrain_editor/mod.rs
+++ b/crates/aether-kit/src/terrain_editor/mod.rs
@@ -190,7 +190,11 @@ impl TerrainEditor {
     }
 
     fn require_idle(&self) -> Result<(), TerrainEditorError> {
-        if self.busy() { Err(TerrainEditorError::Busy) } else { Ok(()) }
+        if self.busy() {
+            Err(TerrainEditorError::Busy)
+        } else {
+            Ok(())
+        }
     }
 
     fn require_mark_book(&self) -> Result<(), TerrainEditorError> {

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -145,7 +145,11 @@ fn intersect_widget_clips(item: Option<WidgetClipRect>, slot: Option<WidgetClipR
             let right = (item.x + item.width).min(slot.x + slot.width);
             let bottom = (item.y + item.height).min(slot.y + slot.height);
             let rect = WidgetClipRect { x, y, width: right - x, height: bottom - y };
-            if rect.is_valid() { WidgetClipIntersection::Finite { rect } } else { WidgetClipIntersection::Empty }
+            if rect.is_valid() {
+                WidgetClipIntersection::Finite { rect }
+            } else {
+                WidgetClipIntersection::Empty
+            }
         }
     }
 }

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -171,8 +171,11 @@ impl WidgetPanel {
 
         let row_rect = |y: f32, width: f32, height: f32| WidgetFrame { x, y, width, height };
 
-        let specs =
-            if self.config.children.is_empty() { reference_stack(&self.theme) } else { self.config.children.clone() };
+        let specs = if self.config.children.is_empty() {
+            reference_stack(&self.theme)
+        } else {
+            self.config.children.clone()
+        };
 
         let mut first = true;
         for spec in &specs {
@@ -721,8 +724,11 @@ fn spawn_behavior_host(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, ro
         ScriptRef::Inline(bytes) => ScriptSource::Inline(bytes),
         ScriptRef::FsRef { namespace, path } => ScriptSource::FsRef { namespace, path },
     };
-    let fuel_per_call =
-        if host_spec.fuel_per_call != 0 { host_spec.fuel_per_call } else { HostConfig::DEFAULT_FUEL_PER_CALL };
+    let fuel_per_call = if host_spec.fuel_per_call != 0 {
+        host_spec.fuel_per_call
+    } else {
+        HostConfig::DEFAULT_FUEL_PER_CALL
+    };
     let disable_after_traps = if host_spec.disable_after_traps != 0 {
         host_spec.disable_after_traps
     } else {
@@ -934,7 +940,11 @@ impl WasmActor for WidgetPanel {
     #[handler::single]
     fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
         if key.code == KEY_TAB {
-            let direction = if self.modifiers.shift { FocusDirection::Backward } else { FocusDirection::Forward };
+            let direction = if self.modifiers.shift {
+                FocusDirection::Backward
+            } else {
+                FocusDirection::Forward
+            };
             if let Some(transition) = self.focus.move_focus(direction) {
                 apply_focus(ctx, transition);
             }

--- a/crates/aether-kit/src/widget/scroll.rs
+++ b/crates/aether-kit/src/widget/scroll.rs
@@ -67,7 +67,11 @@ fn max_offset(viewport_pixels: f32, content_pixels: f32) -> f32 {
 
 #[must_use]
 fn finite_or_zero(value: f32) -> f32 {
-    if value.is_finite() { value } else { 0.0 }
+    if value.is_finite() {
+        value
+    } else {
+        0.0
+    }
 }
 
 #[must_use]

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -164,7 +164,18 @@ pub(super) fn push_control_outlines(
         push_border(items, width, height, 2.0, color);
     }
     if state.focused() {
-        push_inset_border(items, width, height, if validation.is_some() { 2.0 } else { 0.0 }, 2.0, theme.accent);
+        push_inset_border(
+            items,
+            width,
+            height,
+            if validation.is_some() {
+                2.0
+            } else {
+                0.0
+            },
+            2.0,
+            theme.accent,
+        );
     }
 }
 

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -58,7 +58,11 @@ use crate::widget::theme::{Theme, ThemeState};
 use crate::widget::{WidgetControlState, WidgetDrawItem, WidgetDrawList};
 
 fn text_control_theme_state(state: &InteractionState, dragging: bool) -> ThemeState {
-    if state.focused() { state.supporting_theme_state(dragging) } else { state.theme_state(dragging) }
+    if state.focused() {
+        state.supporting_theme_state(dragging)
+    } else {
+        state.theme_state(dragging)
+    }
 }
 
 fn apply_text_control_state(

--- a/crates/aether-kit/src/widget/set/radio.rs
+++ b/crates/aether-kit/src/widget/set/radio.rs
@@ -198,7 +198,11 @@ impl WasmActor for RadioGroupWidget {
             #[allow(clippy::cast_precision_loss)]
             let row_y = i as f32 * row_height;
             let marker_y = (row_height - marker).mul_add(0.5, row_y);
-            let base = if i == self.selected { self.theme.accent } else { self.theme.surface_raised };
+            let base = if i == self.selected {
+                self.theme.accent
+            } else {
+                self.theme.surface_raised
+            };
             let marker_state = if i == self.selected {
                 self.state.theme_state(self.pressed)
             } else {
@@ -225,7 +229,11 @@ impl WasmActor for RadioGroupWidget {
 /// Clamp a 1-past-the-end initial index down to the last option (or `0` for an
 /// empty group).
 fn clamp_index(index: u32, len: usize) -> usize {
-    if len == 0 { 0 } else { (index as usize).min(len - 1) }
+    if len == 0 {
+        0
+    } else {
+        (index as usize).min(len - 1)
+    }
 }
 
 #[cfg(test)]

--- a/crates/aether-kit/src/widget/set/slider.rs
+++ b/crates/aether-kit/src/widget/set/slider.rs
@@ -72,13 +72,21 @@ impl SliderWidget {
     /// The nudge one arrow press applies: `step` when set, else a hundredth of
     /// the range so a continuous slider still moves.
     fn nudge_amount(&self) -> f32 {
-        if self.step > 0.0 { self.step } else { (self.max - self.min) * 0.01 }
+        if self.step > 0.0 {
+            self.step
+        } else {
+            (self.max - self.min) * 0.01
+        }
     }
 
     /// The value as a `0.0..=1.0` fraction of the range, for the fill width.
     fn fill_fraction(&self) -> f32 {
         let span = self.max - self.min;
-        if span > 0.0 { ((self.value - self.min) / span).clamp(0.0, 1.0) } else { 0.0 }
+        if span > 0.0 {
+            ((self.value - self.min) / span).clamp(0.0, 1.0)
+        } else {
+            0.0
+        }
     }
 
     /// Emit the current value up to the panel root, `committed` distinguishing

--- a/crates/aether-kit/src/widget/set/text_area.rs
+++ b/crates/aether-kit/src/widget/set/text_area.rs
@@ -192,7 +192,12 @@ impl TextAreaWidget {
         let local_y = event_y - self.frame.y;
         let row_height = self.theme.row_height.max(1.0);
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let row = if local_y <= 0.0 { 0 } else { (local_y / row_height) as usize }.min(visible.saturating_sub(1));
+        let row = if local_y <= 0.0 {
+            0
+        } else {
+            (local_y / row_height) as usize
+        }
+        .min(visible.saturating_sub(1));
         let line_index = self.scroll_top.saturating_add(row).min(lines.len().saturating_sub(1));
         let line = lines[line_index];
         let local_x = event_x - self.frame.x - self.theme.pad;

--- a/crates/aether-kit/src/widget/set/virtual_list.rs
+++ b/crates/aether-kit/src/widget/set/virtual_list.rs
@@ -158,11 +158,22 @@ impl VirtualListWidget {
             let row_y = row_offset as f32 * row_height;
             let item_index = window.first_index + row_offset;
             let selected = self.selected_index == Some(item_index);
-            let base = if selected { self.theme.accent } else { self.theme.surface_raised };
-            let row_state =
-                if selected { self.state.theme_state(self.pressed) } else { self.state.supporting_theme_state(false) };
+            let base = if selected {
+                self.theme.accent
+            } else {
+                self.theme.surface_raised
+            };
+            let row_state = if selected {
+                self.state.theme_state(self.pressed)
+            } else {
+                self.state.supporting_theme_state(false)
+            };
             items.push(quad(0.0, row_y, self.frame.width, row_height, self.theme.fill(base, row_state)));
-            let text_base = if selected { self.theme.accent_text } else { self.theme.text_primary };
+            let text_base = if selected {
+                self.theme.accent_text
+            } else {
+                self.theme.text_primary
+            };
             items.push(WidgetDrawItem::Text {
                 x: self.theme.pad,
                 y: text_origin_y(row_y, row_height, self.theme.label_size_pixels),

--- a/crates/aether-kit/src/world/data.rs
+++ b/crates/aether-kit/src/world/data.rs
@@ -1007,7 +1007,11 @@ pub(super) fn cliff_material_from_u8(byte: u8) -> Material {
 fn floor_to_i32(v: f32) -> i32 {
     #[allow(clippy::cast_possible_truncation)] // world coordinates are far inside i32
     let t = v as i32;
-    if (t as f32) > v { t - 1 } else { t }
+    if (t as f32) > v {
+        t - 1
+    } else {
+        t
+    }
 }
 
 /// Partition four cyclically-ordered incident members into non-cliff plates
@@ -1092,15 +1096,35 @@ const MAX_DECODED_WATER_PLANES: usize = u16::MAX as usize;
 const MAX_DECODED_CHUNKS: usize = 65_536;
 
 fn chunk_record_bytes(version: u8) -> usize {
-    let overlay_mask_bytes = if version >= 7 { OVERLAY_MASK_WIRE_BYTES } else { 2 * CELLS_PER_CHUNK_AREA };
+    let overlay_mask_bytes = if version >= 7 {
+        OVERLAY_MASK_WIRE_BYTES
+    } else {
+        2 * CELLS_PER_CHUNK_AREA
+    };
     8 + 2 * CELLS_PER_CHUNK_AREA
         + overlay_mask_bytes
         + 4 * CELLS_PER_CHUNK_AREA
-        + if version >= 4 { 2 * CELLS_PER_CHUNK_AREA } else { 0 }
+        + if version >= 4 {
+            2 * CELLS_PER_CHUNK_AREA
+        } else {
+            0
+        }
         + 2 * CELLS_PER_CHUNK_AREA
-        + if version >= 2 { CELLS_PER_CHUNK_AREA } else { 0 }
-        + if version >= 5 { UNDERLAY_POINTS_PER_CHUNK } else { 0 }
-        + if version >= 6 { 2 * HEIGHT_POINTS_PER_CHUNK } else { 0 }
+        + if version >= 2 {
+            CELLS_PER_CHUNK_AREA
+        } else {
+            0
+        }
+        + if version >= 5 {
+            UNDERLAY_POINTS_PER_CHUNK
+        } else {
+            0
+        }
+        + if version >= 6 {
+            2 * HEIGHT_POINTS_PER_CHUNK
+        } else {
+            0
+        }
 }
 
 impl World {
@@ -1182,7 +1206,11 @@ impl World {
             let name_bytes = reader.take(name_len)?;
             let name = String::from_utf8(name_bytes.to_vec()).map_err(|_| WorldDecodeError::BadName)?;
             let default_material = Material::from_u8_or_void(reader.u8()?);
-            let cliff_material = if version >= 3 { cliff_material_from_u8(reader.u8()?) } else { Material::Stone };
+            let cliff_material = if version >= 3 {
+                cliff_material_from_u8(reader.u8()?)
+            } else {
+                Material::Stone
+            };
             regions.push(Region { name, default_material, cliff_material });
         }
         let mut smoothing_profiles = Vec::new();
@@ -1265,7 +1293,11 @@ fn read_overlay_mask(reader: &mut Reader<'_>, version: u8, chunk: &mut Chunk) ->
         for legacy_z in 0..LEGACY_MASK_SUBCELLS_PER_CELL_EDGE {
             for legacy_x in 0..LEGACY_MASK_SUBCELLS_PER_CELL_EDGE {
                 let bit = legacy_z * LEGACY_MASK_SUBCELLS_PER_CELL_EDGE + legacy_x;
-                let coverage = if (mask >> bit) & 1 == 1 { 255 } else { 0 };
+                let coverage = if (mask >> bit) & 1 == 1 {
+                    255
+                } else {
+                    0
+                };
                 for sz in legacy_z * scale..(legacy_z + 1) * scale {
                     for sx in legacy_x * scale..(legacy_x + 1) * scale {
                         chunk.overlay_mask[base + sz * SUBCELLS_PER_CELL_EDGE as usize + sx] = coverage;
@@ -1747,7 +1779,13 @@ mod tests {
         // Rows z=0 at 0 and z=1 at 200 octimeters: a cliff runs along the
         // whole shared edge, so at corner (1,1) the four incident cells
         // split 2/2 and each side reads its own plate mean.
-        let world = height_world(|_, z| if z == 0 { 0 } else { 200 });
+        let world = height_world(|_, z| {
+            if z == 0 {
+                0
+            } else {
+                200
+            }
+        });
         let low = world.cell_corner_heights(cell(0, 0));
         let high = world.cell_corner_heights(cell(0, 1));
         // Cell (0,0)'s far corners (indices 2, 3 — the z+1 pair) sit on the
@@ -2253,7 +2291,11 @@ mod tests {
         let subcells = SUBCELLS_PER_CELL_EDGE as usize;
         for subcell_z in 0..subcells {
             for subcell_x in 0..subcells {
-                chunk.overlay_mask[subcell_z * subcells + subcell_x] = if subcell_x < subcells / 2 { 100 } else { 200 };
+                chunk.overlay_mask[subcell_z * subcells + subcell_x] = if subcell_x < subcells / 2 {
+                    100
+                } else {
+                    200
+                };
             }
         }
         world.insert_chunk(ChunkPos { x: 0, z: 0 }, chunk);

--- a/crates/aether-kit/src/world/mesher/cliffs.rs
+++ b/crates/aether-kit/src/world/mesher/cliffs.rs
@@ -228,8 +228,16 @@ impl WindowPlan {
                         continue;
                     };
                     let (a, b) = edge_corners(edge);
-                    let high = if self.levels[a] > self.levels[b] { a } else { b };
-                    let low = if high == a { b } else { a };
+                    let high = if self.levels[a] > self.levels[b] {
+                        a
+                    } else {
+                        b
+                    };
+                    let low = if high == a {
+                        b
+                    } else {
+                        a
+                    };
                     debug_assert_eq!(self.corners[high], crossing.high_anchor);
                     debug_assert_eq!(self.corners[low], crossing.low_anchor);
                     segments.push(WallSegment {
@@ -618,7 +626,11 @@ fn edge_corners(edge: usize) -> (usize, usize) {
 
 fn make_crossing(gx: i32, gz: i32, edge: usize, corners: [SampleAnchor; 4], levels: [i32; 4]) -> CliffCrossing {
     let (a, b) = edge_corners(edge);
-    let (high, low) = if levels[a] > levels[b] { (a, b) } else { (b, a) };
+    let (high, low) = if levels[a] > levels[b] {
+        (a, b)
+    } else {
+        (b, a)
+    };
     let point = corners[a].point().midpoint(corners[b].point());
     let key = match edge {
         0 => CanonicalEdgeKey { x_subcell: gx - 1, z_subcell: gz - 1, axis: EdgeAxis::East },
@@ -649,7 +661,11 @@ fn classify_case(gx: i32, gz: i32, crossings: [Option<CliffCrossing>; 4], levels
         }
         let high_of = |edge: usize| {
             let (a, b) = edge_corners(edge);
-            if levels[a] > levels[b] { a } else { b }
+            if levels[a] > levels[b] {
+                a
+            } else {
+                b
+            }
         };
         let first_high = high_of(edges[0]);
         let second_high = high_of(edges[1]);
@@ -686,8 +702,16 @@ fn clip_half_plane(polygon: &[PlanarPoint], a: PlanarPoint, b: PlanarPoint, keep
         let next = polygon[(index + 1) % polygon.len()];
         let current_side = cross(a, b, current);
         let next_side = cross(a, b, next);
-        let current_in = if keep_positive { current_side >= -0.01 } else { current_side <= 0.01 };
-        let next_in = if keep_positive { next_side >= -0.01 } else { next_side <= 0.01 };
+        let current_in = if keep_positive {
+            current_side >= -0.01
+        } else {
+            current_side <= 0.01
+        };
+        let next_in = if keep_positive {
+            next_side >= -0.01
+        } else {
+            next_side <= 0.01
+        };
         if current_in {
             out.push(current);
         }
@@ -826,7 +850,13 @@ mod tests {
     }
 
     fn binary_height_window(high_corners: u8) -> WindowPlan {
-        window_for_levels(from_fn(|corner| if high_corners & (1 << corner) != 0 { 200 } else { 0 }))
+        window_for_levels(from_fn(|corner| {
+            if high_corners & (1 << corner) != 0 {
+                200
+            } else {
+                0
+            }
+        }))
     }
 
     fn material_polygons(corners: [u8; 4]) -> Vec<Vec<PlanarPoint>> {
@@ -890,11 +920,19 @@ mod tests {
     fn legal_ramps_do_not_acquire_an_unrelated_cliff_contour() {
         let world = world_with_levels(|x, z| {
             let ramp = (x * 8).clamp(-64, 64);
-            if z >= 4 { ramp + 256 } else { ramp }
+            if z >= 4 {
+                ramp + 256
+            } else {
+                ramp
+            }
         });
         let shifted = world_with_levels(|x, z| {
             let ramp = (x * 8).clamp(-64, 64) + 10_000;
-            if z >= 4 { ramp + 256 } else { ramp }
+            if z >= 4 {
+                ramp + 256
+            } else {
+                ramp
+            }
         });
         let a = CliffPlan::build(&world, ChunkPos { x: 0, z: 0 });
         let b = CliffPlan::build(&shifted, ChunkPos { x: 0, z: 0 });
@@ -1015,7 +1053,14 @@ mod tests {
         // cliff is the north/south 256-octimeter offset at z=8, crossing the
         // x=16 chunk seam. A global numeric-threshold march would contour
         // through the ramp; canonical adjacency classification cannot.
-        let world = world_with_levels(|x, z| x * 4 + if z >= 8 { 256 } else { 0 });
+        let world = world_with_levels(|x, z| {
+            x * 4
+                + if z >= 8 {
+                    256
+                } else {
+                    0
+                }
+        });
         let west = CliffPlan::build(&world, ChunkPos { x: 0, z: 0 });
         let east = CliffPlan::build(&world, ChunkPos { x: 1, z: 0 });
         let west_edges = west.canonical_edges();

--- a/crates/aether-kit/src/world/mesher/contour.rs
+++ b/crates/aether-kit/src/world/mesher/contour.rs
@@ -162,7 +162,11 @@ fn corner_flip(
 /// sample's angle setting; `99` (unreachable — the window holds 24
 /// neighbors) disables the rule at 90 degrees.
 fn t24_of(smoothing_degrees: u32) -> i32 {
-    if smoothing_degrees >= 90 { 99 } else { 13 + ((smoothing_degrees as i32 - 45) * 2 + 15) / 30 }
+    if smoothing_degrees >= 90 {
+        99
+    } else {
+        13 + ((smoothing_degrees as i32 - 45) * 2 + 15) / 30
+    }
 }
 
 /// Upsample `coverage` (`width × height`) by `upsample` and minimize its
@@ -250,7 +254,11 @@ pub fn minimize_corners(
             {
                 m = a;
             }
-            grid[gz * gw + gx] = if m { u8::MAX } else { 0 };
+            grid[gz * gw + gx] = if m {
+                u8::MAX
+            } else {
+                0
+            };
         }
     }
 
@@ -307,7 +315,11 @@ fn prune_one_wide_artifacts(
                     .filter(|(dx, dz)| in_mask(&grid, gw, gh, gx + dx, gz + dz, m))
                     .count();
                 if (m && orth_covered <= 1) || (!m && orth_covered >= 3) {
-                    next[gz as usize * gw + gx as usize] = if m { 0 } else { u8::MAX };
+                    next[gz as usize * gw + gx as usize] = if m {
+                        0
+                    } else {
+                        u8::MAX
+                    };
                     changed = true;
                 }
             }
@@ -384,7 +396,11 @@ fn cellular_pass(
                 flip = c24 >= t24;
             }
             if flip {
-                next[gz as usize * gw + gx as usize] = if m { 0 } else { u8::MAX };
+                next[gz as usize * gw + gx as usize] = if m {
+                    0
+                } else {
+                    u8::MAX
+                };
             }
         }
     }
@@ -907,7 +923,11 @@ fn emit_window_poly(
 ) {
     let step_oct = window.place.step_oct;
     let edge_t = |a: u8, b: u8| -> f32 {
-        if a == b { 0.5 } else { ((COVERAGE_CROSSING - f32::from(a)) / (f32::from(b) - f32::from(a))).clamp(0.0, 1.0) }
+        if a == b {
+            0.5
+        } else {
+            ((COVERAGE_CROSSING - f32::from(a)) / (f32::from(b) - f32::from(a))).clamp(0.0, 1.0)
+        }
     };
     let x_lo = window.place.origin_oct[0] + wi * step_oct;
     let x_hi = window.place.origin_oct[0] + (wi + 1) * step_oct;
@@ -970,7 +990,15 @@ mod tests {
     }
 
     fn coverage(mask: &[bool]) -> Vec<u8> {
-        mask.iter().map(|&sample| if sample { u8::MAX } else { 0 }).collect()
+        mask.iter()
+            .map(|&sample| {
+                if sample {
+                    u8::MAX
+                } else {
+                    0
+                }
+            })
+            .collect()
     }
 
     fn minimize_bool(
@@ -1002,7 +1030,11 @@ mod tests {
         let gw = w * factor;
         for gz in 0..h * factor {
             for gx in 0..gw {
-                out[gz * gw + gx] = if mask[(gz / factor) * w + gx / factor] { u8::MAX } else { 0 };
+                out[gz * gw + gx] = if mask[(gz / factor) * w + gx / factor] {
+                    u8::MAX
+                } else {
+                    0
+                };
             }
         }
         out

--- a/crates/aether-kit/src/world/mesher/surface.rs
+++ b/crates/aether-kit/src/world/mesher/surface.rs
@@ -170,7 +170,11 @@ pub(super) fn fragment_lift(world: &World, owner: CellPos, sides: [Option<(i32, 
             let oct = w * OCTIMETERS_PER_METER;
             if (oct - line as f32).abs() < 0.5 {
                 let lattice = line / OCTIMETERS_PER_SUBCELL;
-                return if above { lattice } else { lattice - 1 };
+                return if above {
+                    lattice
+                } else {
+                    lattice - 1
+                };
             }
         }
         floor_to_i32(w * SUB as f32)
@@ -191,7 +195,11 @@ pub(super) fn fragment_lift(world: &World, owner: CellPos, sides: [Option<(i32, 
 /// negative world coordinates, so step down when it rounded up.
 pub(super) fn floor_to_i32(v: f32) -> i32 {
     let t = v as i32;
-    if (t as f32) > v { t - 1 } else { t }
+    if (t as f32) > v {
+        t - 1
+    } else {
+        t
+    }
 }
 
 /// The effective point surface level in octimeters at octimeter position

--- a/crates/aether-kit/src/world/mesher/tests.rs
+++ b/crates/aether-kit/src/world/mesher/tests.rs
@@ -352,7 +352,11 @@ mod coverage {
         let mut overlay_mask = vec![0u8; CELLS_PER_CHUNK_AREA * SUBCELLS_PER_CELL];
         for sz in 0..sub {
             for sx in 0..sub {
-                overlay_mask[cell_idx * SUBCELLS_PER_CELL + sz * sub + sx] = if sx < sub / 2 { 96 } else { 192 };
+                overlay_mask[cell_idx * SUBCELLS_PER_CELL + sz * sub + sx] = if sx < sub / 2 {
+                    96
+                } else {
+                    192
+                };
             }
         }
         let mut world = World::new();
@@ -496,7 +500,11 @@ mod walls {
                 for local_z in 0..EDGE {
                     for local_x in 0..EDGE {
                         let global_x = chunk_x * EDGE + local_x;
-                        chunk.height[(local_z * EDGE + local_x) as usize] = if global_x >= break_x { 256 } else { 0 };
+                        chunk.height[(local_z * EDGE + local_x) as usize] = if global_x >= break_x {
+                            256
+                        } else {
+                            0
+                        };
                     }
                 }
                 world.insert_chunk(ChunkPos { x: chunk_x, z: chunk_z }, chunk);
@@ -570,8 +578,16 @@ mod walls {
                         let global_x = chunk_x * EDGE + local_x;
                         let global_z = chunk_z * EDGE + local_z;
                         let index = (local_z * EDGE + local_x) as usize;
-                        chunk.height[index] = if global_x >= 8 { 256 } else { 0 };
-                        chunk.region[index] = if global_z < 8 { 1 } else { 2 };
+                        chunk.height[index] = if global_x >= 8 {
+                            256
+                        } else {
+                            0
+                        };
+                        chunk.region[index] = if global_z < 8 {
+                            1
+                        } else {
+                            2
+                        };
                     }
                 }
                 world.insert_chunk(ChunkPos { x: chunk_x, z: chunk_z }, chunk);
@@ -671,7 +687,11 @@ mod walls {
             chunk.underlay = [Material::Grass; CELLS_PER_CHUNK_AREA];
             for lz in 0..EDGE {
                 for lx in 0..EDGE {
-                    chunk.height[(lz * EDGE + lx) as usize] = if lz < 8 { 256 } else { 0 };
+                    chunk.height[(lz * EDGE + lx) as usize] = if lz < 8 {
+                        256
+                    } else {
+                        0
+                    };
                 }
             }
             world.insert_chunk(ChunkPos { x: cx, z: 0 }, chunk);
@@ -893,7 +913,11 @@ mod walls {
             for lz in 0..EDGE {
                 for lx in 0..EDGE {
                     let i = (lz * EDGE + lx) as usize;
-                    chunk.underlay[i] = if lz < 8 { Material::Stone } else { Material::Grass };
+                    chunk.underlay[i] = if lz < 8 {
+                        Material::Stone
+                    } else {
+                        Material::Grass
+                    };
                 }
             }
             world.insert_chunk(ChunkPos { x: cx, z: 0 }, chunk);
@@ -1031,7 +1055,11 @@ mod walls {
             .iter()
             .map(|t| {
                 let tops: Vec<&Vertex> = t.verts.iter().filter(|v| v.y > 0.5).collect();
-                if tops.len() == 2 { (tops[0].z - tops[1].z).abs() } else { 0.0 }
+                if tops.len() == 2 {
+                    (tops[0].z - tops[1].z).abs()
+                } else {
+                    0.0
+                }
             })
             .sum();
         assert!(
@@ -1375,7 +1403,11 @@ mod walls {
                         let foot = foot_x.contains(&gx) && foot_z.contains(&gz);
                         if arm || foot {
                             points[sz * sub + sx] = Material::Stone.to_u8();
-                            deltas[sz * sub + sx] = if arm { 128 } else { 256 };
+                            deltas[sz * sub + sx] = if arm {
+                                128
+                            } else {
+                                256
+                            };
                             any = true;
                         }
                     }
@@ -1407,7 +1439,11 @@ mod voids {
         for lz in 0..EDGE {
             for lx in 0..EDGE {
                 let i = (lz * EDGE + lx) as usize;
-                chunk.underlay[i] = if lx < 8 { Material::Grass } else { Material::Sand };
+                chunk.underlay[i] = if lx < 8 {
+                    Material::Grass
+                } else {
+                    Material::Sand
+                };
                 chunk.height[i] = 8 * lx; // gentle ramp, no cliffs
             }
         }

--- a/crates/aether-kit/src/world/mesher/windows.rs
+++ b/crates/aether-kit/src/world/mesher/windows.rs
@@ -149,7 +149,11 @@ pub(super) fn label_case_is_connected(corners: [u8; 4], label: u8, case: u8) -> 
         return true;
     }
     // The other diagonal pair: [BR, TL] for case 5, [BL, TR] for case 10.
-    let (other_a, other_b) = if case == 5 { (corners[1], corners[2]) } else { (corners[0], corners[3]) };
+    let (other_a, other_b) = if case == 5 {
+        (corners[1], corners[2])
+    } else {
+        (corners[0], corners[3])
+    };
     other_a != other_b || label > other_a
 }
 

--- a/crates/aether-kit/src/world/overlay.rs
+++ b/crates/aether-kit/src/world/overlay.rs
@@ -164,8 +164,16 @@ fn emit_line(world: &World, builder: &mut OverlayBuilder, points: &[WorldPoint],
     if points.len() < 2 {
         return true;
     }
-    let color = if selected { MARK_SELECTED_COLOR } else { MARK_OVERLAY_COLOR };
-    let half_width_meters = if selected { MARK_SELECTED_HALF_WIDTH_METERS } else { MARK_PATH_HALF_WIDTH_METERS };
+    let color = if selected {
+        MARK_SELECTED_COLOR
+    } else {
+        MARK_OVERLAY_COLOR
+    };
+    let half_width_meters = if selected {
+        MARK_SELECTED_HALF_WIDTH_METERS
+    } else {
+        MARK_PATH_HALF_WIDTH_METERS
+    };
     for pair in points.windows(2) {
         if !emit_segment(world, builder, pair[0].into(), pair[1].into(), half_width_meters, color) {
             return false;
@@ -176,7 +184,11 @@ fn emit_line(world: &World, builder: &mut OverlayBuilder, points: &[WorldPoint],
     {
         return false;
     }
-    let join_radius = if selected { MARK_SELECTED_HANDLE_RADIUS_METERS } else { MARK_PATH_HALF_WIDTH_METERS };
+    let join_radius = if selected {
+        MARK_SELECTED_HANDLE_RADIUS_METERS
+    } else {
+        MARK_PATH_HALF_WIDTH_METERS
+    };
     for point in points {
         if !emit_disc(world, builder, (*point).into(), join_radius, color) {
             return false;
@@ -191,8 +203,16 @@ fn emit_mark(world: &World, builder: &mut OverlayBuilder, mark: &Mark, selected:
             world,
             builder,
             (*point).into(),
-            if selected { MARK_SELECTED_HANDLE_RADIUS_METERS } else { MARK_POINT_RADIUS_METERS },
-            if selected { MARK_SELECTED_COLOR } else { MARK_OVERLAY_COLOR },
+            if selected {
+                MARK_SELECTED_HANDLE_RADIUS_METERS
+            } else {
+                MARK_POINT_RADIUS_METERS
+            },
+            if selected {
+                MARK_SELECTED_COLOR
+            } else {
+                MARK_OVERLAY_COLOR
+            },
         ),
         MarkGeometry::Path(points) => emit_line(world, builder, points, false, selected),
         MarkGeometry::Area(points) => emit_line(world, builder, points, true, selected),

--- a/crates/aether-kit/src/world/pick.rs
+++ b/crates/aether-kit/src/world/pick.rs
@@ -103,7 +103,11 @@ fn refine_crossing(
     if above_error > TERRAIN_PICK_EPSILON_METERS || below_error > TERRAIN_PICK_EPSILON_METERS {
         return None;
     }
-    Some(if above_error < below_error { above.into_hit() } else { below.into_hit() })
+    Some(if above_error < below_error {
+        above.into_hit()
+    } else {
+        below.into_hit()
+    })
 }
 
 /// Intersect a validated, bounded world ray with the first markable terrain

--- a/crates/aether-kit/src/world/raster.rs
+++ b/crates/aether-kit/src/world/raster.rs
@@ -311,7 +311,11 @@ pub(super) fn stamp_polygon_bounded(
                 };
                 (material_changes, chunk.overlay_mask[base + within], cleared_subcells)
             });
-        let composed = if material_changes { coverage } else { prior_coverage.max(coverage) };
+        let composed = if material_changes {
+            coverage
+        } else {
+            prior_coverage.max(coverage)
+        };
         let coverage_writes = u32::from(material_changes || prior_coverage != composed);
         let write_cost = cleared_subcells + coverage_writes;
         if write_cost > max_subcells - result.subcells_written {
@@ -530,8 +534,16 @@ mod tests {
         let mut sorting_too_expensive = Vec::with_capacity(MAX_STAMP_VERTICES);
         for index in 0..MAX_STAMP_VERTICES {
             sorting_too_expensive.push(point(
-                if index % 2 == 0 { 0 } else { OCTIMETERS_PER_SUBCELL },
-                if index % 4 < 2 { 0 } else { MAX_STAMP_EDGE_SUBCELLS as i32 * OCTIMETERS_PER_SUBCELL },
+                if index % 2 == 0 {
+                    0
+                } else {
+                    OCTIMETERS_PER_SUBCELL
+                },
+                if index % 4 < 2 {
+                    0
+                } else {
+                    MAX_STAMP_EDGE_SUBCELLS as i32 * OCTIMETERS_PER_SUBCELL
+                },
             ));
         }
         assert!(rasterize_polygon(&sorting_too_expensive).coverage.is_empty());

--- a/crates/aether-math/src/vec.rs
+++ b/crates/aether-math/src/vec.rs
@@ -77,7 +77,11 @@ impl Vec2 {
     #[must_use]
     pub fn normalize(self) -> Self {
         let len = self.length();
-        if len > 0.0 { self * (1.0 / len) } else { Self::ZERO }
+        if len > 0.0 {
+            self * (1.0 / len)
+        } else {
+            Self::ZERO
+        }
     }
 
     #[inline]
@@ -156,7 +160,11 @@ impl Vec3 {
     #[must_use]
     pub fn normalize(self) -> Self {
         let len = self.length();
-        if len > 0.0 { self * (1.0 / len) } else { Self::ZERO }
+        if len > 0.0 {
+            self * (1.0 / len)
+        } else {
+            Self::ZERO
+        }
     }
 
     /// Like [`Self::normalize`] but returns `fallback` (instead of
@@ -215,7 +223,11 @@ impl Vec3 {
         if cross.length_squared() > 1e-10 * mag_a_sq * mag_b_sq {
             return None;
         }
-        Some(if self.dot(other) >= 0.0 { 1.0 } else { -1.0 })
+        Some(if self.dot(other) >= 0.0 {
+            1.0
+        } else {
+            -1.0
+        })
     }
 
     #[inline]
@@ -288,7 +300,11 @@ impl Vec4 {
     #[must_use]
     pub fn normalize(self) -> Self {
         let len = self.length();
-        if len > 0.0 { self * (1.0 / len) } else { Self::ZERO }
+        if len > 0.0 {
+            self * (1.0 / len)
+        } else {
+            Self::ZERO
+        }
     }
 
     #[inline]

--- a/crates/aether-mcp/src/tools/engine.rs
+++ b/crates/aether-mcp/src/tools/engine.rs
@@ -75,7 +75,11 @@ pub(super) async fn spawn_substrate(mcp: &Mcp, args: SpawnSubstrateArgs) -> Resu
     // path-based, now fed by the registry. Hold the temp files across
     // the spawn call — the substrate reads them at boot, before the
     // spawn reply returns — then clean them up.
-    let staged = if args.components.is_empty() { None } else { Some(mcp.stage_boot_manifest(&args.components).await?) };
+    let staged = if args.components.is_empty() {
+        None
+    } else {
+        Some(mcp.stage_boot_manifest(&args.components).await?)
+    };
     let reply = mcp
         .session
         .call_one(local_envelope(

--- a/crates/aether-mcp/src/tools/mail.rs
+++ b/crates/aether-mcp/src/tools/mail.rs
@@ -53,7 +53,12 @@ pub(super) async fn send_mail(mcp: &Mcp, args: SendMailArgs) -> Result<String, M
                     let engine_kinds = engine.map(|e| mcp.snapshot_engine_kinds(e)).unwrap_or_default();
                     replies = decode_reply_events(&events, &engine_kinds, declared_reply);
                     timed_out = hit_timeout;
-                    if hit_timeout { "timeout" } else { "delivered" }.to_owned()
+                    if hit_timeout {
+                        "timeout"
+                    } else {
+                        "delivered"
+                    }
+                    .to_owned()
                 }
                 Err(e) => format!("error: {e}"),
             }

--- a/crates/aether-mesh/src/cleanup/invariants.rs
+++ b/crates/aether-mesh/src/cleanup/invariants.rs
@@ -204,7 +204,11 @@ pub(super) fn find_unrepaired_tjunctions(mesh: &IndexedMesh) -> Vec<UnrepairedTJ
             if a == b {
                 continue;
             }
-            edges.insert(if a < b { (a, b) } else { (b, a) });
+            edges.insert(if a < b {
+                (a, b)
+            } else {
+                (b, a)
+            });
         }
     }
 

--- a/crates/aether-mesh/src/cleanup/merge.rs
+++ b/crates/aether-mesh/src/cleanup/merge.rs
@@ -308,7 +308,11 @@ fn collapse_unbacked_boundary_runs(
     if out.len() >= 2 && out.first() == out.last() {
         out.pop();
     }
-    if out.len() < 3 { verts } else { out }
+    if out.len() < 3 {
+        verts
+    } else {
+        out
+    }
 }
 
 /// Normalize a possibly non-simple loop into a list of simple loops.

--- a/crates/aether-mesh/src/cleanup/slivers.rs
+++ b/crates/aether-mesh/src/cleanup/slivers.rs
@@ -81,7 +81,11 @@ impl IndexedMesh {
                     if ra == rb {
                         continue;
                     }
-                    let (keep, drop) = if ra < rb { (ra, rb) } else { (rb, ra) };
+                    let (keep, drop) = if ra < rb {
+                        (ra, rb)
+                    } else {
+                        (rb, ra)
+                    };
                     merges.insert(drop, keep);
                 }
             }

--- a/crates/aether-mesh/src/cleanup/tjunctions.rs
+++ b/crates/aether-mesh/src/cleanup/tjunctions.rs
@@ -51,7 +51,11 @@ impl IndexedMesh {
                     if a == b {
                         continue;
                     }
-                    edges.insert(if a < b { (a, b) } else { (b, a) });
+                    edges.insert(if a < b {
+                        (a, b)
+                    } else {
+                        (b, a)
+                    });
                 }
             }
 
@@ -101,7 +105,11 @@ impl IndexedMesh {
                     let a = poly.vertices[i];
                     let b = poly.vertices[(i + 1) % n];
                     new_verts.push(a);
-                    let canon = if a < b { (a, b) } else { (b, a) };
+                    let canon = if a < b {
+                        (a, b)
+                    } else {
+                        (b, a)
+                    };
                     if let Some(&v) = subdivisions.get(&canon)
                         && v != a
                         && v != b

--- a/crates/aether-mesh/src/cleanup/twin_edges.rs
+++ b/crates/aether-mesh/src/cleanup/twin_edges.rs
@@ -21,7 +21,11 @@ pub(super) fn surviving_directed_edges(directed: &HashMap<(VertexId, VertexId), 
     let mut keys: Vec<(VertexId, VertexId)> = directed.keys().copied().collect();
     keys.sort_unstable();
     for (a, b) in keys {
-        let canonical = if a < b { (a, b) } else { (b, a) };
+        let canonical = if a < b {
+            (a, b)
+        } else {
+            (b, a)
+        };
         if !seen.insert(canonical) {
             continue;
         }

--- a/crates/aether-mesh/src/debug.rs
+++ b/crates/aether-mesh/src/debug.rs
@@ -152,7 +152,11 @@ pub fn validate_manifold(polygons: &[Polygon]) -> Vec<ManifoldViolation> {
     let mut violations = Vec::new();
     let mut seen = HashSet::new();
     for &(a, b) in directed.keys() {
-        let canonical = if a < b { (a, b) } else { (b, a) };
+        let canonical = if a < b {
+            (a, b)
+        } else {
+            (b, a)
+        };
         if !seen.insert(canonical) {
             continue;
         }
@@ -332,7 +336,11 @@ pub fn validate_normal_coherence(polygons: &[Polygon]) -> Vec<GeometryViolation>
                 if a == b {
                     continue;
                 }
-                let canonical = if a < b { (a, b) } else { (b, a) };
+                let canonical = if a < b {
+                    (a, b)
+                } else {
+                    (b, a)
+                };
                 edges.entry(canonical).or_default().push((i, poly.plane_normal));
             }
         };
@@ -353,7 +361,11 @@ pub fn validate_normal_coherence(polygons: &[Polygon]) -> Vec<GeometryViolation>
         if i0 == i1 {
             continue;
         }
-        let pair = if i0 < i1 { (i0, i1) } else { (i1, i0) };
+        let pair = if i0 < i1 {
+            (i0, i1)
+        } else {
+            (i1, i0)
+        };
         if !seen.insert(pair) {
             continue;
         }
@@ -398,7 +410,11 @@ pub fn validate_no_t_junctions(polygons: &[Polygon]) -> Vec<GeometryViolation> {
                 if a == b {
                     continue;
                 }
-                let canonical = if a < b { (a, b) } else { (b, a) };
+                let canonical = if a < b {
+                    (a, b)
+                } else {
+                    (b, a)
+                };
                 edges.insert(canonical);
             }
         };
@@ -490,7 +506,11 @@ pub fn summary(polygons: &[Polygon]) -> Summary {
         let n = p.vertices.len();
         (mn.min(n), mx.max(n), sum + n)
     });
-    let avg = if polygon_count == 0 { 0.0 } else { vsum as f32 / polygon_count as f32 };
+    let avg = if polygon_count == 0 {
+        0.0
+    } else {
+        vsum as f32 / polygon_count as f32
+    };
     let hole_count_total = polygons.iter().map(|p| p.holes.len()).sum();
     let mut by_plane_direction: HashMap<(i8, i8, i8), usize> = HashMap::new();
     for p in polygons {
@@ -500,7 +520,11 @@ pub fn summary(polygons: &[Polygon]) -> Summary {
     Summary {
         polygon_count,
         triangle_count_after_fan,
-        vertex_count_min: if polygon_count == 0 { 0 } else { vmin },
+        vertex_count_min: if polygon_count == 0 {
+            0
+        } else {
+            vmin
+        },
         vertex_count_max: vmax,
         vertex_count_avg: avg,
         hole_count_total,

--- a/crates/aether-mesh/src/mesh.rs
+++ b/crates/aether-mesh/src/mesh.rs
@@ -408,14 +408,26 @@ fn mesh_sweep(
 
     let mut tangents: Vec<Vec3> = Vec::with_capacity(path.len());
     for k in 0..path.len() {
-        let prev = if k == 0 { path[k] } else { path[k - 1] };
-        let next = if k == path.len() - 1 { path[k] } else { path[k + 1] };
+        let prev = if k == 0 {
+            path[k]
+        } else {
+            path[k - 1]
+        };
+        let next = if k == path.len() - 1 {
+            path[k]
+        } else {
+            path[k + 1]
+        };
         tangents.push((next - prev).normalize_or(Vec3::Z));
     }
 
     let mut rings: Vec<Vec<Vec3>> = Vec::with_capacity(path.len());
     let t0 = tangents[0];
-    let up_ref = if t0.y.abs() > 0.95 { Vec3::X } else { Vec3::Y };
+    let up_ref = if t0.y.abs() > 0.95 {
+        Vec3::X
+    } else {
+        Vec3::Y
+    };
     let mut r = up_ref.cross(t0).normalize_or(Vec3::X);
     let mut u = t0.cross(r);
     for (k, p) in path.iter().enumerate() {
@@ -448,18 +460,28 @@ fn mesh_sweep(
             let b = r1[i];
             let c = r0[j];
             let d = r1[j];
-            let quad: [Vec3; 4] = if profile_ccw { [a, c, d, b] } else { [a, b, d, c] };
+            let quad: [Vec3; 4] = if profile_ccw {
+                [a, c, d, b]
+            } else {
+                [a, b, d, c]
+            };
             push_polygon_from_f32(out, &quad, color)?;
         }
     }
 
     if !open {
         let last = rings.len() - 1;
-        let start_cap: Vec<Vec3> =
-            if profile_ccw { rings[0].iter().rev().copied().collect() } else { rings[0].clone() };
+        let start_cap: Vec<Vec3> = if profile_ccw {
+            rings[0].iter().rev().copied().collect()
+        } else {
+            rings[0].clone()
+        };
         push_polygon_from_f32(out, &start_cap, color)?;
-        let end_cap: Vec<Vec3> =
-            if profile_ccw { rings[last].clone() } else { rings[last].iter().rev().copied().collect() };
+        let end_cap: Vec<Vec3> = if profile_ccw {
+            rings[last].clone()
+        } else {
+            rings[last].iter().rev().copied().collect()
+        };
         push_polygon_from_f32(out, &end_cap, color)?;
     }
     Ok(())

--- a/crates/aether-mesh/src/plane.rs
+++ b/crates/aether-mesh/src/plane.rs
@@ -190,9 +190,17 @@ pub(crate) fn projection_axes(plane: &Plane3) -> (Axis, Axis) {
     let ay = plane.n_y.unsigned_abs();
     let az = plane.n_z.unsigned_abs();
     if ax >= ay && ax >= az {
-        if plane.n_x >= 0 { (Axis::Y, Axis::Z) } else { (Axis::Z, Axis::Y) }
+        if plane.n_x >= 0 {
+            (Axis::Y, Axis::Z)
+        } else {
+            (Axis::Z, Axis::Y)
+        }
     } else if ay >= az {
-        if plane.n_y >= 0 { (Axis::Z, Axis::X) } else { (Axis::X, Axis::Z) }
+        if plane.n_y >= 0 {
+            (Axis::Z, Axis::X)
+        } else {
+            (Axis::X, Axis::Z)
+        }
     } else if plane.n_z >= 0 {
         (Axis::X, Axis::Y)
     } else {

--- a/crates/aether-mesh/src/polygon.rs
+++ b/crates/aether-mesh/src/polygon.rs
@@ -239,7 +239,11 @@ fn point_in_polygon_2d(probe: (i64, i64), poly: &[(i64, i64)]) -> bool {
         let denom = iy - jy;
         let lhs = (px - jx) * denom;
         let rhs = (ix - jx) * (py - jy);
-        let crosses = if denom > 0 { lhs < rhs } else { lhs > rhs };
+        let crosses = if denom > 0 {
+            lhs < rhs
+        } else {
+            lhs > rhs
+        };
         if crosses {
             inside = !inside;
         }

--- a/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
@@ -278,7 +278,11 @@ impl Mesh {
                     };
                     let a = tri.verts[(i + 1) % 3];
                     let b = tri.verts[(i + 2) % 3];
-                    let canon = if a < b { (a, b) } else { (b, a) };
+                    let canon = if a < b {
+                        (a, b)
+                    } else {
+                        (b, a)
+                    };
                     if constraints.contains(&canon) {
                         continue;
                     }
@@ -411,7 +415,9 @@ fn t2_neighbor_arriving(t2: &Triangle, vertex: VertId) -> Option<usize> {
 /// Retarget `neighbor`'s back-pointer from `old` to `new` if it currently
 /// points to `old`. No-op if `neighbor` is `None` or no slot matches.
 fn retarget_back_pointer(mesh: &mut Mesh, neighbor: Option<TriId>, old: TriId, new: TriId) {
-    let Some(n) = neighbor else { return };
+    let Some(n) = neighbor else {
+        return;
+    };
     if let Some(tri) = mesh.triangles[n].as_mut() {
         for i in 0..3 {
             if tri.neighbors[i] == Some(old) {
@@ -509,7 +515,9 @@ impl Mesh {
             // Iterate neighbor slots in fixed order for determinism.
             let neighbors: [Option<TriId>; 3] = tri.neighbors;
             for &maybe_n in &neighbors {
-                let Some(n) = maybe_n else { continue };
+                let Some(n) = maybe_n else {
+                    continue;
+                };
                 if visited[n] {
                     continue;
                 }

--- a/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
@@ -90,7 +90,11 @@ pub(in crate::tessellate) fn triangulate(
                 continue;
             }
             // Canonical (smaller first) for the dedup set.
-            let canon = if u < v { (u, v) } else { (v, u) };
+            let canon = if u < v {
+                (u, v)
+            } else {
+                (v, u)
+            };
             constraints.insert(canon);
             // Sequential enforcement: each call may flip many edges.
             mesh.enforce_constraint(u, v).ok()?;
@@ -190,7 +194,11 @@ fn point_in_polygon_3x(cx3: i128, cy3: i128, poly: &[Point2]) -> bool {
         let denom = piy3 - pjy3;
         let lhs = (cx3 - pjx3) * denom;
         let rhs = (pix3 - pjx3) * (cy3 - pjy3);
-        let crosses = if denom > 0 { lhs < rhs } else { lhs > rhs };
+        let crosses = if denom > 0 {
+            lhs < rhs
+        } else {
+            lhs > rhs
+        };
         if crosses {
             inside = !inside;
         }

--- a/crates/aether-mesh/tests/mesh_v1_remaining.rs
+++ b/crates/aether-mesh/tests/mesh_v1_remaining.rs
@@ -54,7 +54,11 @@ fn cylinder_outward_normals() {
         // Pick the dominant axis component of the centroid as the
         // expected outward direction.
         let radial_len = c.x.hypot(c.z);
-        let outward = if c.y.abs() > radial_len { [0.0, c.y.signum(), 0.0] } else { [c.x, 0.0, c.z] };
+        let outward = if c.y.abs() > radial_len {
+            [0.0, c.y.signum(), 0.0]
+        } else {
+            [c.x, 0.0, c.z]
+        };
         let dot = n.z.mul_add(outward[2], n.x.mul_add(outward[0], n.y * outward[1]));
         assert!(dot > 0.0, "cylinder face normal points inward for triangle {tri:?}");
     }

--- a/crates/aether-substrate-bundle/build.rs
+++ b/crates/aether-substrate-bundle/build.rs
@@ -65,7 +65,11 @@ fn emit_provenance() {
         .filter(|out| out.status.success())
         .and_then(|out| String::from_utf8(out.stdout).ok())
         .map_or_else(|| "unknown".to_owned(), |s| s.trim().to_owned());
-    let git_sha = if git_sha.is_empty() { "unknown".to_owned() } else { git_sha };
+    let git_sha = if git_sha.is_empty() {
+        "unknown".to_owned()
+    } else {
+        git_sha
+    };
     println!("cargo:rustc-env=AETHER_GIT_SHA={git_sha}");
     let profile = env::var("PROFILE").unwrap_or_else(|_| "unknown".to_owned());
     println!("cargo:rustc-env=AETHER_BUILD_PROFILE={profile}");

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -391,7 +391,11 @@ impl SettlementConfig {
     /// trips, so the wait blocks on the signal forever.
     #[must_use]
     pub fn to_cap(&self) -> Duration {
-        if self.cap_secs == 0 { Duration::MAX } else { Duration::from_secs(self.cap_secs) }
+        if self.cap_secs == 0 {
+            Duration::MAX
+        } else {
+            Duration::from_secs(self.cap_secs)
+        }
     }
 }
 

--- a/crates/aether-substrate-bundle/src/chassis_root.rs
+++ b/crates/aether-substrate-bundle/src/chassis_root.rs
@@ -12,5 +12,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// stays reserved as the `MailId::NONE` sentinel.
 pub fn next_chassis_correlation(counter: &AtomicU64) -> u64 {
     let id = counter.fetch_add(1, Ordering::Relaxed);
-    if id == 0 { counter.fetch_add(1, Ordering::Relaxed) } else { id }
+    if id == 0 {
+        counter.fetch_add(1, Ordering::Relaxed)
+    } else {
+        id
+    }
 }

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -501,7 +501,11 @@ impl App {
     /// The slot is taken only when occluded, so a visible-window wake never
     /// steals the entry `RedrawRequested` is about to service.
     fn fail_capture_if_occluded(&mut self) -> bool {
-        let pending = if self.occluded { self.capture_queue.take() } else { None };
+        let pending = if self.occluded {
+            self.capture_queue.take()
+        } else {
+            None
+        };
         match occluded_capture_disposition(self.occluded, pending) {
             OccludedCaptureDisposition::Redraw => false,
             OccludedCaptureDisposition::Empty => true,

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -209,8 +209,11 @@ impl Gpu {
         };
         surface.configure(&device, &config);
 
-        let polygon_mode =
-            if wireframe_mode == WireframeMode::Line { wgpu::PolygonMode::Line } else { wgpu::PolygonMode::Fill };
+        let polygon_mode = if wireframe_mode == WireframeMode::Line {
+            wgpu::PolygonMode::Line
+        } else {
+            wgpu::PolygonMode::Fill
+        };
         render_handles.install_gpu(RenderGpu::new(
             Arc::clone(&device),
             Arc::clone(&queue),
@@ -375,8 +378,11 @@ impl Gpu {
         // Capture path: the copy runs against the offscreen texture,
         // which is unaffected by whether a swapchain image is available
         // this frame. That decouples capture from window visibility.
-        let capture_meta =
-            if capture.is_some() { Some(self.render_handles.record_capture_copy(&mut encoder)) } else { None };
+        let capture_meta = if capture.is_some() {
+            Some(self.render_handles.record_capture_copy(&mut encoder))
+        } else {
+            None
+        };
 
         // Try to obtain a swapchain texture for presentation. If the
         // surface is occluded/lost/outdated we just skip the blit +

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -385,7 +385,15 @@ pub fn max_out_degree(topo: &Topology) -> usize {
 /// the [`depth_chain`] (light) and [`ui_roundtrip`] (real) factories so the
 /// chain-build lives in one place.
 fn forward_chain_edges(d: usize) -> Vec<Vec<usize>> {
-    (0..d).map(|i| if i + 1 < d { vec![i + 1] } else { vec![] }).collect()
+    (0..d)
+        .map(|i| {
+            if i + 1 < d {
+                vec![i + 1]
+            } else {
+                vec![]
+            }
+        })
+        .collect()
 }
 
 /// `0 -> 1 -> ... -> d-1`. Each relay forwards to the next; the last is
@@ -1036,7 +1044,11 @@ pub fn parse_workers() -> Vec<usize> {
         .split(',')
         .filter_map(|tok| {
             let t = tok.trim();
-            if t.eq_ignore_ascii_case("max") { Some(max) } else { t.parse::<usize>().ok().map(|w| w.max(1)) }
+            if t.eq_ignore_ascii_case("max") {
+                Some(max)
+            } else {
+                t.parse::<usize>().ok().map(|w| w.max(1))
+            }
         })
         .collect();
     out.sort_unstable();

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -797,7 +797,11 @@ fn compare_latency(
             let delta_iqr = iqr_sorted(&delta_sorted);
 
             let verdict = classify(&deltas, delta_median, delta_iqr, base_median, Direction::LowerIsBetter, cfg);
-            let delta_pct = if base_median > 0.0 { delta_median / base_median * 100.0 } else { 0.0 };
+            let delta_pct = if base_median > 0.0 {
+                delta_median / base_median * 100.0
+            } else {
+                0.0
+            };
 
             cells.push(CellComparison {
                 workers: key.workers,
@@ -893,7 +897,11 @@ fn compare_throughput(
         let delta_iqr = iqr_sorted(&delta_sorted);
 
         let verdict = classify(&deltas, delta_median, delta_iqr, base_median, Direction::HigherIsBetter, cfg);
-        let delta_pct = if base_median > 0.0 { delta_median / base_median * 100.0 } else { 0.0 };
+        let delta_pct = if base_median > 0.0 {
+            delta_median / base_median * 100.0
+        } else {
+            0.0
+        };
 
         cells.push(ThroughputComparison {
             workers: key.workers,
@@ -962,7 +970,11 @@ fn compare_keepup(
         base_cells.first().map(|c| c.iter().map(|x| (x.workers, x.topo.clone())).collect()).unwrap_or_default();
 
     let pace_ratio = |c: &KeepUpCell| -> f64 {
-        if c.expected_nanos > 0 { c.elapsed_nanos as f64 / c.expected_nanos as f64 } else { 0.0 }
+        if c.expected_nanos > 0 {
+            c.elapsed_nanos as f64 / c.expected_nanos as f64
+        } else {
+            0.0
+        }
     };
 
     for (workers, topo) in &keys {
@@ -1029,7 +1041,11 @@ fn classify(
         Direction::LowerIsBetter => value_fell,
         Direction::HigherIsBetter => !value_fell,
     };
-    if improved { Verdict::Improved } else { Verdict::Regressed }
+    if improved {
+        Verdict::Improved
+    } else {
+        Verdict::Regressed
+    }
 }
 
 fn us(ns: f64) -> String {

--- a/crates/aether-substrate-bundle/src/test_bench/artifacts.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/artifacts.rs
@@ -276,9 +276,21 @@ fn resolve_artifact_root() -> PathBuf {
 /// nothing but underscores falls back to a fixed name rather than
 /// writing into `root` itself.
 fn sanitize_id(id: &str) -> String {
-    let sanitized: String =
-        id.chars().map(|ch| if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' { ch } else { '_' }).collect();
-    if sanitized.trim_matches('_').is_empty() { "unnamed".to_owned() } else { sanitized }
+    let sanitized: String = id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.trim_matches('_').is_empty() {
+        "unnamed".to_owned()
+    } else {
+        sanitized
+    }
 }
 
 #[cfg(test)]

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -930,7 +930,11 @@ impl TestBench {
     fn fresh_correlation_id(&self) -> u64 {
         // 0 is the "no correlation" sentinel so skip it.
         let id = self.next_correlation_id.fetch_add(1, Ordering::SeqCst);
-        if id == 0 { self.next_correlation_id.fetch_add(1, Ordering::SeqCst) } else { id }
+        if id == 0 {
+            self.next_correlation_id.fetch_add(1, Ordering::SeqCst)
+        } else {
+            id
+        }
     }
 
     /// Pump the event channel and the loopback receiver until a

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -807,7 +807,11 @@ fn settlement_detection_latency() {
 #[allow(clippy::print_stdout, clippy::cast_precision_loss)]
 fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
     let us = |ns: u64| -> String { format!("{:.2}", ns as f64 / 1000.0) };
-    let cond = if pace_hz.is_some() { "paced" } else { "warm" };
+    let cond = if pace_hz.is_some() {
+        "paced"
+    } else {
+        "warm"
+    };
 
     println!();
     println!("=== lifecycle-driven mail latency (all values µs; n = sample count) ===");

--- a/crates/aether-substrate-bundle/src/visual.rs
+++ b/crates/aether-substrate-bundle/src/visual.rs
@@ -566,7 +566,11 @@ pub(crate) fn diagnostic_mask(image: &Image, check: &FrameCheck) -> Vec<u8> {
     if let Some(rect) = clamp_region(region, image.width, image.height) {
         for (x, y, rgb) in region_pixels(image, rect) {
             let start = ((y * image.width + x) * 4) as usize;
-            let pixel = if is_lit(rgb, bg, tolerance) { [255, 255, 255, 255] } else { [0, 0, 0, 255] };
+            let pixel = if is_lit(rgb, bg, tolerance) {
+                [255, 255, 255, 255]
+            } else {
+                [0, 0, 0, 255]
+            };
             mask[start..start + 4].copy_from_slice(&pixel);
         }
     }

--- a/crates/aether-substrate-bundle/tests/camera_controller_drives_camera.rs
+++ b/crates/aether-substrate-bundle/tests/camera_controller_drives_camera.rs
@@ -95,7 +95,11 @@ fn split_chunk() -> SetChunk {
     let mut underlay = vec![0u8; CHUNK_EDGE * CHUNK_EDGE];
     for z in 0..CHUNK_EDGE {
         for x in 0..CHUNK_EDGE {
-            let material = if x < CHUNK_EDGE / 2 { Material::Grass } else { Material::Stone };
+            let material = if x < CHUNK_EDGE / 2 {
+                Material::Grass
+            } else {
+                Material::Stone
+            };
             underlay[z * CHUNK_EDGE + x] = material.to_u8();
         }
     }

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -102,7 +102,11 @@ const DEFAULT_REPLY_CAP_SECS: u64 = 300;
 /// stays the live heartbeat). Mirrors #2062's `AETHER_SETTLEMENT_CAP_SECS`
 /// sentinel.
 pub fn cap_from_secs(secs: u64) -> Duration {
-    if secs == 0 { Duration::MAX } else { Duration::from_secs(secs) }
+    if secs == 0 {
+        Duration::MAX
+    } else {
+        Duration::from_secs(secs)
+    }
 }
 
 /// Resolve the steady-state reply backstop from

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -145,7 +145,11 @@ const WS_OPCODE_CLOSE: u8 = 0x8;
 fn ws_client_frame(opcode: u8, payload: &[u8], fin: bool) -> Vec<u8> {
     let mask = [0x12u8, 0x34, 0x56, 0x78];
     let mut out = Vec::with_capacity(payload.len() + 6);
-    let fin_bit = if fin { 0x80 } else { 0x00 };
+    let fin_bit = if fin {
+        0x80
+    } else {
+        0x00
+    };
     out.push(fin_bit | opcode);
     let len = payload.len();
     if len < 126 {

--- a/crates/aether-substrate-bundle/tests/mover_walks_the_world.rs
+++ b/crates/aether-substrate-bundle/tests/mover_walks_the_world.rs
@@ -106,7 +106,11 @@ fn height_break_chunk() -> SetChunk {
     for z in 0..CHUNK_EDGE {
         for x in 0..CHUNK_EDGE {
             let index = z * CHUNK_EDGE + x;
-            height[index] = if z < HEIGHT_BREAK_ROW { CLIFF_HEIGHT_OCTIMETERS } else { 0 };
+            height[index] = if z < HEIGHT_BREAK_ROW {
+                CLIFF_HEIGHT_OCTIMETERS
+            } else {
+                0
+            };
             region[index] = REGION_ID;
         }
     }

--- a/crates/aether-substrate-bundle/tests/widget_actor_cost.rs
+++ b/crates/aether-substrate-bundle/tests/widget_actor_cost.rs
@@ -160,7 +160,11 @@ fn linear_fit(samples: &[(u32, u64)]) -> (f64, f64) {
         num = dx.mul_add(y - mean_y, num);
         den = dx.mul_add(dx, den);
     }
-    let slope = if den == 0.0 { 0.0 } else { num / den };
+    let slope = if den == 0.0 {
+        0.0
+    } else {
+        num / den
+    };
     (mean_y - slope * mean_x, slope)
 }
 
@@ -176,7 +180,11 @@ fn env_counts(key: &str, default: &[usize], min: usize) -> Vec<usize> {
         .ok()
         .map(|v| v.split(',').filter_map(|s| s.trim().parse::<usize>().ok()).filter(|&n| n >= min).collect())
         .unwrap_or_default();
-    if parsed.is_empty() { default.to_vec() } else { parsed }
+    if parsed.is_empty() {
+        default.to_vec()
+    } else {
+        parsed
+    }
 }
 
 #[test]
@@ -202,7 +210,11 @@ fn widget_actor_per_frame_cost() {
     );
 
     for redraw_each_tick in [true, false] {
-        let profile = if redraw_each_tick { "naive" } else { "cached" };
+        let profile = if redraw_each_tick {
+            "naive"
+        } else {
+            "cached"
+        };
         for &count in &counts {
             let mut bench = TestBench::start_with_size(64, 48).expect("boot");
             let ids = load_widgets(&mut bench, &wasm, count, redraw_each_tick, quad_count);

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -407,8 +407,11 @@ fn assert_virtual_list_rows(
         assert_eq!(quad.y, PANEL_Y + row_offset as f32 * ROW_HEIGHT);
         assert_eq!(quad.width, PANEL_WIDTH);
         assert_eq!(quad.height, ROW_HEIGHT);
-        let expected_tint =
-            if row_offset == selected_row_offset { selected_tint } else { Theme::DEFAULT.surface_raised };
+        let expected_tint = if row_offset == selected_row_offset {
+            selected_tint
+        } else {
+            Theme::DEFAULT.surface_raised
+        };
         assert_eq!(quad.tint, expected_tint, "row offset {row_offset} has the wrong selection/state fill");
     }
 }

--- a/crates/aether-substrate/src/actor/native/blob_lifecycle.rs
+++ b/crates/aether-substrate/src/actor/native/blob_lifecycle.rs
@@ -72,7 +72,14 @@ fn sealed_of(w: u64) -> bool {
 }
 #[inline]
 fn pack(cursor: u64, len: u64, done: u64, seal: bool) -> u64 {
-    cursor | (len << LEN_SHIFT) | (done << DONE_SHIFT) | if seal { SEAL_BIT } else { 0 }
+    cursor
+        | (len << LEN_SHIFT)
+        | (done << DONE_SHIFT)
+        | if seal {
+            SEAL_BIT
+        } else {
+            0
+        }
 }
 
 /// Outcome of a producer's [`Lifecycle::publish`].

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -701,7 +701,11 @@ impl<M: ReplyMode> NativeCtx<'_, M> {
     /// mail from this ctx's in-flight context. `MailId::NONE` collapses
     /// to `None` (chassis-root or close/init ctx).
     pub(crate) fn outbound_parent(&self) -> Option<MailId> {
-        if self.in_flight_mail_id == MailId::NONE { None } else { Some(self.in_flight_mail_id) }
+        if self.in_flight_mail_id == MailId::NONE {
+            None
+        } else {
+            Some(self.in_flight_mail_id)
+        }
     }
 
     /// ADR-0080 §5: derive the inherited `root` to stamp on outbound
@@ -709,7 +713,11 @@ impl<M: ReplyMode> NativeCtx<'_, M> {
     /// to `None`, in which case `NativeBinding::send_mail_with_lineage`
     /// mints a fresh root from the outbound's own `mail_id`.
     pub(crate) fn outbound_root(&self) -> Option<MailId> {
-        if self.in_flight_root == MailId::NONE { None } else { Some(self.in_flight_root) }
+        if self.in_flight_root == MailId::NONE {
+            None
+        } else {
+            Some(self.in_flight_root)
+        }
     }
 
     /// The `(parent, root)` pair a [`NativeActorMailbox`] captures at

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -478,7 +478,11 @@ where
         match self.binding.try_recv() {
             Some(env) => {
                 self.dispatch_one(actor, env);
-                if self.state.try_self_requeue() { CycleResult::Requeue } else { CycleResult::Idle }
+                if self.state.try_self_requeue() {
+                    CycleResult::Requeue
+                } else {
+                    CycleResult::Idle
+                }
             }
             None => CycleResult::Idle,
         }

--- a/crates/aether-substrate/src/actor/native/local.rs
+++ b/crates/aether-substrate/src/actor/native/local.rs
@@ -60,7 +60,11 @@ pub fn with_stamped<R>(slots: &ActorSlots, f: impl FnOnce() -> R) -> R {
 /// `None` when no actor is stamped on this thread.
 fn host_lookup() -> Option<*const ActorSlots> {
     let p = CURRENT_SLOTS.get();
-    if p.is_null() { None } else { Some(p) }
+    if p.is_null() {
+        None
+    } else {
+        Some(p)
+    }
 }
 
 /// Install the host thread-local backend as the process-global `Local`

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -258,7 +258,11 @@ impl Spawner {
         // `Abort` in release (the wedge is unrecoverable — route it
         // through the Spawner's aborter). The helper diverges itself on
         // `Panic`; on `Abort` it hands back the wedge for us to abort.
-        let disposition = if cfg!(debug_assertions) { TerminalDisposition::Panic } else { TerminalDisposition::Abort };
+        let disposition = if cfg!(debug_assertions) {
+            TerminalDisposition::Panic
+        } else {
+            TerminalDisposition::Abort
+        };
         for ((id, _entry), rx) in entries.iter().zip(&waiters) {
             // Issue #2509: name the wedged slot in the gate label so a
             // teardown wedge panic/abort points at the actor whose close

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -99,11 +99,19 @@ impl<A> InheritCtx<A> {
     }
 
     fn outbound_parent(&self) -> Option<MailId> {
-        if self.inherited_mail_id == MailId::NONE { None } else { Some(self.inherited_mail_id) }
+        if self.inherited_mail_id == MailId::NONE {
+            None
+        } else {
+            Some(self.inherited_mail_id)
+        }
     }
 
     fn outbound_root(&self) -> Option<MailId> {
-        if self.inherited_root == MailId::NONE { None } else { Some(self.inherited_root) }
+        if self.inherited_root == MailId::NONE {
+            None
+        } else {
+            Some(self.inherited_root)
+        }
     }
 }
 

--- a/crates/aether-substrate/src/actor/wasm/component/ctx.rs
+++ b/crates/aether-substrate/src/actor/wasm/component/ctx.rs
@@ -226,7 +226,11 @@ impl ComponentCtx {
     /// stamp the child's address; for a normally-addressed actor it is the
     /// component's own id, so the stamp is unchanged.
     fn dispatch_identity(&self, from: MailboxId) -> MailboxId {
-        if from == MailboxId::NONE { self.sender } else { from }
+        if from == MailboxId::NONE {
+            self.sender
+        } else {
+            from
+        }
     }
 
     /// Return the correlation id used by the most recent

--- a/crates/aether-substrate/src/actor/wasm/host_fns.rs
+++ b/crates/aether-substrate/src/actor/wasm/host_fns.rs
@@ -579,7 +579,11 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
 /// guest cannot spoof a foreign id. This is the in-cluster check that the
 /// retired `set_dispatch_source_p32` host fn used to gate the ambient cell.
 fn resolve_dispatch_identity(ctx: &ComponentCtx, from: MailboxId) -> MailboxId {
-    if from != MailboxId::NONE && (from == ctx.sender || is_own_cluster_alias(ctx, from)) { from } else { ctx.sender }
+    if from != MailboxId::NONE && (from == ctx.sender || is_own_cluster_alias(ctx, from)) {
+        from
+    } else {
+        ctx.sender
+    }
 }
 
 /// Whether `candidate` is a registered inline-child alias of *this* component

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -240,12 +240,20 @@ pub fn read_producers_from_bytes(wasm: &[u8]) -> String {
             return String::new();
         };
         for field in producers {
-            let Ok(field) = field else { continue };
+            let Ok(field) = field else {
+                continue;
+            };
             let values: Vec<String> = field
                 .values
                 .into_iter()
                 .filter_map(Result::ok)
-                .map(|v| if v.version.is_empty() { v.name.to_owned() } else { format!("{} {}", v.name, v.version) })
+                .map(|v| {
+                    if v.version.is_empty() {
+                        v.name.to_owned()
+                    } else {
+                        format!("{} {}", v.name, v.version)
+                    }
+                })
                 .collect();
             if !values.is_empty() {
                 parts.push(format!("{}: {}", field.name, values.join(", ")));

--- a/crates/aether-substrate/src/chassis/inbox.rs
+++ b/crates/aether-substrate/src/chassis/inbox.rs
@@ -309,7 +309,11 @@ impl InboundMail {
         let reply_id = MailId::new(self.self_mailbox, correlation);
         // ADR-0080 §5: collapse a NONE parent to `None` (chassis-root /
         // lineage-less inbound), mirroring `NativeCtx::outbound_parent`.
-        let parent = if self.env.mail_id == MailId::NONE { None } else { Some(self.env.mail_id) };
+        let parent = if self.env.mail_id == MailId::NONE {
+            None
+        } else {
+            Some(self.env.mail_id)
+        };
         self.mailer.send_reply(self.env.sender, result, reply_id, self.env.root, parent)
     }
 }

--- a/crates/aether-substrate/src/mail/cost.rs
+++ b/crates/aether-substrate/src/mail/cost.rs
@@ -117,7 +117,11 @@ impl CostCell {
 /// scheduler's handoff calibration, which folds with its own shift.
 #[must_use]
 pub fn ewma_step(current: u64, sample: u64, shift: u32) -> u64 {
-    if sample >= current { current + ((sample - current) >> shift) } else { current - ((current - sample) >> shift) }
+    if sample >= current {
+        current + ((sample - current) >> shift)
+    } else {
+        current - ((current - sample) >> shift)
+    }
 }
 
 /// Per-actor cache mapping a handled `KindId` to its shared [`CostCell`].

--- a/crates/aether-substrate/src/mail/registry/tests.rs
+++ b/crates/aether-substrate/src/mail/registry/tests.rs
@@ -321,7 +321,9 @@ fn closure_handler_runs_on_call() {
             c2.fetch_add(dispatch.count, Ordering::SeqCst);
         }),
     );
-    let Some(MailboxEntry::Inbox { handler: h, .. }) = r.entry(id) else { panic!("expected closure entry") };
+    let Some(MailboxEntry::Inbox { handler: h, .. }) = r.entry(id) else {
+        panic!("expected closure entry")
+    };
     // Test-side id is irrelevant — the handler ignores it.
     h.enqueue(test_owned_dispatch(KindId(0), "aether.tick", &[], 7));
     h.enqueue(OwnedDispatch::disarmed(

--- a/crates/aether-substrate/src/mail/ring.rs
+++ b/crates/aether-substrate/src/mail/ring.rs
@@ -371,7 +371,11 @@ impl MailRing {
         } else {
             size
         };
-        let new_write = if start + occupied == self.cap { 0 } else { start + occupied };
+        let new_write = if start + occupied == self.cap {
+            0
+        } else {
+            start + occupied
+        };
         self.write.store(new_write as u32, Ordering::Relaxed);
         self.live.fetch_add(occupied, Ordering::Relaxed);
         if start == 0 && write != 0 {
@@ -654,7 +658,11 @@ impl MailRing {
         }
         self.live.fetch_add(total, Ordering::Relaxed);
         let end = header_off + total;
-        let new_write = if end == self.cap { 0 } else { end };
+        let new_write = if end == self.cap {
+            0
+        } else {
+            end
+        };
         self.write.store(new_write as u32, Ordering::Relaxed);
     }
 
@@ -727,7 +735,11 @@ impl MailRing {
                 break;
             }
             let total = hdr.total_len as usize;
-            let new_front = if front + total == self.cap { 0 } else { front + total };
+            let new_front = if front + total == self.cap {
+                0
+            } else {
+                front + total
+            };
             self.front.store(new_front as u32, Ordering::Relaxed);
             self.live.fetch_sub(total, Ordering::Relaxed);
             reclaimed += total;
@@ -1134,7 +1146,9 @@ mod tests {
                             let guard = rx.lock().unwrap();
                             guard.recv()
                         };
-                        let Ok(r) = r else { break };
+                        let Ok(r) = r else {
+                            break;
+                        };
                         // SAFETY: we hold this ref's lock count until the
                         // `release` below, so the region is live for the read.
                         let bytes = unsafe { ring.payload(r.payload_off, r.len) };

--- a/crates/aether-substrate/src/scheduler/calibrate.rs
+++ b/crates/aether-substrate/src/scheduler/calibrate.rs
@@ -292,7 +292,11 @@ fn median_nanos(samples: &mut [u64]) -> u64 {
     }
     samples.sort_unstable();
     let mid = samples.len() / 2;
-    if samples.len().is_multiple_of(2) { u64::midpoint(samples[mid - 1], samples[mid]) } else { samples[mid] }
+    if samples.len().is_multiple_of(2) {
+        u64::midpoint(samples[mid - 1], samples[mid])
+    } else {
+        samples[mid]
+    }
 }
 
 #[cfg(test)]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,6 @@
 max_width = 120
 use_small_heuristics = "Max"
+# An if-else (and let-else) never collapses onto one line, whatever fits: the
+# branch structure is the point of the expression, so it always reads vertically.
+single_line_if_else_max_width = 0
+single_line_let_else_max_width = 0

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -405,7 +405,11 @@ fn run_bundle(args: &BundleArgs) -> Result<()> {
         |triple| target_dir.join(triple).join(args.profile.as_str()),
     );
     let windows = args.target.as_deref().map_or(cfg!(windows), |t| t.contains("windows"));
-    let exe = profile_dir.join(if windows { format!("{bin}.exe") } else { bin.to_string() });
+    let exe = profile_dir.join(if windows {
+        format!("{bin}.exe")
+    } else {
+        bin.to_string()
+    });
     println!("{} bundle ({} component(s)) -> {}", plan.chassis.as_str(), plan.components.len(), exe.display());
     Ok(())
 }
@@ -450,7 +454,13 @@ fn resolve_bundle_spec(spec_path: &Path, chassis_flag: BundleChassis) -> Result<
     let spec: BundleSpec =
         serde_json::from_str(&text).with_context(|| format!("parse bundle spec {}", spec_path.display()))?;
     let spec_dir = spec_path.parent().unwrap_or_else(|| Path::new("."));
-    let anchor = |path: &Path| -> PathBuf { if path.is_absolute() { path.to_path_buf() } else { spec_dir.join(path) } };
+    let anchor = |path: &Path| -> PathBuf {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            spec_dir.join(path)
+        }
+    };
     let mut components = Vec::new();
     for (i, entry) in spec.components.iter().enumerate() {
         let source = match (&entry.package, &entry.wasm) {
@@ -483,7 +493,11 @@ fn resolve_bundle_spec(spec_path: &Path, chassis_flag: BundleChassis) -> Result<
 /// `.wasm` suffix; anything else is a workspace package name.
 fn classify_component(raw: &str) -> ComponentSource {
     let is_wasm_path = Path::new(raw).extension().is_some_and(|extension| extension.eq_ignore_ascii_case("wasm"));
-    if is_wasm_path { ComponentSource::Prebuilt(PathBuf::from(raw)) } else { ComponentSource::Package(raw.to_string()) }
+    if is_wasm_path {
+        ComponentSource::Prebuilt(PathBuf::from(raw))
+    } else {
+        ComponentSource::Package(raw.to_string())
+    }
 }
 
 /// Render the pack manifest JSON the chassis package's `build.rs`
@@ -521,7 +535,11 @@ fn bundle_manifest_json(plan: &BundlePlan, wasm_paths: &[PathBuf]) -> Result<ser
 /// dir.
 fn wasm_artifact_path(wasm_profile_dir: &Path, component: &Component) -> PathBuf {
     let file = format!("{}.wasm", component.stem);
-    if component.from_example { wasm_profile_dir.join("examples").join(file) } else { wasm_profile_dir.join(file) }
+    if component.from_example {
+        wasm_profile_dir.join("examples").join(file)
+    } else {
+        wasm_profile_dir.join(file)
+    }
 }
 
 fn copy_artifact(src: &Path, dst: &Path) -> Result<()> {
@@ -541,7 +559,11 @@ fn build_component(plan: &BuildPlan, profile: Profile) -> Result<()> {
     if let Some(flag) = profile.cargo_flag() {
         cmd.arg(flag);
     }
-    let label = if plan.examples { format!("{} (examples)", plan.package) } else { plan.package.clone() };
+    let label = if plan.examples {
+        format!("{} (examples)", plan.package)
+    } else {
+        plan.package.clone()
+    };
     run(cmd, &format!("build component {label}"))
 }
 


### PR DESCRIPTION
First rustfmt.toml for the repo:

- `max_width = 120` with `use_small_heuristics = "Max"` — an expression (call, chain, struct literal, array) tries the single line up to the full 120 columns before wrapping.
- `single_line_if_else_max_width = 0` and `single_line_let_else_max_width = 0` — an if-else / let-else never collapses onto one line, however short: the branch structure is the point of the expression, so it always reads vertically. (Default rustfmt keeps sub-50-char if-elses inline; that form is gone too.)

The rest of the diff is the workspace-wide `cargo fmt` sweep the config implies — 91 files, purely mechanical (joins that now fit 120, plus the newly-broken if/let-else bodies).

Note for landing: at 91 changed `.rs` files this trips the review size cap, so the `Review gate` will fail closed — it needs an owner-applied `review:skip` (this is exactly the mass-mechanical-sweep case the waiver exists for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)