### PR TITLE
fix(ci): allow the runner's own control plane through the dogfood egress firewall

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -331,6 +331,31 @@ jobs:
             aether-evidence.s3.amazonaws.com aether-evidence.s3.${RUNS_ON_AWS_REGION}.amazonaws.com \
             ${RUNS_ON_S3_BUCKET_CACHE}.s3.amazonaws.com ${RUNS_ON_S3_BUCKET_CACHE}.s3.${RUNS_ON_AWS_REGION}.amazonaws.com"
 
+          # The runner agent's OWN control plane. Without these, the DROP policy
+          # silences the agent's re-dials: connections opened before the flip
+          # keep working (the ESTABLISHED rule) — so live logs still stream —
+          # but the first channel that must reconnect (session long-poll /
+          # short-lived credential renewal, ~10 min TTL) hits the drop, GitHub
+          # declares the runner lost, and cancels the job after its ~10-minute
+          # grace ("The operation was canceled." mid-build).
+          domains="$domains \
+            pipelines.actions.githubusercontent.com \
+            broker.actions.githubusercontent.com \
+            results-receiver.actions.githubusercontent.com \
+            vstoken.actions.githubusercontent.com \
+            launch.actions.githubusercontent.com \
+            token.actions.githubusercontent.com"
+
+          # Artifact + log payloads (upload-artifact v4, step logs) upload to
+          # GitHub's OWN Azure storage accounts — a finite, GitHub-owned set
+          # (productionresultssa0..N; unresolvable names drop out harmlessly in
+          # the getent loop). Enumerating them keeps uploads pinned to GitHub's
+          # accounts; a blanket *.blob.core.windows.net allow would reopen
+          # arbitrary-account exfiltration, defeating the firewall's whole point.
+          for i in $(seq 0 29); do
+            domains="$domains productionresultssa${i}.blob.core.windows.net"
+          done
+
           # Flush OUTPUT but leave the policy ACCEPT during setup so the getent
           # DNS lookups below still resolve; the final rule flips it to DROP.
           sudo iptables -F OUTPUT


### PR DESCRIPTION
Every live dogfood trial died at 10–11 minutes mid chassis-build with `Error: The operation was canceled.` and the job annotation `The self-hosted runner lost communication with the server`. The egress firewall allowlisted the hosts the *trial* reaches but not the hosts the *runner agent* needs: pre-firewall connections survive via the `ESTABLISHED` rule (which is why live logs kept streaming), but the agent's first re-dial — session long-poll or its ~10-minute credential renewal — hit the DROP, and GitHub cancels a job ~10 minutes after losing the runner. Hence the punctual death clock.

Adds to the rule-time-resolved allowlist:

- the Actions service hosts: `pipelines` / `broker` / `results-receiver` / `vstoken` / `launch` / `token` `.actions.githubusercontent.com`
- the finite GitHub-owned `productionresultssa{0..29}.blob.core.windows.net` storage accounts that artifact + log payloads upload to — enumerated rather than wildcarded, so uploads stay pinned to GitHub's accounts and a blanket `*.blob.core.windows.net` (arbitrary-account exfil) stays closed. Unresolvable names drop out of the getent loop harmlessly.

Note: `workflow_run`/`workflow_dispatch` runs execute the workflow file from **main**, so this only takes effect once merged — rerunning a trial before that will die the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)