### PR TITLE
feat(kit): add editor shell input routing

### DIFF
--- a/crates/aether-kit/src/console/kinds.rs
+++ b/crates/aether-kit/src/console/kinds.rs
@@ -5,10 +5,6 @@ use aether_data::MailboxId;
 use aether_math::Rgba;
 use serde::{Deserialize, Serialize};
 
-const fn owns_input_by_default() -> bool {
-    true
-}
-
 #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct ConsoleTheme {
     pub background_color: Rgba,
@@ -108,6 +104,10 @@ impl Default for ConsoleTheme {
 
 fn scaled_color(color: Rgba, rgb_scale: f32, alpha: f32) -> Rgba {
     Rgba::new(color.r * rgb_scale, color.g * rgb_scale, color.b * rgb_scale, alpha)
+}
+
+const fn owns_input_by_default() -> bool {
+    true
 }
 
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]

--- a/crates/aether-kit/src/console/kinds.rs
+++ b/crates/aether-kit/src/console/kinds.rs
@@ -5,6 +5,10 @@ use aether_data::MailboxId;
 use aether_math::Rgba;
 use serde::{Deserialize, Serialize};
 
+const fn owns_input_by_default() -> bool {
+    true
+}
+
 #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct ConsoleTheme {
     pub background_color: Rgba,
@@ -117,6 +121,10 @@ pub struct ConsoleConfig {
     pub scrollback_limit: u32,
     pub prompt: String,
     pub theme: ConsoleTheme,
+    /// Whether this standalone console subscribes key, text, and wheel input.
+    /// `WindowSize` remains independently subscribed in either mode.
+    #[serde(default = "owns_input_by_default")]
+    pub owns_input: bool,
 }
 
 impl Default for ConsoleConfig {
@@ -130,6 +138,7 @@ impl Default for ConsoleConfig {
             scrollback_limit: 256,
             prompt: String::from("> "),
             theme: ConsoleTheme::default(),
+            owns_input: true,
         }
     }
 }

--- a/crates/aether-kit/src/console/mod.rs
+++ b/crates/aether-kit/src/console/mod.rs
@@ -423,10 +423,12 @@ impl WasmActor for ConsoleOverlay {
     fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
         ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
         let input = ctx.actor::<InputCapability>();
-        input.subscribe::<Key>();
-        input.subscribe::<KeyRelease>();
-        input.subscribe::<TextInput>();
-        input.subscribe::<MouseWheel>();
+        if self.config.owns_input {
+            input.subscribe::<Key>();
+            input.subscribe::<KeyRelease>();
+            input.subscribe::<TextInput>();
+            input.subscribe::<MouseWheel>();
+        }
         input.subscribe::<WindowSize>();
 
         self.request_initial_font(ctx);

--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -39,6 +39,8 @@
 //!   [`widget::WidgetPanel`] and the concrete [`widget::set`] widgets. The
 //!   widget-compositing vocabulary lives in [`widget`] and the visual tokens
 //!   in [`widget::theme`].
+//! - [`widget::EditorShell`] — the input-only arbiter between independently
+//!   rooted editor regions (ADR-0141).
 //!
 //! `export!` (below) packs the actors into one cdylib (ADR-0096 multi-actor
 //! module); the explicit entry type is the bare-load target, and the FFI
@@ -79,7 +81,7 @@ pub use mark::{
     Mark, MarkCreate, MarkCreateResult, MarkDelete, MarkDeleteResult, MarkGeometry, MarkGet, MarkGetResult, MarkId,
     MarkList, MarkListResult, MarkMutationError, MarkRef, MarkUpdate, MarkUpdateResult, SavedMarks,
 };
-pub use mover::MoverTeleport;
+pub use mover::{MoverConfig, MoverTeleport};
 pub use terrain_editor::{
     ClearTerrainSelection, CreateTerrainMark, DeleteTerrainSelection, MoveTerrainSelection, RelabelTerrainSelection,
     SetTerrainSelection, TerrainCommandResult, TerrainEditorConfig, TerrainEditorError, TerrainEditorQuery,
@@ -87,12 +89,12 @@ pub use terrain_editor::{
 };
 pub use widget::theme::{SetTheme, Theme, ThemeState};
 pub use widget::{
-    ButtonClicked, ButtonConfig, ChildrenChanged, Collect, FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig,
-    ImageFit, LabelConfig, MembershipEntry, PanelConfig, RadioConfig, RadioSelected, ScrollConfig, ScrollDelta,
-    ScrollExtent, ScrollOffset, ScrollOutcome, ScrollResidual, SetWidgetState, SliderChanged, SliderConfig,
-    TextAreaConfig, TextCommitted, TextFieldConfig, VirtualListConfig, VirtualListSelected, WidgetChildSpec,
-    WidgetClipRect, WidgetConfig, WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame, WidgetKind,
-    WidgetStateChanged, WidgetValidation,
+    ButtonClicked, ButtonConfig, ChildrenChanged, Collect, EditorConfig, EditorKeyChord, EditorRegionRect, EditorShell,
+    FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig, ImageFit, LabelConfig, MembershipEntry, PanelConfig,
+    RadioConfig, RadioSelected, RegionInputLanes, RegionSpec, ScrollConfig, ScrollDelta, ScrollExtent, ScrollOffset,
+    ScrollOutcome, ScrollResidual, SetWidgetState, SliderChanged, SliderConfig, TextAreaConfig, TextCommitted,
+    TextFieldConfig, VirtualListConfig, VirtualListSelected, WidgetChildSpec, WidgetClipRect, WidgetConfig,
+    WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged, WidgetValidation,
 };
 pub use world::{
     ApplyBrush, AutomatonRule, BrushParameters, CELLS_PER_CHUNK, CELLS_PER_CHUNK_AREA, CHUNK_BITS, CellPos, Chunk,
@@ -147,6 +149,7 @@ aether_actor::export!(
     widget::set::LabelWidget,
     widget::set::ImageWidget,
     widget::set::VirtualListWidget,
+    EditorShell,
     widget::WidgetPanel
 );
 
@@ -170,6 +173,7 @@ aether_actor::export!(
     widget::set::LabelWidget,
     widget::set::ImageWidget,
     widget::set::VirtualListWidget,
+    EditorShell,
     widget::WidgetPanel,
     aether_behavior::BehaviorHost
 );

--- a/crates/aether-kit/src/mover/kinds.rs
+++ b/crates/aether-kit/src/mover/kinds.rs
@@ -5,6 +5,25 @@
 
 use serde::{Deserialize, Serialize};
 
+const fn owns_input_by_default() -> bool {
+    true
+}
+
+/// `aether.kit.mover.config` — standalone input ownership for the world mover.
+/// Empty component config resolves to this type's default (`owns_input = true`).
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy)]
+#[kind(name = "aether.kit.mover.config")]
+pub struct MoverConfig {
+    #[serde(default = "owns_input_by_default")]
+    pub owns_input: bool,
+}
+
+impl Default for MoverConfig {
+    fn default() -> Self {
+        Self { owns_input: true }
+    }
+}
+
 /// `aether.kit.mover.teleport` — place the controlled body at the center of
 /// the named cell on the world lattice. The cell address is unbounded; a
 /// negative cell is valid (the world plane extends in every direction).

--- a/crates/aether-kit/src/mover/mod.rs
+++ b/crates/aether-kit/src/mover/mod.rs
@@ -156,6 +156,8 @@ impl CamHeld {
 
 /// The controllable body on the painted world.
 pub struct WorldMover {
+    /// Whether this standalone mover subscribes raw interactive input.
+    owns_input: bool,
     /// Body position in octimeters on the world XZ plane.
     pos: (i32, i32),
     /// Held WASD directions.
@@ -179,12 +181,14 @@ pub struct WorldMover {
     cam_held: CamHeld,
 }
 
-#[actor]
+#[actor(instanced)]
 impl WasmActor for WorldMover {
+    type Config = MoverConfig;
     const NAMESPACE: &'static str = "aether.kit.mover";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+    fn init(config: MoverConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Self {
+            owns_input: config.owns_input,
             pos: SPAWN_CELL.center_octimeters(),
             held: Held::default(),
             target: None,
@@ -199,10 +203,12 @@ impl WasmActor for WorldMover {
 
     fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
         let input = ctx.actor::<InputCapability>();
-        input.subscribe::<Key>();
-        input.subscribe::<KeyRelease>();
-        input.subscribe::<MouseButton>();
-        input.subscribe::<MouseMove>();
+        if self.owns_input {
+            input.subscribe::<Key>();
+            input.subscribe::<KeyRelease>();
+            input.subscribe::<MouseButton>();
+            input.subscribe::<MouseMove>();
+        }
         input.subscribe::<WindowSize>();
         let lifecycle = ctx.actor::<LifecycleCapability>();
         lifecycle.subscribe::<Tick>();

--- a/crates/aether-kit/src/widget/editor.rs
+++ b/crates/aether-kit/src/widget/editor.rs
@@ -1,0 +1,126 @@
+//! Input-only editor shell over independently-rooted peer regions (ADR-0141).
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::InputCapability;
+use aether_capabilities::input::InputMailboxExt;
+use aether_kinds::{
+    ImePreedit, Key, KeyRelease, Modifiers, MouseButton, MouseButtonRelease, MouseMove, MouseWheel, TextInput,
+};
+
+use super::EditorConfig;
+use super::routing::{RegionFocusTransition, RegionInputLane, RegionKeyRoute, RegionPointerRoute, Routing};
+
+/// The sole interactive-input subscriber for a configured set of editor peers.
+pub struct EditorShell {
+    routing: Routing,
+}
+
+impl EditorShell {
+    fn prime_focus(&self, ctx: &mut WasmCtx<'_>, transition: Option<RegionFocusTransition>) {
+        let Some(target) = transition.and_then(|transition| transition.next) else {
+            return;
+        };
+        if self.routing.target_accepts(target, RegionInputLane::Modifiers) {
+            ctx.send_to(target, &self.routing.cached_modifiers());
+        }
+    }
+
+    fn forward_pointer<K: aether_data::Kind>(&self, ctx: &mut WasmCtx<'_>, route: RegionPointerRoute, payload: &K) {
+        self.prime_focus(ctx, route.focus);
+        if let Some(target) = route.target {
+            ctx.send_to(target, payload);
+        }
+    }
+
+    fn forward_key<K: aether_data::Kind>(&self, ctx: &mut WasmCtx<'_>, route: RegionKeyRoute, payload: &K) {
+        self.prime_focus(ctx, route.focus);
+        if let Some(target) = route.target {
+            ctx.send_to(target, payload);
+        }
+    }
+}
+
+#[actor(instanced)]
+impl WasmActor for EditorShell {
+    type Config = EditorConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.editor";
+
+    fn init(config: EditorConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Self { routing: Routing::new(&config.regions) })
+    }
+
+    /// Subscribe only raw interactive input. The shell has no lifecycle,
+    /// render, or window-size role.
+    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+        let input = ctx.actor::<InputCapability>();
+        input.subscribe::<MouseButton>();
+        input.subscribe::<MouseButtonRelease>();
+        input.subscribe::<MouseMove>();
+        input.subscribe::<MouseWheel>();
+        input.subscribe::<Key>();
+        input.subscribe::<KeyRelease>();
+        input.subscribe::<TextInput>();
+        input.subscribe::<ImePreedit>();
+        input.subscribe::<Modifiers>();
+    }
+
+    #[handler::single]
+    fn on_mouse_button(&mut self, ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        let route = self.routing.pointer_press(press);
+        self.forward_pointer(ctx, route, &press);
+    }
+
+    #[handler::single]
+    fn on_mouse_button_release(&mut self, ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
+        if let Some(target) = self.routing.pointer_release(release) {
+            ctx.send_to(target, &release);
+        }
+    }
+
+    #[handler::single]
+    fn on_mouse_move(&mut self, ctx: &mut WasmCtx<'_>, moved: MouseMove) {
+        if let Some(target) = self.routing.pointer_motion(moved) {
+            ctx.send_to(target, &moved);
+        }
+    }
+
+    #[handler::single]
+    fn on_mouse_wheel(&mut self, ctx: &mut WasmCtx<'_>, wheel: MouseWheel) {
+        if let Some(target) = self.routing.wheel(wheel) {
+            ctx.send_to(target, &wheel);
+        }
+    }
+
+    #[handler::single]
+    fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
+        let route = self.routing.key_press(key);
+        self.forward_key(ctx, route, &key);
+    }
+
+    #[handler::single]
+    fn on_key_release(&mut self, ctx: &mut WasmCtx<'_>, release: KeyRelease) {
+        let route = self.routing.key_release(release);
+        self.forward_key(ctx, route, &release);
+    }
+
+    #[handler::single]
+    fn on_text_input(&mut self, ctx: &mut WasmCtx<'_>, input: TextInput) {
+        if let Some(target) = self.routing.text_input_target() {
+            ctx.send_to(target, &input);
+        }
+    }
+
+    #[handler::single]
+    fn on_ime_preedit(&mut self, ctx: &mut WasmCtx<'_>, preedit: ImePreedit) {
+        if let Some(target) = self.routing.ime_preedit_target() {
+            ctx.send_to(target, &preedit);
+        }
+    }
+
+    #[handler::single]
+    fn on_modifiers(&mut self, ctx: &mut WasmCtx<'_>, modifiers: Modifiers) {
+        if let Some(target) = self.routing.modifiers(modifiers) {
+            ctx.send_to(target, &modifiers);
+        }
+    }
+}

--- a/crates/aether-kit/src/widget/editor.rs
+++ b/crates/aether-kit/src/widget/editor.rs
@@ -3,12 +3,13 @@
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::InputCapability;
 use aether_capabilities::input::InputMailboxExt;
+use aether_data::{Kind, MailboxId};
 use aether_kinds::{
     ImePreedit, Key, KeyRelease, Modifiers, MouseButton, MouseButtonRelease, MouseMove, MouseWheel, TextInput,
 };
 
 use super::EditorConfig;
-use super::routing::{RegionFocusTransition, RegionInputLane, RegionKeyRoute, RegionPointerRoute, Routing};
+use super::routing::{RegionFocusTransition, RegionInputLane, Routing};
 
 /// The sole interactive-input subscriber for a configured set of editor peers.
 pub struct EditorShell {
@@ -25,16 +26,15 @@ impl EditorShell {
         }
     }
 
-    fn forward_pointer<K: aether_data::Kind>(&self, ctx: &mut WasmCtx<'_>, route: RegionPointerRoute, payload: &K) {
-        self.prime_focus(ctx, route.focus);
-        if let Some(target) = route.target {
-            ctx.send_to(target, payload);
-        }
-    }
-
-    fn forward_key<K: aether_data::Kind>(&self, ctx: &mut WasmCtx<'_>, route: RegionKeyRoute, payload: &K) {
-        self.prime_focus(ctx, route.focus);
-        if let Some(target) = route.target {
+    fn forward<K: Kind>(
+        &self,
+        ctx: &mut WasmCtx<'_>,
+        focus: Option<RegionFocusTransition>,
+        target: Option<MailboxId>,
+        payload: &K,
+    ) {
+        self.prime_focus(ctx, focus);
+        if let Some(target) = target {
             ctx.send_to(target, payload);
         }
     }
@@ -67,7 +67,7 @@ impl WasmActor for EditorShell {
     #[handler::single]
     fn on_mouse_button(&mut self, ctx: &mut WasmCtx<'_>, press: MouseButton) {
         let route = self.routing.pointer_press(press);
-        self.forward_pointer(ctx, route, &press);
+        self.forward(ctx, route.focus, route.target, &press);
     }
 
     #[handler::single]
@@ -94,13 +94,13 @@ impl WasmActor for EditorShell {
     #[handler::single]
     fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
         let route = self.routing.key_press(key);
-        self.forward_key(ctx, route, &key);
+        self.forward(ctx, route.focus, route.target, &key);
     }
 
     #[handler::single]
     fn on_key_release(&mut self, ctx: &mut WasmCtx<'_>, release: KeyRelease) {
         let route = self.routing.key_release(release);
-        self.forward_key(ctx, route, &release);
+        self.forward(ctx, route.focus, route.target, &release);
     }
 
     #[handler::single]

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -819,6 +819,84 @@ pub struct HoverGained;
 #[kind(name = "aether.kit.widget.hover_lost")]
 pub struct HoverLost;
 
+/// A fixed editor region in window pixel coordinates.
+///
+/// Named axes and units keep hit geometry explicit at the wire boundary.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq)]
+pub struct EditorRegionRect {
+    pub x_pixels: f32,
+    pub y_pixels: f32,
+    pub width_pixels: f32,
+    pub height_pixels: f32,
+}
+
+/// Raw input lanes an editor region accepts from [`EditorShell`](crate::widget::EditorShell).
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct RegionInputLanes {
+    pub pointer_press: bool,
+    pub pointer_release: bool,
+    pub pointer_motion: bool,
+    pub wheel: bool,
+    pub key_press: bool,
+    pub key_release: bool,
+    pub text_input: bool,
+    pub ime_preedit: bool,
+    pub modifiers: bool,
+}
+
+impl RegionInputLanes {
+    /// Every raw editor-input lane enabled.
+    pub const ALL: Self = Self {
+        pointer_press: true,
+        pointer_release: true,
+        pointer_motion: true,
+        wheel: true,
+        key_press: true,
+        key_release: true,
+        text_input: true,
+        ime_preedit: true,
+        modifiers: true,
+    };
+}
+
+/// An exact editor-global key chord, matched against the shell's cached
+/// modifier snapshot.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+// Named modifier fields are the schema contract, matching `Modifiers` rather
+// than hiding the chord behind an opaque mask.
+#[allow(clippy::struct_excessive_bools)]
+pub struct EditorKeyChord {
+    pub key_code: u32,
+    pub shift: bool,
+    pub ctrl: bool,
+    pub alt: bool,
+    pub meta: bool,
+}
+
+/// One independently-rooted editor surface registered with the shell.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct RegionSpec {
+    pub name: String,
+    pub rect: EditorRegionRect,
+    pub target: MailboxId,
+    pub keyboard_focus_eligible: bool,
+    pub input_lanes: RegionInputLanes,
+    pub activation_chord: Option<EditorKeyChord>,
+}
+
+/// `aether.kit.widget.editor.config` — ordered peer regions routed by an
+/// input-only [`EditorShell`](crate::widget::EditorShell).
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
+#[kind(name = "aether.kit.widget.editor.config")]
+pub struct EditorConfig {
+    pub regions: Vec<RegionSpec>,
+}
+
+const fn owns_input_by_default() -> bool {
+    true
+}
+
 /// `aether.kit.widget.panel.config` — the reference panel root's layout
 /// config: where the vertical widget stack sits (`x` / `y` top-left, `width`),
 /// its base [`Theme`], the font it loads through `aether.text` to fill the
@@ -841,6 +919,10 @@ pub struct PanelConfig {
     pub font_path: String,
     pub theme: Theme,
     pub children: Vec<WidgetChildSpec>,
+    /// Whether this standalone panel subscribes the raw interactive streams.
+    /// Set false when an [`EditorShell`](crate::widget::EditorShell) owns them.
+    #[serde(default = "owns_input_by_default")]
+    pub owns_input: bool,
 }
 
 impl Default for PanelConfig {
@@ -853,6 +935,7 @@ impl Default for PanelConfig {
             font_path: String::new(),
             theme: Theme::default(),
             children: Vec::new(),
+            owns_input: true,
         }
     }
 }

--- a/crates/aether-kit/src/widget/mod.rs
+++ b/crates/aether-kit/src/widget/mod.rs
@@ -39,14 +39,17 @@
 mod kinds;
 pub use kinds::*;
 pub mod composite;
+mod editor;
 pub mod focus;
 mod panel;
+pub mod routing;
 mod scroll;
 pub mod set;
 mod state;
 pub mod text_edit;
 pub mod theme;
 
+pub use editor::EditorShell;
 pub use panel::WidgetPanel;
 pub use scroll::ScrollWidget;
 

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -827,16 +827,18 @@ impl WasmActor for WidgetPanel {
     /// stage (lifecycle cap) once, and kick off the font load. Widgets never
     /// subscribe — the root forwards everything.
     fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
-        let input = ctx.actor::<InputCapability>();
-        input.subscribe::<MouseButton>();
-        input.subscribe::<MouseButtonRelease>();
-        input.subscribe::<MouseMove>();
-        input.subscribe::<MouseWheel>();
-        input.subscribe::<Key>();
-        input.subscribe::<KeyRelease>();
-        input.subscribe::<TextInput>();
-        input.subscribe::<ImePreedit>();
-        input.subscribe::<Modifiers>();
+        if self.config.owns_input {
+            let input = ctx.actor::<InputCapability>();
+            input.subscribe::<MouseButton>();
+            input.subscribe::<MouseButtonRelease>();
+            input.subscribe::<MouseMove>();
+            input.subscribe::<MouseWheel>();
+            input.subscribe::<Key>();
+            input.subscribe::<KeyRelease>();
+            input.subscribe::<TextInput>();
+            input.subscribe::<ImePreedit>();
+            input.subscribe::<Modifiers>();
+        }
         ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
         if !self.config.font_path.is_empty() {
             ctx.actor::<TextCapability>()

--- a/crates/aether-kit/src/widget/routing.rs
+++ b/crates/aether-kit/src/widget/routing.rs
@@ -46,8 +46,8 @@ impl RegionInputLanes {
 impl EditorKeyChord {
     #[must_use]
     pub const fn matches(self, key: Key, modifiers: Modifiers) -> bool {
-        let pressed_code = key.code;
-        self.key_code == pressed_code
+        let key_code = key.code;
+        self.key_code == key_code
             && self.shift == modifiers.shift
             && self.ctrl == modifiers.ctrl
             && self.alt == modifiers.alt

--- a/crates/aether-kit/src/widget/routing.rs
+++ b/crates/aether-kit/src/widget/routing.rs
@@ -1,0 +1,465 @@
+//! Editor-wide input routing between independently-rooted peer regions.
+//!
+//! [`Routing`] owns only deterministic state. The [`EditorShell`](super::EditorShell)
+//! actor owns subscriptions and turns these named effects into raw mail sends.
+
+use alloc::vec::Vec;
+
+use aether_data::MailboxId;
+use aether_kinds::keycode::KEY_TAB;
+use aether_kinds::{Key, KeyRelease, Modifiers, MouseButton, MouseButtonRelease, MouseMove, MouseWheel};
+use aether_math::{Aabb, Vec3};
+
+use super::{EditorKeyChord, EditorRegionRect, RegionInputLanes, RegionSpec};
+
+/// One raw input lane considered by the router.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionInputLane {
+    PointerPress,
+    PointerRelease,
+    PointerMotion,
+    Wheel,
+    KeyPress,
+    KeyRelease,
+    TextInput,
+    ImePreedit,
+    Modifiers,
+}
+
+impl RegionInputLanes {
+    #[must_use]
+    pub const fn accepts(self, lane: RegionInputLane) -> bool {
+        match lane {
+            RegionInputLane::PointerPress => self.pointer_press,
+            RegionInputLane::PointerRelease => self.pointer_release,
+            RegionInputLane::PointerMotion => self.pointer_motion,
+            RegionInputLane::Wheel => self.wheel,
+            RegionInputLane::KeyPress => self.key_press,
+            RegionInputLane::KeyRelease => self.key_release,
+            RegionInputLane::TextInput => self.text_input,
+            RegionInputLane::ImePreedit => self.ime_preedit,
+            RegionInputLane::Modifiers => self.modifiers,
+        }
+    }
+}
+
+impl EditorKeyChord {
+    #[must_use]
+    pub const fn matches(self, key: Key, modifiers: Modifiers) -> bool {
+        let pressed_code = key.code;
+        self.key_code == pressed_code
+            && self.shift == modifiers.shift
+            && self.ctrl == modifiers.ctrl
+            && self.alt == modifiers.alt
+            && self.meta == modifiers.meta
+    }
+}
+
+/// Region-level pointer capture, tied to the button that established it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegionPressOwner {
+    pub target: MailboxId,
+    pub button: u32,
+}
+
+/// Direction of the reserved editor-region focus cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionFocusDirection {
+    Forward,
+    Backward,
+}
+
+/// One editor-region focus edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegionFocusTransition {
+    pub previous: Option<MailboxId>,
+    pub next: Option<MailboxId>,
+}
+
+/// A pointer press route plus any focus edge it caused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegionPointerRoute {
+    pub target: Option<MailboxId>,
+    pub focus: Option<RegionFocusTransition>,
+}
+
+/// A key route. Reserved editor chords are consumed with no target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegionKeyRoute {
+    pub target: Option<MailboxId>,
+    pub focus: Option<RegionFocusTransition>,
+    pub consumed: bool,
+}
+
+#[derive(Debug, Clone)]
+struct RegionEntry {
+    target: MailboxId,
+    rect: Aabb,
+    keyboard_focus_eligible: bool,
+    input_lanes: RegionInputLanes,
+    activation_chord: Option<EditorKeyChord>,
+}
+
+impl RegionEntry {
+    fn from_spec(spec: &RegionSpec) -> Option<Self> {
+        valid_rect(spec.rect).then(|| Self {
+            target: spec.target,
+            rect: Aabb::from_min_max(
+                Vec3::new(spec.rect.x_pixels, spec.rect.y_pixels, 0.0),
+                Vec3::new(
+                    spec.rect.x_pixels + spec.rect.width_pixels,
+                    spec.rect.y_pixels + spec.rect.height_pixels,
+                    0.0,
+                ),
+            ),
+            keyboard_focus_eligible: spec.keyboard_focus_eligible,
+            input_lanes: spec.input_lanes,
+            activation_chord: spec.activation_chord,
+        })
+    }
+}
+
+fn valid_rect(rect: EditorRegionRect) -> bool {
+    rect.x_pixels.is_finite()
+        && rect.y_pixels.is_finite()
+        && rect.width_pixels.is_finite()
+        && rect.height_pixels.is_finite()
+        && rect.width_pixels > 0.0
+        && rect.height_pixels > 0.0
+        && (rect.x_pixels + rect.width_pixels).is_finite()
+        && (rect.y_pixels + rect.height_pixels).is_finite()
+}
+
+/// Deterministic editor-wide routing state. Holds no mailbox or capability
+/// handle; callers turn its named targets/transitions into sends.
+#[derive(Default)]
+pub struct Routing {
+    entries: Vec<RegionEntry>,
+    focused: Option<MailboxId>,
+    modifiers: Modifiers,
+    cycle_armed: bool,
+    press_owner: Option<RegionPressOwner>,
+}
+
+impl Routing {
+    #[must_use]
+    pub fn new(regions: &[RegionSpec]) -> Self {
+        Self { entries: regions.iter().filter_map(RegionEntry::from_spec).collect(), ..Self::default() }
+    }
+
+    #[must_use]
+    pub fn focused(&self) -> Option<MailboxId> {
+        self.focused
+    }
+
+    #[must_use]
+    pub const fn cached_modifiers(&self) -> Modifiers {
+        self.modifiers
+    }
+
+    #[must_use]
+    pub fn press_owner(&self) -> Option<RegionPressOwner> {
+        self.press_owner
+    }
+
+    #[must_use]
+    pub fn target_accepts(&self, target: MailboxId, lane: RegionInputLane) -> bool {
+        self.accepting_target(target, lane).is_some()
+    }
+
+    #[must_use]
+    pub fn hit_test(&self, x_pixels: f32, y_pixels: f32) -> Option<MailboxId> {
+        if !x_pixels.is_finite() || !y_pixels.is_finite() {
+            return None;
+        }
+        let point = Vec3::new(x_pixels, y_pixels, 0.0);
+        self.entries.iter().rev().find(|entry| entry.rect.contains_point(point)).map(|entry| entry.target)
+    }
+
+    pub fn pointer_press(&mut self, press: MouseButton) -> RegionPointerRoute {
+        if let Some(owner) = self.press_owner {
+            return RegionPointerRoute {
+                target: self.accepting_target(owner.target, RegionInputLane::PointerPress),
+                focus: None,
+            };
+        }
+        let target = self
+            .hit_test(press.x, press.y)
+            .and_then(|target| self.accepting_target(target, RegionInputLane::PointerPress));
+        let focus = target.and_then(|target| {
+            self.press_owner = Some(RegionPressOwner { target, button: press.button });
+            self.focus_target(target)
+        });
+        RegionPointerRoute { target, focus }
+    }
+
+    pub fn pointer_release(&mut self, release: MouseButtonRelease) -> Option<MailboxId> {
+        if let Some(owner) = self.press_owner {
+            if release.button == owner.button {
+                self.press_owner = None;
+            }
+            return self.accepting_target(owner.target, RegionInputLane::PointerRelease);
+        }
+        self.hit_test(release.x, release.y)
+            .and_then(|target| self.accepting_target(target, RegionInputLane::PointerRelease))
+    }
+
+    #[must_use]
+    pub fn pointer_motion(&self, moved: MouseMove) -> Option<MailboxId> {
+        if let Some(owner) = self.press_owner {
+            return self.accepting_target(owner.target, RegionInputLane::PointerMotion);
+        }
+        self.hit_test(moved.x, moved.y).and_then(|target| self.accepting_target(target, RegionInputLane::PointerMotion))
+    }
+
+    #[must_use]
+    pub fn wheel(&self, wheel: MouseWheel) -> Option<MailboxId> {
+        self.hit_test(wheel.x, wheel.y).and_then(|target| self.accepting_target(target, RegionInputLane::Wheel))
+    }
+
+    pub fn key_press(&mut self, key: Key) -> RegionKeyRoute {
+        if key.code == KEY_TAB && self.modifiers.ctrl {
+            self.cycle_armed = true;
+            let direction = if self.modifiers.shift {
+                RegionFocusDirection::Backward
+            } else {
+                RegionFocusDirection::Forward
+            };
+            return RegionKeyRoute { target: None, focus: self.move_focus(direction), consumed: true };
+        }
+
+        if let Some(target) = self.activation_target(key) {
+            let focus = self.focus_target(target);
+            return RegionKeyRoute {
+                target: self.accepting_target(target, RegionInputLane::KeyPress),
+                focus,
+                consumed: false,
+            };
+        }
+
+        RegionKeyRoute { target: self.focused_target(RegionInputLane::KeyPress), focus: None, consumed: false }
+    }
+
+    pub fn key_release(&mut self, release: KeyRelease) -> RegionKeyRoute {
+        if release.code == KEY_TAB && self.cycle_armed {
+            self.cycle_armed = false;
+            return RegionKeyRoute { target: None, focus: None, consumed: true };
+        }
+        RegionKeyRoute { target: self.focused_target(RegionInputLane::KeyRelease), focus: None, consumed: false }
+    }
+
+    pub fn modifiers(&mut self, modifiers: Modifiers) -> Option<MailboxId> {
+        self.modifiers = modifiers;
+        self.focused_target(RegionInputLane::Modifiers)
+    }
+
+    #[must_use]
+    pub fn text_input_target(&self) -> Option<MailboxId> {
+        self.focused_target(RegionInputLane::TextInput)
+    }
+
+    #[must_use]
+    pub fn ime_preedit_target(&self) -> Option<MailboxId> {
+        self.focused_target(RegionInputLane::ImePreedit)
+    }
+
+    fn activation_target(&self, key: Key) -> Option<MailboxId> {
+        self.entries
+            .iter()
+            .find(|entry| {
+                entry.keyboard_focus_eligible
+                    && entry.activation_chord.is_some_and(|chord| chord.matches(key, self.modifiers))
+            })
+            .map(|entry| entry.target)
+    }
+
+    fn accepting_target(&self, target: MailboxId, lane: RegionInputLane) -> Option<MailboxId> {
+        self.entries
+            .iter()
+            .find(|entry| entry.target == target)
+            .filter(|entry| entry.input_lanes.accepts(lane))
+            .map(|entry| entry.target)
+    }
+
+    fn focused_target(&self, lane: RegionInputLane) -> Option<MailboxId> {
+        self.focused.and_then(|target| self.accepting_target(target, lane))
+    }
+
+    fn focus_target(&mut self, target: MailboxId) -> Option<RegionFocusTransition> {
+        let eligible = self.entries.iter().any(|entry| entry.target == target && entry.keyboard_focus_eligible);
+        if !eligible || self.focused == Some(target) {
+            return None;
+        }
+        let previous = self.focused;
+        self.focused = Some(target);
+        Some(RegionFocusTransition { previous, next: Some(target) })
+    }
+
+    fn move_focus(&mut self, direction: RegionFocusDirection) -> Option<RegionFocusTransition> {
+        let count = self.entries.len();
+        if count == 0 {
+            return None;
+        }
+        let current = self.focused.and_then(|target| self.entries.iter().position(|entry| entry.target == target));
+        for offset in 0..count {
+            let index = match (direction, current) {
+                (RegionFocusDirection::Forward, Some(index)) => (index + 1 + offset) % count,
+                (RegionFocusDirection::Forward, None) => offset,
+                (RegionFocusDirection::Backward, Some(index)) => (index + count - 1 - offset) % count,
+                (RegionFocusDirection::Backward, None) => count - 1 - offset,
+            };
+            if self.entries[index].keyboard_focus_eligible {
+                return self.focus_target(self.entries[index].target);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(x_pixels: f32, y_pixels: f32, width_pixels: f32, height_pixels: f32) -> EditorRegionRect {
+        EditorRegionRect { x_pixels, y_pixels, width_pixels, height_pixels }
+    }
+
+    fn region(target: u64, rect: EditorRegionRect, keyboard: bool, input_lanes: RegionInputLanes) -> RegionSpec {
+        RegionSpec {
+            name: alloc::format!("region-{target}"),
+            rect,
+            target: MailboxId(target),
+            keyboard_focus_eligible: keyboard,
+            input_lanes,
+            activation_chord: None,
+        }
+    }
+
+    fn press(button: u32, x: f32, y: f32) -> MouseButton {
+        MouseButton { button, x, y }
+    }
+
+    fn release(button: u32, x: f32, y: f32) -> MouseButtonRelease {
+        MouseButtonRelease { button, x, y }
+    }
+
+    #[test]
+    fn overlap_chooses_topmost_and_lane_rejection_does_not_fall_through() {
+        let lower = region(1, rect(0.0, 0.0, 20.0, 20.0), true, RegionInputLanes::ALL);
+        let upper = region(2, rect(10.0, 10.0, 20.0, 20.0), true, RegionInputLanes::default());
+        let mut routing = Routing::new(&[lower, upper]);
+
+        assert_eq!(routing.hit_test(15.0, 15.0), Some(MailboxId(2)));
+        assert_eq!(routing.pointer_press(press(0, 15.0, 15.0)).target, None);
+        assert_eq!(routing.press_owner(), None);
+        assert_eq!(routing.pointer_press(press(0, 5.0, 5.0)).target, Some(MailboxId(1)));
+    }
+
+    #[test]
+    fn first_press_owns_cross_region_motion_until_its_matching_release() {
+        let mut routing = Routing::new(&[
+            region(1, rect(0.0, 0.0, 10.0, 10.0), true, RegionInputLanes::ALL),
+            region(2, rect(20.0, 0.0, 10.0, 10.0), true, RegionInputLanes::ALL),
+        ]);
+
+        let route = routing.pointer_press(press(0, 5.0, 5.0));
+        assert_eq!(route.target, Some(MailboxId(1)));
+        assert_eq!(route.focus, Some(RegionFocusTransition { previous: None, next: Some(MailboxId(1)) }));
+        assert_eq!(routing.pointer_press(press(1, 25.0, 5.0)).target, Some(MailboxId(1)));
+        assert_eq!(routing.pointer_motion(MouseMove { x: 25.0, y: 5.0 }), Some(MailboxId(1)));
+
+        assert_eq!(routing.pointer_release(release(1, 25.0, 5.0)), Some(MailboxId(1)));
+        assert_eq!(routing.press_owner(), Some(RegionPressOwner { target: MailboxId(1), button: 0 }));
+        assert_eq!(routing.pointer_release(release(0, 25.0, 5.0)), Some(MailboxId(1)));
+        assert_eq!(routing.press_owner(), None);
+        assert_eq!(routing.pointer_motion(MouseMove { x: 25.0, y: 5.0 }), Some(MailboxId(2)));
+    }
+
+    #[test]
+    fn release_without_owner_and_wheel_route_by_current_hit_and_lane() {
+        let mut no_wheel = RegionInputLanes::ALL;
+        no_wheel.wheel = false;
+        let mut routing = Routing::new(&[
+            region(1, rect(0.0, 0.0, 10.0, 10.0), true, RegionInputLanes::ALL),
+            region(2, rect(20.0, 0.0, 10.0, 10.0), true, no_wheel),
+        ]);
+
+        assert_eq!(routing.pointer_release(release(0, 25.0, 5.0)), Some(MailboxId(2)));
+        assert_eq!(routing.wheel(MouseWheel { delta_x: 0.0, delta_y: 2.0, x: 25.0, y: 5.0 }), None);
+        assert_eq!(routing.wheel(MouseWheel { delta_x: 0.0, delta_y: 2.0, x: 5.0, y: 5.0 }), Some(MailboxId(1)));
+    }
+
+    #[test]
+    fn ctrl_tab_cycles_regions_reverse_with_shift_and_plain_tab_routes() {
+        let mut routing = Routing::new(&[
+            region(1, rect(0.0, 0.0, 10.0, 10.0), true, RegionInputLanes::ALL),
+            region(2, rect(20.0, 0.0, 10.0, 10.0), false, RegionInputLanes::ALL),
+            region(3, rect(40.0, 0.0, 10.0, 10.0), true, RegionInputLanes::ALL),
+        ]);
+        routing.pointer_press(press(0, 5.0, 5.0));
+        routing.pointer_release(release(0, 5.0, 5.0));
+
+        routing.modifiers(Modifiers { ctrl: true, ..Modifiers::default() });
+        let forward = routing.key_press(Key { code: KEY_TAB });
+        assert!(forward.consumed);
+        assert_eq!(forward.target, None);
+        assert_eq!(
+            forward.focus,
+            Some(RegionFocusTransition { previous: Some(MailboxId(1)), next: Some(MailboxId(3)) })
+        );
+        assert!(routing.key_release(KeyRelease { code: KEY_TAB }).consumed);
+
+        routing.modifiers(Modifiers { ctrl: true, shift: true, ..Modifiers::default() });
+        assert_eq!(
+            routing.key_press(Key { code: KEY_TAB }).focus,
+            Some(RegionFocusTransition { previous: Some(MailboxId(3)), next: Some(MailboxId(1)) })
+        );
+        routing.key_release(KeyRelease { code: KEY_TAB });
+
+        routing.modifiers(Modifiers::default());
+        let plain = routing.key_press(Key { code: KEY_TAB });
+        assert!(!plain.consumed);
+        assert_eq!(plain.target, Some(MailboxId(1)));
+        assert_eq!(plain.focus, None);
+    }
+
+    #[test]
+    fn activation_chord_focuses_and_lane_filters_keyboard_text_and_ime() {
+        let first = region(1, rect(0.0, 0.0, 10.0, 10.0), true, RegionInputLanes::ALL);
+        let mut second_lanes = RegionInputLanes::ALL;
+        second_lanes.text_input = false;
+        second_lanes.ime_preedit = false;
+        let mut second = region(2, rect(20.0, 0.0, 10.0, 10.0), true, second_lanes);
+        second.activation_chord = Some(EditorKeyChord { key_code: 96, ..EditorKeyChord::default() });
+        let mut routing = Routing::new(&[first, second]);
+
+        routing.pointer_press(press(0, 5.0, 5.0));
+        routing.pointer_release(release(0, 5.0, 5.0));
+        let activation = routing.key_press(Key { code: 96 });
+        assert_eq!(activation.target, Some(MailboxId(2)));
+        assert_eq!(
+            activation.focus,
+            Some(RegionFocusTransition { previous: Some(MailboxId(1)), next: Some(MailboxId(2)) })
+        );
+        assert_eq!(routing.text_input_target(), None);
+        assert_eq!(routing.ime_preedit_target(), None);
+        assert_eq!(routing.key_release(KeyRelease { code: 96 }).target, Some(MailboxId(2)));
+    }
+
+    #[test]
+    fn empty_invalid_and_all_unfocusable_tables_stay_unrouted() {
+        let mut empty = Routing::new(&[]);
+        assert_eq!(empty.pointer_press(press(0, 1.0, 1.0)).target, None);
+        empty.modifiers(Modifiers { ctrl: true, ..Modifiers::default() });
+        assert_eq!(empty.key_press(Key { code: KEY_TAB }).focus, None);
+
+        let invalid = region(1, rect(0.0, 0.0, f32::NAN, 10.0), true, RegionInputLanes::ALL);
+        let overflowing = region(3, rect(f32::MAX, 0.0, f32::MAX, 10.0), true, RegionInputLanes::ALL);
+        let static_region = region(2, rect(20.0, 0.0, 10.0, 10.0), false, RegionInputLanes::ALL);
+        let mut routing = Routing::new(&[invalid, overflowing, static_region]);
+        assert_eq!(routing.hit_test(1.0, 1.0), None);
+        assert_eq!(routing.pointer_press(press(0, 25.0, 5.0)).focus, None);
+        routing.modifiers(Modifiers { ctrl: true, ..Modifiers::default() });
+        assert_eq!(routing.key_press(Key { code: KEY_TAB }).focus, None);
+    }
+}

--- a/crates/aether-substrate-bundle/tests/behavior_host.rs
+++ b/crates/aether-substrate-bundle/tests/behavior_host.rs
@@ -116,6 +116,7 @@ fn load_panel_with_host(bench: &mut TestBench, kit_wasm: &[u8], script: Vec<u8>)
             clip: None,
             config: host_spec.encode_into_bytes(),
         }],
+        owns_input: true,
     };
     let loaded = bench
         .execute(vec![(

--- a/crates/aether-substrate-bundle/tests/console_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/console_render_interaction.rs
@@ -20,13 +20,15 @@ use std::path::{Path, PathBuf};
 use aether_actor::Addressable;
 use aether_capabilities::RenderCapability;
 use aether_capabilities::fs::NamespaceRoots;
-use aether_data::Kind;
+use aether_data::{Kind, MailboxId};
 use aether_kinds::keycode::KEY_BACKQUOTE;
 use aether_kinds::{
     CaptureFrame, CaptureFrameResult, FrameCheck, FrameCheckResult, FrameRect, FrameReduction, Key, LoadComponent,
     LoadResult, NamedMail, Tick, WindowSize,
 };
-use aether_kit::{ConsoleCommandOutput, ConsoleConfig};
+use aether_kit::{
+    ConsoleCommandOutput, ConsoleConfig, EditorConfig, EditorKeyChord, EditorRegionRect, RegionInputLanes, RegionSpec,
+};
 use aether_substrate_bundle::test_bench::{
     BenchOp, TestBench,
     test_helpers::{init_save_sandbox, require_runtime},
@@ -71,11 +73,11 @@ fn envelope<K: Kind>(recipient: &str, mail: &K) -> NamedMail {
     }
 }
 
-fn load_console(bench: &mut TestBench, wasm: &[u8]) {
-    load_console_with_config(bench, wasm, &ConsoleConfig::default());
+fn load_console(bench: &mut TestBench, wasm: &[u8]) -> MailboxId {
+    load_console_with_config(bench, wasm, &ConsoleConfig::default())
 }
 
-fn load_console_with_config(bench: &mut TestBench, wasm: &[u8], config: &ConsoleConfig) {
+fn load_console_with_config(bench: &mut TestBench, wasm: &[u8], config: &ConsoleConfig) -> MailboxId {
     let loaded = bench
         .execute(vec![(
             "load",
@@ -91,10 +93,48 @@ fn load_console_with_config(bench: &mut TestBench, wasm: &[u8], config: &Console
         )])
         .expect("load sequence");
     match loaded.reply::<LoadResult>("load").expect("decode LoadResult") {
-        LoadResult::Ok { name, .. } => {
+        LoadResult::Ok { mailbox_id, name, .. } => {
             assert!(name.ends_with(":console"), "console should register under :console; got {name}");
+            mailbox_id
         }
         LoadResult::Err { error } => panic!("load console: {error}"),
+    }
+}
+
+fn load_editor_shell(bench: &mut TestBench, wasm: &[u8], target: MailboxId) {
+    let config = EditorConfig {
+        regions: vec![RegionSpec {
+            name: "console".to_owned(),
+            rect: EditorRegionRect { x_pixels: 0.0, y_pixels: 0.0, width_pixels: 320.0, height_pixels: 200.0 },
+            target,
+            keyboard_focus_eligible: true,
+            input_lanes: RegionInputLanes::ALL,
+            activation_chord: Some(EditorKeyChord {
+                key_code: KEY_BACKQUOTE,
+                shift: false,
+                ctrl: false,
+                alt: false,
+                meta: false,
+            }),
+        }],
+    };
+    let loaded = bench
+        .execute(vec![(
+            "load-editor",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: wasm.to_vec(),
+                    name: Some("editor".to_owned()),
+                    config: config.encode_into_bytes(),
+                    export: Some("aether.kit.widget.editor".to_owned()),
+                },
+            ),
+        )])
+        .expect("load editor shell");
+    match loaded.reply::<LoadResult>("load-editor").expect("decode editor LoadResult") {
+        LoadResult::Ok { .. } => {}
+        LoadResult::Err { error } => panic!("load editor shell: {error}"),
     }
 }
 
@@ -201,6 +241,36 @@ fn backquote_key_opens_console_overlay() {
 
     let open = top_band_coverage(&mut bench, "open");
     assert!(open > 0.90, "backquote should open the console and cover the top band; coverage={open:.3}");
+}
+
+#[test]
+fn editor_shell_exclusively_forwards_console_input_while_window_size_stays_direct() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = build_bench();
+    let console =
+        load_console_with_config(&mut bench, &wasm, &ConsoleConfig { owns_input: false, ..ConsoleConfig::default() });
+
+    bench
+        .execute(vec![
+            (
+                "size-direct-fanout",
+                BenchOp::send_mail("aether.input", &WindowSize { width: WINDOW_WIDTH, height: WINDOW_HEIGHT }),
+            ),
+            ("unrouted-toggle", BenchOp::send_mail("aether.input", &Key { code: KEY_BACKQUOTE })),
+        ])
+        .expect("direct fanout before editor shell");
+    let closed = top_band_coverage(&mut bench, "owns-input-disabled");
+    assert!(closed < 0.01, "console must not self-subscribe to interactive input; coverage={closed:.3}");
+
+    load_editor_shell(&mut bench, &wasm, console);
+    bench
+        .execute(vec![("routed-toggle", BenchOp::send_mail("aether.input", &Key { code: KEY_BACKQUOTE }))])
+        .expect("toggle through editor shell");
+    let open = top_band_coverage(&mut bench, "editor-routed");
+    assert!(open > 0.90, "editor shell should forward backquote exactly once; coverage={open:.3}");
 }
 
 #[test]

--- a/crates/aether-substrate-bundle/tests/mover_walks_the_world.rs
+++ b/crates/aether-substrate-bundle/tests/mover_walks_the_world.rs
@@ -19,14 +19,16 @@
 use std::fs;
 
 use aether_actor::Addressable;
-use aether_data::Kind;
+use aether_data::{Kind, MailboxId};
 use aether_kinds::keycode::KEY_W;
 use aether_kinds::{
     CaptureFrame, CaptureFrameResult, FrameCheck, FrameCheckResult, FrameReduction, Key, KeyRelease, LoadComponent,
     LoadResult, NamedMail, Render, WindowSize,
 };
-use aether_kit::MoverTeleport;
 use aether_kit::world::{Material, SetChunk, SetRegion};
+use aether_kit::{
+    EditorConfig, EditorKeyChord, EditorRegionRect, MoverConfig, MoverTeleport, RegionInputLanes, RegionSpec,
+};
 use aether_substrate_bundle::test_bench::{ArtifactGuard, BenchOp, TestBench, test_helpers::require_runtime};
 use aether_substrate_bundle::visual::{ColorRegionStats, Rect, decode_png, mean_absolute_error, target_color_stats};
 
@@ -73,7 +75,17 @@ fn envelope<K: Kind>(recipient: &str, mail: &K) -> NamedMail {
     }
 }
 
-fn load_kit_export(bench: &mut TestBench, wasm: &[u8], export: &str, name: &str) {
+fn load_kit_export(bench: &mut TestBench, wasm: &[u8], export: &str, name: &str) -> MailboxId {
+    load_kit_export_with_config(bench, wasm, export, name, Vec::new())
+}
+
+fn load_kit_export_with_config(
+    bench: &mut TestBench,
+    wasm: &[u8],
+    export: &str,
+    name: &str,
+    config: Vec<u8>,
+) -> MailboxId {
     let loaded = bench
         .execute(vec![(
             "load",
@@ -82,19 +94,44 @@ fn load_kit_export(bench: &mut TestBench, wasm: &[u8], export: &str, name: &str)
                 &LoadComponent {
                     wasm: wasm.to_vec(),
                     name: Some(name.to_owned()),
-                    config: Vec::new(),
+                    config,
                     export: Some(export.to_owned()),
                 },
             ),
         )])
         .expect("load sequence");
     match loaded.reply::<LoadResult>("load").expect("decode LoadResult") {
-        LoadResult::Ok { name: address, .. } => assert!(
-            address.ends_with(&format!(":{name}")),
-            "export {export} should register under :{name}; got {address}",
-        ),
+        LoadResult::Ok { mailbox_id, name: address, .. } => {
+            assert!(
+                address.ends_with(&format!(":{name}")),
+                "export {export} should register under :{name}; got {address}",
+            );
+            mailbox_id
+        }
         LoadResult::Err { error } => panic!("load {export}: {error}"),
     }
+}
+
+fn load_mover_editor_shell(bench: &mut TestBench, wasm: &[u8], mover: MailboxId) {
+    let lanes = RegionInputLanes { key_press: true, key_release: true, ..RegionInputLanes::default() };
+    let config = EditorConfig {
+        regions: vec![RegionSpec {
+            name: "world".to_owned(),
+            rect: EditorRegionRect { x_pixels: 0.0, y_pixels: 0.0, width_pixels: 128.0, height_pixels: 96.0 },
+            target: mover,
+            keyboard_focus_eligible: true,
+            input_lanes: lanes,
+            activation_chord: Some(EditorKeyChord {
+                key_code: KEY_W,
+                shift: false,
+                ctrl: false,
+                alt: false,
+                meta: false,
+            }),
+        }],
+    };
+    let _editor =
+        load_kit_export_with_config(bench, wasm, "aether.kit.widget.editor", "editor", config.encode_into_bytes());
 }
 
 /// Chunk 0 is one grass region. Rows north of z=8 sit one meter above the
@@ -201,6 +238,82 @@ fn assert_cliff_shape(label: &str, stats: ColorRegionStats, exclusion: ColorRegi
             && (1..=14).contains(&height),
         "{label} sand target should be a wide, shallow interior cliff face; \
          bounds={bounds:?} width={width} height={height} stats={stats:?}",
+    );
+}
+
+#[test]
+fn mover_opts_out_of_interactive_fanout_but_moves_when_the_editor_routes_input() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = TestBench::start_with_size(WINDOW_WIDTH, WINDOW_HEIGHT).expect("boot");
+    let world = component_address("world");
+    let mover_address = component_address("mover");
+    let _world_mailbox = load_kit_export(&mut bench, &wasm, "aether.kit.world", "world");
+    let mover_mailbox = load_kit_export_with_config(
+        &mut bench,
+        &wasm,
+        "aether.kit.mover",
+        "mover",
+        MoverConfig { owns_input: false }.encode_into_bytes(),
+    );
+
+    bench
+        .execute(vec![
+            (
+                "region",
+                BenchOp::send_mail(
+                    world.as_str(),
+                    &SetRegion {
+                        region_id: REGION_ID,
+                        name: "meadow".to_owned(),
+                        default_material: Material::Grass.to_u8(),
+                        cliff_material: Material::Sand.to_u8(),
+                    },
+                ),
+            ),
+            ("chunk", BenchOp::send_mail(world.as_str(), &height_break_chunk())),
+            (
+                "retained-window-size",
+                BenchOp::send_mail("aether.input", &WindowSize { width: WINDOW_WIDTH, height: WINDOW_HEIGHT }),
+            ),
+            ("place", BenchOp::send_mail(mover_address.as_str(), &MoverTeleport { cell_x: 8, cell_z: 12 })),
+            ("settle", BenchOp::advance(2)),
+        ])
+        .expect("author world and settle opted-out mover");
+
+    let before = capture_scene(&mut bench, &mover_address, &world, "opt-out-before");
+    bench
+        .execute(vec![
+            ("unrouted-w", BenchOp::send_mail("aether.input", &Key { code: KEY_W })),
+            ("unrouted-advance", BenchOp::advance(32)),
+        ])
+        .expect("unrouted input window");
+    let blocked = capture_scene(&mut bench, &mover_address, &world, "opt-out-blocked");
+
+    load_mover_editor_shell(&mut bench, &wasm, mover_mailbox);
+    bench
+        .execute(vec![
+            ("routed-w", BenchOp::send_mail("aether.input", &Key { code: KEY_W })),
+            ("routed-advance", BenchOp::advance(32)),
+            ("routed-release", BenchOp::send_mail("aether.input", &KeyRelease { code: KEY_W })),
+        ])
+        .expect("editor-routed input window");
+    let routed = capture_scene(&mut bench, &mover_address, &world, "editor-routed");
+
+    let before_image = decode_png(&before.png).expect("decode before png");
+    let blocked_image = decode_png(&blocked.png).expect("decode blocked png");
+    let routed_image = decode_png(&routed.png).expect("decode routed png");
+    let blocked_mae = mean_absolute_error(&blocked_image, &before_image).expect("same-size blocked captures");
+    let routed_mae = mean_absolute_error(&routed_image, &blocked_image).expect("same-size routed captures");
+    assert!(
+        blocked_mae < 0.005,
+        "owns_input=false must prevent the mover from self-subscribing to W; blocked MAE={blocked_mae:.4}",
+    );
+    assert!(
+        (0.002..0.35).contains(&routed_mae),
+        "the editor shell must forward W to the opted-out mover; routed MAE={routed_mae:.4}",
     );
 }
 

--- a/crates/aether-substrate-bundle/tests/widget_compositing.rs
+++ b/crates/aether-substrate-bundle/tests/widget_compositing.rs
@@ -178,6 +178,7 @@ fn load_scroll_panel(bench: &mut TestBench, wasm: &[u8], child: WidgetChildSpec)
         font_path: String::new(),
         theme: Theme::DEFAULT,
         children: vec![child],
+        owns_input: true,
     };
     let loaded = bench
         .execute(vec![(

--- a/crates/aether-substrate-bundle/tests/widget_editor_routing.rs
+++ b/crates/aether-substrate-bundle/tests/widget_editor_routing.rs
@@ -1,0 +1,227 @@
+//! Strict acceptance for ADR-0141 editor-wide input routing.
+
+use std::fs;
+use std::path::Path;
+
+use aether_data::{Kind, MailboxId};
+use aether_kinds::keycode::{KEY_BACKQUOTE, KEY_TAB};
+use aether_kinds::{
+    ImePreedit, Key, KeyRelease, LoadComponent, LoadResult, Modifiers, MouseButton, MouseButtonRelease, MouseMove,
+    MouseWheel, TextInput,
+};
+use aether_kit::{EditorConfig, EditorKeyChord, EditorRegionRect, RegionInputLanes, RegionSpec};
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
+use aether_test_fixtures_kinds::{
+    DrainEditorInputs, DrainEditorInputsResult, EditorRegionProbeConfig, ObservedEditorInput,
+};
+
+struct LoadedActor {
+    mailbox_id: MailboxId,
+    address: String,
+}
+
+fn load_actor<K: Kind>(bench: &mut TestBench, wasm_path: &Path, export: &str, name: &str, config: &K) -> LoadedActor {
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: fs::read(wasm_path).expect("read wasm component"),
+                    name: Some(name.to_owned()),
+                    config: config.encode_into_bytes(),
+                    export: Some(export.to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded.reply::<LoadResult>("load").expect("decode LoadResult") {
+        LoadResult::Ok { mailbox_id, name: address, .. } => LoadedActor { mailbox_id, address },
+        LoadResult::Err { error } => panic!("load {export} as {name}: {error}"),
+    }
+}
+
+fn region(name: &str, target: MailboxId, x_pixels: f32, input_lanes: RegionInputLanes) -> RegionSpec {
+    RegionSpec {
+        name: name.to_owned(),
+        rect: EditorRegionRect { x_pixels, y_pixels: 0.0, width_pixels: 100.0, height_pixels: 100.0 },
+        target,
+        keyboard_focus_eligible: true,
+        input_lanes,
+        activation_chord: None,
+    }
+}
+
+fn load_probe(bench: &mut TestBench, wasm_path: &Path, name: &str) -> LoadedActor {
+    load_actor(
+        bench,
+        wasm_path,
+        "test.editor_region_probe",
+        name,
+        &EditorRegionProbeConfig { region_name: name.to_owned() },
+    )
+}
+
+fn load_shell(bench: &mut TestBench, wasm_path: &Path, regions: Vec<RegionSpec>) {
+    let _shell = load_actor(bench, wasm_path, "aether.kit.widget.editor", "editor", &EditorConfig { regions });
+}
+
+fn drain(bench: &mut TestBench, actor: &LoadedActor, label: &'static str) -> DrainEditorInputsResult {
+    bench
+        .execute(vec![(label, BenchOp::send_and_await(actor.address.as_str(), &DrainEditorInputs))])
+        .expect("drain sequence")
+        .reply::<DrainEditorInputsResult>(label)
+        .expect("decode DrainEditorInputsResult")
+}
+
+#[test]
+fn first_press_owns_cross_region_drag_and_lanes_filter_at_the_hit_region() {
+    let (Some(kit_wasm), Some(fixtures_wasm)) =
+        (require_runtime("aether_kit"), require_runtime("aether_test_fixtures_bundle"))
+    else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(200, 100).expect("boot");
+    let region_a = load_probe(&mut bench, &fixtures_wasm, "region-a");
+    let region_b = load_probe(&mut bench, &fixtures_wasm, "region-b");
+    let mut b_lanes = RegionInputLanes::ALL;
+    b_lanes.wheel = false;
+    load_shell(
+        &mut bench,
+        &kit_wasm,
+        vec![
+            region("region-a", region_a.mailbox_id, 0.0, RegionInputLanes::ALL),
+            region("region-b", region_b.mailbox_id, 100.0, b_lanes),
+        ],
+    );
+
+    bench
+        .execute(vec![
+            ("press-a", BenchOp::send_mail("aether.input", &MouseButton { button: 0, x: 20.0, y: 20.0 })),
+            ("drag-b", BenchOp::send_mail("aether.input", &MouseMove { x: 140.0, y: 25.0 })),
+            (
+                "release-other-b",
+                BenchOp::send_mail("aether.input", &MouseButtonRelease { button: 1, x: 140.0, y: 25.0 }),
+            ),
+            (
+                "release-owner-b",
+                BenchOp::send_mail("aether.input", &MouseButtonRelease { button: 0, x: 140.0, y: 25.0 }),
+            ),
+            ("move-b", BenchOp::send_mail("aether.input", &MouseMove { x: 150.0, y: 30.0 })),
+            (
+                "release-without-owner-b",
+                BenchOp::send_mail("aether.input", &MouseButtonRelease { button: 0, x: 150.0, y: 30.0 }),
+            ),
+            (
+                "filtered-wheel-b",
+                BenchOp::send_mail("aether.input", &MouseWheel { delta_x: 0.0, delta_y: -12.0, x: 150.0, y: 30.0 }),
+            ),
+        ])
+        .expect("route pointer sequence");
+
+    assert_eq!(
+        drain(&mut bench, &region_a, "drain-a"),
+        DrainEditorInputsResult {
+            region_name: "region-a".to_owned(),
+            inputs: vec![
+                ObservedEditorInput::Modifiers { shift: false, ctrl: false, alt: false, meta: false },
+                ObservedEditorInput::PointerPress { button: 0, x_pixels: 20.0, y_pixels: 20.0 },
+                ObservedEditorInput::PointerMotion { x_pixels: 140.0, y_pixels: 25.0 },
+                ObservedEditorInput::PointerRelease { button: 1, x_pixels: 140.0, y_pixels: 25.0 },
+                ObservedEditorInput::PointerRelease { button: 0, x_pixels: 140.0, y_pixels: 25.0 },
+            ],
+        },
+    );
+    assert_eq!(
+        drain(&mut bench, &region_b, "drain-b"),
+        DrainEditorInputsResult {
+            region_name: "region-b".to_owned(),
+            inputs: vec![
+                ObservedEditorInput::PointerMotion { x_pixels: 150.0, y_pixels: 30.0 },
+                ObservedEditorInput::PointerRelease { button: 0, x_pixels: 150.0, y_pixels: 30.0 },
+            ],
+        },
+    );
+}
+
+#[test]
+fn focus_activation_and_reserved_cycle_route_each_keyboard_lane_once() {
+    let (Some(kit_wasm), Some(fixtures_wasm)) =
+        (require_runtime("aether_kit"), require_runtime("aether_test_fixtures_bundle"))
+    else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(200, 100).expect("boot");
+    let region_a = load_probe(&mut bench, &fixtures_wasm, "focus-a");
+    let region_b = load_probe(&mut bench, &fixtures_wasm, "focus-b");
+    let a = region("focus-a", region_a.mailbox_id, 0.0, RegionInputLanes::ALL);
+    let mut b = region("focus-b", region_b.mailbox_id, 100.0, RegionInputLanes::ALL);
+    b.activation_chord =
+        Some(EditorKeyChord { key_code: KEY_BACKQUOTE, shift: false, ctrl: false, alt: false, meta: false });
+    load_shell(&mut bench, &kit_wasm, vec![a, b]);
+
+    bench
+        .execute(vec![
+            ("focus-a", BenchOp::send_mail("aether.input", &MouseButton { button: 0, x: 20.0, y: 20.0 })),
+            ("release-a", BenchOp::send_mail("aether.input", &MouseButtonRelease { button: 0, x: 20.0, y: 20.0 })),
+        ])
+        .expect("prime focus");
+    let _initial_a = drain(&mut bench, &region_a, "drain-initial-a");
+
+    bench
+        .execute(vec![
+            ("key-a", BenchOp::send_mail("aether.input", &Key { code: 65 })),
+            ("text-a", BenchOp::send_mail("aether.input", &TextInput { text: "a".to_owned() })),
+            ("activate-b", BenchOp::send_mail("aether.input", &Key { code: KEY_BACKQUOTE })),
+            (
+                "ime-b",
+                BenchOp::send_mail(
+                    "aether.input",
+                    &ImePreedit { text: "composition".to_owned(), cursor_begin: Some(1), cursor_end: Some(3) },
+                ),
+            ),
+            ("text-b", BenchOp::send_mail("aether.input", &TextInput { text: "b".to_owned() })),
+            (
+                "ctrl-b",
+                BenchOp::send_mail("aether.input", &Modifiers { shift: false, ctrl: true, alt: false, meta: false }),
+            ),
+            ("cycle-a", BenchOp::send_mail("aether.input", &Key { code: KEY_TAB })),
+            ("cycle-release", BenchOp::send_mail("aether.input", &KeyRelease { code: KEY_TAB })),
+            ("clear-modifiers", BenchOp::send_mail("aether.input", &Modifiers::default())),
+            ("plain-tab", BenchOp::send_mail("aether.input", &Key { code: KEY_TAB })),
+            ("plain-tab-release", BenchOp::send_mail("aether.input", &KeyRelease { code: KEY_TAB })),
+        ])
+        .expect("route keyboard sequence");
+
+    assert_eq!(
+        drain(&mut bench, &region_a, "drain-focus-a"),
+        DrainEditorInputsResult {
+            region_name: "focus-a".to_owned(),
+            inputs: vec![
+                ObservedEditorInput::KeyPress { key_code: 65 },
+                ObservedEditorInput::TextInput { text: "a".to_owned() },
+                ObservedEditorInput::Modifiers { shift: false, ctrl: true, alt: false, meta: false },
+                ObservedEditorInput::Modifiers { shift: false, ctrl: false, alt: false, meta: false },
+                ObservedEditorInput::KeyPress { key_code: KEY_TAB },
+                ObservedEditorInput::KeyRelease { key_code: KEY_TAB },
+            ],
+        },
+    );
+    assert_eq!(
+        drain(&mut bench, &region_b, "drain-focus-b"),
+        DrainEditorInputsResult {
+            region_name: "focus-b".to_owned(),
+            inputs: vec![
+                ObservedEditorInput::Modifiers { shift: false, ctrl: false, alt: false, meta: false },
+                ObservedEditorInput::KeyPress { key_code: KEY_BACKQUOTE },
+                ObservedEditorInput::ImePreedit {
+                    text: "composition".to_owned(),
+                    cursor_begin: Some(1),
+                    cursor_end: Some(3),
+                },
+                ObservedEditorInput::TextInput { text: "b".to_owned() },
+                ObservedEditorInput::Modifiers { shift: false, ctrl: true, alt: false, meta: false },
+            ],
+        },
+    );
+}

--- a/crates/aether-substrate-bundle/tests/widget_editor_routing.rs
+++ b/crates/aether-substrate-bundle/tests/widget_editor_routing.rs
@@ -53,13 +53,7 @@ fn region(name: &str, target: MailboxId, x_pixels: f32, input_lanes: RegionInput
 }
 
 fn load_probe(bench: &mut TestBench, wasm_path: &Path, name: &str) -> LoadedActor {
-    load_actor(
-        bench,
-        wasm_path,
-        "test.editor_region_probe",
-        name,
-        &EditorRegionProbeConfig { region_name: name.to_owned() },
-    )
+    load_actor(bench, wasm_path, "test.editor_region_probe", name, &EditorRegionProbeConfig { name: name.to_owned() })
 }
 
 fn load_shell(bench: &mut TestBench, wasm_path: &Path, regions: Vec<RegionSpec>) {
@@ -198,12 +192,12 @@ fn focus_activation_and_reserved_cycle_route_each_keyboard_lane_once() {
         DrainEditorInputsResult {
             region_name: "focus-a".to_owned(),
             inputs: vec![
-                ObservedEditorInput::KeyPress { key_code: 65 },
+                ObservedEditorInput::KeyPress { code: 65 },
                 ObservedEditorInput::TextInput { text: "a".to_owned() },
                 ObservedEditorInput::Modifiers { shift: false, ctrl: true, alt: false, meta: false },
                 ObservedEditorInput::Modifiers { shift: false, ctrl: false, alt: false, meta: false },
-                ObservedEditorInput::KeyPress { key_code: KEY_TAB },
-                ObservedEditorInput::KeyRelease { key_code: KEY_TAB },
+                ObservedEditorInput::KeyPress { code: KEY_TAB },
+                ObservedEditorInput::KeyRelease { code: KEY_TAB },
             ],
         },
     );
@@ -213,7 +207,7 @@ fn focus_activation_and_reserved_cycle_route_each_keyboard_lane_once() {
             region_name: "focus-b".to_owned(),
             inputs: vec![
                 ObservedEditorInput::Modifiers { shift: false, ctrl: false, alt: false, meta: false },
-                ObservedEditorInput::KeyPress { key_code: KEY_BACKQUOTE },
+                ObservedEditorInput::KeyPress { code: KEY_BACKQUOTE },
                 ObservedEditorInput::ImePreedit {
                     text: "composition".to_owned(),
                     cursor_begin: Some(1),

--- a/crates/aether-substrate-bundle/tests/widget_image.rs
+++ b/crates/aether-substrate-bundle/tests/widget_image.rs
@@ -90,6 +90,7 @@ fn load_panel(bench: &mut TestBench, wasm: &[u8], config: &ImageConfig) -> Strin
             clip: None,
             config: config.encode_into_bytes(),
         }],
+        owns_input: true,
     };
     let loaded = bench
         .execute(vec![(

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -249,7 +249,7 @@ fn load_editor_probe(bench: &mut TestBench, wasm_path: &Path) -> LoadedProbe {
                 &LoadComponent {
                     wasm: fs::read(wasm_path).expect("read fixture wasm"),
                     name: Some("region-b".to_owned()),
-                    config: EditorRegionProbeConfig { region_name: "region-b".to_owned() }.encode_into_bytes(),
+                    config: EditorRegionProbeConfig { name: "region-b".to_owned() }.encode_into_bytes(),
                     export: Some("test.editor_region_probe".to_owned()),
                 },
             ),

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -44,7 +44,7 @@ use aether_capabilities::RenderCapability;
 use aether_capabilities::fs::NamespaceRoots;
 use aether_capabilities::render::{DrawTexturedQuads, WHITE_TEXTURE_ID};
 use aether_capabilities::text::{FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontResult};
-use aether_data::{Kind, mailbox_id_from_path};
+use aether_data::{Kind, MailboxId, mailbox_id_from_path};
 use aether_kinds::keycode::{KEY_BACKSPACE, KEY_DOWN, KEY_ENTER, KEY_PAGE_DOWN, KEY_RIGHT, KEY_TAB, KEY_UP};
 use aether_kinds::mouse_button::LEFT;
 use aether_kinds::{
@@ -53,9 +53,10 @@ use aether_kinds::{
     MouseButtonRelease, MouseMove, MouseWheel, NamedMail, TextInput, Tick,
 };
 use aether_kit::{
-    ButtonConfig, LabelConfig, PanelConfig, ScrollConfig, ScrollExtent, ScrollOffset, SetTheme, SetWidgetState,
-    SliderConfig, TextAreaConfig, Theme, ThemeState, VirtualListConfig, WidgetChildSpec, WidgetConfig,
-    WidgetControlState, WidgetDrawItem, WidgetKind, WidgetValidation,
+    ButtonConfig, EditorConfig, EditorRegionRect, LabelConfig, PanelConfig, RegionInputLanes, RegionSpec, ScrollConfig,
+    ScrollExtent, ScrollOffset, SetTheme, SetWidgetState, SliderConfig, TextAreaConfig, TextFieldConfig, Theme,
+    ThemeState, VirtualListConfig, WidgetChildSpec, WidgetConfig, WidgetControlState, WidgetDrawItem, WidgetKind,
+    WidgetValidation,
 };
 use aether_math::Rgba;
 use aether_substrate_bundle::test_bench::{
@@ -63,6 +64,7 @@ use aether_substrate_bundle::test_bench::{
     test_helpers::{init_save_sandbox, require_runtime},
 };
 use aether_substrate_bundle::visual::{Image, decode_png};
+use aether_test_fixtures_kinds::{DrainEditorInputs, DrainEditorInputsResult, EditorRegionProbeConfig};
 
 /// Panel origin and stack width (widget-local `(0, 0)` maps to this window
 /// point), matching `widget_set` / `widget_text_alignment`.
@@ -180,11 +182,26 @@ fn load_metrics(bench: &mut TestBench, font_id: u32) -> CachedFontMetrics {
 /// theme pinned to the already-resident `font_id` (empty font path, so the
 /// panel does not kick off its own load). Every widget draws text with that
 /// font.
-fn load_panel(bench: &mut TestBench, wasm: &[u8], font_id: u32) {
-    load_panel_with_children(bench, wasm, font_id, Vec::new());
+fn load_panel(bench: &mut TestBench, wasm: &[u8], font_id: u32) -> MailboxId {
+    load_panel_with_children(bench, wasm, font_id, Vec::new())
 }
 
-fn load_panel_with_children(bench: &mut TestBench, wasm: &[u8], font_id: u32, children: Vec<WidgetChildSpec>) {
+fn load_panel_with_children(
+    bench: &mut TestBench,
+    wasm: &[u8],
+    font_id: u32,
+    children: Vec<WidgetChildSpec>,
+) -> MailboxId {
+    load_panel_with_children_and_ownership(bench, wasm, font_id, children, true)
+}
+
+fn load_panel_with_children_and_ownership(
+    bench: &mut TestBench,
+    wasm: &[u8],
+    font_id: u32,
+    children: Vec<WidgetChildSpec>,
+    owns_input: bool,
+) -> MailboxId {
     let config = PanelConfig {
         x: PANEL_X,
         y: PANEL_Y,
@@ -193,6 +210,7 @@ fn load_panel_with_children(bench: &mut TestBench, wasm: &[u8], font_id: u32, ch
         font_path: String::new(),
         theme: Theme { font_id, ..Theme::DEFAULT },
         children,
+        owns_input,
     };
     let loaded = bench
         .execute(vec![(
@@ -209,11 +227,103 @@ fn load_panel_with_children(bench: &mut TestBench, wasm: &[u8], font_id: u32, ch
         )])
         .expect("load sequence");
     match loaded.reply::<LoadResult>("load").expect("decode LoadResult") {
-        LoadResult::Ok { name, .. } => {
+        LoadResult::Ok { mailbox_id, name, .. } => {
             assert!(name.ends_with(":panel"), "the panel root should register under :panel; got {name}");
+            mailbox_id
         }
         LoadResult::Err { error } => panic!("load WidgetPanel root: {error}"),
     }
+}
+
+struct LoadedProbe {
+    mailbox_id: MailboxId,
+    address: String,
+}
+
+fn load_editor_probe(bench: &mut TestBench, wasm_path: &Path) -> LoadedProbe {
+    let loaded = bench
+        .execute(vec![(
+            "load-region-probe",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: fs::read(wasm_path).expect("read fixture wasm"),
+                    name: Some("region-b".to_owned()),
+                    config: EditorRegionProbeConfig { region_name: "region-b".to_owned() }.encode_into_bytes(),
+                    export: Some("test.editor_region_probe".to_owned()),
+                },
+            ),
+        )])
+        .expect("load editor region probe");
+    match loaded.reply::<LoadResult>("load-region-probe").expect("decode probe LoadResult") {
+        LoadResult::Ok { mailbox_id, name: address, .. } => LoadedProbe { mailbox_id, address },
+        LoadResult::Err { error } => panic!("load editor region probe: {error}"),
+    }
+}
+
+fn load_editor_shell(bench: &mut TestBench, wasm: &[u8], panel: MailboxId, probe: MailboxId) {
+    let probe_lanes = RegionInputLanes {
+        pointer_press: true,
+        pointer_release: true,
+        pointer_motion: true,
+        ..RegionInputLanes::default()
+    };
+    let config = EditorConfig {
+        regions: vec![
+            RegionSpec {
+                name: "panel".to_owned(),
+                rect: EditorRegionRect {
+                    x_pixels: 0.0,
+                    y_pixels: 0.0,
+                    width_pixels: 120.0,
+                    height_pixels: WINDOW_HEIGHT as f32,
+                },
+                target: panel,
+                keyboard_focus_eligible: true,
+                input_lanes: RegionInputLanes::ALL,
+                activation_chord: None,
+            },
+            RegionSpec {
+                name: "region-b".to_owned(),
+                rect: EditorRegionRect {
+                    x_pixels: 120.0,
+                    y_pixels: 0.0,
+                    width_pixels: 120.0,
+                    height_pixels: WINDOW_HEIGHT as f32,
+                },
+                target: probe,
+                keyboard_focus_eligible: false,
+                input_lanes: probe_lanes,
+                activation_chord: None,
+            },
+        ],
+    };
+    let loaded = bench
+        .execute(vec![(
+            "load-editor-shell",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: wasm.to_vec(),
+                    name: Some("editor".to_owned()),
+                    config: config.encode_into_bytes(),
+                    export: Some("aether.kit.widget.editor".to_owned()),
+                },
+            ),
+        )])
+        .expect("load editor shell");
+    match loaded.reply::<LoadResult>("load-editor-shell").expect("decode editor LoadResult") {
+        LoadResult::Ok { .. } => {}
+        LoadResult::Err { error } => panic!("load editor shell: {error}"),
+    }
+}
+
+fn drain_editor_probe(bench: &mut TestBench, probe: &LoadedProbe) -> DrainEditorInputsResult {
+    bench
+        .execute(vec![("drain-editor-probe", BenchOp::send_and_await(probe.address.as_str(), &DrainEditorInputs))])
+        .expect("drain editor region probe")
+        .reply::<DrainEditorInputsResult>("drain-editor-probe")
+        .expect("decode DrainEditorInputsResult")
 }
 
 /// Load font + panel and warm the render path: the first tick spawns + lays out
@@ -354,6 +464,22 @@ fn virtual_list_child(subname: &str, state: WidgetControlState) -> WidgetChildSp
             visible_row_count: 5,
             theme: Theme::DEFAULT,
             state,
+        }
+        .encode_into_bytes(),
+    }
+}
+
+fn text_field_child(subname: &str, initial: &str) -> WidgetChildSpec {
+    WidgetChildSpec {
+        subname: subname.to_owned(),
+        kind: WidgetKind::TextField,
+        origin: [0.0, 0.0],
+        clip: None,
+        config: TextFieldConfig {
+            initial: initial.to_owned(),
+            max_chars: 0,
+            theme: Theme::DEFAULT,
+            state: WidgetControlState::default(),
         }
         .encode_into_bytes(),
     }
@@ -835,6 +961,54 @@ fn slider_drag_renders_fill_at_track_fraction() {
         (fraction - expected).abs() <= 0.05,
         "the rendered slider fill should reach {expected:.3} of the track; it reached \
          {fraction:.3} (right edge x={fill_right:.0}) — the fill-fraction render class",
+    );
+}
+
+#[test]
+fn editor_shell_keeps_a_real_panel_drag_owned_across_a_peer_region() {
+    let (Some(kit_wasm_path), Some(fixtures_wasm_path)) =
+        (require_runtime("aether_kit"), require_runtime("aether_test_fixtures_bundle"))
+    else {
+        return;
+    };
+    let kit_wasm = fs::read(&kit_wasm_path).expect("read kit wasm");
+    let mut bench = build_bench();
+    let font_id = load_font(&mut bench);
+    let panel = load_panel_with_children_and_ownership(
+        &mut bench,
+        &kit_wasm,
+        font_id,
+        vec![text_field_child("field", "abcd")],
+        false,
+    );
+    warm_panel(&mut bench);
+    let probe = load_editor_probe(&mut bench, &fixtures_wasm_path);
+    load_editor_shell(&mut bench, &kit_wasm, panel, probe.mailbox_id);
+
+    // The press begins in the panel editor region. Motion and release cross
+    // x=120 into the peer region, but the shell's first-press ownership keeps
+    // the complete drag addressed to the panel. Selecting all of `abcd`, then
+    // typing `Z`, distinguishes capture (`Z`) from a lost drag (`Zabcd`).
+    bench
+        .execute(vec![
+            ("press", BenchOp::send_mail("aether.input", &press(PANEL_X + PAD, PANEL_Y + 12.0))),
+            ("cross-region-drag", BenchOp::send_mail("aether.input", &MouseMove { x: 150.0, y: PANEL_Y + 12.0 })),
+            ("cross-region-release", BenchOp::send_mail("aether.input", &release(150.0, PANEL_Y + 12.0))),
+            ("replace-selection", BenchOp::send_mail("aether.input", &TextInput { text: "Z".to_owned() })),
+            ("commit", BenchOp::send_mail("aether.input", &Key { code: KEY_ENTER })),
+        ])
+        .expect("route real panel drag through editor shell");
+
+    let log = panel_log_messages(&mut bench);
+    let joined = log.join("\n");
+    assert!(
+        log.iter().any(|message| message.contains("widget text committed") && message.contains("text=Z")),
+        "cross-region drag must select the complete initial value before replacement; log was:\n{joined}",
+    );
+    assert_eq!(
+        drain_editor_probe(&mut bench, &probe),
+        DrainEditorInputsResult { region_name: "region-b".to_owned(), inputs: Vec::new() },
+        "the peer region must not steal motion or release from the press owner",
     );
 }
 

--- a/crates/aether-substrate-bundle/tests/widget_set.rs
+++ b/crates/aether-substrate-bundle/tests/widget_set.rs
@@ -63,6 +63,7 @@ fn load_panel(bench: &mut TestBench, wasm: &[u8]) -> String {
         font_path: String::new(),
         theme: Theme::DEFAULT,
         children: Vec::new(),
+        owns_input: true,
     };
     let loaded = bench
         .execute(vec![(
@@ -290,6 +291,7 @@ fn load_panel_with(bench: &mut TestBench, wasm: &[u8], children: Vec<WidgetChild
         font_path: String::new(),
         theme: Theme::DEFAULT,
         children,
+        owns_input: true,
     };
     let loaded = bench
         .execute(vec![(

--- a/crates/aether-substrate-bundle/tests/widget_text_alignment.rs
+++ b/crates/aether-substrate-bundle/tests/widget_text_alignment.rs
@@ -126,6 +126,7 @@ fn load_panel(bench: &mut TestBench, wasm: &[u8], font_id: u32) {
         font_path: String::new(),
         theme: Theme { font_id, ..Theme::DEFAULT },
         children: Vec::new(),
+        owns_input: true,
     };
     let loaded = bench
         .execute(vec![(

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/editor_region_probe.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/editor_region_probe.rs
@@ -21,7 +21,7 @@ impl WasmActor for EditorRegionProbe {
     const NAMESPACE: &'static str = "test.editor_region_probe";
 
     fn init(config: EditorRegionProbeConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
-        Ok(Self { region_name: config.region_name, inputs: Vec::new() })
+        Ok(Self { region_name: config.name, inputs: Vec::new() })
     }
 
     #[handler::single]
@@ -59,12 +59,12 @@ impl WasmActor for EditorRegionProbe {
 
     #[handler::single]
     fn on_key(&mut self, _ctx: &mut WasmCtx<'_>, key: Key) {
-        self.inputs.push(ObservedEditorInput::KeyPress { key_code: key.code });
+        self.inputs.push(ObservedEditorInput::KeyPress { code: key.code });
     }
 
     #[handler::single]
     fn on_key_release(&mut self, _ctx: &mut WasmCtx<'_>, release: KeyRelease) {
-        self.inputs.push(ObservedEditorInput::KeyRelease { key_code: release.code });
+        self.inputs.push(ObservedEditorInput::KeyRelease { code: release.code });
     }
 
     #[handler::single]

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/editor_region_probe.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/editor_region_probe.rs
@@ -1,0 +1,103 @@
+//! Typed sink used to assert editor-shell routing without giving peer regions
+//! their own input subscriptions.
+
+use aether_actor::{ActorInitError, Manual, OutboundReply, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_kinds::{
+    ImePreedit, Key, KeyRelease, Modifiers, MouseButton, MouseButtonRelease, MouseMove, MouseWheel, TextInput,
+};
+use aether_test_fixtures_kinds::{
+    DrainEditorInputs, DrainEditorInputsResult, EditorRegionProbeConfig, ObservedEditorInput,
+};
+use core::mem;
+
+pub struct EditorRegionProbe {
+    region_name: String,
+    inputs: Vec<ObservedEditorInput>,
+}
+
+#[actor(instanced)]
+impl WasmActor for EditorRegionProbe {
+    type Config = EditorRegionProbeConfig;
+    const NAMESPACE: &'static str = "test.editor_region_probe";
+
+    fn init(config: EditorRegionProbeConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Self { region_name: config.region_name, inputs: Vec::new() })
+    }
+
+    #[handler::single]
+    fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        self.inputs.push(ObservedEditorInput::PointerPress {
+            button: press.button,
+            x_pixels: press.x,
+            y_pixels: press.y,
+        });
+    }
+
+    #[handler::single]
+    fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
+        self.inputs.push(ObservedEditorInput::PointerRelease {
+            button: release.button,
+            x_pixels: release.x,
+            y_pixels: release.y,
+        });
+    }
+
+    #[handler::single]
+    fn on_mouse_move(&mut self, _ctx: &mut WasmCtx<'_>, moved: MouseMove) {
+        self.inputs.push(ObservedEditorInput::PointerMotion { x_pixels: moved.x, y_pixels: moved.y });
+    }
+
+    #[handler::single]
+    fn on_mouse_wheel(&mut self, _ctx: &mut WasmCtx<'_>, wheel: MouseWheel) {
+        self.inputs.push(ObservedEditorInput::Wheel {
+            delta_x_pixels: wheel.delta_x,
+            delta_y_pixels: wheel.delta_y,
+            x_pixels: wheel.x,
+            y_pixels: wheel.y,
+        });
+    }
+
+    #[handler::single]
+    fn on_key(&mut self, _ctx: &mut WasmCtx<'_>, key: Key) {
+        self.inputs.push(ObservedEditorInput::KeyPress { key_code: key.code });
+    }
+
+    #[handler::single]
+    fn on_key_release(&mut self, _ctx: &mut WasmCtx<'_>, release: KeyRelease) {
+        self.inputs.push(ObservedEditorInput::KeyRelease { key_code: release.code });
+    }
+
+    #[handler::single]
+    fn on_text_input(&mut self, _ctx: &mut WasmCtx<'_>, input: TextInput) {
+        self.inputs.push(ObservedEditorInput::TextInput { text: input.text });
+    }
+
+    #[handler::single]
+    fn on_ime_preedit(&mut self, _ctx: &mut WasmCtx<'_>, preedit: ImePreedit) {
+        self.inputs.push(ObservedEditorInput::ImePreedit {
+            text: preedit.text,
+            cursor_begin: preedit.cursor_begin,
+            cursor_end: preedit.cursor_end,
+        });
+    }
+
+    #[handler::single]
+    fn on_modifiers(&mut self, _ctx: &mut WasmCtx<'_>, modifiers: Modifiers) {
+        self.inputs.push(ObservedEditorInput::Modifiers {
+            shift: modifiers.shift,
+            ctrl: modifiers.ctrl,
+            alt: modifiers.alt,
+            meta: modifiers.meta,
+        });
+    }
+
+    #[handler::manual]
+    fn on_drain_editor_inputs(&mut self, ctx: &mut WasmCtx<'_, Manual>, _query: DrainEditorInputs) {
+        if ctx.reply_target().is_some() {
+            ctx.reply(&DrainEditorInputsResult {
+                region_name: self.region_name.clone(),
+                inputs: mem::take(&mut self.inputs),
+            });
+        }
+    }
+}

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
@@ -15,6 +15,7 @@
 //! so each lives in its own satellite crate.
 
 mod cube;
+mod editor_region_probe;
 mod fs_demux;
 mod http_handler;
 mod inline_child;
@@ -27,6 +28,7 @@ mod stateful_replace;
 mod ui_widget;
 
 pub use cube::Cube;
+pub use editor_region_probe::EditorRegionProbe;
 pub use fs_demux::FsDemux;
 pub use http_handler::{
     HttpHandler, RoutedHttpHandler, RoutedStreamingHttpHandler, StreamingHttpHandler, WebSocketHandler,
@@ -53,6 +55,7 @@ aether_actor::export!(
     RootManager,
     Panel,
     Cube,
+    EditorRegionProbe,
     FsDemux,
     MatSource,
     UiWidget,

--- a/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
@@ -377,7 +377,7 @@ pub const MATRIX_CELL_CHILD_TO_SELF: u32 = 4;
 )]
 #[kind(name = "aether.test_fixtures.editor_region_probe.config")]
 pub struct EditorRegionProbeConfig {
-    pub region_name: String,
+    pub name: String,
 }
 
 /// One raw input observed by an editor-region probe.
@@ -387,8 +387,8 @@ pub enum ObservedEditorInput {
     PointerRelease { button: u32, x_pixels: f32, y_pixels: f32 },
     PointerMotion { x_pixels: f32, y_pixels: f32 },
     Wheel { delta_x_pixels: f32, delta_y_pixels: f32, x_pixels: f32, y_pixels: f32 },
-    KeyPress { key_code: u32 },
-    KeyRelease { key_code: u32 },
+    KeyPress { code: u32 },
+    KeyRelease { code: u32 },
     TextInput { text: String },
     ImePreedit { text: String, cursor_begin: Option<u32>, cursor_end: Option<u32> },
     Modifiers { shift: bool, ctrl: bool, alt: bool, meta: bool },

--- a/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
@@ -15,6 +15,7 @@
 extern crate alloc;
 
 use alloc::string::String;
+use alloc::vec::Vec;
 use bytemuck::{Pod, Zeroable};
 
 /// Mirror of `aether_substrate_bundle::test_bench::TEST_BENCH_OBSERVER_MAILBOX_NAME`.
@@ -367,3 +368,41 @@ pub const MATRIX_CELL_CHILD_TO_PARENT: u32 = 2;
 pub const MATRIX_CELL_CHILD_TO_SIBLING: u32 = 3;
 /// [`MatrixPing::cell`] marker — child a to self (in place).
 pub const MATRIX_CELL_CHILD_TO_SELF: u32 = 4;
+
+/// Typed config for an editor-region probe. The probe intentionally does not
+/// subscribe to input itself: an editor shell must address each observation
+/// directly to the probe's mailbox.
+#[derive(
+    aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq,
+)]
+#[kind(name = "aether.test_fixtures.editor_region_probe.config")]
+pub struct EditorRegionProbeConfig {
+    pub region_name: String,
+}
+
+/// One raw input observed by an editor-region probe.
+#[derive(aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+pub enum ObservedEditorInput {
+    PointerPress { button: u32, x_pixels: f32, y_pixels: f32 },
+    PointerRelease { button: u32, x_pixels: f32, y_pixels: f32 },
+    PointerMotion { x_pixels: f32, y_pixels: f32 },
+    Wheel { delta_x_pixels: f32, delta_y_pixels: f32, x_pixels: f32, y_pixels: f32 },
+    KeyPress { key_code: u32 },
+    KeyRelease { key_code: u32 },
+    TextInput { text: String },
+    ImePreedit { text: String, cursor_begin: Option<u32>, cursor_end: Option<u32> },
+    Modifiers { shift: bool, ctrl: bool, alt: bool, meta: bool },
+}
+
+/// Query that drains an editor-region probe's observations.
+#[derive(aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
+#[kind(name = "aether.test_fixtures.drain_editor_inputs")]
+pub struct DrainEditorInputs;
+
+/// Reply containing every editor input observed since the previous drain.
+#[derive(aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+#[kind(name = "aether.test_fixtures.drain_editor_inputs_result")]
+pub struct DrainEditorInputsResult {
+    pub region_name: String,
+    pub inputs: Vec<ObservedEditorInput>,
+}

--- a/docs/adr/0141-editor-shell-input-ownership.md
+++ b/docs/adr/0141-editor-shell-input-ownership.md
@@ -1,6 +1,6 @@
 # ADR-0141: Editor-shell input ownership across region roots
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-07-09
 
 ## Context
@@ -113,3 +113,38 @@ mechanism.
   issues (#2915/#2916) amend ADR-0117 because they stay within one cluster;
   editor-wide input ownership crosses cluster roots, the boundary #2919
   reserved for a dedicated decision record.
+
+## Realization
+
+Issue #2918 realizes the decision in `aether-kit` with `EditorShell` at export
+namespace `aether.kit.widget.editor`. Its `EditorConfig` contains ordered
+`RegionSpec` records. Each spec names an `EditorRegionRect`, a target
+`MailboxId`, whether it participates in editor keyboard focus, a
+`RegionInputLanes` record, and an optional exact `EditorKeyChord`. Invalid or
+non-positive rectangles are ignored. Hit testing is ordered and topmost-first;
+when that hit region rejects a lane, routing stops rather than falling through
+to a covered region.
+
+The plain `widget::routing::Routing` state records focus, cached `Modifiers`,
+and a named `RegionPressOwner { target, button }`. The first accepted press
+owns motion and release until the matching button release; a different button
+release remains addressed to that owner without clearing it. Wheel routes by
+its own cursor coordinates. Exact activation chords can focus a region.
+Ctrl+Tab is reserved for forward region cycling, Ctrl+Shift+Tab cycles
+backward, and the matching Tab release is consumed; plain Tab press/release is
+forwarded to the focused region for its internal focus ring.
+
+`EditorShell` subscribes only the nine interactive raw kinds: pointer press,
+pointer release, pointer motion, wheel, key press, key release, committed text,
+IME preedit, and modifiers. It has no lifecycle, render, or `WindowSize`
+subscription. Focus transitions prime a target that accepts the modifier lane
+with the shell's cached named `Modifiers` record before forwarding the event
+that caused focus.
+
+`PanelConfig`, `ConsoleConfig`, and `MoverConfig` expose a default-compatible
+`owns_input: true`. Setting it to `false` gates only their interactive input
+subscriptions. The console and mover retain their direct `WindowSize`
+subscriptions, and every peer retains its existing lifecycle and render roles.
+Editor assembly therefore loads peer roots first, records their returned
+mailbox ids, disables their interactive ownership, and then loads one shell
+whose region config addresses those peers.

--- a/docs/guide/systems/widgets.md
+++ b/docs/guide/systems/widgets.md
@@ -198,6 +198,36 @@ panel is logged as a terminal residual and dropped.
 live restyles and the panel's resolved session font id intact through nested
 scroll containers.
 
+## Editor-wide region ownership
+
+`EditorShell` (export `aether.kit.widget.editor`) composes several independent
+roots into one input domain without turning them into one widget tree. It is
+the sole subscriber for interactive input across its configured regions; each
+panel still owns widget focus and capture inside its own cluster, while the
+shell owns region focus and capture between clusters.
+
+Assemble an editor peer-first. Load each panel, console, or mover, retain the
+returned `MailboxId`, and set its config's `owns_input` to `false`. Then load
+one `EditorShell` with an ordered `EditorConfig { regions }`. Each `RegionSpec`
+contains a named pixel rectangle, target mailbox, keyboard eligibility,
+`RegionInputLanes`, and optional exact `EditorKeyChord`. Later entries are
+topmost. A topmost region that rejects a lane blocks that event; routing does
+not fall through to a covered region.
+
+The first accepted pointer press owns pointer motion and releases across region
+boundaries until the matching button is released. Wheel uses the position in
+its own event. Keyboard, committed text, IME preedit, and modifiers route only
+to the focused region. An exact activation chord can focus a region (for
+example, the console's backquote chord). Ctrl+Tab cycles editor regions,
+Ctrl+Shift+Tab cycles backward, and both the reserved press and matching
+release are consumed. Plain Tab is forwarded unchanged so the focused panel's
+own widget traversal remains intact.
+
+`owns_input` defaults to `true`, preserving standalone behavior. It gates only
+interactive subscriptions: panel/console/mover lifecycle and render roles are
+unchanged, and console/mover continue subscribing to `WindowSize` directly.
+The shell itself owns no lifecycle, render, or window-size work.
+
 ## The reference panel
 
 `WidgetPanel` (export `aether.kit.widget.panel`) is the worked example — the


### PR DESCRIPTION
Closes #2918.

## Summary

- add an input-only `EditorShell` with named region, lane, focus, chord, and press-owner vocabulary
- route cross-region pointer ownership and single-region keyboard/text input while preserving panel-local traversal
- let panel, console, and mover peers opt out of raw interactive subscriptions without dropping their render, lifecycle, tick, or window-size responsibilities
- prove the contract with typed region probes and strict real-wasm panel, console, and mover TestBench scenarios

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p aether-kit --lib` (315 passed)
- strict `widget_editor_routing` TestBench (2 passed)
- strict `widget_render_interaction` TestBench (14 passed)
- strict `console_render_interaction` TestBench (4 passed)
- strict `mover_walks_the_world` TestBench (2 passed)

## Generated by

`/implement` — agent execution of scoped issue #2918.
