### PR TITLE
feat(kit): add toggle, segmented, and numeric controls

### DIFF
--- a/crates/aether-kit/Cargo.toml
+++ b/crates/aether-kit/Cargo.toml
@@ -30,7 +30,7 @@ aether-actor = { path = "../aether-actor" }
 # marker face is off (`default-features = false`); the `host` feature the kit
 # forwards to turns on exactly the host surface, not the guest `runtime` SDK.
 aether-behavior = { path = "../aether-behavior", default-features = false, optional = true }
-aether-capabilities = { path = "../aether-capabilities", default-features = false, features = ["render", "text"] }
+aether-capabilities = { path = "../aether-capabilities", default-features = false, features = ["clipboard", "render", "text"] }
 aether-data = { path = "../aether-data", features = ["derive"] }
 aether-kinds = { path = "../aether-kinds" }
 aether-math = { path = "../aether-math" }

--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -91,9 +91,10 @@ pub use widget::theme::{SetTheme, Theme, ThemeState};
 pub use widget::{
     ButtonClicked, ButtonConfig, ChildrenChanged, Collect, EditorConfig, EditorKeyChord, EditorRegionRect, EditorShell,
     FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig, ImageFit, LabelConfig, MembershipEntry, PanelConfig,
-    RadioConfig, RadioSelected, RegionInputLanes, RegionSpec, ScrollConfig, ScrollDelta, ScrollExtent, ScrollOffset,
-    ScrollOutcome, ScrollResidual, SetWidgetState, SliderChanged, SliderConfig, TextAreaConfig, TextCommitted,
-    TextFieldConfig, VirtualListConfig, VirtualListSelected, WidgetChildSpec, WidgetClipRect, WidgetConfig,
+    NumericChanged, NumericConfig, RadioConfig, RadioSelected, RegionInputLanes, RegionSpec, ScrollConfig, ScrollDelta,
+    ScrollExtent, ScrollOffset, ScrollOutcome, ScrollResidual, SegmentedConfig, SegmentedSelected, SetWidgetState,
+    SliderChanged, SliderConfig, TextAreaConfig, TextCommitted, TextFieldConfig, ToggleChanged, ToggleConfig,
+    VirtualListConfig, VirtualListSelected, WidgetChildSpec, WidgetClipRect, WidgetConfig,
     WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged, WidgetValidation,
 };
 pub use world::{
@@ -149,6 +150,9 @@ aether_actor::export!(
     widget::set::LabelWidget,
     widget::set::ImageWidget,
     widget::set::VirtualListWidget,
+    widget::set::ToggleWidget,
+    widget::set::SegmentedWidget,
+    widget::set::NumericWidget,
     EditorShell,
     widget::WidgetPanel
 );
@@ -173,6 +177,9 @@ aether_actor::export!(
     widget::set::LabelWidget,
     widget::set::ImageWidget,
     widget::set::VirtualListWidget,
+    widget::set::ToggleWidget,
+    widget::set::SegmentedWidget,
+    widget::set::NumericWidget,
     EditorShell,
     widget::WidgetPanel,
     aether_behavior::BehaviorHost

--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -90,11 +90,11 @@ pub use terrain_editor::{
 pub use widget::theme::{SetTheme, Theme, ThemeState};
 pub use widget::{
     ButtonClicked, ButtonConfig, ChildrenChanged, Collect, EditorConfig, EditorKeyChord, EditorRegionRect, EditorShell,
-    FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig, ImageFit, LabelConfig, MembershipEntry, PanelConfig,
-    NumericChanged, NumericConfig, RadioConfig, RadioSelected, RegionInputLanes, RegionSpec, ScrollConfig, ScrollDelta,
-    ScrollExtent, ScrollOffset, ScrollOutcome, ScrollResidual, SegmentedConfig, SegmentedSelected, SetWidgetState,
-    SliderChanged, SliderConfig, TextAreaConfig, TextCommitted, TextFieldConfig, ToggleChanged, ToggleConfig,
-    VirtualListConfig, VirtualListSelected, WidgetChildSpec, WidgetClipRect, WidgetConfig,
+    FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig, ImageFit, LabelConfig, MembershipEntry,
+    NumericChanged, NumericConfig, PanelConfig, RadioConfig, RadioSelected, RegionInputLanes, RegionSpec, ScrollConfig,
+    ScrollDelta, ScrollExtent, ScrollOffset, ScrollOutcome, ScrollResidual, SegmentedConfig, SegmentedSelected,
+    SetWidgetState, SliderChanged, SliderConfig, TextAreaConfig, TextCommitted, TextFieldConfig, ToggleChanged,
+    ToggleConfig, VirtualListConfig, VirtualListSelected, WidgetChildSpec, WidgetClipRect, WidgetConfig,
     WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged, WidgetValidation,
 };
 pub use world::{

--- a/crates/aether-kit/src/widget/kinds.rs
+++ b/crates/aether-kit/src/widget/kinds.rs
@@ -405,6 +405,15 @@ pub enum WidgetKind {
     /// Appended after `Scroll` to preserve every established wire discriminant
     /// above.
     VirtualList,
+    /// A boolean switch — `config` decodes as [`ToggleConfig`].
+    /// Appended to preserve every established wire discriminant above.
+    Toggle,
+    /// A horizontal exclusive choice — `config` decodes as
+    /// [`SegmentedConfig`]. Appended to preserve established discriminants.
+    Segmented,
+    /// A typed and steppable bounded number — `config` decodes as
+    /// [`NumericConfig`]. Appended to preserve established discriminants.
+    Numeric,
 }
 
 impl WidgetKind {
@@ -433,6 +442,9 @@ impl WidgetKind {
             Self::TextArea => aether_data::mailbox_id_from_name("aether.kit.widget.text_area").0,
             Self::Button => aether_data::mailbox_id_from_name("aether.kit.widget.button").0,
             Self::VirtualList => aether_data::mailbox_id_from_name("aether.kit.widget.virtual_list").0,
+            Self::Toggle => aether_data::mailbox_id_from_name("aether.kit.widget.toggle").0,
+            Self::Segmented => aether_data::mailbox_id_from_name("aether.kit.widget.segmented").0,
+            Self::Numeric => aether_data::mailbox_id_from_name("aether.kit.widget.numeric").0,
             Self::Composite | Self::Scroll | Self::BehaviorHost => return None,
         };
         Some(tag)
@@ -677,6 +689,58 @@ pub struct ButtonConfig {
     pub state: WidgetControlState,
 }
 
+/// `aether.kit.widget.toggle.config` — a boolean switch with a visible
+/// `label`, starting at `initial`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
+#[kind(name = "aether.kit.widget.toggle.config")]
+pub struct ToggleConfig {
+    pub label: String,
+    pub initial: bool,
+    pub theme: Theme,
+    #[serde(default)]
+    pub state: WidgetControlState,
+}
+
+/// `aether.kit.widget.segmented.config` — a horizontal list of equal-width,
+/// mutually exclusive named options, starting at `initial_index` (clamped
+/// into range at init).
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
+#[kind(name = "aether.kit.widget.segmented.config")]
+pub struct SegmentedConfig {
+    pub options: Vec<String>,
+    pub initial_index: u32,
+    pub theme: Theme,
+    #[serde(default)]
+    pub state: WidgetControlState,
+}
+
+/// `aether.kit.widget.numeric.config` — a typed, steppable number bounded by
+/// `min..=max`, snapped to `step`, and starting at `initial`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.numeric.config")]
+pub struct NumericConfig {
+    pub min: f32,
+    pub max: f32,
+    pub step: f32,
+    pub initial: f32,
+    pub theme: Theme,
+    #[serde(default)]
+    pub state: WidgetControlState,
+}
+
+impl Default for NumericConfig {
+    fn default() -> Self {
+        Self {
+            min: 0.0,
+            max: 1.0,
+            step: 0.0,
+            initial: 0.0,
+            theme: Theme::default(),
+            state: WidgetControlState::default(),
+        }
+    }
+}
+
 /// `aether.kit.widget.label.config` — static, non-interactive `text`. A label
 /// is not focus-eligible (the root's focus register skips it).
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
@@ -778,6 +842,31 @@ pub struct VirtualListSelected {
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.kit.widget.button.clicked")]
 pub struct ButtonClicked;
+
+/// `aether.kit.widget.toggle.changed` — a toggle's value-up event.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.toggle.changed")]
+pub struct ToggleChanged {
+    pub on: bool,
+}
+
+/// `aether.kit.widget.segmented.selected` — a segmented control's value-up
+/// event carrying the newly selected zero-based `index`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.segmented.selected")]
+pub struct SegmentedSelected {
+    pub index: u32,
+}
+
+/// `aether.kit.widget.numeric.changed` — a numeric editor's value-up event.
+/// Preview edits carry `committed: false`; Enter, blur, and step-key changes
+/// carry `committed: true`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.widget.numeric.changed")]
+pub struct NumericChanged {
+    pub value: f32,
+    pub committed: bool,
+}
 
 /// `aether.kit.widget.frame` — the layout rect the root assigns a child,
 /// data-down. `(x, y)` is the child's top-left in window pixels and
@@ -977,11 +1066,17 @@ mod tests {
         let text_area = wire::to_vec(&WidgetKind::TextArea).expect("encode TextArea");
         let scroll = wire::to_vec(&WidgetKind::Scroll).expect("encode Scroll");
         let virtual_list = wire::to_vec(&WidgetKind::VirtualList).expect("encode VirtualList");
+        let toggle = wire::to_vec(&WidgetKind::Toggle).expect("encode Toggle");
+        let segmented = wire::to_vec(&WidgetKind::Segmented).expect("encode Segmented");
+        let numeric = wire::to_vec(&WidgetKind::Numeric).expect("encode Numeric");
         assert_eq!(behavior_host.as_slice(), 6_u32.to_le_bytes());
         assert_eq!(image.as_slice(), 7_u32.to_le_bytes());
         assert_eq!(text_area.as_slice(), 8_u32.to_le_bytes());
         assert_eq!(scroll.as_slice(), 9_u32.to_le_bytes());
         assert_eq!(virtual_list.as_slice(), 10_u32.to_le_bytes());
+        assert_eq!(toggle.as_slice(), 11_u32.to_le_bytes());
+        assert_eq!(segmented.as_slice(), 12_u32.to_le_bytes());
+        assert_eq!(numeric.as_slice(), 13_u32.to_le_bytes());
     }
 
     #[test]

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -33,8 +33,9 @@
 //!   up — and emits the whole panel as contiguous equal-clip solid batches
 //!   (plus text) from one root render sender.
 //! - **Value.** Each value-up event (`SliderChanged` / `TextCommitted` /
-//!   `RadioSelected` / `VirtualListSelected` / `ButtonClicked`), attributed
-//!   by `ctx.source_mailbox()`, is the seam a real editor translates into
+//!   `RadioSelected` / `VirtualListSelected` / `ButtonClicked` / `ToggleChanged` /
+//!   `SegmentedSelected` / `NumericChanged`), attributed by
+//!   `ctx.source_mailbox()`, is the seam a real editor translates into
 //!   world-knob driver mail; the reference logs it.
 
 use alloc::string::String;
@@ -59,14 +60,15 @@ use crate::widget::focus::{
     AvailabilityEffects, Focus, FocusDirection, FocusEligibility, FocusRect, FocusTransition, HoverTransition,
 };
 use crate::widget::set::{
-    ButtonWidget, ImageWidget, LabelWidget, RadioGroupWidget, SliderWidget, TextAreaWidget, TextFieldWidget,
-    VirtualListWidget, quad,
+    ButtonWidget, ImageWidget, LabelWidget, NumericWidget, RadioGroupWidget, SegmentedWidget, SliderWidget,
+    TextAreaWidget, TextFieldWidget, ToggleWidget, VirtualListWidget, quad,
 };
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{
     ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig, LabelConfig,
-    PanelConfig, RadioConfig, RadioSelected, ScrollConfig, ScrollExtent, ScrollOutcome, ScrollResidual, ScrollWidget,
-    SliderChanged, SliderConfig, TextAreaConfig, TextCommitted, TextFieldConfig, VirtualListConfig,
+    NumericChanged, NumericConfig, PanelConfig, RadioConfig, RadioSelected, SegmentedConfig, SegmentedSelected,
+    ScrollConfig, ScrollExtent, ScrollOutcome, ScrollResidual, ScrollWidget, SliderChanged, SliderConfig,
+    TextAreaConfig, TextCommitted, TextFieldConfig, ToggleChanged, ToggleConfig, VirtualListConfig,
     VirtualListSelected, Widget, WidgetChildSpec, WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame,
     WidgetKind, WidgetStateChanged,
 };
@@ -369,6 +371,7 @@ pub fn spawn_widget_child(
             })
         }),
         WidgetKind::VirtualList => spawn_virtual_list_child(ctx, spec, row),
+        WidgetKind::Toggle | WidgetKind::Segmented | WidgetKind::Numeric => spawn_added_control(ctx, spec, row),
         WidgetKind::BehaviorHost => spawn_behavior_host(ctx, spec, row),
         WidgetKind::Composite => spawn_composite_child(ctx, spec, layout, row),
         WidgetKind::Scroll => spawn_scroll_child(ctx, spec, layout),
@@ -474,6 +477,54 @@ fn spawn_scroll_child(
             scroll_viewport: Some(viewport),
         })
     })
+}
+
+/// Spawn the three issue-2926 one-row controls. Keeping their mechanical
+/// decode/spawn profiles together prevents the main exhaustive dispatcher from
+/// becoming a second long-form implementation surface.
+fn spawn_added_control(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, row: f32) -> Option<SpawnedChild> {
+    match spec.kind {
+        WidgetKind::Toggle => decode_child::<ToggleConfig>(spec).and_then(|config| {
+            let state = config.state.clone();
+            spawn::<ToggleWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
+                id,
+                width_pixels: None,
+                height_pixels: row,
+                pointer_eligible: true,
+                focusable: true,
+                state,
+                type_namespace: <ToggleWidget as Addressable>::NAMESPACE,
+                scroll_viewport: None,
+            })
+        }),
+        WidgetKind::Segmented => decode_child::<SegmentedConfig>(spec).and_then(|config| {
+            let state = config.state.clone();
+            spawn::<SegmentedWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
+                id,
+                width_pixels: None,
+                height_pixels: row,
+                pointer_eligible: true,
+                focusable: true,
+                state,
+                type_namespace: <SegmentedWidget as Addressable>::NAMESPACE,
+                scroll_viewport: None,
+            })
+        }),
+        WidgetKind::Numeric => decode_child::<NumericConfig>(spec).and_then(|config| {
+            let state = config.state.clone();
+            spawn::<NumericWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
+                id,
+                width_pixels: None,
+                height_pixels: row,
+                pointer_eligible: true,
+                focusable: true,
+                state,
+                type_namespace: <NumericWidget as Addressable>::NAMESPACE,
+                scroll_viewport: None,
+            })
+        }),
+        _ => None,
+    }
 }
 
 /// Decode one child spec's opaque config bytes as the concrete config type
@@ -625,11 +676,17 @@ fn behavior_mirror_kinds() -> Vec<u64> {
         ButtonConfig::ID.0,
         RadioConfig::ID.0,
         VirtualListConfig::ID.0,
+        ToggleConfig::ID.0,
+        SegmentedConfig::ID.0,
+        NumericConfig::ID.0,
         SliderChanged::ID.0,
         TextCommitted::ID.0,
         ButtonClicked::ID.0,
         RadioSelected::ID.0,
         VirtualListSelected::ID.0,
+        ToggleChanged::ID.0,
+        SegmentedSelected::ID.0,
+        NumericChanged::ID.0,
         FocusGained::ID.0,
         FocusLost::ID.0,
         HoverGained::ID.0,
@@ -717,6 +774,18 @@ fn spawn_behavior_host(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, ro
                 state: config.state,
             }
         }
+        WidgetKind::Toggle => {
+            let config = decode_named::<ToggleConfig>(&spec.subname, &host_spec.wrapped_config)?;
+            ChildProfile { height: row, pointer_eligible: true, focusable: true, state: config.state }
+        }
+        WidgetKind::Segmented => {
+            let config = decode_named::<SegmentedConfig>(&spec.subname, &host_spec.wrapped_config)?;
+            ChildProfile { height: row, pointer_eligible: true, focusable: true, state: config.state }
+        }
+        WidgetKind::Numeric => {
+            let config = decode_named::<NumericConfig>(&spec.subname, &host_spec.wrapped_config)?;
+            ChildProfile { height: row, pointer_eligible: true, focusable: true, state: config.state }
+        }
         WidgetKind::Composite | WidgetKind::Scroll | WidgetKind::BehaviorHost => return None,
     };
     let script = match host_spec.script {
@@ -799,7 +868,8 @@ fn spawn_behavior_host(_ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, _
 /// `PanelConfig` (top-left, width, theme, a font to load, and the `children`
 /// it stacks). With an empty `children` list it spawns a demonstration stack
 /// of the original interactive/reference widgets; otherwise it stacks exactly
-/// the declared specs (including `Image` children). It routes
+/// the declared specs (including `Image`, `Toggle`, `Segmented`, and `Numeric`
+/// children). It routes
 /// real input through the focus model and logs each value-up event. Fork it
 /// into a real editor panel by handing it your own `children` and translating
 /// the value-up handlers into your own world-knob driver mail.
@@ -1108,6 +1178,40 @@ impl WasmActor for WidgetPanel {
         );
     }
 
+    /// A toggle value-up. The map-editor seam; the reference logs it.
+    #[handler::manual]
+    fn on_toggle_changed(&mut self, ctx: &mut WasmCtx<'_, Manual>, changed: ToggleChanged) {
+        tracing::info!(
+            target: "aether_kit",
+            widget = self.child_name(ctx.source_mailbox()),
+            on = changed.on,
+            "widget toggle changed",
+        );
+    }
+
+    /// A segmented selection. The map-editor seam; the reference logs it.
+    #[handler::manual]
+    fn on_segmented_selected(&mut self, ctx: &mut WasmCtx<'_, Manual>, selected: SegmentedSelected) {
+        tracing::info!(
+            target: "aether_kit",
+            widget = self.child_name(ctx.source_mailbox()),
+            index = selected.index,
+            "widget segmented selected",
+        );
+    }
+
+    /// A numeric preview or commit. The map-editor seam; the reference logs it.
+    #[handler::manual]
+    fn on_numeric_changed(&mut self, ctx: &mut WasmCtx<'_, Manual>, changed: NumericChanged) {
+        tracing::info!(
+            target: "aether_kit",
+            widget = self.child_name(ctx.source_mailbox()),
+            value = changed.value,
+            committed = changed.committed,
+            "widget numeric changed",
+        );
+    }
+
     /// The font finished loading: stamp the real `font_id` into the theme and
     /// re-fan it so every child draws text with it.
     #[handler::single]
@@ -1213,6 +1317,9 @@ mod behavior_tests {
         assert_eq!(WidgetKind::TextField.type_tag(), Some(ActorTypeTag::of::<TextFieldWidget>().0));
         assert_eq!(WidgetKind::TextArea.type_tag(), Some(ActorTypeTag::of::<TextAreaWidget>().0));
         assert_eq!(WidgetKind::VirtualList.type_tag(), Some(ActorTypeTag::of::<VirtualListWidget>().0));
+        assert_eq!(WidgetKind::Toggle.type_tag(), Some(ActorTypeTag::of::<ToggleWidget>().0));
+        assert_eq!(WidgetKind::Segmented.type_tag(), Some(ActorTypeTag::of::<SegmentedWidget>().0));
+        assert_eq!(WidgetKind::Numeric.type_tag(), Some(ActorTypeTag::of::<NumericWidget>().0));
         assert_eq!(WidgetKind::Composite.type_tag(), None);
         assert_eq!(WidgetKind::Scroll.type_tag(), None);
         assert_eq!(WidgetKind::BehaviorHost.type_tag(), None);

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -356,25 +356,28 @@ pub fn spawn_widget_child(
                 scroll_viewport: None,
             })
         }),
-        WidgetKind::Button => decode_child::<ButtonConfig>(spec).and_then(|config| {
-            let id = spawn::<ButtonWidget>(ctx, &spec.subname, &config)?;
-            Some(SpawnedChild {
-                id,
-                width_pixels: None,
-                height_pixels: row,
-                pointer_eligible: true,
-                focusable: true,
-                state: config.state,
-                type_namespace: <ButtonWidget as Addressable>::NAMESPACE,
-                scroll_viewport: None,
-            })
-        }),
+        WidgetKind::Button => spawn_button_child(ctx, spec, row),
         WidgetKind::VirtualList => spawn_virtual_list_child(ctx, spec, row),
         WidgetKind::Toggle | WidgetKind::Segmented | WidgetKind::Numeric => spawn_added_control(ctx, spec, row),
         WidgetKind::BehaviorHost => spawn_behavior_host(ctx, spec, row),
         WidgetKind::Composite => spawn_composite_child(ctx, spec, layout, row),
         WidgetKind::Scroll => spawn_scroll_child(ctx, spec, layout),
     }
+}
+
+fn spawn_button_child(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, row: f32) -> Option<SpawnedChild> {
+    let config = decode_child::<ButtonConfig>(spec)?;
+    let id = spawn::<ButtonWidget>(ctx, &spec.subname, &config)?;
+    Some(SpawnedChild {
+        id,
+        width_pixels: None,
+        height_pixels: row,
+        pointer_eligible: true,
+        focusable: true,
+        state: config.state,
+        type_namespace: <ButtonWidget as Addressable>::NAMESPACE,
+        scroll_viewport: None,
+    })
 }
 
 fn spawn_virtual_list_child(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, row: f32) -> Option<SpawnedChild> {

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -358,7 +358,7 @@ pub fn spawn_widget_child(
         }),
         WidgetKind::Button => spawn_button_child(ctx, spec, row),
         WidgetKind::VirtualList => spawn_virtual_list_child(ctx, spec, row),
-        WidgetKind::Toggle | WidgetKind::Segmented | WidgetKind::Numeric => spawn_added_control(ctx, spec, row),
+        WidgetKind::Toggle | WidgetKind::Segmented | WidgetKind::Numeric => spawn_row_control_child(ctx, spec, row),
         WidgetKind::BehaviorHost => spawn_behavior_host(ctx, spec, row),
         WidgetKind::Composite => spawn_composite_child(ctx, spec, layout, row),
         WidgetKind::Scroll => spawn_scroll_child(ctx, spec, layout),
@@ -481,46 +481,43 @@ fn spawn_scroll_child(
     })
 }
 
-/// Spawn the three issue-2926 one-row controls. Keeping their mechanical
-/// decode/spawn profiles together prevents the main exhaustive dispatcher from
-/// becoming a second long-form implementation surface.
-fn spawn_added_control(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, row: f32) -> Option<SpawnedChild> {
+/// Spawn the three issue-2926 one-row control children. Keeping their
+/// mechanical decode/spawn profiles together prevents the main exhaustive
+/// dispatcher from becoming a second long-form implementation surface.
+fn spawn_row_control_child(ctx: &mut WasmCtx<'_, Manual>, spec: &WidgetChildSpec, row: f32) -> Option<SpawnedChild> {
     match spec.kind {
         WidgetKind::Toggle => decode_child::<ToggleConfig>(spec).and_then(|config| {
-            let state = config.state.clone();
             spawn::<ToggleWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
                 id,
                 width_pixels: None,
                 height_pixels: row,
                 pointer_eligible: true,
                 focusable: true,
-                state,
+                state: config.state,
                 type_namespace: <ToggleWidget as Addressable>::NAMESPACE,
                 scroll_viewport: None,
             })
         }),
         WidgetKind::Segmented => decode_child::<SegmentedConfig>(spec).and_then(|config| {
-            let state = config.state.clone();
             spawn::<SegmentedWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
                 id,
                 width_pixels: None,
                 height_pixels: row,
                 pointer_eligible: true,
                 focusable: true,
-                state,
+                state: config.state,
                 type_namespace: <SegmentedWidget as Addressable>::NAMESPACE,
                 scroll_viewport: None,
             })
         }),
         WidgetKind::Numeric => decode_child::<NumericConfig>(spec).and_then(|config| {
-            let state = config.state.clone();
             spawn::<NumericWidget>(ctx, &spec.subname, &config).map(|id| SpawnedChild {
                 id,
                 width_pixels: None,
                 height_pixels: row,
                 pointer_eligible: true,
                 focusable: true,
-                state,
+                state: config.state,
                 type_namespace: <NumericWidget as Addressable>::NAMESPACE,
                 scroll_viewport: None,
             })

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -66,11 +66,10 @@ use crate::widget::set::{
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{
     ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, HoverGained, HoverLost, ImageConfig, LabelConfig,
-    NumericChanged, NumericConfig, PanelConfig, RadioConfig, RadioSelected, SegmentedConfig, SegmentedSelected,
-    ScrollConfig, ScrollExtent, ScrollOutcome, ScrollResidual, ScrollWidget, SliderChanged, SliderConfig,
-    TextAreaConfig, TextCommitted, TextFieldConfig, ToggleChanged, ToggleConfig, VirtualListConfig,
-    VirtualListSelected, Widget, WidgetChildSpec, WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame,
-    WidgetKind, WidgetStateChanged,
+    NumericChanged, NumericConfig, PanelConfig, RadioConfig, RadioSelected, ScrollConfig, ScrollExtent, ScrollOutcome,
+    ScrollResidual, ScrollWidget, SegmentedConfig, SegmentedSelected, SliderChanged, SliderConfig, TextAreaConfig,
+    TextCommitted, TextFieldConfig, ToggleChanged, ToggleConfig, VirtualListConfig, VirtualListSelected, Widget,
+    WidgetChildSpec, WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged,
 };
 use crate::widget::{FrameDischarge, decode_nested_widget_config};
 use crate::widget::{accept_child_list, emit, flush_membership};

--- a/crates/aether-kit/src/widget/set/button.rs
+++ b/crates/aether-kit/src/widget/set/button.rs
@@ -13,23 +13,16 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
-use aether_kinds::keycode::{KEY_ENTER, KEY_SPACE};
 use aether_kinds::mouse_button;
 use aether_kinds::{Key, KeyRelease, MouseButton, MouseButtonRelease};
 
-use crate::widget::set::{push_border, quad, reply_if_hidden, text_origin_y};
+use crate::widget::set::{ActivationArms, push_border, quad, reply_if_hidden, text_origin_y};
 use crate::widget::state::{InteractionState, emit_state_changed};
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{
     ButtonClicked, ButtonConfig, Collect, FocusGained, FocusLost, HoverGained, HoverLost, SetWidgetState,
     WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum KeyboardArm {
-    Enter,
-    Space,
-}
 
 /// A momentary push button. Holds its label plus the cached theme / frame /
 /// focus and the armed (`pressed`) state.
@@ -38,45 +31,29 @@ pub struct ButtonWidget {
     theme: Theme,
     frame: WidgetFrame,
     state: InteractionState,
-    /// Armed by a pointer press inside; a release-inside fires the click.
-    pointer_pressed: bool,
-    /// Suppresses key-repeat duplicates. Enter fires on its first press; Space
-    /// fires on the matching release.
-    keyboard_arm: Option<KeyboardArm>,
+    /// Shared pointer/keyboard activation state; a release-inside fires the click.
+    arms: ActivationArms,
 }
 
 impl ButtonWidget {
-    /// Whether a window-space point falls inside the button's frame.
-    fn contains(&self, x: f32, y: f32) -> bool {
-        x >= self.frame.x
-            && x <= self.frame.x + self.frame.width
-            && y >= self.frame.y
-            && y <= self.frame.y + self.frame.height
-    }
-
     /// Arm the button if the press landed inside. Owned state-machine step —
     /// unit-tested.
     fn press_at(&mut self, x: f32, y: f32) {
-        if self.state.is_available() && self.contains(x, y) {
-            self.pointer_pressed = true;
-        }
+        self.arms.press_pointer(&self.frame, self.state.is_available(), x, y);
     }
 
     /// Resolve a release: returns `true` (a click fired) only if the button
     /// was armed and the release landed back inside. Disarms either way.
     fn release_at(&mut self, x: f32, y: f32) -> bool {
-        let clicked = self.state.is_available() && self.pointer_pressed && self.contains(x, y);
-        self.pointer_pressed = false;
-        clicked
+        self.arms.release_pointer(&self.frame, self.state.is_available(), x, y)
     }
 
     fn pressed(&self) -> bool {
-        self.pointer_pressed || self.keyboard_arm == Some(KeyboardArm::Space)
+        self.arms.pressed()
     }
 
     fn clear_arms(&mut self) {
-        self.pointer_pressed = false;
-        self.keyboard_arm = None;
+        self.arms.clear();
     }
 
     fn apply_control_state(&mut self, ctx: &WasmCtx<'_>, next: WidgetControlState) {
@@ -96,35 +73,12 @@ impl ButtonWidget {
 
     /// Apply one key press. Returns whether activation fires immediately.
     fn press_key(&mut self, code: u32) -> bool {
-        if !self.state.is_available() || self.keyboard_arm.is_some() {
-            return false;
-        }
-        match code {
-            KEY_ENTER => {
-                self.keyboard_arm = Some(KeyboardArm::Enter);
-                true
-            }
-            KEY_SPACE => {
-                self.keyboard_arm = Some(KeyboardArm::Space);
-                false
-            }
-            _ => false,
-        }
+        self.arms.press_key(self.state.is_available(), code)
     }
 
     /// Apply one matching key release. Returns whether activation fires now.
     fn release_key(&mut self, code: u32) -> bool {
-        match (code, self.keyboard_arm) {
-            (KEY_ENTER, Some(KeyboardArm::Enter)) => {
-                self.keyboard_arm = None;
-                false
-            }
-            (KEY_SPACE, Some(KeyboardArm::Space)) => {
-                self.keyboard_arm = None;
-                self.state.is_available()
-            }
-            _ => false,
-        }
+        self.arms.release_key(self.state.is_available(), code)
     }
 }
 
@@ -145,8 +99,7 @@ impl WasmActor for ButtonWidget {
             theme: config.theme,
             state: InteractionState::new(config.state),
             frame: WidgetFrame { x: 0.0, y: 0.0, width: 0.0, height: 0.0 },
-            pointer_pressed: false,
-            keyboard_arm: None,
+            arms: ActivationArms::default(),
         })
     }
 
@@ -275,7 +228,10 @@ impl WasmActor for ButtonWidget {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aether_kinds::keycode::{KEY_ENTER, KEY_SPACE};
+
     use crate::widget::WidgetControlState;
+    use crate::widget::set::KeyboardArm;
 
     fn button() -> ButtonWidget {
         ButtonWidget {
@@ -283,8 +239,7 @@ mod tests {
             theme: Theme::DEFAULT,
             state: InteractionState::new(WidgetControlState::default()),
             frame: WidgetFrame { x: 10.0, y: 10.0, width: 40.0, height: 20.0 },
-            pointer_pressed: false,
-            keyboard_arm: None,
+            arms: ActivationArms::default(),
         }
     }
 
@@ -292,9 +247,9 @@ mod tests {
     fn press_inside_then_release_inside_clicks() {
         let mut b = button();
         b.press_at(20.0, 20.0);
-        assert!(b.pointer_pressed);
+        assert!(b.arms.pointer_pressed);
         assert!(b.release_at(30.0, 25.0), "press-inside then release-inside is a click");
-        assert!(!b.pointer_pressed, "disarmed after release");
+        assert!(!b.arms.pointer_pressed, "disarmed after release");
     }
 
     #[test]
@@ -302,14 +257,14 @@ mod tests {
         let mut b = button();
         b.press_at(20.0, 20.0);
         assert!(!b.release_at(200.0, 200.0), "a release that drifts off the button does not click");
-        assert!(!b.pointer_pressed, "disarmed even on a cancel");
+        assert!(!b.arms.pointer_pressed, "disarmed even on a cancel");
     }
 
     #[test]
     fn press_outside_never_arms() {
         let mut b = button();
         b.press_at(200.0, 200.0);
-        assert!(!b.pointer_pressed);
+        assert!(!b.arms.pointer_pressed);
         assert!(!b.release_at(20.0, 20.0), "a release with no prior inside-press does not click");
     }
 
@@ -326,9 +281,9 @@ mod tests {
     fn space_fires_only_on_matching_release_and_cancels_with_focus_loss() {
         let mut b = button();
         assert!(!b.press_key(KEY_SPACE));
-        assert_eq!(b.keyboard_arm, Some(KeyboardArm::Space));
+        assert_eq!(b.arms.keyboard_arm, Some(KeyboardArm::Space));
         assert!(b.release_key(KEY_SPACE));
-        assert_eq!(b.keyboard_arm, None);
+        assert_eq!(b.arms.keyboard_arm, None);
 
         b.press_key(KEY_SPACE);
         b.state.lose_focus();

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -38,8 +38,8 @@ pub mod segmented;
 pub mod slider;
 pub mod text_area;
 pub mod text_field;
-pub mod virtual_list;
 pub mod toggle;
+pub mod virtual_list;
 
 pub use button::ButtonWidget;
 pub use image::ImageWidget;
@@ -50,8 +50,8 @@ pub use segmented::SegmentedWidget;
 pub use slider::SliderWidget;
 pub use text_area::TextAreaWidget;
 pub use text_field::TextFieldWidget;
-pub use virtual_list::VirtualListWidget;
 pub use toggle::ToggleWidget;
+pub use virtual_list::VirtualListWidget;
 
 use alloc::vec::Vec;
 

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -12,6 +12,9 @@
 //! - [`LabelWidget`] — static, non-interactive text.
 //! - [`ImageWidget`] — a static, non-interactive borrowed texture.
 //! - [`VirtualListWidget`] — a fixed-row virtualized item list.
+//! - [`ToggleWidget`] — a boolean switch.
+//! - [`SegmentedWidget`] — a horizontal exclusive choice.
+//! - [`NumericWidget`] — a typed and steppable bounded number.
 //!
 //! Each caches its assigned [`WidgetFrame`](crate::widget::WidgetFrame) rect
 //! and its [`Theme`], answers every
@@ -29,20 +32,26 @@
 pub mod button;
 pub mod image;
 pub mod label;
+pub mod numeric;
 pub mod radio;
+pub mod segmented;
 pub mod slider;
 pub mod text_area;
 pub mod text_field;
 pub mod virtual_list;
+pub mod toggle;
 
 pub use button::ButtonWidget;
 pub use image::ImageWidget;
 pub use label::LabelWidget;
+pub use numeric::NumericWidget;
 pub use radio::RadioGroupWidget;
+pub use segmented::SegmentedWidget;
 pub use slider::SliderWidget;
 pub use text_area::TextAreaWidget;
 pub use text_field::TextFieldWidget;
 pub use virtual_list::VirtualListWidget;
+pub use toggle::ToggleWidget;
 
 use alloc::vec::Vec;
 

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -58,13 +58,84 @@ use alloc::vec::Vec;
 use aether_actor::WasmCtx;
 use aether_capabilities::TextCapability;
 use aether_capabilities::text::{FontMetricsRequest, FontRef};
+use aether_kinds::keycode::{KEY_ENTER, KEY_SPACE};
 use aether_kinds::{Modifiers, MouseButtonRelease, mouse_button};
 use aether_math::Rgba;
 
 use crate::widget::state::{InteractionState, emit_state_changed};
 use crate::widget::text_edit::{FontMetricsAdapter, TextEditState};
 use crate::widget::theme::{Theme, ThemeState};
-use crate::widget::{WidgetControlState, WidgetDrawItem, WidgetDrawList};
+use crate::widget::{WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyboardArm {
+    Enter,
+    Space,
+}
+
+#[derive(Debug, Default)]
+struct ActivationArms {
+    pointer_pressed: bool,
+    keyboard_arm: Option<KeyboardArm>,
+}
+
+impl ActivationArms {
+    fn contains(frame: &WidgetFrame, x: f32, y: f32) -> bool {
+        x >= frame.x && x <= frame.x + frame.width && y >= frame.y && y <= frame.y + frame.height
+    }
+
+    fn press_pointer(&mut self, frame: &WidgetFrame, eligible: bool, x: f32, y: f32) {
+        if eligible && Self::contains(frame, x, y) {
+            self.pointer_pressed = true;
+        }
+    }
+
+    fn release_pointer(&mut self, frame: &WidgetFrame, eligible: bool, x: f32, y: f32) -> bool {
+        let activates = eligible && self.pointer_pressed && Self::contains(frame, x, y);
+        self.pointer_pressed = false;
+        activates
+    }
+
+    fn press_key(&mut self, eligible: bool, code: u32) -> bool {
+        if !eligible || self.keyboard_arm.is_some() {
+            return false;
+        }
+        match code {
+            KEY_ENTER => {
+                self.keyboard_arm = Some(KeyboardArm::Enter);
+                true
+            }
+            KEY_SPACE => {
+                self.keyboard_arm = Some(KeyboardArm::Space);
+                false
+            }
+            _ => false,
+        }
+    }
+
+    fn release_key(&mut self, eligible: bool, code: u32) -> bool {
+        match (code, self.keyboard_arm) {
+            (KEY_ENTER, Some(KeyboardArm::Enter)) => {
+                self.keyboard_arm = None;
+                false
+            }
+            (KEY_SPACE, Some(KeyboardArm::Space)) => {
+                self.keyboard_arm = None;
+                eligible
+            }
+            _ => false,
+        }
+    }
+
+    fn pressed(&self) -> bool {
+        self.pointer_pressed || self.keyboard_arm == Some(KeyboardArm::Space)
+    }
+
+    fn clear(&mut self) {
+        self.pointer_pressed = false;
+        self.keyboard_arm = None;
+    }
+}
 
 fn text_control_theme_state(state: &InteractionState, dragging: bool) -> ThemeState {
     if state.focused() {

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -16,7 +16,7 @@
 //! - [`SegmentedWidget`] — a horizontal exclusive choice.
 //! - [`NumericWidget`] — a typed and steppable bounded number.
 //!
-//! Each caches its assigned [`WidgetFrame`](crate::widget::WidgetFrame) rect
+//! Each caches its assigned [`WidgetFrame`] rect
 //! and its [`Theme`], answers every
 //! [`Collect`](crate::widget::Collect) with a
 //! [`WidgetDrawList`] drawn in its own local

--- a/crates/aether-kit/src/widget/set/numeric.rs
+++ b/crates/aether-kit/src/widget/set/numeric.rs
@@ -50,9 +50,21 @@ struct NumericBounds {
 
 impl NumericBounds {
     fn from_config(min: f32, max: f32) -> Self {
-        let min = if min.is_finite() { min } else { f32::MIN };
-        let max = if max.is_finite() { max } else { f32::MAX };
-        if min <= max { Self { min, max } } else { Self { min: max, max: min } }
+        let min = if min.is_finite() {
+            min
+        } else {
+            f32::MIN
+        };
+        let max = if max.is_finite() {
+            max
+        } else {
+            f32::MAX
+        };
+        if min <= max {
+            Self { min, max }
+        } else {
+            Self { min: max, max: min }
+        }
     }
 }
 
@@ -141,11 +153,19 @@ impl NumericWidget {
         // The finite check below rejects an f64 result outside f32's range.
         #[allow(clippy::cast_possible_truncation)]
         let snapped = snapped as f32;
-        Some(if snapped.is_finite() { snapped.clamp(bounds.min, bounds.max) } else { clamped })
+        Some(if snapped.is_finite() {
+            snapped.clamp(bounds.min, bounds.max)
+        } else {
+            clamped
+        })
     }
 
     fn canonical(value: f32) -> String {
-        if value == 0.0 { String::from("0") } else { value.to_string() }
+        if value == 0.0 {
+            String::from("0")
+        } else {
+            value.to_string()
+        }
     }
 
     fn policy() -> EditPolicy {
@@ -162,14 +182,22 @@ impl NumericWidget {
 
     fn insert_text(&mut self, text: &str) -> Option<NumericEmission> {
         self.edit.clear_composition();
-        if self.edit.insert(text, Self::policy()) { self.preview() } else { None }
+        if self.edit.insert(text, Self::policy()) {
+            self.preview()
+        } else {
+            None
+        }
     }
 
     fn delete_backward(&mut self) -> Option<NumericEmission> {
         let before = String::from(self.edit.value());
         self.edit.clear_composition();
         self.edit.delete_backward();
-        if self.edit.value() == before { None } else { self.preview() }
+        if self.edit.value() == before {
+            None
+        } else {
+            self.preview()
+        }
     }
 
     fn copy_selection(&self) -> Option<String> {
@@ -196,7 +224,11 @@ impl NumericWidget {
 
     fn stepped(&mut self, direction: StepDirection) -> NumericEmission {
         let base = self.parsed_buffer().unwrap_or(self.committed_value);
-        let amount = if self.step.is_finite() && self.step > 0.0 { self.step } else { 1.0 };
+        let amount = if self.step.is_finite() && self.step > 0.0 {
+            self.step
+        } else {
+            1.0
+        };
         let raw = match direction {
             StepDirection::Down => f64::from(base) - f64::from(amount),
             StepDirection::Up => f64::from(base) + f64::from(amount),
@@ -655,7 +687,11 @@ mod tests {
         for invalid in ["", "-", ".", "NaN", "inf", "-inf"] {
             widget.edit.select_all();
             widget.edit.delete_backward();
-            let emission = if invalid.is_empty() { widget.preview() } else { widget.insert_text(invalid) };
+            let emission = if invalid.is_empty() {
+                widget.preview()
+            } else {
+                widget.insert_text(invalid)
+            };
             assert_eq!(emission, None, "{invalid:?} is not a finite numeric preview");
             assert_eq!(widget.edit.value(), invalid);
         }

--- a/crates/aether-kit/src/widget/set/numeric.rs
+++ b/crates/aether-kit/src/widget/set/numeric.rs
@@ -1,0 +1,731 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `widget/mod.rs`).
+#![allow(clippy::needless_pass_by_value)]
+
+//! Typed, steppable numeric editor (issue 2926).
+//!
+//! The visible edit buffer is deliberately separate from the last committed
+//! number. Invalid intermediates remain visible without emitting a numeric
+//! value; valid edits preview their clamped/snapped value without rewriting the
+//! buffer. Enter or blur commits and canonicalizes, while an invalid commit
+//! reverts. Up/Down step and commit immediately. Clipboard edits use the same
+//! selection and parse paths as typed edits.
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::clipboard::{GetClipboardTextResult, SetClipboardTextResult};
+use aether_capabilities::text::{FontMetricsRequest, FontMetricsResult, FontRef};
+use aether_capabilities::{ClipboardCapability, ClipboardMailboxExt, TextCapability};
+use aether_kinds::keycode::{
+    KEY_A, KEY_BACKSPACE, KEY_C, KEY_DOWN, KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_UP, KEY_V, KEY_X,
+};
+use aether_kinds::{
+    CachedFontMetrics, ImePreedit, Key, Modifiers, MouseButton, MouseButtonRelease, MouseMove, TextInput, mouse_button,
+};
+
+use crate::widget::set::{
+    APPROX_ADVANCE_RATIO, approx_text_width, push_control_outlines, quad, reply_if_hidden, text_origin_y,
+};
+use crate::widget::state::{InteractionState, emit_state_changed};
+use crate::widget::text_edit::{EditPolicy, SingleLineLayout, TextEditState, TextSpan};
+use crate::widget::theme::{SetTheme, Theme, ThemeState};
+use crate::widget::{
+    Collect, FocusGained, FocusLost, HoverGained, HoverLost, NumericChanged, NumericConfig, SetWidgetState,
+    WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct NumericEmission {
+    value: f32,
+    committed: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NumericBounds {
+    min: f32,
+    max: f32,
+}
+
+impl NumericBounds {
+    fn from_config(min: f32, max: f32) -> Self {
+        let min = if min.is_finite() { min } else { f32::MIN };
+        let max = if max.is_finite() { max } else { f32::MAX };
+        if min <= max { Self { min, max } } else { Self { min: max, max: min } }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StepDirection {
+    Down,
+    Up,
+}
+
+#[derive(Debug, PartialEq)]
+struct CutEdit {
+    copied: String,
+    emission: Option<NumericEmission>,
+}
+
+struct DisplayedNumeric {
+    text: String,
+    caret_byte: usize,
+    selection_span: Option<TextSpan>,
+    preedit_span: Option<TextSpan>,
+    preedit_cursor_span: Option<TextSpan>,
+    composing: bool,
+}
+
+/// A single-line numeric editor with an independent display buffer and
+/// committed number.
+pub struct NumericWidget {
+    min: f32,
+    max: f32,
+    step: f32,
+    committed_value: f32,
+    edit: TextEditState,
+    theme: Theme,
+    frame: WidgetFrame,
+    state: InteractionState,
+    modifiers: Modifiers,
+    dragging: bool,
+    paste_pending: bool,
+    desired_font_id: u32,
+    current_font_id: Option<u32>,
+    inflight_font_id: Option<u32>,
+    metrics: Option<CachedFontMetrics>,
+}
+
+impl NumericWidget {
+    fn configured(config: NumericConfig) -> Self {
+        let desired_font_id = config.theme.font_id;
+        let mut widget = Self {
+            min: config.min,
+            max: config.max,
+            step: config.step,
+            committed_value: 0.0,
+            edit: TextEditState::default(),
+            theme: config.theme,
+            frame: WidgetFrame { x: 0.0, y: 0.0, width: 0.0, height: 0.0 },
+            state: InteractionState::new(config.state),
+            modifiers: Modifiers::default(),
+            dragging: false,
+            paste_pending: false,
+            desired_font_id,
+            current_font_id: None,
+            inflight_font_id: None,
+            metrics: None,
+        };
+        let initial = widget.normalize(config.initial).or_else(|| widget.normalize(0.0)).unwrap_or(0.0);
+        widget.committed_value = initial;
+        widget.edit = TextEditState::new(Self::canonical(initial));
+        widget
+    }
+
+    fn bounds(&self) -> NumericBounds {
+        NumericBounds::from_config(self.min, self.max)
+    }
+
+    fn normalize(&self, raw: f32) -> Option<f32> {
+        if !raw.is_finite() {
+            return None;
+        }
+        let bounds = self.bounds();
+        let clamped = raw.clamp(bounds.min, bounds.max);
+        if !self.step.is_finite() || self.step <= 0.0 {
+            return Some(clamped);
+        }
+        let steps = ((f64::from(clamped) - f64::from(bounds.min)) / f64::from(self.step)).round();
+        let snapped = steps.mul_add(f64::from(self.step), f64::from(bounds.min));
+        // The finite check below rejects an f64 result outside f32's range.
+        #[allow(clippy::cast_possible_truncation)]
+        let snapped = snapped as f32;
+        Some(if snapped.is_finite() { snapped.clamp(bounds.min, bounds.max) } else { clamped })
+    }
+
+    fn canonical(value: f32) -> String {
+        if value == 0.0 { String::from("0") } else { value.to_string() }
+    }
+
+    fn policy() -> EditPolicy {
+        EditPolicy { single_line: true, max_chars: 0 }
+    }
+
+    fn parsed_buffer(&self) -> Option<f32> {
+        self.edit.value().parse::<f32>().ok().and_then(|value| self.normalize(value))
+    }
+
+    fn preview(&self) -> Option<NumericEmission> {
+        self.parsed_buffer().map(|value| NumericEmission { value, committed: false })
+    }
+
+    fn insert_text(&mut self, text: &str) -> Option<NumericEmission> {
+        self.edit.clear_composition();
+        if self.edit.insert(text, Self::policy()) { self.preview() } else { None }
+    }
+
+    fn delete_backward(&mut self) -> Option<NumericEmission> {
+        let before = String::from(self.edit.value());
+        self.edit.clear_composition();
+        self.edit.delete_backward();
+        if self.edit.value() == before { None } else { self.preview() }
+    }
+
+    fn copy_selection(&self) -> Option<String> {
+        let selection = self.edit.selection();
+        (!selection.is_collapsed()).then(|| String::from(&self.edit.value()[selection.start_byte..selection.end_byte]))
+    }
+
+    fn cut_selection(&mut self) -> Option<CutEdit> {
+        let copied = self.copy_selection()?;
+        self.edit.clear_composition();
+        self.edit.delete_backward();
+        Some(CutEdit { copied, emission: self.preview() })
+    }
+
+    fn commit_buffer(&mut self) -> Option<NumericEmission> {
+        let Some(value) = self.parsed_buffer() else {
+            self.edit = TextEditState::new(Self::canonical(self.committed_value));
+            return None;
+        };
+        self.committed_value = value;
+        self.edit = TextEditState::new(Self::canonical(value));
+        Some(NumericEmission { value, committed: true })
+    }
+
+    fn stepped(&mut self, direction: StepDirection) -> NumericEmission {
+        let base = self.parsed_buffer().unwrap_or(self.committed_value);
+        let amount = if self.step.is_finite() && self.step > 0.0 { self.step } else { 1.0 };
+        let raw = match direction {
+            StepDirection::Down => f64::from(base) - f64::from(amount),
+            StepDirection::Up => f64::from(base) + f64::from(amount),
+        };
+        let bounds = self.bounds();
+        let raw = if raw > f64::from(f32::MAX) {
+            bounds.max
+        } else if raw < f64::from(f32::MIN) {
+            bounds.min
+        } else {
+            // The two guards above prove `raw` is inside f32's finite range.
+            #[allow(clippy::cast_possible_truncation)]
+            let raw = raw as f32;
+            raw
+        };
+        let value = self.normalize(raw).unwrap_or(self.committed_value);
+        self.committed_value = value;
+        self.edit = TextEditState::new(Self::canonical(value));
+        NumericEmission { value, committed: true }
+    }
+
+    fn emit(ctx: &WasmCtx<'_>, emission: NumericEmission) {
+        if let Some(parent) = ctx.parent() {
+            parent.send(&NumericChanged { value: emission.value, committed: emission.committed });
+        }
+    }
+
+    fn set_desired_font_id(&mut self, desired_font_id: u32) {
+        if self.desired_font_id == desired_font_id {
+            return;
+        }
+        self.desired_font_id = desired_font_id;
+        self.current_font_id = None;
+        self.metrics = None;
+    }
+
+    fn resolved_metrics(&self) -> Option<&CachedFontMetrics> {
+        (self.current_font_id == Some(self.desired_font_id)).then_some(self.metrics.as_ref()).flatten()
+    }
+
+    fn pending_request(&self) -> Option<u32> {
+        if self.inflight_font_id.is_some()
+            || (self.current_font_id == Some(self.desired_font_id) && self.metrics.is_some())
+        {
+            None
+        } else {
+            Some(self.desired_font_id)
+        }
+    }
+
+    fn take_pending_request(&mut self) -> Option<u32> {
+        let id = self.pending_request()?;
+        self.inflight_font_id = Some(id);
+        Some(id)
+    }
+
+    fn accept_reply(&mut self, metrics: Option<CachedFontMetrics>) -> bool {
+        let Some(id) = self.inflight_font_id.take() else {
+            return false;
+        };
+        if id != self.desired_font_id {
+            return true;
+        }
+        if let Some(metrics) = metrics {
+            self.current_font_id = Some(id);
+            self.metrics = Some(metrics);
+        }
+        false
+    }
+
+    fn pump_font_metrics(&mut self, ctx: &mut WasmCtx<'_>) {
+        if let Some(id) = self.take_pending_request() {
+            ctx.actor::<TextCapability>().send(&FontMetricsRequest { font: FontRef::Id(id) });
+        }
+    }
+
+    fn hit_byte(&self, event_x: f32) -> usize {
+        let size = self.theme.value_size_pixels;
+        let local_x = event_x - self.frame.x - self.theme.pad;
+        let text = self.edit.value();
+        if let Some(metrics) = self.resolved_metrics() {
+            return SingleLineLayout::build(text, metrics, size).hit_test(local_x);
+        }
+        let advance = (size * APPROX_ADVANCE_RATIO).max(1.0);
+        let index = if local_x <= 0.0 {
+            0
+        } else {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let rounded = (local_x / advance + 0.5) as usize;
+            rounded.min(text.chars().count())
+        };
+        text.char_indices().nth(index).map_or(text.len(), |(byte, _)| byte)
+    }
+
+    fn displayed(&self) -> DisplayedNumeric {
+        let selection = self.edit.selection();
+        if self.edit.preedit().is_empty() {
+            return DisplayedNumeric {
+                text: String::from(self.edit.value()),
+                caret_byte: self.edit.caret(),
+                selection_span: (!selection.is_collapsed()).then_some(selection),
+                preedit_span: None,
+                preedit_cursor_span: None,
+                composing: false,
+            };
+        }
+        let preedit = self.edit.preedit();
+        let mut text = String::with_capacity(self.edit.value().len() + preedit.len());
+        text.push_str(&self.edit.value()[..selection.start_byte]);
+        text.push_str(preedit);
+        text.push_str(&self.edit.value()[selection.end_byte..]);
+        let end = selection.start_byte + preedit.len();
+        let cursor = self.edit.preedit_cursor().unwrap_or_else(|| TextSpan::new(preedit.len(), preedit.len()));
+        DisplayedNumeric {
+            text,
+            caret_byte: end,
+            selection_span: None,
+            preedit_span: Some(TextSpan::new(selection.start_byte, end)),
+            preedit_cursor_span: Some(TextSpan::new(
+                selection.start_byte + cursor.start_byte,
+                selection.start_byte + cursor.end_byte,
+            )),
+            composing: true,
+        }
+    }
+
+    fn theme_state(&self) -> ThemeState {
+        if self.state.focused() {
+            self.state.supporting_theme_state(self.dragging)
+        } else {
+            self.state.theme_state(self.dragging)
+        }
+    }
+
+    fn apply_control_state(&mut self, ctx: &WasmCtx<'_>, next: WidgetControlState) {
+        if self.state.replace(next) {
+            if !self.state.can_mutate() {
+                self.edit.clear_composition();
+                self.paste_pending = false;
+            }
+            if !self.state.is_available() {
+                self.dragging = false;
+            }
+            emit_state_changed(ctx, &self.state);
+        }
+    }
+}
+
+/// A numeric editor. Spawned inline by a panel root with a [`NumericConfig`];
+/// reports preview and committed [`NumericChanged`] events.
+#[actor(instanced)]
+impl WasmActor for NumericWidget {
+    type Config = NumericConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.numeric";
+
+    fn init(config: NumericConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Self::configured(config))
+    }
+
+    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+        self.pump_font_metrics(ctx);
+    }
+
+    #[handler::single]
+    fn on_config(&mut self, ctx: &mut WasmCtx<'_>, config: NumericConfig) {
+        self.min = config.min;
+        self.max = config.max;
+        self.step = config.step;
+        self.set_desired_font_id(config.theme.font_id);
+        self.theme = config.theme;
+        let initial = self.normalize(config.initial).or_else(|| self.normalize(0.0)).unwrap_or(0.0);
+        self.committed_value = initial;
+        self.edit = TextEditState::new(Self::canonical(initial));
+        self.dragging = false;
+        self.paste_pending = false;
+        self.apply_control_state(ctx, config.state);
+        self.pump_font_metrics(ctx);
+    }
+
+    #[handler::single]
+    fn on_set_widget_state(&mut self, ctx: &mut WasmCtx<'_>, set: SetWidgetState) {
+        self.apply_control_state(ctx, set.state);
+    }
+
+    #[handler::single]
+    fn on_set_theme(&mut self, ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.set_desired_font_id(set.theme.font_id);
+        self.theme = set.theme;
+        self.pump_font_metrics(ctx);
+    }
+
+    #[handler::single]
+    fn on_frame(&mut self, _ctx: &mut WasmCtx<'_>, frame: WidgetFrame) {
+        self.frame = frame;
+    }
+
+    #[handler::single]
+    fn on_focus_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: FocusGained) {
+        self.state.gain_focus();
+    }
+
+    #[handler::single]
+    fn on_focus_lost(&mut self, ctx: &mut WasmCtx<'_>, _lost: FocusLost) {
+        if self.state.can_mutate()
+            && let Some(emission) = self.commit_buffer()
+        {
+            Self::emit(ctx, emission);
+        }
+        self.state.lose_focus();
+        self.dragging = false;
+        self.paste_pending = false;
+        self.edit.clear_composition();
+    }
+
+    #[handler::single]
+    fn on_hover_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: HoverGained) {
+        self.state.set_hovered(true);
+    }
+
+    #[handler::single]
+    fn on_hover_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: HoverLost) {
+        self.state.set_hovered(false);
+    }
+
+    #[handler::single]
+    fn on_text_input(&mut self, ctx: &mut WasmCtx<'_>, input: TextInput) {
+        if self.state.can_mutate()
+            && let Some(emission) = self.insert_text(&input.text)
+        {
+            Self::emit(ctx, emission);
+        }
+    }
+
+    #[handler::single]
+    fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
+        if !self.state.is_available() {
+            return;
+        }
+        if self.modifiers.ctrl {
+            match key.code {
+                KEY_A => self.edit.select_all(),
+                KEY_C => {
+                    if let Some(text) = self.copy_selection() {
+                        ctx.actor::<ClipboardCapability>().set_text(&text);
+                    }
+                }
+                KEY_X if self.state.can_mutate() => {
+                    if let Some(cut) = self.cut_selection() {
+                        ctx.actor::<ClipboardCapability>().set_text(&cut.copied);
+                        if let Some(emission) = cut.emission {
+                            Self::emit(ctx, emission);
+                        }
+                    }
+                }
+                KEY_V if self.state.can_mutate() && !self.paste_pending => {
+                    self.paste_pending = true;
+                    ctx.actor::<ClipboardCapability>().get_text();
+                }
+                _ => {}
+            }
+            return;
+        }
+        let extend = self.modifiers.shift;
+        match key.code {
+            KEY_BACKSPACE if self.state.can_mutate() => {
+                if let Some(emission) = self.delete_backward() {
+                    Self::emit(ctx, emission);
+                }
+            }
+            KEY_LEFT => self.edit.move_left(extend),
+            KEY_RIGHT => self.edit.move_right(extend),
+            KEY_ENTER if self.state.can_mutate() => {
+                if let Some(emission) = self.commit_buffer() {
+                    Self::emit(ctx, emission);
+                }
+            }
+            KEY_DOWN if self.state.can_mutate() => Self::emit(ctx, self.stepped(StepDirection::Down)),
+            KEY_UP if self.state.can_mutate() => Self::emit(ctx, self.stepped(StepDirection::Up)),
+            _ => {}
+        }
+    }
+
+    #[handler::single]
+    fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        if press.button != mouse_button::LEFT || !self.state.is_available() {
+            return;
+        }
+        self.dragging = true;
+        let byte = self.hit_byte(press.x);
+        self.edit.place_caret(byte);
+    }
+
+    #[handler::single]
+    fn on_mouse_move(&mut self, _ctx: &mut WasmCtx<'_>, moved: MouseMove) {
+        if self.dragging && self.state.is_available() {
+            let byte = self.hit_byte(moved.x);
+            self.edit.extend_to(byte);
+        }
+    }
+
+    #[handler::single]
+    fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
+        if release.button == mouse_button::LEFT {
+            self.dragging = false;
+        }
+    }
+
+    #[handler::single]
+    fn on_modifiers(&mut self, _ctx: &mut WasmCtx<'_>, modifiers: Modifiers) {
+        if self.state.is_available() {
+            self.modifiers = modifiers;
+        }
+    }
+
+    #[handler::single]
+    fn on_ime_preedit(&mut self, _ctx: &mut WasmCtx<'_>, preedit: ImePreedit) {
+        if !self.state.can_mutate() {
+            return;
+        }
+        let cursor = match (preedit.cursor_begin, preedit.cursor_end) {
+            (Some(begin), Some(end)) => Some(TextSpan::new(begin as usize, end as usize)),
+            _ => None,
+        };
+        self.edit.set_composition(preedit.text, cursor);
+    }
+
+    #[handler::single]
+    fn on_get_clipboard_text_result(&mut self, ctx: &mut WasmCtx<'_>, result: GetClipboardTextResult) {
+        if !self.paste_pending {
+            return;
+        }
+        self.paste_pending = false;
+        match result {
+            GetClipboardTextResult::Ok { text } if self.state.can_mutate() => {
+                if let Some(emission) = self.insert_text(&text) {
+                    Self::emit(ctx, emission);
+                }
+            }
+            GetClipboardTextResult::Ok { .. } => {}
+            GetClipboardTextResult::Err { error } => {
+                tracing::warn!(target: "aether_kit", %error, "numeric clipboard paste failed");
+            }
+        }
+    }
+
+    #[handler::single]
+    #[allow(clippy::unused_self)]
+    fn on_set_clipboard_text_result(&mut self, _ctx: &mut WasmCtx<'_>, result: SetClipboardTextResult) {
+        if let SetClipboardTextResult::Err { error } = result {
+            tracing::warn!(target: "aether_kit", %error, "numeric clipboard copy failed");
+        }
+    }
+
+    #[handler::single]
+    fn on_font_metrics_result(&mut self, ctx: &mut WasmCtx<'_>, result: FontMetricsResult) {
+        let pump_deferred = match result {
+            FontMetricsResult::Ok { metrics } => self.accept_reply(Some(CachedFontMetrics::new(&metrics))),
+            FontMetricsResult::Err { error } => {
+                tracing::warn!(target: "aether_kit", %error, "numeric font metrics failed");
+                self.accept_reply(None)
+            }
+        };
+        if pump_deferred {
+            self.pump_font_metrics(ctx);
+        }
+    }
+
+    #[handler::single]
+    fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
+        if reply_if_hidden(ctx, &self.state) {
+            return;
+        }
+        let Some(parent) = ctx.parent() else {
+            return;
+        };
+        let width = self.frame.width;
+        let height = self.frame.height;
+        let pad = self.theme.pad;
+        let size = self.theme.value_size_pixels;
+        let text_y = text_origin_y(0.0, height, size);
+        let caret_height = pad.mul_add(-2.0, height).max(1.0);
+        let theme_state = self.theme_state();
+        let displayed = self.displayed();
+        let layout = self.resolved_metrics().map(|metrics| SingleLineLayout::build(&displayed.text, metrics, size));
+        let prefix_width = |byte: usize| {
+            layout.as_ref().map_or_else(
+                || approx_text_width(displayed.text[..byte].chars().count(), size),
+                |layout| layout.caret_x(byte),
+            )
+        };
+
+        let mut items = Vec::new();
+        items.push(quad(0.0, 0.0, width, height, self.theme.fill(self.theme.surface_raised, theme_state)));
+        if let Some(span) = displayed.selection_span {
+            let x0 = pad + prefix_width(span.start_byte);
+            let x1 = pad + prefix_width(span.end_byte);
+            items.push(quad(x0, pad, (x1 - x0).max(1.0), caret_height, self.theme.accent));
+        }
+        if let Some(span) = displayed.preedit_cursor_span.filter(|span| !span.is_collapsed()) {
+            let x0 = pad + prefix_width(span.start_byte);
+            let x1 = pad + prefix_width(span.end_byte);
+            items.push(quad(x0, pad, (x1 - x0).max(1.0), caret_height, self.theme.accent));
+        }
+        if !displayed.text.is_empty() {
+            items.push(WidgetDrawItem::Text {
+                x: pad,
+                y: text_y,
+                font_id: self.theme.font_id,
+                text: displayed.text.clone(),
+                size_pixels: size,
+                color: self.theme.fill(self.theme.text_primary, theme_state),
+                clip: None,
+            });
+        }
+        if let Some(span) = displayed.preedit_span {
+            let x0 = pad + prefix_width(span.start_byte);
+            let x1 = pad + prefix_width(span.end_byte);
+            items.push(quad(x0, text_y + size, (x1 - x0).max(1.0), 1.0, self.theme.accent));
+            if let Some(cursor) = displayed.preedit_cursor_span.filter(|cursor| cursor.is_collapsed()) {
+                let cursor_x = pad + prefix_width(cursor.end_byte);
+                items.push(quad(cursor_x, pad, 1.0, caret_height, self.theme.accent));
+            }
+        }
+        if self.state.focused() && !displayed.composing {
+            let caret_x = pad + prefix_width(displayed.caret_byte);
+            items.push(quad(caret_x, pad, 1.0, caret_height, self.theme.accent));
+        }
+        push_control_outlines(&mut items, width, height, &self.state, &self.theme);
+        parent.send(&WidgetDrawList { intrinsic: None, items });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn numeric(min: f32, max: f32, step: f32, initial: f32) -> NumericWidget {
+        NumericWidget::configured(NumericConfig {
+            min,
+            max,
+            step,
+            initial,
+            theme: Theme::DEFAULT,
+            state: WidgetControlState::default(),
+        })
+    }
+
+    fn replace_buffer(widget: &mut NumericWidget, text: &str) -> Option<NumericEmission> {
+        widget.edit.select_all();
+        widget.insert_text(text)
+    }
+
+    #[test]
+    fn invalid_intermediates_and_non_finite_values_stay_visible_without_events() {
+        let mut widget = numeric(-10.0, 20.0, 0.5, 2.0);
+        for invalid in ["", "-", ".", "NaN", "inf", "-inf"] {
+            widget.edit.select_all();
+            widget.edit.delete_backward();
+            let emission = if invalid.is_empty() { widget.preview() } else { widget.insert_text(invalid) };
+            assert_eq!(emission, None, "{invalid:?} is not a finite numeric preview");
+            assert_eq!(widget.edit.value(), invalid);
+        }
+        assert_eq!(widget.committed_value, 2.0);
+    }
+
+    #[test]
+    fn preview_clamps_and_snaps_without_rewriting_then_commit_canonicalizes() {
+        let mut widget = numeric(0.0, 10.0, 0.5, 2.0);
+        assert_eq!(replace_buffer(&mut widget, "7.26"), Some(NumericEmission { value: 7.5, committed: false }));
+        assert_eq!(widget.edit.value(), "7.26", "preview preserves the authored buffer");
+        assert_eq!(widget.commit_buffer(), Some(NumericEmission { value: 7.5, committed: true }));
+        assert_eq!(widget.edit.value(), "7.5");
+
+        assert_eq!(replace_buffer(&mut widget, "99"), Some(NumericEmission { value: 10.0, committed: false }));
+        assert_eq!(widget.edit.value(), "99");
+    }
+
+    #[test]
+    fn invalid_commit_reverts_to_the_last_canonical_value_without_event() {
+        let mut widget = numeric(-10.0, 20.0, 0.5, 2.0);
+        assert_eq!(replace_buffer(&mut widget, "-"), None);
+        assert_eq!(widget.commit_buffer(), None);
+        assert_eq!(widget.edit.value(), "2");
+        assert_eq!(widget.committed_value, 2.0);
+    }
+
+    #[test]
+    fn step_uses_the_current_valid_value_or_falls_back_to_committed() {
+        let mut widget = numeric(-10.0, 20.0, 0.5, 2.0);
+        assert_eq!(replace_buffer(&mut widget, "4.2"), Some(NumericEmission { value: 4.0, committed: false }));
+        assert_eq!(widget.stepped(StepDirection::Up), NumericEmission { value: 4.5, committed: true });
+        assert_eq!(widget.edit.value(), "4.5");
+
+        assert_eq!(replace_buffer(&mut widget, "-"), None);
+        assert_eq!(widget.stepped(StepDirection::Down), NumericEmission { value: 4.0, committed: true });
+        assert_eq!(widget.edit.value(), "4");
+    }
+
+    #[test]
+    fn copy_cut_and_paste_core_share_selection_and_preview_paths() {
+        let mut widget = numeric(-10.0, 20.0, 0.5, 12.5);
+        widget.edit.select_all();
+        assert_eq!(widget.copy_selection().as_deref(), Some("12.5"));
+        let cut = widget.cut_selection().expect("selected text cuts");
+        assert_eq!(cut, CutEdit { copied: String::from("12.5"), emission: None });
+        assert_eq!(widget.edit.value(), "");
+        assert_eq!(widget.insert_text(&cut.copied), Some(NumericEmission { value: 12.5, committed: false }));
+        assert_eq!(widget.edit.value(), "12.5");
+    }
+
+    #[test]
+    fn pointer_placement_and_selection_never_split_multibyte_text() {
+        let mut widget = numeric(-10.0, 20.0, 0.5, 2.0);
+        widget.frame = WidgetFrame { x: 10.0, y: 0.0, width: 100.0, height: 24.0 };
+        widget.edit = TextEditState::new(String::from("1é2"));
+        let byte = widget.hit_byte(widget.theme.value_size_pixels.mul_add(0.75, 10.0 + widget.theme.pad));
+        assert!([0, 1, 3, 4].contains(&byte), "hit byte {byte} must be a UTF-8 boundary");
+        widget.edit.place_caret(byte);
+        widget.edit.move_right(true);
+        let selection = widget.edit.selection();
+        assert!(widget.edit.value().is_char_boundary(selection.start_byte));
+        assert!(widget.edit.value().is_char_boundary(selection.end_byte));
+    }
+
+    #[test]
+    fn canonical_zero_drops_negative_sign_and_reversed_bounds_are_safe() {
+        assert_eq!(NumericWidget::canonical(-0.0), "0");
+        let widget = numeric(10.0, -10.0, 1.0, 99.0);
+        assert_eq!(widget.committed_value, 10.0);
+        assert_eq!(widget.edit.value(), "10");
+    }
+}

--- a/crates/aether-kit/src/widget/set/numeric.rs
+++ b/crates/aether-kit/src/widget/set/numeric.rs
@@ -36,6 +36,10 @@ use crate::widget::{
     WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
 };
 
+/// Retained edit-buffer bound; comfortably exceeds every canonical finite
+/// `f32` literal while preventing unbounded typed or pasted intermediates.
+const NUMERIC_EDIT_MAX_CHARS: u32 = 32;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct NumericEmission {
     value: f32,
@@ -169,7 +173,7 @@ impl NumericWidget {
     }
 
     fn policy() -> EditPolicy {
-        EditPolicy { single_line: true, max_chars: 0 }
+        EditPolicy { single_line: true, max_chars: NUMERIC_EDIT_MAX_CHARS }
     }
 
     fn parsed_buffer(&self) -> Option<f32> {
@@ -548,10 +552,10 @@ impl WasmActor for NumericWidget {
         if !self.state.can_mutate() {
             return;
         }
-        let cursor = match (preedit.cursor_begin, preedit.cursor_end) {
-            (Some(begin), Some(end)) => Some(TextSpan::new(begin as usize, end as usize)),
-            _ => None,
-        };
+        let cursor = preedit
+            .cursor_begin
+            .zip(preedit.cursor_end)
+            .map(|(begin, end)| TextSpan::new(begin as usize, end as usize));
         self.edit.set_composition(preedit.text, cursor);
     }
 
@@ -741,6 +745,21 @@ mod tests {
         assert_eq!(widget.edit.value(), "");
         assert_eq!(widget.insert_text(&cut.copied), Some(NumericEmission { value: 12.5, committed: false }));
         assert_eq!(widget.edit.value(), "12.5");
+    }
+
+    #[test]
+    fn typed_insertions_respect_internal_cap_and_normal_numeric_edits_continue() {
+        let mut widget = numeric(-f32::MAX, f32::MAX, 0.0, 0.0);
+        widget.edit.select_all();
+        widget.edit.delete_backward();
+        for _ in 0..40 {
+            widget.insert_text("1");
+        }
+        assert_eq!(widget.edit.value().chars().count(), NUMERIC_EDIT_MAX_CHARS as usize);
+        assert_eq!(widget.edit.value(), "11111111111111111111111111111111");
+
+        assert_eq!(replace_buffer(&mut widget, "7.5"), Some(NumericEmission { value: 7.5, committed: false }));
+        assert_eq!(widget.edit.value(), "7.5");
     }
 
     #[test]

--- a/crates/aether-kit/src/widget/set/segmented.rs
+++ b/crates/aether-kit/src/widget/set/segmented.rs
@@ -289,7 +289,7 @@ mod tests {
 
     fn segmented(options: usize, selected: usize) -> SegmentedWidget {
         SegmentedWidget {
-            options: (0..options).map(|index| alloc::format!("option-{index}")).collect(),
+            options: (0..options).map(|index| format!("option-{index}")).collect(),
             selected,
             theme: Theme::DEFAULT,
             frame: WidgetFrame { x: 10.0, y: 0.0, width: 90.0, height: 24.0 },

--- a/crates/aether-kit/src/widget/set/segmented.rs
+++ b/crates/aether-kit/src/widget/set/segmented.rs
@@ -1,0 +1,330 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `widget/mod.rs`).
+#![allow(clippy::needless_pass_by_value, clippy::cast_precision_loss)]
+
+//! Horizontal exclusive segmented control (issue 2926).
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_kinds::keycode::{KEY_LEFT, KEY_RIGHT};
+use aether_kinds::mouse_button;
+use aether_kinds::{Key, MouseButton, MouseButtonRelease, MouseMove};
+
+use crate::widget::set::{push_control_outlines, quad, reply_if_hidden, text_origin_y};
+use crate::widget::state::{InteractionState, emit_state_changed};
+use crate::widget::theme::{SetTheme, Theme, ThemeState};
+use crate::widget::{
+    Collect, FocusGained, FocusLost, HoverGained, HoverLost, SegmentedConfig, SegmentedSelected, SetWidgetState,
+    WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+};
+
+#[derive(Debug, Clone, Copy)]
+enum SegmentDirection {
+    Previous,
+    Next,
+}
+
+/// A horizontal row of equal-width exclusive choices.
+pub struct SegmentedWidget {
+    options: Vec<String>,
+    selected: usize,
+    theme: Theme,
+    frame: WidgetFrame,
+    state: InteractionState,
+    pressed_segment: Option<usize>,
+    hovered_segment: Option<usize>,
+}
+
+impl SegmentedWidget {
+    fn segment_at_local_x(local_x: f32, width: f32, option_count: usize) -> Option<usize> {
+        if option_count == 0
+            || !local_x.is_finite()
+            || !width.is_finite()
+            || width <= 0.0
+            || local_x < 0.0
+            || local_x >= width
+        {
+            return None;
+        }
+        let segment_width = width / option_count as f32;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let index = (local_x / segment_width) as usize;
+        (index < option_count).then_some(index)
+    }
+
+    fn segment_at_pointer_x(&self, pointer_x: f32) -> Option<usize> {
+        Self::segment_at_local_x(pointer_x - self.frame.x, self.frame.width, self.options.len())
+    }
+
+    fn select_at(&mut self, pointer_x: f32) -> Option<usize> {
+        if !self.state.can_mutate() {
+            return None;
+        }
+        let segment = self.segment_at_pointer_x(pointer_x)?;
+        self.pressed_segment = Some(segment);
+        if segment == self.selected {
+            return None;
+        }
+        self.selected = segment;
+        Some(segment)
+    }
+
+    fn step(&mut self, direction: SegmentDirection) -> Option<usize> {
+        if !self.state.can_mutate() || self.options.is_empty() {
+            return None;
+        }
+        let next = match direction {
+            SegmentDirection::Previous => self.selected.saturating_sub(1),
+            SegmentDirection::Next => (self.selected + 1).min(self.options.len() - 1),
+        };
+        if next == self.selected {
+            return None;
+        }
+        self.selected = next;
+        Some(next)
+    }
+
+    fn adopt_control_state(&mut self, next: WidgetControlState) -> bool {
+        if !self.state.replace(next) {
+            return false;
+        }
+        if !self.state.can_mutate() {
+            self.pressed_segment = None;
+        }
+        if !self.state.is_available() {
+            self.hovered_segment = None;
+        }
+        true
+    }
+
+    fn apply_control_state(&mut self, ctx: &WasmCtx<'_>, next: WidgetControlState) {
+        if self.adopt_control_state(next) {
+            emit_state_changed(ctx, &self.state);
+        }
+    }
+
+    fn emit(ctx: &WasmCtx<'_>, selected: usize) {
+        if let Some(parent) = ctx.parent() {
+            #[allow(clippy::cast_possible_truncation)]
+            let index = selected as u32;
+            parent.send(&SegmentedSelected { index });
+        }
+    }
+}
+
+/// A segmented widget. Spawned inline by a panel root with a
+/// [`SegmentedConfig`]; reports [`SegmentedSelected`] on selection changes.
+#[actor(instanced)]
+impl WasmActor for SegmentedWidget {
+    type Config = SegmentedConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.segmented";
+
+    fn init(config: SegmentedConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        let selected = clamp_index(config.initial_index, config.options.len());
+        Ok(Self {
+            options: config.options,
+            selected,
+            theme: config.theme,
+            frame: WidgetFrame { x: 0.0, y: 0.0, width: 0.0, height: 0.0 },
+            state: InteractionState::new(config.state),
+            pressed_segment: None,
+            hovered_segment: None,
+        })
+    }
+
+    #[handler::single]
+    fn on_config(&mut self, ctx: &mut WasmCtx<'_>, config: SegmentedConfig) {
+        self.selected = clamp_index(config.initial_index, config.options.len());
+        self.options = config.options;
+        self.theme = config.theme;
+        self.pressed_segment = None;
+        self.hovered_segment = None;
+        self.apply_control_state(ctx, config.state);
+    }
+
+    #[handler::single]
+    fn on_set_widget_state(&mut self, ctx: &mut WasmCtx<'_>, set: SetWidgetState) {
+        self.apply_control_state(ctx, set.state);
+    }
+
+    #[handler::single]
+    fn on_set_theme(&mut self, _ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.theme = set.theme;
+    }
+
+    #[handler::single]
+    fn on_frame(&mut self, _ctx: &mut WasmCtx<'_>, frame: WidgetFrame) {
+        self.frame = frame;
+    }
+
+    #[handler::single]
+    fn on_focus_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: FocusGained) {
+        self.state.gain_focus();
+    }
+
+    #[handler::single]
+    fn on_focus_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: FocusLost) {
+        self.state.lose_focus();
+        self.pressed_segment = None;
+    }
+
+    #[handler::single]
+    fn on_hover_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: HoverGained) {
+        self.state.set_hovered(true);
+    }
+
+    #[handler::single]
+    fn on_hover_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: HoverLost) {
+        self.state.set_hovered(false);
+        self.hovered_segment = None;
+    }
+
+    #[handler::single]
+    fn on_mouse_button(&mut self, ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        if press.button == mouse_button::LEFT
+            && let Some(selected) = self.select_at(press.x)
+        {
+            Self::emit(ctx, selected);
+        }
+    }
+
+    #[handler::single]
+    fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
+        if release.button == mouse_button::LEFT {
+            self.pressed_segment = None;
+        }
+    }
+
+    #[handler::single]
+    fn on_mouse_move(&mut self, _ctx: &mut WasmCtx<'_>, moved: MouseMove) {
+        if self.state.is_available() {
+            self.hovered_segment = self.segment_at_pointer_x(moved.x);
+        }
+    }
+
+    #[handler::single]
+    fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
+        let direction = match key.code {
+            KEY_LEFT => SegmentDirection::Previous,
+            KEY_RIGHT => SegmentDirection::Next,
+            _ => return,
+        };
+        if let Some(selected) = self.step(direction) {
+            Self::emit(ctx, selected);
+        }
+    }
+
+    #[handler::single]
+    fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
+        if reply_if_hidden(ctx, &self.state) {
+            return;
+        }
+        let width = self.frame.width;
+        let height = self.frame.height;
+        let mut items = Vec::new();
+        if !self.options.is_empty() {
+            let segment_width = width / self.options.len() as f32;
+            for (index, option) in self.options.iter().enumerate() {
+                let x = index as f32 * segment_width;
+                let selected = index == self.selected;
+                let base = if selected { self.theme.accent } else { self.theme.surface_raised };
+                let theme_state = if self.pressed_segment == Some(index) {
+                    ThemeState::Pressed
+                } else if self.hovered_segment == Some(index) {
+                    ThemeState::Hover
+                } else if !self.state.control().enabled {
+                    ThemeState::Disabled
+                } else {
+                    ThemeState::Normal
+                };
+                items.push(quad(x, 0.0, segment_width, height, self.theme.fill(base, theme_state)));
+                if index > 0 {
+                    items.push(quad(x, 0.0, 1.0, height, self.theme.fill(self.theme.outline, theme_state)));
+                }
+                if !option.is_empty() {
+                    let size = self.theme.label_size_pixels;
+                    items.push(WidgetDrawItem::Text {
+                        x: x + self.theme.pad,
+                        y: text_origin_y(0.0, height, size),
+                        font_id: self.theme.font_id,
+                        text: option.clone(),
+                        size_pixels: size,
+                        color: self
+                            .theme
+                            .fill(if selected { self.theme.accent_text } else { self.theme.text_primary }, theme_state),
+                        clip: None,
+                    });
+                }
+            }
+        }
+        push_control_outlines(&mut items, width, height, &self.state, &self.theme);
+        if let Some(parent) = ctx.parent() {
+            parent.send(&WidgetDrawList { intrinsic: None, items });
+        }
+    }
+}
+
+fn clamp_index(index: u32, len: usize) -> usize {
+    if len == 0 { 0 } else { (index as usize).min(len - 1) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segmented(options: usize, selected: usize) -> SegmentedWidget {
+        SegmentedWidget {
+            options: (0..options).map(|index| alloc::format!("option-{index}")).collect(),
+            selected,
+            theme: Theme::DEFAULT,
+            frame: WidgetFrame { x: 10.0, y: 0.0, width: 90.0, height: 24.0 },
+            state: InteractionState::new(WidgetControlState::default()),
+            pressed_segment: None,
+            hovered_segment: None,
+        }
+    }
+
+    #[test]
+    fn empty_and_boundary_hits_are_explicit() {
+        assert_eq!(SegmentedWidget::segment_at_local_x(0.0, 90.0, 0), None);
+        assert_eq!(SegmentedWidget::segment_at_local_x(-0.1, 90.0, 3), None);
+        assert_eq!(SegmentedWidget::segment_at_local_x(0.0, 90.0, 3), Some(0));
+        assert_eq!(SegmentedWidget::segment_at_local_x(29.99, 90.0, 3), Some(0));
+        assert_eq!(SegmentedWidget::segment_at_local_x(30.0, 90.0, 3), Some(1));
+        assert_eq!(SegmentedWidget::segment_at_local_x(60.0, 90.0, 3), Some(2));
+        assert_eq!(SegmentedWidget::segment_at_local_x(90.0, 90.0, 3), None);
+    }
+
+    #[test]
+    fn pointer_bucketing_and_arrow_steps_clamp_at_the_ends() {
+        let mut control = segmented(3, 0);
+        assert_eq!(control.select_at(75.0), Some(2));
+        assert_eq!(control.step(SegmentDirection::Next), None, "right at the end is clamped");
+        assert_eq!(control.step(SegmentDirection::Previous), Some(1));
+        assert_eq!(control.step(SegmentDirection::Previous), Some(0));
+        assert_eq!(control.step(SegmentDirection::Previous), None, "left at the start is clamped");
+    }
+
+    #[test]
+    fn initial_index_clamps_for_nonempty_and_empty_options() {
+        assert_eq!(clamp_index(9, 3), 2);
+        assert_eq!(clamp_index(9, 0), 0);
+    }
+
+    #[test]
+    fn unavailable_and_read_only_states_block_pointer_and_key_mutation() {
+        let mut control = segmented(3, 0);
+        let read_only = WidgetControlState { read_only: true, ..WidgetControlState::default() };
+        assert!(control.adopt_control_state(read_only));
+        assert_eq!(control.select_at(75.0), None);
+        assert_eq!(control.step(SegmentDirection::Next), None);
+        assert_eq!(control.selected, 0);
+
+        let disabled = WidgetControlState { enabled: false, ..WidgetControlState::default() };
+        assert!(control.adopt_control_state(disabled));
+        assert_eq!(control.select_at(75.0), None);
+        assert_eq!(control.selected, 0);
+    }
+}

--- a/crates/aether-kit/src/widget/set/segmented.rs
+++ b/crates/aether-kit/src/widget/set/segmented.rs
@@ -229,7 +229,11 @@ impl WasmActor for SegmentedWidget {
             for (index, option) in self.options.iter().enumerate() {
                 let x = index as f32 * segment_width;
                 let selected = index == self.selected;
-                let base = if selected { self.theme.accent } else { self.theme.surface_raised };
+                let base = if selected {
+                    self.theme.accent
+                } else {
+                    self.theme.surface_raised
+                };
                 let theme_state = if self.pressed_segment == Some(index) {
                     ThemeState::Pressed
                 } else if self.hovered_segment == Some(index) {
@@ -251,9 +255,14 @@ impl WasmActor for SegmentedWidget {
                         font_id: self.theme.font_id,
                         text: option.clone(),
                         size_pixels: size,
-                        color: self
-                            .theme
-                            .fill(if selected { self.theme.accent_text } else { self.theme.text_primary }, theme_state),
+                        color: self.theme.fill(
+                            if selected {
+                                self.theme.accent_text
+                            } else {
+                                self.theme.text_primary
+                            },
+                            theme_state,
+                        ),
                         clip: None,
                     });
                 }
@@ -267,7 +276,11 @@ impl WasmActor for SegmentedWidget {
 }
 
 fn clamp_index(index: u32, len: usize) -> usize {
-    if len == 0 { 0 } else { (index as usize).min(len - 1) }
+    if len == 0 {
+        0
+    } else {
+        (index as usize).min(len - 1)
+    }
 }
 
 #[cfg(test)]

--- a/crates/aether-kit/src/widget/set/toggle.rs
+++ b/crates/aether-kit/src/widget/set/toggle.rs
@@ -1,0 +1,327 @@
+// `#[handler]` methods take their decoded mail by value per the ADR-0033
+// dispatch ABI (see `widget/mod.rs`).
+#![allow(clippy::needless_pass_by_value)]
+
+//! Boolean toggle control (issue 2926).
+//!
+//! A left press arms the switch and a release back inside toggles it once.
+//! Enter toggles on its first key press; Space toggles on its matching release.
+//! Focus loss, read-only state, and unavailability cancel every arm.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_kinds::keycode::{KEY_ENTER, KEY_SPACE};
+use aether_kinds::mouse_button;
+use aether_kinds::{Key, KeyRelease, MouseButton, MouseButtonRelease};
+
+use crate::widget::set::{push_control_outlines, quad, reply_if_hidden, text_origin_y};
+use crate::widget::state::{InteractionState, emit_state_changed};
+use crate::widget::theme::{SetTheme, Theme};
+use crate::widget::{
+    Collect, FocusGained, FocusLost, HoverGained, HoverLost, SetWidgetState, ToggleChanged, ToggleConfig,
+    WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyboardArm {
+    Enter,
+    Space,
+}
+
+/// A boolean switch with a track, knob, and optional label.
+pub struct ToggleWidget {
+    label: String,
+    on: bool,
+    theme: Theme,
+    frame: WidgetFrame,
+    state: InteractionState,
+    pointer_pressed: bool,
+    keyboard_arm: Option<KeyboardArm>,
+}
+
+impl ToggleWidget {
+    fn contains(&self, x: f32, y: f32) -> bool {
+        x >= self.frame.x
+            && x <= self.frame.x + self.frame.width
+            && y >= self.frame.y
+            && y <= self.frame.y + self.frame.height
+    }
+
+    fn clear_arms(&mut self) {
+        self.pointer_pressed = false;
+        self.keyboard_arm = None;
+    }
+
+    fn pressed(&self) -> bool {
+        self.pointer_pressed || self.keyboard_arm == Some(KeyboardArm::Space)
+    }
+
+    fn toggle(&mut self) -> bool {
+        self.on = !self.on;
+        self.on
+    }
+
+    fn press_at(&mut self, x: f32, y: f32) {
+        if self.state.can_mutate() && self.contains(x, y) {
+            self.pointer_pressed = true;
+        }
+    }
+
+    fn release_at(&mut self, x: f32, y: f32) -> Option<bool> {
+        let activates = self.state.can_mutate() && self.pointer_pressed && self.contains(x, y);
+        self.pointer_pressed = false;
+        activates.then(|| self.toggle())
+    }
+
+    fn press_key(&mut self, code: u32) -> Option<bool> {
+        if !self.state.can_mutate() || self.keyboard_arm.is_some() {
+            return None;
+        }
+        match code {
+            KEY_ENTER => {
+                self.keyboard_arm = Some(KeyboardArm::Enter);
+                Some(self.toggle())
+            }
+            KEY_SPACE => {
+                self.keyboard_arm = Some(KeyboardArm::Space);
+                None
+            }
+            _ => None,
+        }
+    }
+
+    fn release_key(&mut self, code: u32) -> Option<bool> {
+        match (code, self.keyboard_arm) {
+            (KEY_ENTER, Some(KeyboardArm::Enter)) => {
+                self.keyboard_arm = None;
+                None
+            }
+            (KEY_SPACE, Some(KeyboardArm::Space)) => {
+                self.keyboard_arm = None;
+                self.state.can_mutate().then(|| self.toggle())
+            }
+            _ => None,
+        }
+    }
+
+    fn adopt_control_state(&mut self, next: WidgetControlState) -> bool {
+        if !self.state.replace(next) {
+            return false;
+        }
+        if !self.state.can_mutate() {
+            self.clear_arms();
+        }
+        true
+    }
+
+    fn apply_control_state(&mut self, ctx: &WasmCtx<'_>, next: WidgetControlState) {
+        if self.adopt_control_state(next) {
+            emit_state_changed(ctx, &self.state);
+        }
+    }
+
+    fn emit(ctx: &WasmCtx<'_>, on: bool) {
+        if let Some(parent) = ctx.parent() {
+            parent.send(&ToggleChanged { on });
+        }
+    }
+}
+
+/// A toggle widget. Spawned inline by a panel root with a [`ToggleConfig`];
+/// reports [`ToggleChanged`] after each completed activation.
+#[actor(instanced)]
+impl WasmActor for ToggleWidget {
+    type Config = ToggleConfig;
+    const NAMESPACE: &'static str = "aether.kit.widget.toggle";
+
+    fn init(config: ToggleConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Self {
+            label: config.label,
+            on: config.initial,
+            theme: config.theme,
+            frame: WidgetFrame { x: 0.0, y: 0.0, width: 0.0, height: 0.0 },
+            state: InteractionState::new(config.state),
+            pointer_pressed: false,
+            keyboard_arm: None,
+        })
+    }
+
+    #[handler::single]
+    fn on_config(&mut self, ctx: &mut WasmCtx<'_>, config: ToggleConfig) {
+        self.label = config.label;
+        self.on = config.initial;
+        self.theme = config.theme;
+        self.clear_arms();
+        self.apply_control_state(ctx, config.state);
+    }
+
+    #[handler::single]
+    fn on_set_widget_state(&mut self, ctx: &mut WasmCtx<'_>, set: SetWidgetState) {
+        self.apply_control_state(ctx, set.state);
+    }
+
+    #[handler::single]
+    fn on_set_theme(&mut self, _ctx: &mut WasmCtx<'_>, set: SetTheme) {
+        self.theme = set.theme;
+    }
+
+    #[handler::single]
+    fn on_frame(&mut self, _ctx: &mut WasmCtx<'_>, frame: WidgetFrame) {
+        self.frame = frame;
+    }
+
+    #[handler::single]
+    fn on_focus_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: FocusGained) {
+        self.state.gain_focus();
+    }
+
+    #[handler::single]
+    fn on_focus_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: FocusLost) {
+        self.state.lose_focus();
+        self.clear_arms();
+    }
+
+    #[handler::single]
+    fn on_hover_gained(&mut self, _ctx: &mut WasmCtx<'_>, _gained: HoverGained) {
+        self.state.set_hovered(true);
+    }
+
+    #[handler::single]
+    fn on_hover_lost(&mut self, _ctx: &mut WasmCtx<'_>, _lost: HoverLost) {
+        self.state.set_hovered(false);
+    }
+
+    #[handler::single]
+    fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, press: MouseButton) {
+        if press.button == mouse_button::LEFT {
+            self.press_at(press.x, press.y);
+        }
+    }
+
+    #[handler::single]
+    fn on_mouse_button_release(&mut self, ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
+        if release.button == mouse_button::LEFT
+            && let Some(on) = self.release_at(release.x, release.y)
+        {
+            Self::emit(ctx, on);
+        }
+    }
+
+    #[handler::single]
+    fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
+        if let Some(on) = self.press_key(key.code) {
+            Self::emit(ctx, on);
+        }
+    }
+
+    #[handler::single]
+    fn on_key_release(&mut self, ctx: &mut WasmCtx<'_>, release: KeyRelease) {
+        if let Some(on) = self.release_key(release.code) {
+            Self::emit(ctx, on);
+        }
+    }
+
+    #[handler::single]
+    fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
+        if reply_if_hidden(ctx, &self.state) {
+            return;
+        }
+        let width = self.frame.width;
+        let height = self.frame.height;
+        let track_height = (height * 0.65).clamp(4.0, height.max(4.0));
+        let track_width = (track_height * 1.8).min(width.max(0.0));
+        let track_y = (height - track_height) * 0.5;
+        let knob_size = (track_height - 4.0).max(1.0);
+        let knob_x = if self.on { (track_width - knob_size - 2.0).max(2.0) } else { 2.0 };
+        let state = self.state.theme_state(self.pressed());
+        let track_color = if self.on { self.theme.accent } else { self.theme.surface_raised };
+        let knob_color = if self.on { self.theme.accent_text } else { self.theme.outline };
+
+        let mut items = Vec::new();
+        items.push(quad(0.0, track_y, track_width, track_height, self.theme.fill(track_color, state)));
+        items.push(quad(
+            knob_x,
+            track_y + 2.0,
+            knob_size,
+            knob_size,
+            self.theme.fill(knob_color, self.state.supporting_theme_state(false)),
+        ));
+        if !self.label.is_empty() {
+            let size = self.theme.label_size_pixels;
+            items.push(WidgetDrawItem::Text {
+                x: track_width + self.theme.pad,
+                y: text_origin_y(0.0, height, size),
+                font_id: self.theme.font_id,
+                text: self.label.clone(),
+                size_pixels: size,
+                color: self.theme.fill(self.theme.text_primary, self.state.supporting_theme_state(false)),
+                clip: None,
+            });
+        }
+        push_control_outlines(&mut items, width, height, &self.state, &self.theme);
+        if let Some(parent) = ctx.parent() {
+            parent.send(&WidgetDrawList { intrinsic: None, items });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn toggle() -> ToggleWidget {
+        ToggleWidget {
+            label: String::from("snap"),
+            on: false,
+            theme: Theme::DEFAULT,
+            frame: WidgetFrame { x: 10.0, y: 20.0, width: 100.0, height: 24.0 },
+            state: InteractionState::new(WidgetControlState::default()),
+            pointer_pressed: false,
+            keyboard_arm: None,
+        }
+    }
+
+    #[test]
+    fn pointer_activation_toggles_once_and_release_outside_cancels() {
+        let mut toggle = toggle();
+        toggle.press_at(20.0, 30.0);
+        assert_eq!(toggle.release_at(20.0, 30.0), Some(true));
+        assert_eq!(toggle.release_at(20.0, 30.0), None, "an unarmed release cannot toggle twice");
+
+        toggle.press_at(20.0, 30.0);
+        assert_eq!(toggle.release_at(200.0, 30.0), None);
+        assert!(toggle.on, "release outside preserves the prior value");
+    }
+
+    #[test]
+    fn enter_and_space_suppress_repeat_and_toggle_on_their_owned_edge() {
+        let mut toggle = toggle();
+        assert_eq!(toggle.press_key(KEY_ENTER), Some(true));
+        assert_eq!(toggle.press_key(KEY_ENTER), None, "repeat while armed is suppressed");
+        assert_eq!(toggle.release_key(KEY_ENTER), None);
+
+        assert_eq!(toggle.press_key(KEY_SPACE), None);
+        assert_eq!(toggle.press_key(KEY_SPACE), None, "repeat while armed is suppressed");
+        assert_eq!(toggle.release_key(KEY_SPACE), Some(false));
+    }
+
+    #[test]
+    fn read_only_or_unavailable_state_cancels_live_arms_and_blocks_mutation() {
+        let mut toggle = toggle();
+        toggle.press_at(20.0, 30.0);
+        toggle.press_key(KEY_SPACE);
+        let read_only = WidgetControlState { read_only: true, ..WidgetControlState::default() };
+        assert!(toggle.adopt_control_state(read_only));
+        assert!(!toggle.pointer_pressed);
+        assert_eq!(toggle.keyboard_arm, None);
+        assert_eq!(toggle.release_at(20.0, 30.0), None);
+        assert_eq!(toggle.press_key(KEY_ENTER), None);
+
+        let disabled = WidgetControlState { enabled: false, ..WidgetControlState::default() };
+        assert!(toggle.adopt_control_state(disabled));
+        toggle.press_at(20.0, 30.0);
+        assert!(!toggle.pointer_pressed);
+    }
+}

--- a/crates/aether-kit/src/widget/set/toggle.rs
+++ b/crates/aether-kit/src/widget/set/toggle.rs
@@ -12,23 +12,16 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
-use aether_kinds::keycode::{KEY_ENTER, KEY_SPACE};
 use aether_kinds::mouse_button;
 use aether_kinds::{Key, KeyRelease, MouseButton, MouseButtonRelease};
 
-use crate::widget::set::{push_control_outlines, quad, reply_if_hidden, text_origin_y};
+use crate::widget::set::{ActivationArms, push_control_outlines, quad, reply_if_hidden, text_origin_y};
 use crate::widget::state::{InteractionState, emit_state_changed};
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{
     Collect, FocusGained, FocusLost, HoverGained, HoverLost, SetWidgetState, ToggleChanged, ToggleConfig,
     WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum KeyboardArm {
-    Enter,
-    Space,
-}
 
 /// A boolean switch with a track, knob, and optional label.
 pub struct ToggleWidget {
@@ -37,25 +30,16 @@ pub struct ToggleWidget {
     theme: Theme,
     frame: WidgetFrame,
     state: InteractionState,
-    pointer_pressed: bool,
-    keyboard_arm: Option<KeyboardArm>,
+    arms: ActivationArms,
 }
 
 impl ToggleWidget {
-    fn contains(&self, x: f32, y: f32) -> bool {
-        x >= self.frame.x
-            && x <= self.frame.x + self.frame.width
-            && y >= self.frame.y
-            && y <= self.frame.y + self.frame.height
-    }
-
     fn clear_arms(&mut self) {
-        self.pointer_pressed = false;
-        self.keyboard_arm = None;
+        self.arms.clear();
     }
 
     fn pressed(&self) -> bool {
-        self.pointer_pressed || self.keyboard_arm == Some(KeyboardArm::Space)
+        self.arms.pressed()
     }
 
     fn toggle(&mut self) -> bool {
@@ -64,46 +48,19 @@ impl ToggleWidget {
     }
 
     fn press_at(&mut self, x: f32, y: f32) {
-        if self.state.can_mutate() && self.contains(x, y) {
-            self.pointer_pressed = true;
-        }
+        self.arms.press_pointer(&self.frame, self.state.can_mutate(), x, y);
     }
 
     fn release_at(&mut self, x: f32, y: f32) -> Option<bool> {
-        let activates = self.state.can_mutate() && self.pointer_pressed && self.contains(x, y);
-        self.pointer_pressed = false;
-        activates.then(|| self.toggle())
+        self.arms.release_pointer(&self.frame, self.state.can_mutate(), x, y).then(|| self.toggle())
     }
 
     fn press_key(&mut self, code: u32) -> Option<bool> {
-        if !self.state.can_mutate() || self.keyboard_arm.is_some() {
-            return None;
-        }
-        match code {
-            KEY_ENTER => {
-                self.keyboard_arm = Some(KeyboardArm::Enter);
-                Some(self.toggle())
-            }
-            KEY_SPACE => {
-                self.keyboard_arm = Some(KeyboardArm::Space);
-                None
-            }
-            _ => None,
-        }
+        self.arms.press_key(self.state.can_mutate(), code).then(|| self.toggle())
     }
 
     fn release_key(&mut self, code: u32) -> Option<bool> {
-        match (code, self.keyboard_arm) {
-            (KEY_ENTER, Some(KeyboardArm::Enter)) => {
-                self.keyboard_arm = None;
-                None
-            }
-            (KEY_SPACE, Some(KeyboardArm::Space)) => {
-                self.keyboard_arm = None;
-                self.state.can_mutate().then(|| self.toggle())
-            }
-            _ => None,
-        }
+        self.arms.release_key(self.state.can_mutate(), code).then(|| self.toggle())
     }
 
     fn adopt_control_state(&mut self, next: WidgetControlState) -> bool {
@@ -143,8 +100,7 @@ impl WasmActor for ToggleWidget {
             theme: config.theme,
             frame: WidgetFrame { x: 0.0, y: 0.0, width: 0.0, height: 0.0 },
             state: InteractionState::new(config.state),
-            pointer_pressed: false,
-            keyboard_arm: None,
+            arms: ActivationArms::default(),
         })
     }
 
@@ -282,6 +238,7 @@ impl WasmActor for ToggleWidget {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aether_kinds::keycode::{KEY_ENTER, KEY_SPACE};
 
     fn toggle() -> ToggleWidget {
         ToggleWidget {
@@ -290,8 +247,7 @@ mod tests {
             theme: Theme::DEFAULT,
             frame: WidgetFrame { x: 10.0, y: 20.0, width: 100.0, height: 24.0 },
             state: InteractionState::new(WidgetControlState::default()),
-            pointer_pressed: false,
-            keyboard_arm: None,
+            arms: ActivationArms::default(),
         }
     }
 
@@ -326,14 +282,14 @@ mod tests {
         toggle.press_key(KEY_SPACE);
         let read_only = WidgetControlState { read_only: true, ..WidgetControlState::default() };
         assert!(toggle.adopt_control_state(read_only));
-        assert!(!toggle.pointer_pressed);
-        assert_eq!(toggle.keyboard_arm, None);
+        assert!(!toggle.arms.pointer_pressed);
+        assert_eq!(toggle.arms.keyboard_arm, None);
         assert_eq!(toggle.release_at(20.0, 30.0), None);
         assert_eq!(toggle.press_key(KEY_ENTER), None);
 
         let disabled = WidgetControlState { enabled: false, ..WidgetControlState::default() };
         assert!(toggle.adopt_control_state(disabled));
         toggle.press_at(20.0, 30.0);
-        assert!(!toggle.pointer_pressed);
+        assert!(!toggle.arms.pointer_pressed);
     }
 }

--- a/crates/aether-kit/src/widget/set/toggle.rs
+++ b/crates/aether-kit/src/widget/set/toggle.rs
@@ -234,10 +234,22 @@ impl WasmActor for ToggleWidget {
         let track_width = (track_height * 1.8).min(width.max(0.0));
         let track_y = (height - track_height) * 0.5;
         let knob_size = (track_height - 4.0).max(1.0);
-        let knob_x = if self.on { (track_width - knob_size - 2.0).max(2.0) } else { 2.0 };
+        let knob_x = if self.on {
+            (track_width - knob_size - 2.0).max(2.0)
+        } else {
+            2.0
+        };
         let state = self.state.theme_state(self.pressed());
-        let track_color = if self.on { self.theme.accent } else { self.theme.surface_raised };
-        let knob_color = if self.on { self.theme.accent_text } else { self.theme.outline };
+        let track_color = if self.on {
+            self.theme.accent
+        } else {
+            self.theme.surface_raised
+        };
+        let knob_color = if self.on {
+            self.theme.accent_text
+        } else {
+            self.theme.outline
+        };
 
         let mut items = Vec::new();
         items.push(quad(0.0, track_y, track_width, track_height, self.theme.fill(track_color, state)));

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -40,23 +40,27 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use aether_actor::Addressable;
-use aether_capabilities::RenderCapability;
+use aether_capabilities::clipboard::{GetClipboardText, GetClipboardTextResult};
 use aether_capabilities::fs::NamespaceRoots;
 use aether_capabilities::render::{DrawTexturedQuads, WHITE_TEXTURE_ID};
 use aether_capabilities::text::{FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontResult};
+use aether_capabilities::{ClipboardCapability, RenderCapability};
 use aether_data::{Kind, MailboxId, mailbox_id_from_path};
-use aether_kinds::keycode::{KEY_BACKSPACE, KEY_DOWN, KEY_ENTER, KEY_PAGE_DOWN, KEY_RIGHT, KEY_TAB, KEY_UP};
+use aether_kinds::keycode::{
+    KEY_A, KEY_BACKSPACE, KEY_C, KEY_DOWN, KEY_ENTER, KEY_LEFT, KEY_PAGE_DOWN, KEY_RIGHT, KEY_SPACE, KEY_TAB, KEY_UP,
+    KEY_V, KEY_X,
+};
 use aether_kinds::mouse_button::LEFT;
 use aether_kinds::{
     CachedFontMetrics, CaptureFrame, CaptureFrameResult, ClipRect, FrameCheck, FrameCheckResult, FrameRect,
-    FrameReduction, FrameVerdict, ImePreedit, Key, LoadComponent, LoadResult, LogTailResult, Modifiers, MouseButton,
-    MouseButtonRelease, MouseMove, MouseWheel, NamedMail, TextInput, Tick,
+    FrameReduction, FrameVerdict, ImePreedit, Key, KeyRelease, LoadComponent, LoadResult, LogTailResult, Modifiers,
+    MouseButton, MouseButtonRelease, MouseMove, MouseWheel, NamedMail, TextInput, Tick,
 };
 use aether_kit::{
     ButtonConfig, EditorConfig, EditorRegionRect, LabelConfig, PanelConfig, RegionInputLanes, RegionSpec, ScrollConfig,
-    ScrollExtent, ScrollOffset, SetTheme, SetWidgetState, SliderConfig, TextAreaConfig, TextFieldConfig, Theme,
-    ThemeState, VirtualListConfig, WidgetChildSpec, WidgetConfig, WidgetControlState, WidgetDrawItem, WidgetKind,
-    WidgetValidation,
+    ScrollExtent, ScrollOffset, SegmentedConfig, SetTheme, SetWidgetState, SliderConfig, TextAreaConfig,
+    TextFieldConfig, Theme, ThemeState, ToggleConfig, VirtualListConfig, WidgetChildSpec, WidgetConfig,
+    WidgetControlState, WidgetDrawItem, WidgetKind, WidgetValidation, NumericConfig,
 };
 use aether_math::Rgba;
 use aether_substrate_bundle::test_bench::{
@@ -500,6 +504,100 @@ fn control_state_children() -> Vec<WidgetChildSpec> {
     ]
 }
 
+fn toggle_child(subname: &str, label: &str, initial: bool, state: WidgetControlState) -> WidgetChildSpec {
+    WidgetChildSpec {
+        subname: subname.to_owned(),
+        kind: WidgetKind::Toggle,
+        origin: [0.0, 0.0],
+        clip: None,
+        config: ToggleConfig { label: label.to_owned(), initial, theme: Theme::DEFAULT, state }.encode_into_bytes(),
+    }
+}
+
+fn segmented_child(subname: &str, options: &[&str], initial_index: u32, state: WidgetControlState) -> WidgetChildSpec {
+    WidgetChildSpec {
+        subname: subname.to_owned(),
+        kind: WidgetKind::Segmented,
+        origin: [0.0, 0.0],
+        clip: None,
+        config: SegmentedConfig {
+            options: options.iter().map(|option| (*option).to_owned()).collect(),
+            initial_index,
+            theme: Theme::DEFAULT,
+            state,
+        }
+        .encode_into_bytes(),
+    }
+}
+
+fn numeric_child(subname: &str, initial: f32, state: WidgetControlState) -> WidgetChildSpec {
+    WidgetChildSpec {
+        subname: subname.to_owned(),
+        kind: WidgetKind::Numeric,
+        origin: [0.0, 0.0],
+        clip: None,
+        config: NumericConfig { min: -10.0, max: 20.0, step: 0.5, initial, theme: Theme::DEFAULT, state }
+            .encode_into_bytes(),
+    }
+}
+
+fn advanced_control_children() -> Vec<WidgetChildSpec> {
+    let disabled = WidgetControlState { enabled: false, ..WidgetControlState::default() };
+    let read_only = WidgetControlState { read_only: true, ..WidgetControlState::default() };
+    let hidden = WidgetControlState { visible: false, ..WidgetControlState::default() };
+    vec![
+        toggle_child("toggle", "Snap", false, WidgetControlState::default()),
+        segmented_child("segment", &["Raise", "Lower", "Smooth"], 0, WidgetControlState::default()),
+        numeric_child("numeric", 2.0, WidgetControlState::default()),
+        toggle_child("disabled_toggle", "Blocked", false, disabled),
+        segmented_child("readonly_segment", &["A", "B", "C"], 0, read_only),
+        numeric_child("hidden_numeric", 3.0, hidden),
+    ]
+}
+
+fn assert_advanced_control_snapshot(snapshot: &[DrawTexturedQuads]) {
+    let toggle = solid_for(snapshot, &row_clip(PANEL_Y));
+    assert_eq!(toggle.quads.len(), 2, "toggle direct draw is track then knob");
+    assert_eq!(toggle.quads[0].tint, Theme::DEFAULT.accent, "the final toggle value is on");
+    assert_eq!(toggle.quads[1].tint, Theme::DEFAULT.accent_text, "the on knob uses accent text");
+    assert!(
+        toggle.quads[1].x > toggle.quads[0].x + toggle.quads[0].width * 0.5,
+        "the on knob sits in the track's right half",
+    );
+
+    let segment_y = PANEL_Y + ROW_HEIGHT + GAP;
+    let segmented = solid_for(snapshot, &row_clip(segment_y));
+    assert_eq!(segmented.quads.len(), 5, "three fills and two ordered dividers");
+    let segment_width = PANEL_WIDTH / 3.0;
+    assert_eq!(segmented.quads[0].x, PANEL_X);
+    assert_eq!(segmented.quads[0].width, segment_width);
+    assert_eq!(segmented.quads[1].x, PANEL_X + segment_width);
+    assert_eq!(segmented.quads[1].tint, Theme::DEFAULT.accent, "middle segment remains selected");
+    assert_eq!(segmented.quads[2].x, PANEL_X + segment_width);
+    assert_eq!(segmented.quads[2].width, 1.0, "divider follows its segment fill");
+    assert_eq!(segmented.quads[3].x, PANEL_X + segment_width * 2.0);
+    assert_eq!(segmented.quads[4].x, PANEL_X + segment_width * 2.0);
+
+    let numeric_y = PANEL_Y + (ROW_HEIGHT + GAP) * 2.0;
+    let numeric = solid_for(snapshot, &row_clip(numeric_y));
+    assert_eq!(numeric.quads.len(), 1, "blurred canonical numeric draw has only its background solid");
+    assert_eq!(numeric.quads[0].tint, Theme::DEFAULT.surface_raised);
+
+    let disabled_y = PANEL_Y + (ROW_HEIGHT + GAP) * 3.0;
+    let disabled = solid_for(snapshot, &row_clip(disabled_y));
+    assert_eq!(
+        disabled.quads[0].tint,
+        Theme::DEFAULT.fill(Theme::DEFAULT.surface_raised, ThemeState::Disabled),
+        "disabled toggle stays off and uses disabled presentation",
+    );
+
+    let hidden_clip = row_clip(PANEL_Y + (ROW_HEIGHT + GAP) * 5.0);
+    assert!(
+        snapshot.iter().all(|batch| batch.clip.as_ref() != Some(&hidden_clip)),
+        "hidden numeric retains its slot but contributes no overlay batch",
+    );
+}
+
 fn row_clip(y: f32) -> ClipRect {
     ClipRect { x: PANEL_X, y, width: PANEL_WIDTH, height: ROW_HEIGHT }
 }
@@ -743,6 +841,16 @@ fn image_rgb(image: &Image, x: u32, y: u32) -> [u8; 3] {
 
 fn reads_yellow(pixel: [u8; 3]) -> bool {
     pixel[0] > 150 && pixel[1] > 150 && pixel[2] < 150
+}
+
+fn clipboard_text(bench: &mut TestBench) -> String {
+    let result = bench
+        .execute(vec![("clipboard", BenchOp::send_and_await(ClipboardCapability::NAMESPACE, &GetClipboardText))])
+        .expect("read deterministic clipboard");
+    match result.reply::<GetClipboardTextResult>("clipboard").expect("decode clipboard reply") {
+        GetClipboardTextResult::Ok { text } => text,
+        GetClipboardTextResult::Err { error } => panic!("read clipboard: {error}"),
+    }
 }
 
 /// The window rect of stack row `index` (0 = label), height `rows` row-heights.
@@ -1776,6 +1884,212 @@ fn control_state_drives_exact_overlay_batches_and_runtime_updates() {
         .expect("runtime state update snapshot");
 
     assert_updated_control_snapshot(&bench.committed_overlay_snapshot(), slider_y, hover_y);
+}
+
+fn drive_toggle_and_segmented(bench: &mut TestBench, panel: &str) {
+    let toggle_y = PANEL_Y + ROW_HEIGHT * 0.5;
+    let segment_top = PANEL_Y + ROW_HEIGHT + GAP;
+    let segment_y = segment_top + ROW_HEIGHT * 0.5;
+    let segment_width = PANEL_WIDTH / 3.0;
+    bench
+        .execute(vec![
+            ("toggle_press", BenchOp::send_mail(panel, &press(PANEL_X + 12.0, toggle_y))),
+            ("toggle_release", BenchOp::send_mail(panel, &release(PANEL_X + 12.0, toggle_y))),
+            ("space_press", BenchOp::send_mail(panel, &Key { code: KEY_SPACE })),
+            ("space_release", BenchOp::send_mail(panel, &KeyRelease { code: KEY_SPACE })),
+            ("enter_press", BenchOp::send_mail(panel, &Key { code: KEY_ENTER })),
+            ("enter_release", BenchOp::send_mail(panel, &KeyRelease { code: KEY_ENTER })),
+        ])
+        .expect("toggle pointer and keyboard activation");
+    let middle_x = PANEL_X + segment_width * 1.5;
+    bench
+        .execute(vec![
+            ("segment_press", BenchOp::send_mail(panel, &press(middle_x, segment_y))),
+            ("segment_release", BenchOp::send_mail(panel, &release(middle_x, segment_y))),
+            ("segment_right", BenchOp::send_mail(panel, &Key { code: KEY_RIGHT })),
+            ("segment_left", BenchOp::send_mail(panel, &Key { code: KEY_LEFT })),
+        ])
+        .expect("segmented pointer and arrow selection");
+}
+
+fn drive_numeric_lifecycle(bench: &mut TestBench, panel: &str) {
+    let numeric_y = PANEL_Y + (ROW_HEIGHT + GAP) * 2.0 + ROW_HEIGHT * 0.5;
+    bench
+        .execute(vec![
+            ("numeric_press", BenchOp::send_mail(panel, &press(PANEL_X + PAD + 4.0, numeric_y))),
+            ("numeric_release", BenchOp::send_mail(panel, &release(PANEL_X + PAD + 4.0, numeric_y))),
+            ("ctrl_on", BenchOp::send_mail(panel, &Modifiers { ctrl: true, ..Modifiers::default() })),
+            ("select_all", BenchOp::send_mail(panel, &Key { code: KEY_A })),
+            ("ctrl_off", BenchOp::send_mail(panel, &Modifiers::default())),
+            ("type_numeric", BenchOp::send_mail(panel, &TextInput { text: "12.4".to_owned() })),
+            ("move_left", BenchOp::send_mail(panel, &Key { code: KEY_LEFT })),
+            ("backspace", BenchOp::send_mail(panel, &Key { code: KEY_BACKSPACE })),
+            ("replace_decimal", BenchOp::send_mail(panel, &TextInput { text: ".".to_owned() })),
+            ("commit_numeric", BenchOp::send_mail(panel, &Key { code: KEY_ENTER })),
+            ("step_up", BenchOp::send_mail(panel, &Key { code: KEY_UP })),
+            ("step_down", BenchOp::send_mail(panel, &Key { code: KEY_DOWN })),
+            ("clipboard_ctrl_on", BenchOp::send_mail(panel, &Modifiers { ctrl: true, ..Modifiers::default() })),
+            ("clipboard_select", BenchOp::send_mail(panel, &Key { code: KEY_A })),
+            ("copy", BenchOp::send_mail(panel, &Key { code: KEY_C })),
+        ])
+        .expect("numeric typed, step, and copy lifecycle");
+    assert_eq!(clipboard_text(bench), "12.5", "Ctrl+C copies the selected canonical buffer");
+    bench
+        .execute(vec![
+            ("cut", BenchOp::send_mail(panel, &Key { code: KEY_X })),
+            ("paste", BenchOp::send_mail(panel, &Key { code: KEY_V })),
+            ("clipboard_ctrl_off", BenchOp::send_mail(panel, &Modifiers::default())),
+        ])
+        .expect("numeric cut and paste lifecycle");
+}
+
+fn drive_blur_and_blocked_states(bench: &mut TestBench, panel: &str) {
+    let segment_width = PANEL_WIDTH / 3.0;
+    let disabled_y = PANEL_Y + (ROW_HEIGHT + GAP) * 3.0 + ROW_HEIGHT * 0.5;
+    let readonly_y = PANEL_Y + (ROW_HEIGHT + GAP) * 4.0 + ROW_HEIGHT * 0.5;
+    bench
+        .execute(vec![
+            ("invalid_ctrl_on", BenchOp::send_mail(panel, &Modifiers { ctrl: true, ..Modifiers::default() })),
+            ("invalid_select", BenchOp::send_mail(panel, &Key { code: KEY_A })),
+            ("invalid_ctrl_off", BenchOp::send_mail(panel, &Modifiers::default())),
+            ("invalid_text", BenchOp::send_mail(panel, &TextInput { text: "-".to_owned() })),
+            ("blur_press", BenchOp::send_mail(panel, &press(WINDOW_WIDTH as f32 - 2.0, WINDOW_HEIGHT as f32 - 2.0))),
+            (
+                "blur_release",
+                BenchOp::send_mail(panel, &release(WINDOW_WIDTH as f32 - 2.0, WINDOW_HEIGHT as f32 - 2.0)),
+            ),
+            ("disabled_press", BenchOp::send_mail(panel, &press(PANEL_X + 12.0, disabled_y))),
+            ("disabled_release", BenchOp::send_mail(panel, &release(PANEL_X + 12.0, disabled_y))),
+            ("readonly_press", BenchOp::send_mail(panel, &press(PANEL_X + segment_width * 2.5, readonly_y))),
+            ("readonly_release", BenchOp::send_mail(panel, &release(PANEL_X + segment_width * 2.5, readonly_y))),
+            ("readonly_right", BenchOp::send_mail(panel, &Key { code: KEY_RIGHT })),
+        ])
+        .expect("blur and blocked state mutations");
+}
+
+fn assert_advanced_control_logs(logs: &[String]) {
+    let joined = logs.join("\n");
+    assert!(
+        logs.iter().any(|message| {
+            message.contains("widget toggle changed")
+                && message.contains("widget=toggle")
+                && message.contains("on=true")
+        }),
+        "toggle value-up must be source-attributed; log was:\n{joined}",
+    );
+    assert!(
+        logs.iter().any(|message| {
+            message.contains("widget segmented selected")
+                && message.contains("widget=segment")
+                && message.contains("index=1")
+        }),
+        "segmented value-up must identify the middle option; log was:\n{joined}",
+    );
+    assert!(
+        logs.iter().any(|message| {
+            message.contains("widget numeric changed")
+                && message.contains("widget=numeric")
+                && message.contains("value=12.5")
+                && message.contains("committed=false")
+        }),
+        "typed/pasted valid buffers must preview the snapped value; log was:\n{joined}",
+    );
+    let pasted_preview_count = logs
+        .iter()
+        .filter(|message| {
+            message.contains("widget numeric changed")
+                && message.contains("widget=numeric")
+                && message.contains("value=12.5")
+                && message.contains("committed=false")
+        })
+        .count();
+    assert!(
+        pasted_preview_count >= 3,
+        "typed reconstruction produces two 12.5 previews and successful paste produces the third; \
+         count={pasted_preview_count}, log was:\n{joined}",
+    );
+    assert!(
+        logs.iter().any(|message| {
+            message.contains("widget numeric changed")
+                && message.contains("widget=numeric")
+                && message.contains("value=12.5")
+                && message.contains("committed=true")
+        }),
+        "Enter/step lifecycle must commit the canonical value; log was:\n{joined}",
+    );
+    assert!(
+        logs.iter().all(|message| !message.contains("widget=disabled_toggle")),
+        "disabled toggle mutation must be absent; log was:\n{joined}",
+    );
+    assert!(
+        logs.iter().all(|message| !message.contains("widget=readonly_segment")),
+        "read-only segmented mutation must be absent; log was:\n{joined}",
+    );
+}
+
+fn assert_advanced_control_raster(bench: &mut TestBench) {
+    let segment_top = PANEL_Y + ROW_HEIGHT + GAP;
+    let segment_width = PANEL_WIDTH / 3.0;
+    let numeric_top = PANEL_Y + (ROW_HEIGHT + GAP) * 2.0;
+    let selected_band = rect(
+        PANEL_X + segment_width + 2.0,
+        segment_top + ROW_HEIGHT - 5.0,
+        PANEL_X + segment_width * 2.0 - 2.0,
+        segment_top + ROW_HEIGHT - 2.0,
+    );
+    let unselected_band = rect(
+        PANEL_X + 2.0,
+        segment_top + ROW_HEIGHT - 5.0,
+        PANEL_X + segment_width - 2.0,
+        segment_top + ROW_HEIGHT - 2.0,
+    );
+    let numeric_text = rect(PANEL_X + PAD, numeric_top + 2.0, PANEL_X + 70.0, numeric_top + ROW_HEIGHT - 2.0);
+    let verdict = capture(
+        bench,
+        vec![
+            check(FrameReduction::Coverage, selected_band, SURFACE_RAISED_SRGB, PARTITION_TOLERANCE),
+            check(FrameReduction::Coverage, unselected_band, SURFACE_RAISED_SRGB, PARTITION_TOLERANCE),
+            check(FrameReduction::BoundingBox, numeric_text, SURFACE_RAISED_SRGB, PARTITION_TOLERANCE),
+        ],
+    );
+    let selected_coverage = coverage(&verdict.results[0]);
+    let unselected_coverage = coverage(&verdict.results[1]);
+    assert!(
+        selected_coverage > 0.8 && unselected_coverage < 0.2,
+        "selected raster band must differ from its unselected neighbor; selected={selected_coverage:.3}, \
+         unselected={unselected_coverage:.3}",
+    );
+    assert!(bounding_box(&verdict.results[2]).is_some(), "canonical numeric text must remain raster-visible");
+
+    let snapshot = bench.committed_overlay_snapshot();
+    assert_advanced_control_snapshot(&snapshot);
+    let numeric_clip = row_clip(numeric_top);
+    let numeric_glyphs: usize = snapshot
+        .iter()
+        .filter(|batch| batch.texture_id != WHITE_TEXTURE_ID && batch.clip.as_ref() == Some(&numeric_clip))
+        .map(|batch| batch.quads.len())
+        .sum();
+    assert_eq!(numeric_glyphs, 4, "canonical `12.5` renders four resident glyphs");
+}
+
+/// The three issue-2926 controls share one explicit panel scene so pointer,
+/// keyboard, clipboard, value-up attribution, normalized overlay batches, and
+/// bounded raster evidence all exercise the real wasm actors together.
+#[test]
+fn toggle_segmented_and_numeric_complete_the_real_panel_contract() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read kit wasm");
+    let mut bench = build_bench();
+    boot_panel_with_children(&mut bench, &wasm, advanced_control_children());
+
+    let panel = panel_address();
+    drive_toggle_and_segmented(&mut bench, &panel);
+    drive_numeric_lifecycle(&mut bench, &panel);
+    drive_blur_and_blocked_states(&mut bench, &panel);
+    assert_advanced_control_logs(&panel_log_messages(&mut bench));
+    assert_advanced_control_raster(&mut bench);
 }
 
 #[test]

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -57,10 +57,10 @@ use aether_kinds::{
     MouseButton, MouseButtonRelease, MouseMove, MouseWheel, NamedMail, TextInput, Tick,
 };
 use aether_kit::{
-    ButtonConfig, EditorConfig, EditorRegionRect, LabelConfig, PanelConfig, RegionInputLanes, RegionSpec, ScrollConfig,
-    ScrollExtent, ScrollOffset, SegmentedConfig, SetTheme, SetWidgetState, SliderConfig, TextAreaConfig,
-    TextFieldConfig, Theme, ThemeState, ToggleConfig, VirtualListConfig, WidgetChildSpec, WidgetConfig,
-    WidgetControlState, WidgetDrawItem, WidgetKind, WidgetValidation, NumericConfig,
+    ButtonConfig, EditorConfig, EditorRegionRect, LabelConfig, NumericConfig, PanelConfig, RegionInputLanes,
+    RegionSpec, ScrollConfig, ScrollExtent, ScrollOffset, SegmentedConfig, SetTheme, SetWidgetState, SliderConfig,
+    TextAreaConfig, TextFieldConfig, Theme, ThemeState, ToggleConfig, VirtualListConfig, WidgetChildSpec, WidgetConfig,
+    WidgetControlState, WidgetDrawItem, WidgetKind, WidgetValidation,
 };
 use aether_math::Rgba;
 use aether_substrate_bundle::test_bench::{

--- a/docs/guide/systems/widgets.md
+++ b/docs/guide/systems/widgets.md
@@ -2,7 +2,8 @@
 
 `aether-kit` ships a set of guest-side widgets — a slider, a text field, a
 multiline text area, a radio group, a fixed-row virtual list, a button, a label,
-and an image — as ordinary `#[actor(instanced)]` types.
+an image, a toggle, a segmented control, and a numeric editor — as ordinary
+`#[actor(instanced)]` types.
 A panel root spawns them as inline children (ADR-0114) and drives them entirely
 by mail, so composing an editor panel is a matter of laying out widgets and
 translating their value events, never re-deriving hit rects, focus, or per-row
@@ -27,8 +28,9 @@ widget sends can misreport it.
 
 - **Config, down.** One `Config` kind per widget — `SliderConfig`,
   `TextFieldConfig`, `TextAreaConfig`, `RadioConfig`, `VirtualListConfig`,
-  `ButtonConfig`, `LabelConfig`, `ImageConfig` — each embedding a
-  `theme: Theme`. The config is both the value
+  `ButtonConfig`, `LabelConfig`, `ImageConfig`, `ToggleConfig`,
+  `SegmentedConfig`, `NumericConfig` — each embedding a `theme: Theme`. The
+  config is both the value
   `spawn_inline_child::<W>(subname, &config)` boots the widget with and a
   re-sendable mail: send a widget its config kind again to reconfigure it in
   place (a slider's range, a field's cap, a button's label).
@@ -51,8 +53,9 @@ widget sends can misreport it.
   `WidgetStateChanged` so panel routing cannot drift. Hidden widgets keep their
   slot and answer `Collect` with an empty `WidgetDrawList`; disabled widgets
   draw muted but leave input routing; read-only Slider, Radio, TextField,
-  TextArea, and VirtualList remain focusable but reject mutation. Button and
-  Label ignore read-only and validation.
+  TextArea, VirtualList, Toggle, Segmented, and Numeric controls remain
+  focusable but reject mutation. Button and Label ignore read-only and
+  validation.
 - **Interaction, down.** The root sends `FocusGained` / `FocusLost` and
   `HoverGained` / `HoverLost`. Hover comes from explicit edges, not from a child
   inferring absence from raw motion. Pressed and hover select an exclusive fill
@@ -64,6 +67,10 @@ widget sends can misreport it.
   `committed: false` values through a drag and a final `committed: true` on
   release, so a consumer previews the drag and commits the expensive work
   once.
+
+  `ToggleChanged { on }`, `SegmentedSelected { index }`, and
+  `NumericChanged { value, committed }` use that same source-attributed lane;
+  Numeric applies the preview/commit distinction to typed values.
 
 ## Fixed-row virtual lists
 
@@ -109,6 +116,42 @@ but draw nothing. Disabled images stay visible with the theme's disabled alpha
 applied to their configured tint. Images are never pointer- or focus-eligible;
 read-only and validation state have no visual or behavioral meaning for this
 static leaf.
+
+## Toggle, segmented, and numeric controls
+
+`WidgetKind::Toggle` spawns `ToggleWidget` from `ToggleConfig { label,
+initial, theme, state }`. A left press arms the switch and a release back
+inside toggles it once. A focused Enter press or matching Space release also
+toggles once; key repeats, focus loss, read-only state, and unavailability
+cancel the arm. `ToggleChanged { on }` reports the new boolean value. The
+local draw orders the track before its moving knob and label, then adds the
+common validation/focus outlines.
+
+`WidgetKind::Segmented` spawns `SegmentedWidget` from `SegmentedConfig {
+options, initial_index, theme, state }`. The assigned row is divided into
+equal-width named segments. A pointer press selects its bucket, and focused
+Left/Right movement clamps at the first and last option. Empty option lists
+have no hit buckets. `SegmentedSelected { index }` reports only actual changes;
+selected, hovered, pressed, disabled, validation, and focus presentation use
+the common theme/state contract.
+
+`WidgetKind::Numeric` spawns `NumericWidget` from `NumericConfig { min, max,
+step, initial, theme, state }`. It reuses the shared `TextEditState`, named
+`TextSpan`, and measured `SingleLineLayout`, so pointer placement, dragging,
+selection, replacement, and clipboard edits stay on UTF-8 boundaries. Typed
+characters arrive only through `TextInput`; `Key` remains navigation and
+control (`Backspace`, Left/Right, Enter, Up/Down, and Ctrl+A/C/X/V).
+
+Numeric keeps the visible buffer separate from its last committed number.
+Empty, `-`, `.`, and other invalid or non-finite intermediates remain visible
+and emit nothing. A finite edit is clamped and snapped for a
+`NumericChanged { committed: false }` preview without rewriting what the user
+typed. Enter or focus loss canonicalizes a valid value and emits
+`committed: true`; an invalid buffer reverts to the last canonical value
+without an event. Up/Down step from the current valid value, falling back to
+the committed value, and immediately canonicalize and commit. Copy never
+mutates, while cut and asynchronous paste pass through the same selection,
+parse, clamp, and preview path.
 
 ## Root-owned focus and input
 

--- a/docs/guide/systems/widgets.md
+++ b/docs/guide/systems/widgets.md
@@ -329,7 +329,11 @@ an inline structured `config` object or `config_path` pointing to a JSON object;
 the harness schema-encodes that JSON to `PanelConfig`. Do not pre-encode
 `LoadComponent.config` bytes in tool JSON. Use `describe_component` for the live
 config kind and `describe_kinds` for its schema, and set `children` to `[]` to
-request the built-in stack above.
+request the built-in stack above. `children: []` selects that fallback inside
+an otherwise complete `PanelConfig`; the MCP schema encoder does not fill the
+other fields from Rust's `Default`, so provide `x`, `y`, `width`,
+`font_namespace`, `font_path`, and the complete `theme` object (while
+`owns_input` retains its serde default).
 
 That built-in stack is limited to `label`, `slider`, `radio`, `text_field`, and
 `button`; it does not demonstrate the other stock kinds, including `Toggle`,

--- a/docs/guide/systems/widgets.md
+++ b/docs/guide/systems/widgets.md
@@ -332,8 +332,7 @@ config kind and `describe_kinds` for its schema, and set `children` to `[]` to
 request the built-in stack above. `children: []` selects that fallback inside
 an otherwise complete `PanelConfig`; the MCP schema encoder does not fill the
 other fields from Rust's `Default`, so provide `x`, `y`, `width`,
-`font_namespace`, `font_path`, and the complete `theme` object (while
-`owns_input` retains its serde default).
+`font_namespace`, `font_path`, `owns_input`, and the complete `theme` object.
 
 That built-in stack is limited to `label`, `slider`, `radio`, `text_field`, and
 `button`; it does not demonstrate the other stock kinds, including `Toggle`,

--- a/docs/guide/systems/widgets.md
+++ b/docs/guide/systems/widgets.md
@@ -331,6 +331,17 @@ the harness schema-encodes that JSON to `PanelConfig`. Do not pre-encode
 config kind and `describe_kinds` for its schema, and set `children` to `[]` to
 request the built-in stack above.
 
+That built-in stack is limited to `label`, `slider`, `radio`, `text_field`, and
+`button`; it does not demonstrate the other stock kinds, including `Toggle`,
+`Segmented`, or `Numeric`. A non-empty `children` list crosses a second schema
+boundary: each `WidgetChildSpec.config` is already-encoded bytes for that
+child's concrete config kind. The MCP harness can transport those bytes (for
+example through its bytes embeds), but it does not currently provide a generic
+nested-kind encoder that creates them from structured child JSON. Until that
+primitive exists, author custom panel trees from Rust/component configuration
+code rather than expecting `load_component` to recursively encode child
+configs.
+
 To add a new widget — a dropdown, a checkbox, a color well — write one more
 `#[actor(instanced)]` type that speaks the same state/interaction lanes and answers `Collect`
 with a `WidgetDrawList`, then spawn it into a panel's stack. The focus model and


### PR DESCRIPTION
## Summary

- add named public configs and value events for toggle, segmented, and numeric stock controls
- route, render, mirror, and export all three controls through WidgetPanel while preserving established WidgetKind wire order
- exercise pointer, keyboard, clipboard, preview/commit, state, and rendered behavior through strict TestBench coverage

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test -p aether-kit --lib (329 passed)
- [x] AETHER_REQUIRE_RUNTIME=1 cargo test -p aether-substrate-bundle --test widget_render_interaction -- --nocapture (15 passed)
- [x] AETHER_REQUIRE_RUNTIME=1 cargo test -p aether-substrate-bundle --test widget_editor_routing -- --nocapture (2 passed)
- [x] release wasm build for aether-kit and aether-test-fixtures-bundle

## Related

- Closes #2926
- ADR: 0117