### PR TITLE
feat(ci): report dogfood MCP token usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,16 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  dogfood-token-table:
+    name: Dogfood token table
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node --test scripts/dogfood-token-table.test.mjs
+
   clippy:
     name: Clippy
     needs: changes
@@ -416,13 +426,14 @@ jobs:
   ci-pass:
     name: CI pass
     if: always()
-    needs: [ changes, fmt, clippy, docs, marker-build, test, desktop, qodana ]
+    needs: [ changes, fmt, dogfood-token-table, clippy, docs, marker-build, test, desktop, qodana ]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
         run: |
           echo "changes: ${{ needs.changes.result }}"
           echo "fmt:     ${{ needs.fmt.result }}"
+          echo "dogfood-token-table: ${{ needs.dogfood-token-table.result }}"
           echo "clippy:  ${{ needs.clippy.result }}"
           echo "docs:    ${{ needs.docs.result }}"
           echo "marker-build: ${{ needs.marker-build.result }}"
@@ -432,6 +443,7 @@ jobs:
           fail=0
           [[ "${{ needs.changes.result }}" == "success" ]] || fail=1
           [[ "${{ needs.fmt.result }}"     == "success" ]] || fail=1
+          [[ "${{ needs.dogfood-token-table.result }}" == "success" ]] || fail=1
           [[ "${{ needs.clippy.result }}"  == "success" || "${{ needs.clippy.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.docs.result }}"    == "success" || "${{ needs.docs.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.marker-build.result }}" == "success" || "${{ needs.marker-build.result }}" == "skipped" ]] || fail=1

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -598,6 +598,11 @@ jobs:
           name: dogfood-run
           path: dogfood-run
 
+      # The trusted helper from main enriches the downloaded trial data before
+      # either reporting sink consumes it. PR code is never executed here.
+      - name: Account MCP tool tokens
+        run: node scripts/dogfood-token-table.mjs dogfood-run/transcript.jsonl dogfood-run/rollup.json
+
       # Commit this attempt's run directory to the orphan dogfood/evidence
       # branch at evidence/<issue>/<run-id>/ (the script pushes with retries).
       - name: Push the run to the evidence branch

--- a/docs/evidence-viewer/index.html
+++ b/docs/evidence-viewer/index.html
@@ -287,6 +287,42 @@
     return wrap;
   }
 
+  function renderTokenTable(tokensPerTool) {
+    if (!Array.isArray(tokensPerTool)) return null;
+
+    var wrap = document.createDocumentFragment();
+    if (tokensPerTool.length === 0) {
+      wrap.appendChild(el("p", { className: "muted", text: "No MCP tool traffic recorded." }));
+      return wrap;
+    }
+
+    var rows = tokensPerTool.slice().sort(function (left, right) {
+      var leftTotal = Number(left && left.tokensIn || 0) + Number(left && left.tokensOut || 0);
+      var rightTotal = Number(right && right.tokensIn || 0) + Number(right && right.tokensOut || 0);
+      return rightTotal - leftTotal || fieldText(left && left.tool).localeCompare(fieldText(right && right.tool));
+    });
+    var table = el("table");
+    var thead = el("thead");
+    var headRow = el("tr");
+    ["tool", "calls", "tokens in", "tokens out"].forEach(function (heading) {
+      headRow.appendChild(el("th", { text: heading }));
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+    var tbody = el("tbody");
+    rows.forEach(function (row) {
+      var tr = el("tr");
+      tr.appendChild(el("td", { text: fieldText(row && row.tool) }));
+      tr.appendChild(el("td", { text: fieldText(row && row.calls) }));
+      tr.appendChild(el("td", { text: fieldText(row && row.tokensIn) }));
+      tr.appendChild(el("td", { text: fieldText(row && row.tokensOut) }));
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    wrap.appendChild(table);
+    return wrap;
+  }
+
   function renderSoftHolds(softHolds) {
     var wrap = document.createDocumentFragment();
     if (!Array.isArray(softHolds) || softHolds.length === 0) {
@@ -352,6 +388,12 @@
 
     app.appendChild(el("h2", { text: "Soft-holds" }));
     app.appendChild(renderSoftHolds(rollup.softHolds));
+
+    var tokenTable = renderTokenTable(rollup.tokensPerTool);
+    if (tokenTable) {
+      app.appendChild(el("h2", { text: "MCP tool tokens" }));
+      app.appendChild(tokenTable);
+    }
 
     app.appendChild(el("h2", { text: "Media & artifacts" }));
     app.appendChild(renderMedia(run));

--- a/scripts/dogfood-token-table.mjs
+++ b/scripts/dogfood-token-table.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+import { createReadStream } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
+import { createInterface } from 'node:readline'
+import { pathToFileURL } from 'node:url'
+
+function jsonBytes(value) {
+  const encoded = JSON.stringify(value)
+  return encoded === undefined ? 0 : Buffer.byteLength(encoded, 'utf8')
+}
+
+function collectBlocks(value, role, toolUses, toolResults) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectBlocks(item, role, toolUses, toolResults)
+    return
+  }
+  if (!value || typeof value !== 'object') return
+
+  const nextRole = value.type === 'assistant' || value.type === 'user'
+    ? value.type
+    : value.role === 'assistant' || value.role === 'user'
+      ? value.role
+      : role
+
+  if (value.type === 'tool_use') {
+    if (
+      nextRole === 'assistant'
+      && typeof value.id === 'string'
+      && typeof value.name === 'string'
+      && value.name.startsWith('mcp__')
+      && !toolUses.has(value.id)
+    ) {
+      toolUses.set(value.id, { tool: value.name, bytesIn: jsonBytes(value.input) })
+    }
+    return
+  }
+
+  if (value.type === 'tool_result') {
+    if (nextRole === 'user' && typeof value.tool_use_id === 'string' && !toolResults.has(value.tool_use_id)) {
+      toolResults.set(value.tool_use_id, value.content)
+    }
+    collectBlocks(value.content, null, toolUses, toolResults)
+    return
+  }
+
+  for (const child of Object.values(value)) collectBlocks(child, nextRole, toolUses, toolResults)
+}
+
+export async function tokenTableFromTranscript(transcriptPath) {
+  const toolUses = new Map()
+  const toolResults = new Map()
+  const lines = createInterface({
+    input: createReadStream(transcriptPath, { encoding: 'utf8' }),
+    crlfDelay: Infinity,
+  })
+
+  for await (const line of lines) {
+    if (!line.trim()) continue
+    try {
+      collectBlocks(JSON.parse(line), null, toolUses, toolResults)
+    } catch {
+      // Stream transcripts can contain partial frames after an interrupted run.
+    }
+  }
+
+  const byTool = new Map()
+  for (const [id, toolUse] of toolUses) {
+    const row = byTool.get(toolUse.tool) ?? { tool: toolUse.tool, calls: 0, bytesIn: 0, bytesOut: 0 }
+    row.calls += 1
+    row.bytesIn += toolUse.bytesIn
+    if (toolResults.has(id)) row.bytesOut += jsonBytes(toolResults.get(id))
+    byTool.set(toolUse.tool, row)
+  }
+
+  const tokensPerTool = Array.from(byTool.values(), (row) => ({
+    ...row,
+    tokensIn: Math.round(row.bytesIn / 4),
+    tokensOut: Math.round(row.bytesOut / 4),
+  })).sort((left, right) => left.tool.localeCompare(right.tool))
+
+  return { tokensPerTool }
+}
+
+export async function enrichRollupFromTranscript(transcriptPath, rollupPath) {
+  const tokenTable = await tokenTableFromTranscript(transcriptPath)
+  const raw = JSON.parse(await readFile(rollupPath, 'utf8'))
+  const rollup = raw && raw.rollup ? raw.rollup : raw
+  if (!rollup || typeof rollup !== 'object' || Array.isArray(rollup)) {
+    throw new Error('dogfood-token-table: rollup must be an object')
+  }
+
+  rollup.tokensPerTool = tokenTable.tokensPerTool
+  await writeFile(rollupPath, `${JSON.stringify(raw, null, 2)}\n`)
+  return tokenTable
+}
+
+async function main() {
+  const [transcriptPath, rollupPath] = process.argv.slice(2)
+  if (!transcriptPath) {
+    throw new Error('usage: dogfood-token-table.mjs <transcript.jsonl> [rollup.json]')
+  }
+
+  if (rollupPath) {
+    await enrichRollupFromTranscript(transcriptPath, rollupPath)
+  } else {
+    process.stdout.write(`${JSON.stringify(await tokenTableFromTranscript(transcriptPath), null, 2)}\n`)
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message)
+    process.exitCode = 1
+  })
+}

--- a/scripts/dogfood-token-table.test.mjs
+++ b/scripts/dogfood-token-table.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import { enrichRollupFromTranscript, tokenTableFromTranscript } from './dogfood-token-table.mjs'
+
+const FIXTURE = new URL('./fixtures/dogfood-token-table/transcript.jsonl', import.meta.url)
+
+test('accounts observed nested MCP tool calls and exact result shapes', async () => {
+  assert.deepEqual(await tokenTableFromTranscript(FIXTURE), {
+    tokensPerTool: [
+      {
+        tool: 'mcp__aether-hub__capture_frame',
+        calls: 2,
+        bytesIn: 61,
+        bytesOut: 125,
+        tokensIn: 15,
+        tokensOut: 31,
+      },
+      {
+        tool: 'mcp__aether-hub__list_engines',
+        calls: 1,
+        bytesIn: 2,
+        bytesOut: 18,
+        tokensIn: 1,
+        tokensOut: 5,
+      },
+    ],
+  })
+})
+
+test('a failed transcript with no MCP traffic produces an empty table', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'aether-dogfood-token-table-'))
+  const transcriptPath = join(directory, 'transcript.jsonl')
+  await writeFile(transcriptPath, '{"type":"result","subtype":"error","result":"trial failed"}\n')
+
+  try {
+    assert.deepEqual(await tokenTableFromTranscript(transcriptPath), { tokensPerTool: [] })
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('enriches both wrapped and bare rollups with named records', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'aether-dogfood-token-table-'))
+
+  try {
+    for (const fixture of [
+      { name: 'wrapped.json', initial: { rollup: { succeeded: true }, task: { issue: 3011 } } },
+      { name: 'bare.json', initial: { succeeded: true } },
+    ]) {
+      const rollupPath = join(directory, fixture.name)
+      await writeFile(rollupPath, JSON.stringify(fixture.initial))
+      await enrichRollupFromTranscript(FIXTURE, rollupPath)
+      const enriched = JSON.parse(await readFile(rollupPath, 'utf8'))
+      const rollup = enriched.rollup ?? enriched
+      assert.equal(rollup.tokensPerTool.length, 2)
+      assert.equal(rollup.tokensPerTool[0].tool, 'mcp__aether-hub__capture_frame')
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})

--- a/scripts/fixtures/dogfood-token-table/transcript.jsonl
+++ b/scripts/fixtures/dogfood-token-table/transcript.jsonl
@@ -1,0 +1,8 @@
+{"type":"system","subtype":"init","session_id":"fixture-session"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_engines","name":"mcp__aether-hub__list_engines","input":{}}]},"parent_tool_use_id":"toolu_attempt"}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_engines","content":"{\"engines\":[]}"}]},"parent_tool_use_id":"toolu_attempt"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_frame_1","name":"mcp__aether-hub__capture_frame","input":{"engine_id":"engine-1"}}]},"parent_tool_use_id":"toolu_judge"}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_frame_1","content":"frame-ready"}]},"parent_tool_use_id":"toolu_judge"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_frame_2","name":"mcp__aether-hub__capture_frame","input":{"engine_id":"engine-1","actor_id":7}},{"type":"tool_use","id":"toolu_bash","name":"Bash","input":{"command":"true"}}]},"parent_tool_use_id":"toolu_judge"}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_frame_2","content":[{"type":"text","text":"ok"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AA=="}}]},{"type":"tool_result","tool_use_id":"toolu_bash","content":"done"}]},"parent_tool_use_id":"toolu_judge"}
+{"type":

--- a/scripts/post-dogfood-rollup.mjs
+++ b/scripts/post-dogfood-rollup.mjs
@@ -146,6 +146,27 @@ function frictionLines(friction) {
   return lines
 }
 
+function tokenTableLines(tokensPerTool) {
+  if (!Array.isArray(tokensPerTool)) return []
+
+  const lines = ['', '### MCP tool tokens']
+  if (!tokensPerTool.length) {
+    lines.push('', '_No MCP tool traffic recorded._')
+    return lines
+  }
+
+  const rows = [...tokensPerTool].sort((left, right) => {
+    const tokenDifference = Number(right.tokensIn || 0) + Number(right.tokensOut || 0)
+      - Number(left.tokensIn || 0) - Number(left.tokensOut || 0)
+    return tokenDifference || String(left.tool || '').localeCompare(String(right.tool || ''))
+  })
+  lines.push('', '| tool | calls | tokens in | tokens out |', '| --- | ---: | ---: | ---: |')
+  for (const row of rows) {
+    lines.push(`| ${cell(row.tool)} | ${cell(row.calls)} | ${cell(row.tokensIn)} | ${cell(row.tokensOut)} |`)
+  }
+  return lines
+}
+
 // Escape pipes and collapse newlines so a finding never breaks the table.
 function cell(v) {
   return String(v ?? '').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').trim() || '—'
@@ -179,6 +200,7 @@ function renderComment(rollup, hasFrame) {
   lines.push('', '### Friction')
   lines.push(...frictionLines(rollup.friction))
   lines.push(...softHoldLines(rollup.softHolds))
+  lines.push(...tokenTableLines(rollup.tokensPerTool))
   if (hasFrame) {
     lines.push('', '### Judged frame', '', `![judged frame](${RAW_BASE}/${RUN_REF}/frame.png)`)
   }


### PR DESCRIPTION
Closes #3011.

## Summary

Account the estimated input and output tokens consumed by each MCP tool in a dogfood transcript, enrich the trusted rollup before evidence publication, and render the named per-tool records in both the living comment and evidence viewer. The metric is descriptive and uses the agreed UTF-8 JSON byte proxy without budgets.

## Test plan

- `node --test scripts/dogfood-token-table.test.mjs`
- Node syntax checks for the parser and comment poster
- Evidence-viewer script compilation
- Workflow YAML parsing
- `cargo fmt --all -- --check`

## Generated by

`/implement` — agent execution of [scoped issue #3011](https://github.com/iamacoffeepot/aether/issues/3011).
