### PR TITLE
fix(ci): dogfood recording guard matches only the bare none expected artifact

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -200,6 +200,9 @@ jobs:
           prompt="$(field prompt)"
           surface="$(field surfaceUnderTest)"
           artifact="$(field expectedArtifact)"
+          # A brief authored as "none (…gloss…)" means the bare sentinel — collapse it so the
+          # downstream literal-equality sites (recording guards, task-object jq) hold.
+          if grep -qiE '^none[[:space:]]*(\(.*\))?$' <<<"$artifact"; then artifact="none"; fi
           [ -n "$medium" ] && [ -n "$prompt" ] || skip "Issue #${issue} brief is malformed (medium/prompt missing) — skipping."
 
           # Emit the free-text fields through random-delimiter heredocs so a


### PR DESCRIPTION
Closes #3070

## Summary

- normalize the dogfood recording contract only when the expected artifact is the bare `none` sentinel
- accept the sentinel's optional explanatory parenthetical without matching ordinary prose that merely contains “none”

## Verification

- positive and counterexample shell-regex probes
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`

Generated by the Aether implement workflow.
