### PR TITLE
feat(workflow): persist wish grounding and add refresh mode

### DIFF
--- a/.claude/skills/wish/SKILL.md
+++ b/.claude/skills/wish/SKILL.md
@@ -178,6 +178,12 @@ parent: ../wish.md                # omit if root
 supports:                           # optional, only if branch-overlap with memory
   - "[[memory-entry-name]]"
 producible: true | false            # true means this wish IS a plan
+grounded_surfaces:                  # every pass writes re-greppable `identifier` — crates/aether-*/src/path citations
+  - "`aether.fs.read` — crates/aether-capabilities/src/fs/kinds.rs"
+grounding_stale: true | false        # optional: --refresh writes whether any cited surface drifted
+drifted_surfaces:                   # optional: --refresh writes the citations that no longer resolve
+  - "`<identifier>` — crates/aether-*/src/<path>.rs"
+grounding_checked: YYYY-MM-DD        # optional: --refresh writes the most recent grounding check
 ---
 
 <free-form prose body — no fixed section headers — articulating naturally:>
@@ -213,6 +219,7 @@ The user reads top-down:
 /wish <theme> --as <role>           combine
 /wish --under <wish-path>           drill into one subtree (chosen or alternative)
                                     from a prior pass
+/wish --refresh <tree-path>         re-grep each node's cited surfaces; mark drifted nodes grounding-stale
 /wish --deep <theme>                deep mode: best-first fan-out drilling (workflow-backed)
 /wish --deep <theme> --beam N       fan-out width per round (default 3) — the shape knob
 /wish --deep <theme> --budget N     max driller agents the loop spawns (default 40) — the size knob
@@ -263,7 +270,7 @@ After the frontier drains, a final agent reads every node's bounded summary and 
 
 ### Resumability
 
-The on-disk wish tree persists across sessions, so a deep wish becomes resumable: a later `/wish --under <wish-path>` drills a subtree further, complementing the in-session Workflow journal. The file tree is the durable record; the journal is the live one.
+The on-disk wish tree persists across sessions, so a deep wish becomes resumable: a later `/wish --under <wish-path>` drills a subtree further, complementing the in-session Workflow journal. Before resuming with `--under`, run `/wish --refresh <tree-path>` so re-drilling does not build on drifted grounding. The file tree is the durable record; the journal is the live one.
 
 ## Steps the agent runs
 
@@ -306,9 +313,9 @@ On `--deep`, run steps 1 (pre-load adversity) and 2 (generate roots) inline in t
 2. **Compute `wishDir`.** The absolute path to `wishes/<YYYY-MM-DD>-<theme-slug>/`. Create the directory so the drillers have a place to write.
 3. **Gather `groundingNotes`.** The grep-confirmed engine surfaces from step 1, as a short shared block, so the drillers extend the grounding rather than each re-deriving it.
 4. **Call the workflow.** `Workflow({name: "wish", args: {theme, role, beam, budget, roots, wishDir, groundingNotes}})` — `roots` is `[{slug, wish, doors_opened, unresolvedness}]`; `beam` and `budget` come from the flags (defaults 3 and 40); `role` is null if not given. The workflow holds the best-first frontier, spawns the parallel drillers + the skeptic gate + the synthesis writer, and the agents write every `wish.md` and `index.md` themselves.
-5. **Report from the returned stats.** On completion the workflow returns `{rootCount, totalNodes, leafCount, maxDepth, skepticDemotions, undrilled, ...}`. Print the deep-mode report (step 7) from those, and surface that the tree is on disk and resumable.
+5. **Report from the returned stats.** On completion the workflow returns `{rootCount, totalNodes, leafCount, maxDepth, skepticDemotions, undrilled, ...}`. Print the deep-mode report (step 8) from those, and surface that the tree is on disk and resumable.
 
-Deep mode does not run steps 4-6 inline — filtering and the on-disk write are the drillers' and synthesis agent's job inside the workflow. Step 7's report template has a deep-mode variant.
+Deep mode does not run steps 4-7 inline — filtering and the on-disk write are the drillers' and synthesis agent's job inside the workflow. Step 8's report template has a deep-mode variant.
 
 ### 4. Filter against existing work (tree-aware)
 
@@ -329,7 +336,17 @@ Deep mode does not run steps 4-6 inline — filtering and the on-disk write are 
 
 When `/wish --under <wish-path>` is invoked, walk the target as if it were a chosen wish — generate its own sub-wishes, possibly its own sub-alternatives, and recurse to producibility. If the target is an `alternatives/<slug>` path that is not yet on disk, resolve `<slug>` against the parent wish's prose-named alternatives and drill that counter-path directly into a full subtree using the chosen-path `wish.md` shape. Refuse only when the target matches neither an existing path nor a prose-named alternative. The result is a competing subtree the user can compare against the original chosen path's subtree.
 
-### 6. Write the tree
+### 6. Refresh grounding on `--refresh`
+
+When `/wish --refresh <tree-path>` is invoked, resolve `<tree-path>` to an existing `wishes/<YYYY-MM-DD>-<theme-slug>/` directory or a subtree within one. Walk every `wish.md` beneath it, including those in `alternatives/`, and read each node's `grounded_surfaces:` frontmatter list.
+
+For every citation in the required `` `identifier` — crates/aether-*/src/path `` form, re-grep the identifier within its cited path: `git grep -F '<identifier>' -- '<path>'`. An empty result means that cited surface has drifted. If any citation has drifted, set `grounding_stale: true`, write `drifted_surfaces:` to exactly the failed citations, and set `grounding_checked: <today>` in that node's frontmatter. If all citations resolve, set `grounding_stale: false`, remove any prior `drifted_surfaces:`, and set `grounding_checked: <today>`.
+
+Skip nodes that have no `grounded_surfaces:` and report them as unverifiable rather than marking them stale. Mark drift per node only: a stale child does not make its parent stale. This mode only detects and flags drift; never re-drill or otherwise rewrite a node's wish body.
+
+Report the nodes checked, nodes drifted, and any unverifiable nodes, then list each drifted node path with the cited surfaces that failed. The user can then re-drill selected nodes with `/wish --under` or discard the stale subtree.
+
+### 7. Write the tree
 
 Output root: `wishes/<YYYY-MM-DD>-<theme-slug>/`. Write `index.md` and each `wish.md`.
 
@@ -344,7 +361,7 @@ Output root: `wishes/<YYYY-MM-DD>-<theme-slug>/`. Write `index.md` and each `wis
 - Considered-and-dropped list
 - Notes
 
-### 7. Report to user
+### 8. Report to user
 
 ```
 ✓ Wish pass complete.
@@ -416,6 +433,8 @@ The "why rejected as the chosen path" line names which dimension(s) the chosen w
 - **Unverifiable surface a wish leans on**: don't substitute a plausible name. Either the surface doesn't exist (drill the absence) or it's renamed (grep for the real name). A guessed surface makes producibility a lie.
 - **Children don't compose to satisfy parent**: back up, restate.
 - **`--under` invoked on a path that doesn't exist**: when the target is an `alternatives/<slug>` path, resolve `<slug>` against the parent wish's prose-named alternatives and drill that counter-path; refuse only when it matches neither an existing path nor a prose-named alternative.
+- **`--refresh` invoked on a tree that doesn't exist**: refuse and list valid prior-pass `wishes/<YYYY-MM-DD>-<theme-slug>/` paths, mirroring `--under`'s path check.
+- **A refreshed tree predates `grounded_surfaces:`**: report each affected node as unverifiable; do not mark it grounding-stale.
 
 ## Output gitignore
 

--- a/.claude/workflows/wish.js
+++ b/.claude/workflows/wish.js
@@ -58,7 +58,7 @@ const DRILL_SCHEMA = {
   properties: {
     producible: { type: 'boolean', description: 'true means this wish is now a plan — writable with known, grep-confirmed means within current resources' },
     summary: { type: 'string', description: 'bounded self-summary (2-4 sentences): the shape this wish settled on and why, enough for a child driller to compose upward without re-reading the full wish.md' },
-    grounded_surfaces: { type: 'array', items: { type: 'string' }, description: 'engine surfaces this wish builds on, each grep-confirmed and cited crate/path or file:line' },
+    grounded_surfaces: { type: 'array', items: { type: 'string' }, description: 'engine surfaces this wish builds on, each grep-confirmed as a re-greppable `identifier` — crates/aether-*/src/path citation; never a bare path or file:line' },
     children: {
       type: 'array',
       description: 'the wish-worthy absences — each becomes a sub-wish. A child is ONLY a genuine production-blocking gap (an un-grep-confirmed surface, a step not writable within current resources, or a "known mean" that is really another wish). Field existence, parameter defaults, naming, and "parent not built yet" are inline decisions resolved in this wish.md prose, NEVER children. EMPTY when producible:true.',
@@ -139,10 +139,13 @@ const WISH_MD_SHAPE =
   'adversity: data | empathy\n' +
   'parent: ../wish.md            # omit if this node is a root\n' +
   'producible: true | false      # true means this wish IS a plan\n' +
+  'grounded_surfaces:             # re-greppable `identifier` — crates/aether-*/src/path citations\n' +
+  '  - "`aether.fs.read` — crates/aether-capabilities/src/fs/kinds.rs"\n' +
   '---\n\n' +
   '<prose body, no headers: the wish + the adversity that grounds it + the goal it serves;\n' +
   ' the shape that would satisfy it at THIS level of depth (coarse near the root, fine near leaves);\n' +
   ' whether that shape is producible with known, grep-confirmed means within current resources;\n' +
+  ' the grounded_surfaces frontmatter list, which is the same set returned in your compact struct;\n' +
   ' if producible: the plan, concrete enough that someone could start;\n' +
   ' if not: the absences, each named with the sub-wish that would resolve it;\n' +
   ' coherence with the parent: how this wish resolves upward into the parent plan;\n' +
@@ -185,7 +188,7 @@ const drillPrompt = (node, file) => {
     '4. Write your full wish.md to the EXACT path:\n   ' + file + '\n' +
     '   ' + WISH_MD_SHAPE + '\n' +
     '5. Return the compact struct: producible, a bounded 2-4 sentence summary (your children inherit it as lineage — do not dump your whole reasoning), ' +
-    'grounded_surfaces (the cited real surfaces), and children (empty if producible).\n\n' +
+    'grounded_surfaces (each a re-greppable `identifier` — crates/aether-*/src/path citation, matching the frontmatter list), and children (empty if producible).\n\n' +
     'Be honest about depth: do not pad a shallow chain to look deep, do not truncate a deep one to "good enough". ' +
     'The chain stops only when producibility says so.\n\nStructured output only — and you MUST write the wish.md file.'
   )


### PR DESCRIPTION
Closes #3056

## Summary

- persist each wish node’s grep-grounded engine surfaces in frontmatter
- make the deep driller return the same re-greppable identifier/path citations it writes
- add `/wish --refresh` to flag stale citations per node without rewriting wish prose

## Verification

- `node --check .claude/workflows/wish.js`
- manual `/tmp` refresh fixture covering current and drifted citations
- `cargo fmt -- --check`
- `git diff --check`
- `cargo clippy --all-targets -- -D warnings`

Generated by the Aether implement workflow.
