### PR TITLE
refactor(kit): rename terrain editor to terra

### DIFF
--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -23,9 +23,9 @@
 //! - [`mark::MarkBook`] — owns revisioned terrain annotations with stable ids,
 //!   selected by the `aether_kit@aether.kit.mark` export. Its CRUD and
 //!   snapshot vocabulary lives in [`mark`].
-//! - [`terrain_editor::TerrainEditor`] — owns an ordered terrain-mark
+//! - [`terra::TerraEditor`] — owns an ordered terrain-mark
 //!   selection and correlated semantic commands, selected by the
-//!   `aether_kit@aether.kit.terrain_editor` export.
+//!   `aether_kit@aether.kit.terra` export.
 //! - [`world::WorldView`] — meshes the chunked world plane stack into a
 //!   flat-color marching-squares base render, selected by the
 //!   `aether_kit@aether.kit.world` export. The [`world`] module also holds
@@ -68,7 +68,7 @@ pub mod console;
 pub mod mark;
 pub mod mesh;
 pub mod mover;
-pub mod terrain_editor;
+pub mod terra;
 pub mod widget;
 pub mod world;
 
@@ -81,10 +81,10 @@ pub use mark::{
     MarkList, MarkListResult, MarkMutationError, MarkRef, MarkUpdate, MarkUpdateResult, SavedMarks,
 };
 pub use mover::{MoverConfig, MoverTeleport};
-pub use terrain_editor::{
-    ClearTerrainSelection, CreateTerrainMark, DeleteTerrainSelection, MoveTerrainSelection, RelabelTerrainSelection,
-    SetTerrainSelection, TerrainCommandResult, TerrainEditorConfig, TerrainEditorError, TerrainEditorQuery,
-    TerrainEditorQueryResult, ToggleTerrainSelection, WorldDelta,
+pub use terra::{
+    ClearTerraSelection, CreateTerraMark, DeleteTerraSelection, MoveTerraSelection, RelabelTerraSelection,
+    SetTerraSelection, TerraCommandResult, TerraConfig, TerraError, TerraQuery, TerraQueryResult, ToggleTerraSelection,
+    WorldDelta,
 };
 pub use widget::theme::{SetTheme, Theme, ThemeState};
 pub use widget::{
@@ -136,7 +136,7 @@ aether_actor::export!(
     camera::controller::CameraController,
     mark::MarkBook,
     mesh::MeshViewer,
-    terrain_editor::TerrainEditor,
+    terra::TerraEditor,
     world::WorldView,
     mover::WorldMover,
     widget::Widget,
@@ -163,7 +163,7 @@ aether_actor::export!(
     camera::controller::CameraController,
     mark::MarkBook,
     mesh::MeshViewer,
-    terrain_editor::TerrainEditor,
+    terra::TerraEditor,
     world::WorldView,
     mover::WorldMover,
     widget::Widget,

--- a/crates/aether-kit/src/terra/kinds.rs
+++ b/crates/aether-kit/src/terra/kinds.rs
@@ -1,4 +1,4 @@
-//! Wire vocabulary for terrain-editor selection and semantic commands.
+//! Wire vocabulary for terra selection and semantic commands.
 
 use alloc::{string::String, vec::Vec};
 
@@ -9,40 +9,40 @@ use crate::mark::{MarkGeometry, MarkId, MarkMutationError, MarkRef};
 
 /// Mailbox configuration for the standalone terrain-mark store.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
-#[kind(name = "aether.kit.terrain_editor.config")]
-pub struct TerrainEditorConfig {
+#[kind(name = "aether.kit.terra.config")]
+pub struct TerraConfig {
     pub mark_book_mailbox: MailboxId,
 }
 
-impl Default for TerrainEditorConfig {
+impl Default for TerraConfig {
     fn default() -> Self {
         Self { mark_book_mailbox: MailboxId::NONE }
     }
 }
 
-/// Replace the editor's ordered selection after validating every reference.
+/// Replace terra's ordered selection after validating every reference.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-#[kind(name = "aether.kit.terrain_editor.set_selection")]
-pub struct SetTerrainSelection {
+#[kind(name = "aether.kit.terra.set_selection")]
+pub struct SetTerraSelection {
     pub references: Vec<MarkRef>,
 }
 
 /// Toggle one validated mark reference in the ordered selection.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy)]
-#[kind(name = "aether.kit.terrain_editor.toggle_selection")]
-pub struct ToggleTerrainSelection {
+#[kind(name = "aether.kit.terra.toggle_selection")]
+pub struct ToggleTerraSelection {
     pub reference: MarkRef,
 }
 
 /// Clear the local selection without consulting the mark store.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, Default)]
-#[kind(name = "aether.kit.terrain_editor.clear_selection")]
-pub struct ClearTerrainSelection;
+#[kind(name = "aether.kit.terra.clear_selection")]
+pub struct ClearTerraSelection;
 
 /// Create one mark and select the returned reference.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-#[kind(name = "aether.kit.terrain_editor.create_mark")]
-pub struct CreateTerrainMark {
+#[kind(name = "aether.kit.terra.create_mark")]
+pub struct CreateTerraMark {
     pub geometry: MarkGeometry,
     pub label: String,
 }
@@ -56,39 +56,39 @@ pub struct WorldDelta {
 
 /// Translate every selected mark after a complete read-only preflight.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy)]
-#[kind(name = "aether.kit.terrain_editor.move_selection")]
-pub struct MoveTerrainSelection {
+#[kind(name = "aether.kit.terra.move_selection")]
+pub struct MoveTerraSelection {
     pub delta: WorldDelta,
 }
 
 /// Replace the label of every selected mark that does not already match it.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-#[kind(name = "aether.kit.terrain_editor.relabel_selection")]
-pub struct RelabelTerrainSelection {
+#[kind(name = "aether.kit.terra.relabel_selection")]
+pub struct RelabelTerraSelection {
     pub label: String,
 }
 
 /// Delete every selected mark after a complete read-only preflight.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, Default)]
-#[kind(name = "aether.kit.terrain_editor.delete_selection")]
-pub struct DeleteTerrainSelection;
+#[kind(name = "aether.kit.terra.delete_selection")]
+pub struct DeleteTerraSelection;
 
 /// Read the cached selection and one-flight busy flag.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, Default)]
-#[kind(name = "aether.kit.terrain_editor.query")]
-pub struct TerrainEditorQuery;
+#[kind(name = "aether.kit.terra.query")]
+pub struct TerraQuery;
 
-/// Immediate cached editor state.
+/// Immediate cached terra state.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[kind(name = "aether.kit.terrain_editor.query_result")]
-pub struct TerrainEditorQueryResult {
+#[kind(name = "aether.kit.terra.query_result")]
+pub struct TerraQueryResult {
     pub selection: Vec<MarkRef>,
     pub busy: bool,
 }
 
 /// Structured failure for selection validation and semantic mark mutations.
 #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub enum TerrainEditorError {
+pub enum TerraError {
     Busy,
     EmptySelection,
     DuplicateSelection { id: MarkId },
@@ -102,23 +102,11 @@ pub enum TerrainEditorError {
     MarkProtocol { reason: String },
 }
 
-/// Common reply for all terrain-editor commands.
+/// Common reply for all terra commands.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[kind(name = "aether.kit.terrain_editor.command_result")]
-pub enum TerrainCommandResult {
-    Applied {
-        selection: Vec<MarkRef>,
-        changed: Vec<MarkRef>,
-        deleted: Vec<MarkRef>,
-    },
-    Rejected {
-        selection: Vec<MarkRef>,
-        error: TerrainEditorError,
-    },
-    PartiallyApplied {
-        selection: Vec<MarkRef>,
-        changed: Vec<MarkRef>,
-        deleted: Vec<MarkRef>,
-        error: TerrainEditorError,
-    },
+#[kind(name = "aether.kit.terra.command_result")]
+pub enum TerraCommandResult {
+    Applied { selection: Vec<MarkRef>, changed: Vec<MarkRef>, deleted: Vec<MarkRef> },
+    Rejected { selection: Vec<MarkRef>, error: TerraError },
+    PartiallyApplied { selection: Vec<MarkRef>, changed: Vec<MarkRef>, deleted: Vec<MarkRef>, error: TerraError },
 }

--- a/crates/aether-kit/src/terra/mod.rs
+++ b/crates/aether-kit/src/terra/mod.rs
@@ -1,6 +1,6 @@
-//! Correlated one-flight terrain-editor actor.
+//! Correlated one-flight terra actor.
 //!
-//! The editor owns only an ordered selection and semantic command state. It
+//! Terra owns only an ordered selection and semantic command state. It
 //! talks to a separately loaded [`crate::mark::MarkBook`] by configured
 //! mailbox, preflights every batch completely, and never mutates a world view.
 
@@ -30,12 +30,12 @@ use self::selection::{
 /// Selection-and-command facade over a standalone terrain mark book.
 ///
 /// # Agent
-/// Load `aether_kit@aether.kit.terrain_editor` with a
-/// [`TerrainEditorConfig`] containing the mailbox id returned when the mark
+/// Load `aether_kit@aether.kit.terra` with a
+/// [`TerraConfig`] containing the mailbox id returned when the mark
 /// book was loaded. Send at most one mutation command at a time; queries stay
 /// available while that command is in flight.
-pub struct TerrainEditor {
-    config: TerrainEditorConfig,
+pub struct TerraEditor {
+    config: TerraConfig,
     selection: Selection,
     pending: Option<PendingCommand>,
     pending_request: Option<RequestId>,
@@ -87,7 +87,7 @@ enum MarkRequestStage {
 }
 
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
-#[kind(name = "aether.kit.terrain_editor.mark_request_context")]
+#[kind(name = "aether.kit.terra.mark_request_context")]
 struct MarkRequestContext {
     stage: MarkRequestStage,
     index: u32,
@@ -169,37 +169,37 @@ impl PendingCommand {
 }
 
 fn index_u32(index: usize) -> u32 {
-    u32::try_from(index).expect("terrain selection cannot exceed u32::MAX entries")
+    u32::try_from(index).expect("terra selection cannot exceed u32::MAX entries")
 }
 
-impl TerrainEditor {
+impl TerraEditor {
     fn busy(&self) -> bool {
         self.pending.is_some()
     }
 
-    fn query_result(&self) -> TerrainEditorQueryResult {
-        TerrainEditorQueryResult { selection: self.selection.snapshot(), busy: self.busy() }
+    fn query_result(&self) -> TerraQueryResult {
+        TerraQueryResult { selection: self.selection.snapshot(), busy: self.busy() }
     }
 
-    fn rejection(&self, error: TerrainEditorError) -> TerrainCommandResult {
-        TerrainCommandResult::Rejected { selection: self.selection.snapshot(), error }
+    fn rejection(&self, error: TerraError) -> TerraCommandResult {
+        TerraCommandResult::Rejected { selection: self.selection.snapshot(), error }
     }
 
-    fn applied_without_mark_mutation(&self) -> TerrainCommandResult {
-        TerrainCommandResult::Applied { selection: self.selection.snapshot(), changed: Vec::new(), deleted: Vec::new() }
+    fn applied_without_mark_mutation(&self) -> TerraCommandResult {
+        TerraCommandResult::Applied { selection: self.selection.snapshot(), changed: Vec::new(), deleted: Vec::new() }
     }
 
-    fn require_idle(&self) -> Result<(), TerrainEditorError> {
+    fn require_idle(&self) -> Result<(), TerraError> {
         if self.busy() {
-            Err(TerrainEditorError::Busy)
+            Err(TerraError::Busy)
         } else {
             Ok(())
         }
     }
 
-    fn require_mark_book(&self) -> Result<(), TerrainEditorError> {
+    fn require_mark_book(&self) -> Result<(), TerraError> {
         if self.config.mark_book_mailbox == MailboxId::NONE {
-            Err(TerrainEditorError::MarkBookNotConfigured)
+            Err(TerraError::MarkBookNotConfigured)
         } else {
             Ok(())
         }
@@ -253,19 +253,19 @@ impl TerrainEditor {
             tracing::warn!(
                 target: "aether_kit",
                 observed = source.map_or(MailboxId::NONE.0, |mailbox| mailbox.0),
-                "terrain editor ignored correlated mail carrying an ordinary component source",
+                "terra ignored correlated mail carrying an ordinary component source",
             );
             return None;
         }
         let Some(request) = ctx.in_reply_to() else {
-            tracing::warn!(target: "aether_kit", "terrain editor ignored uncorrelated mark reply");
+            tracing::warn!(target: "aether_kit", "terra ignored uncorrelated mark reply");
             return None;
         };
         if self.pending_request != Some(request) {
             tracing::warn!(
                 target: "aether_kit",
                 observed = request.0,
-                "terrain editor ignored unmatched or duplicate mark reply",
+                "terra ignored unmatched or duplicate mark reply",
             );
             return None;
         }
@@ -273,7 +273,7 @@ impl TerrainEditor {
             tracing::warn!(
                 target: "aether_kit",
                 request = request.0,
-                "terrain editor ignored mark reply with missing typed context",
+                "terra ignored mark reply with missing typed context",
             );
             return None;
         };
@@ -284,14 +284,14 @@ impl TerrainEditor {
                 request = request.0,
                 stage = ?context.stage,
                 index = context.index,
-                "terrain editor ignored wrong-stage mark reply",
+                "terra ignored wrong-stage mark reply",
             );
             return None;
         }
         Some(envelope)
     }
 
-    fn finish(&mut self, ctx: &mut WasmCtx<'_, Manual>, result: &TerrainCommandResult) {
+    fn finish(&mut self, ctx: &mut WasmCtx<'_, Manual>, result: &TerraCommandResult) {
         let reply = self.pending.as_ref().and_then(PendingCommand::reply);
         if let Some(reply) = reply {
             ctx.reply_to(reply, result);
@@ -300,7 +300,7 @@ impl TerrainEditor {
         self.pending_request = None;
     }
 
-    fn finish_error(&mut self, ctx: &mut WasmCtx<'_, Manual>, error: TerrainEditorError) {
+    fn finish_error(&mut self, ctx: &mut WasmCtx<'_, Manual>, error: TerraError) {
         let result = match self.pending.as_mut() {
             Some(PendingCommand::Batch { progress, .. }) => take(progress).finish(&self.selection, Some(error)),
             _ => self.rejection(error),
@@ -313,7 +313,7 @@ impl TerrainEditor {
             return;
         }
         if self.selection.is_empty() {
-            ctx.reply(&self.rejection(TerrainEditorError::EmptySelection));
+            ctx.reply(&self.rejection(TerraError::EmptySelection));
             return;
         }
         let requested = self.selection.snapshot();
@@ -336,7 +336,7 @@ impl TerrainEditor {
             let Some(PendingCommand::Batch { operation, marks, .. }) = self.pending.as_ref() else {
                 self.finish_error(
                     ctx,
-                    TerrainEditorError::MarkProtocol { reason: String::from("preflight completed outside a batch") },
+                    TerraError::MarkProtocol { reason: String::from("preflight completed outside a batch") },
                 );
                 return;
             };
@@ -364,7 +364,7 @@ impl TerrainEditor {
         self.issue_next(ctx);
     }
 
-    fn apply_update_result(&mut self, requested: MarkRef, result: MarkUpdateResult) -> Option<TerrainEditorError> {
+    fn apply_update_result(&mut self, requested: MarkRef, result: MarkUpdateResult) -> Option<TerraError> {
         match result {
             MarkUpdateResult::Updated { reference: observed } => {
                 let expected = MarkRef {
@@ -374,41 +374,41 @@ impl TerrainEditor {
                 if let Some(PendingCommand::Batch { progress, .. }) = self.pending.as_mut() {
                     progress.record_update(&mut self.selection, observed);
                 }
-                (observed != expected).then_some(TerrainEditorError::RevisionRace { expected, observed })
+                (observed != expected).then_some(TerraError::RevisionRace { expected, observed })
             }
-            MarkUpdateResult::NotFound { .. } => Some(TerrainEditorError::MarkMissing { requested }),
+            MarkUpdateResult::NotFound { .. } => Some(TerraError::MarkMissing { requested }),
             MarkUpdateResult::Rejected { error } => {
-                Some(TerrainEditorError::MarkMutationRejected { requested: Some(requested), error })
+                Some(TerraError::MarkMutationRejected { requested: Some(requested), error })
             }
         }
     }
 
-    fn apply_create_result(&mut self, result: MarkCreateResult) -> TerrainCommandResult {
+    fn apply_create_result(&mut self, result: MarkCreateResult) -> TerraCommandResult {
         match result {
             MarkCreateResult::Created { reference } => {
                 self.selection.replace(vec![reference]);
-                TerrainCommandResult::Applied {
+                TerraCommandResult::Applied {
                     selection: self.selection.snapshot(),
                     changed: vec![reference],
                     deleted: Vec::new(),
                 }
             }
             MarkCreateResult::Rejected { error } => {
-                self.rejection(TerrainEditorError::MarkMutationRejected { requested: None, error })
+                self.rejection(TerraError::MarkMutationRejected { requested: None, error })
             }
         }
     }
 
-    fn apply_delete_result(&mut self, requested: MarkRef, result: &MarkDeleteResult) -> Option<TerrainEditorError> {
+    fn apply_delete_result(&mut self, requested: MarkRef, result: &MarkDeleteResult) -> Option<TerraError> {
         match result {
             MarkDeleteResult::Deleted { reference: observed } => {
                 let observed = *observed;
                 if let Some(PendingCommand::Batch { progress, .. }) = self.pending.as_mut() {
                     progress.record_delete(&mut self.selection, observed);
                 }
-                (observed != requested).then_some(TerrainEditorError::RevisionRace { expected: requested, observed })
+                (observed != requested).then_some(TerraError::RevisionRace { expected: requested, observed })
             }
-            MarkDeleteResult::NotFound { .. } => Some(TerrainEditorError::MarkMissing { requested }),
+            MarkDeleteResult::NotFound { .. } => Some(TerraError::MarkMissing { requested }),
         }
     }
 
@@ -426,16 +426,16 @@ impl TerrainEditor {
 }
 
 #[actor]
-impl WasmActor for TerrainEditor {
-    type Config = TerrainEditorConfig;
-    const NAMESPACE: &'static str = "aether.kit.terrain_editor";
+impl WasmActor for TerraEditor {
+    type Config = TerraConfig;
+    const NAMESPACE: &'static str = "aether.kit.terra";
 
-    fn init(config: TerrainEditorConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+    fn init(config: TerraConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Self { config, selection: Selection::default(), pending: None, pending_request: None })
     }
 
     #[handler::manual]
-    fn on_set_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, command: SetTerrainSelection) {
+    fn on_set_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, command: SetTerraSelection) {
         if let Err(error) = self.require_idle() {
             ctx.reply(&self.rejection(error));
             return;
@@ -460,7 +460,7 @@ impl WasmActor for TerrainEditor {
     }
 
     #[handler::manual]
-    fn on_toggle_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, command: ToggleTerrainSelection) {
+    fn on_toggle_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, command: ToggleTerraSelection) {
         if !self.mark_book_command_ready(ctx) {
             return;
         }
@@ -468,7 +468,7 @@ impl WasmActor for TerrainEditor {
     }
 
     #[handler::manual]
-    fn on_clear_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, _command: ClearTerrainSelection) {
+    fn on_clear_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, _command: ClearTerraSelection) {
         if let Err(error) = self.require_idle() {
             ctx.reply(&self.rejection(error));
             return;
@@ -478,7 +478,7 @@ impl WasmActor for TerrainEditor {
     }
 
     #[handler::manual]
-    fn on_create_mark(&mut self, ctx: &mut WasmCtx<'_, Manual>, command: CreateTerrainMark) {
+    fn on_create_mark(&mut self, ctx: &mut WasmCtx<'_, Manual>, command: CreateTerraMark) {
         if !self.mark_book_command_ready(ctx) {
             return;
         }
@@ -492,22 +492,22 @@ impl WasmActor for TerrainEditor {
     }
 
     #[handler::manual]
-    fn on_move_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, command: MoveTerrainSelection) {
+    fn on_move_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, command: MoveTerraSelection) {
         self.start_batch(ctx, BatchOperation::Move(command.delta));
     }
 
     #[handler::manual]
-    fn on_relabel_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, command: RelabelTerrainSelection) {
+    fn on_relabel_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, command: RelabelTerraSelection) {
         self.start_batch(ctx, BatchOperation::Relabel(command.label));
     }
 
     #[handler::manual]
-    fn on_delete_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, _command: DeleteTerrainSelection) {
+    fn on_delete_selection(&mut self, ctx: &mut WasmCtx<'_, Manual>, _command: DeleteTerraSelection) {
         self.start_batch(ctx, BatchOperation::Delete);
     }
 
     #[handler::manual]
-    fn on_query(&mut self, ctx: &mut WasmCtx<'_, Manual>, _query: TerrainEditorQuery) {
+    fn on_query(&mut self, ctx: &mut WasmCtx<'_, Manual>, _query: TerraQuery) {
         ctx.reply(&self.query_result());
     }
 
@@ -558,7 +558,7 @@ impl WasmActor for TerrainEditor {
             }
             _ => self.finish_error(
                 ctx,
-                TerrainEditorError::MarkProtocol { reason: String::from("MarkGetResult arrived for a non-get stage") },
+                TerraError::MarkProtocol { reason: String::from("MarkGetResult arrived for a non-get stage") },
             ),
         }
     }
@@ -571,9 +571,7 @@ impl WasmActor for TerrainEditor {
         if !matches!(self.pending, Some(PendingCommand::Create { .. })) {
             self.finish_error(
                 ctx,
-                TerrainEditorError::MarkProtocol {
-                    reason: String::from("MarkCreateResult arrived for a non-create stage"),
-                },
+                TerraError::MarkProtocol { reason: String::from("MarkCreateResult arrived for a non-create stage") },
             );
             return;
         }
@@ -593,9 +591,7 @@ impl WasmActor for TerrainEditor {
         } else {
             self.finish_error(
                 ctx,
-                TerrainEditorError::MarkProtocol {
-                    reason: String::from("MarkUpdateResult arrived for a non-update stage"),
-                },
+                TerraError::MarkProtocol { reason: String::from("MarkUpdateResult arrived for a non-update stage") },
             );
             return;
         };
@@ -626,9 +622,7 @@ impl WasmActor for TerrainEditor {
         } else {
             self.finish_error(
                 ctx,
-                TerrainEditorError::MarkProtocol {
-                    reason: String::from("MarkDeleteResult arrived for a non-delete stage"),
-                },
+                TerraError::MarkProtocol { reason: String::from("MarkDeleteResult arrived for a non-delete stage") },
             );
             return;
         };
@@ -658,9 +652,9 @@ mod tests {
         MarkRef { id: MarkId::new(id), revision }
     }
 
-    fn editor() -> TerrainEditor {
-        TerrainEditor {
-            config: TerrainEditorConfig { mark_book_mailbox: MailboxId(44) },
+    fn editor() -> TerraEditor {
+        TerraEditor {
+            config: TerraConfig { mark_book_mailbox: MailboxId(44) },
             selection: Selection::default(),
             pending: None,
             pending_request: None,
@@ -675,10 +669,10 @@ mod tests {
     fn query_is_available_and_reports_busy_from_pending_state() {
         let mut editor = editor();
         editor.selection.replace(vec![reference(2, 1)]);
-        assert_eq!(editor.query_result(), TerrainEditorQueryResult { selection: vec![reference(2, 1)], busy: false });
+        assert_eq!(editor.query_result(), TerraQueryResult { selection: vec![reference(2, 1)], busy: false });
         editor.pending = Some(PendingCommand::ToggleSelection { reply: None, requested: reference(3, 1) });
         assert!(editor.busy());
-        assert_eq!(editor.require_idle(), Err(TerrainEditorError::Busy));
+        assert_eq!(editor.require_idle(), Err(TerraError::Busy));
         assert!(editor.query_result().busy);
     }
 
@@ -694,8 +688,8 @@ mod tests {
             request: RequestId(12),
             context: MarkRequestContext { stage: MarkRequestStage::Update, index: 0 },
         };
-        assert!(TerrainEditor::reply_source_allowed(None));
-        assert!(!TerrainEditor::reply_source_allowed(Some(MailboxId(44))));
+        assert!(TerraEditor::reply_source_allowed(None));
+        assert!(!TerraEditor::reply_source_allowed(Some(MailboxId(44))));
         assert!(!editor.accepts_envelope(&stale_request));
         assert!(!editor.accepts_envelope(&wrong_stage));
         assert_eq!(
@@ -714,15 +708,15 @@ mod tests {
         editor.selection.replace(vec![previous]);
         assert_eq!(
             editor.apply_create_result(MarkCreateResult::Created { reference: created }),
-            TerrainCommandResult::Applied { selection: vec![created], changed: vec![created], deleted: Vec::new() }
+            TerraCommandResult::Applied { selection: vec![created], changed: vec![created], deleted: Vec::new() }
         );
 
         let error = MarkMutationError::IdExhausted;
         assert_eq!(
             editor.apply_create_result(MarkCreateResult::Rejected { error: error.clone() }),
-            TerrainCommandResult::Rejected {
+            TerraCommandResult::Rejected {
                 selection: vec![created],
-                error: TerrainEditorError::MarkMutationRejected { requested: None, error },
+                error: TerraError::MarkMutationRejected { requested: None, error },
             }
         );
         assert_eq!(editor.selection.snapshot(), vec![created]);
@@ -749,22 +743,20 @@ mod tests {
         });
         assert_eq!(
             editor.apply_update_result(old, MarkUpdateResult::Updated { reference: observed }),
-            Some(TerrainEditorError::RevisionRace { expected: reference(1, 5), observed })
+            Some(TerraError::RevisionRace { expected: reference(1, 5), observed })
         );
         let result = match editor.pending.as_mut() {
-            Some(PendingCommand::Batch { progress, .. }) => take(progress).finish(
-                &editor.selection,
-                Some(TerrainEditorError::RevisionRace { expected: reference(1, 5), observed }),
-            ),
+            Some(PendingCommand::Batch { progress, .. }) => take(progress)
+                .finish(&editor.selection, Some(TerraError::RevisionRace { expected: reference(1, 5), observed })),
             _ => panic!("batch pending"),
         };
         assert_eq!(
             result,
-            TerrainCommandResult::PartiallyApplied {
+            TerraCommandResult::PartiallyApplied {
                 selection: vec![observed],
                 changed: vec![observed],
                 deleted: Vec::new(),
-                error: TerrainEditorError::RevisionRace { expected: reference(1, 5), observed },
+                error: TerraError::RevisionRace { expected: reference(1, 5), observed },
             }
         );
     }
@@ -787,7 +779,7 @@ mod tests {
         });
         assert_eq!(
             editor.apply_delete_result(expected, &MarkDeleteResult::Deleted { reference: observed }),
-            Some(TerrainEditorError::RevisionRace { expected, observed })
+            Some(TerraError::RevisionRace { expected, observed })
         );
         assert_eq!(editor.selection.snapshot(), vec![other]);
     }
@@ -809,16 +801,14 @@ mod tests {
         let error = MarkMutationError::EmptyUpdate;
         assert_eq!(
             editor.apply_update_result(selected, MarkUpdateResult::Rejected { error: error.clone() }),
-            Some(TerrainEditorError::MarkMutationRejected { requested: Some(selected), error: error.clone() })
+            Some(TerraError::MarkMutationRejected { requested: Some(selected), error: error.clone() })
         );
         let result = match editor.pending.as_mut() {
-            Some(PendingCommand::Batch { progress, .. }) => take(progress).finish(
-                &editor.selection,
-                Some(TerrainEditorError::MarkMutationRejected { requested: Some(selected), error }),
-            ),
+            Some(PendingCommand::Batch { progress, .. }) => take(progress)
+                .finish(&editor.selection, Some(TerraError::MarkMutationRejected { requested: Some(selected), error })),
             _ => panic!("batch pending"),
         };
-        assert!(matches!(result, TerrainCommandResult::Rejected { .. }));
+        assert!(matches!(result, TerraCommandResult::Rejected { .. }));
         assert_eq!(editor.selection.snapshot(), vec![selected]);
     }
 }

--- a/crates/aether-kit/src/terra/selection.rs
+++ b/crates/aether-kit/src/terra/selection.rs
@@ -5,7 +5,7 @@ use alloc::{collections::BTreeSet, format, string::String, vec::Vec};
 use crate::mark::{Mark, MarkGeometry, MarkMutationError, MarkRef};
 use crate::world::{MAX_STAMP_VERTICES, WorldPoint};
 
-use super::{TerrainCommandResult, TerrainEditorError, WorldDelta};
+use super::{TerraCommandResult, TerraError, WorldDelta};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(super) struct Selection {
@@ -27,11 +27,11 @@ impl Selection {
         self.references.is_empty()
     }
 
-    pub(super) fn validate_unique(references: &[MarkRef]) -> Result<(), TerrainEditorError> {
+    pub(super) fn validate_unique(references: &[MarkRef]) -> Result<(), TerraError> {
         let mut ids = BTreeSet::new();
         for reference in references {
             if !ids.insert(reference.id) {
-                return Err(TerrainEditorError::DuplicateSelection { id: reference.id });
+                return Err(TerraError::DuplicateSelection { id: reference.id });
             }
         }
         Ok(())
@@ -96,14 +96,14 @@ impl BatchProgress {
         self.deleted.push(observed);
     }
 
-    pub(super) fn finish(self, selection: &Selection, error: Option<TerrainEditorError>) -> TerrainCommandResult {
+    pub(super) fn finish(self, selection: &Selection, error: Option<TerraError>) -> TerraCommandResult {
         let snapshot = selection.snapshot();
         match error {
-            None => TerrainCommandResult::Applied { selection: snapshot, changed: self.changed, deleted: self.deleted },
+            None => TerraCommandResult::Applied { selection: snapshot, changed: self.changed, deleted: self.deleted },
             Some(error) if self.changed.is_empty() && self.deleted.is_empty() => {
-                TerrainCommandResult::Rejected { selection: snapshot, error }
+                TerraCommandResult::Rejected { selection: snapshot, error }
             }
-            Some(error) => TerrainCommandResult::PartiallyApplied {
+            Some(error) => TerraCommandResult::PartiallyApplied {
                 selection: snapshot,
                 changed: self.changed,
                 deleted: self.deleted,
@@ -113,18 +113,18 @@ impl BatchProgress {
     }
 }
 
-pub(super) fn validate_mark(requested: MarkRef, mark: Option<&Mark>) -> Result<(), TerrainEditorError> {
+pub(super) fn validate_mark(requested: MarkRef, mark: Option<&Mark>) -> Result<(), TerraError> {
     let Some(mark) = mark else {
-        return Err(TerrainEditorError::MarkMissing { requested });
+        return Err(TerraError::MarkMissing { requested });
     };
     let current = mark.reference();
     if current != requested {
-        return Err(TerrainEditorError::StaleReference { requested, current });
+        return Err(TerraError::StaleReference { requested, current });
     }
     Ok(())
 }
 
-pub(super) fn validate_batch_marks(marks: &[Mark]) -> Result<(), TerrainEditorError> {
+pub(super) fn validate_batch_marks(marks: &[Mark]) -> Result<(), TerraError> {
     for mark in marks {
         let minimum = match &mark.geometry {
             MarkGeometry::Point(_) => continue,
@@ -150,7 +150,7 @@ pub(super) fn validate_batch_marks(marks: &[Mark]) -> Result<(), TerrainEditorEr
             MarkGeometry::Path(points) | MarkGeometry::Area(points) => points.len(),
             MarkGeometry::Point(_) => unreachable!("points are always valid"),
         };
-        return Err(TerrainEditorError::MarkMutationRejected {
+        return Err(TerraError::MarkMutationRejected {
             requested: Some(mark.reference()),
             error: MarkMutationError::InvalidGeometry {
                 reason: format!("{kind} requires {minimum}..={MAX_STAMP_VERTICES} world points; got {length}"),
@@ -160,27 +160,27 @@ pub(super) fn validate_batch_marks(marks: &[Mark]) -> Result<(), TerrainEditorEr
     Ok(())
 }
 
-pub(super) fn plan_move(marks: &[Mark], delta: WorldDelta) -> Result<Vec<PlannedUpdate>, TerrainEditorError> {
+pub(super) fn plan_move(marks: &[Mark], delta: WorldDelta) -> Result<Vec<PlannedUpdate>, TerraError> {
     if delta == WorldDelta::default() {
-        return Err(TerrainEditorError::NoChange);
+        return Err(TerraError::NoChange);
     }
     let mut updates = Vec::with_capacity(marks.len());
     for mark in marks {
         let requested = mark.reference();
         if mark.revision == u32::MAX {
-            return Err(TerrainEditorError::MarkMutationRejected {
+            return Err(TerraError::MarkMutationRejected {
                 requested: Some(requested),
                 error: MarkMutationError::RevisionExhausted,
             });
         }
-        let geometry = translate_geometry(&mark.geometry, delta)
-            .ok_or(TerrainEditorError::CoordinateOverflow { reference: requested })?;
+        let geometry =
+            translate_geometry(&mark.geometry, delta).ok_or(TerraError::CoordinateOverflow { reference: requested })?;
         updates.push(PlannedUpdate { requested, geometry: Some(geometry), label: None });
     }
     Ok(updates)
 }
 
-pub(super) fn plan_relabel(marks: &[Mark], label: &str) -> Result<Vec<PlannedUpdate>, TerrainEditorError> {
+pub(super) fn plan_relabel(marks: &[Mark], label: &str) -> Result<Vec<PlannedUpdate>, TerraError> {
     let mut updates = Vec::new();
     for mark in marks {
         if mark.label == label {
@@ -188,7 +188,7 @@ pub(super) fn plan_relabel(marks: &[Mark], label: &str) -> Result<Vec<PlannedUpd
         }
         let requested = mark.reference();
         if mark.revision == u32::MAX {
-            return Err(TerrainEditorError::MarkMutationRejected {
+            return Err(TerraError::MarkMutationRejected {
                 requested: Some(requested),
                 error: MarkMutationError::RevisionExhausted,
             });
@@ -196,7 +196,7 @@ pub(super) fn plan_relabel(marks: &[Mark], label: &str) -> Result<Vec<PlannedUpd
         updates.push(PlannedUpdate { requested, geometry: None, label: Some(String::from(label)) });
     }
     if updates.is_empty() {
-        return Err(TerrainEditorError::NoChange);
+        return Err(TerraError::NoChange);
     }
     Ok(updates)
 }
@@ -269,26 +269,26 @@ mod tests {
         let duplicate = reference(7, 2);
         assert_eq!(
             Selection::validate_unique(&[first, duplicate]),
-            Err(TerrainEditorError::DuplicateSelection { id: first.id })
+            Err(TerraError::DuplicateSelection { id: first.id })
         );
     }
 
     #[test]
     fn missing_and_stale_references_fail_before_any_plan_exists() {
         let requested = reference(4, 2);
-        assert_eq!(validate_mark(requested, None), Err(TerrainEditorError::MarkMissing { requested }));
+        assert_eq!(validate_mark(requested, None), Err(TerraError::MarkMissing { requested }));
         let current = point_mark(4, 3, 0, 0, "camp");
         assert_eq!(
             validate_mark(requested, Some(&current)),
-            Err(TerrainEditorError::StaleReference { requested, current: current.reference() })
+            Err(TerraError::StaleReference { requested, current: current.reference() })
         );
     }
 
     #[test]
     fn zero_move_and_matching_relabel_are_no_change() {
         let mark = point_mark(1, 1, 8, 9, "camp");
-        assert_eq!(plan_move(from_ref(&mark), WorldDelta::default()), Err(TerrainEditorError::NoChange));
-        assert_eq!(plan_relabel(&[mark], "camp"), Err(TerrainEditorError::NoChange));
+        assert_eq!(plan_move(from_ref(&mark), WorldDelta::default()), Err(TerraError::NoChange));
+        assert_eq!(plan_relabel(&[mark], "camp"), Err(TerraError::NoChange));
     }
 
     #[test]
@@ -297,7 +297,7 @@ mod tests {
         let overflow = point_mark(2, 1, i32::MAX, 30, "second");
         assert_eq!(
             plan_move(&[first, overflow.clone()], WorldDelta { x_octimeters: 1, z_octimeters: 0 }),
-            Err(TerrainEditorError::CoordinateOverflow { reference: overflow.reference() })
+            Err(TerraError::CoordinateOverflow { reference: overflow.reference() })
         );
     }
 
@@ -311,13 +311,13 @@ mod tests {
         };
         assert!(matches!(
             validate_batch_marks(&[invalid]),
-            Err(TerrainEditorError::MarkMutationRejected { error: MarkMutationError::InvalidGeometry { .. }, .. })
+            Err(TerraError::MarkMutationRejected { error: MarkMutationError::InvalidGeometry { .. }, .. })
         ));
 
         let exhausted = point_mark(6, u32::MAX, 0, 0, "exhausted");
         assert_eq!(
             plan_relabel(from_ref(&exhausted), "new"),
-            Err(TerrainEditorError::MarkMutationRejected {
+            Err(TerraError::MarkMutationRejected {
                 requested: Some(exhausted.reference()),
                 error: MarkMutationError::RevisionExhausted,
             })
@@ -360,14 +360,14 @@ mod tests {
         let updated = reference(1, 2);
         let mut progress = BatchProgress::default();
         progress.record_update(&mut selection, updated);
-        let result = progress.finish(&selection, Some(TerrainEditorError::MarkMissing { requested: second }));
+        let result = progress.finish(&selection, Some(TerraError::MarkMissing { requested: second }));
         assert_eq!(
             result,
-            TerrainCommandResult::PartiallyApplied {
+            TerraCommandResult::PartiallyApplied {
                 selection: vec![updated, second],
                 changed: vec![updated],
                 deleted: Vec::new(),
-                error: TerrainEditorError::MarkMissing { requested: second },
+                error: TerraError::MarkMissing { requested: second },
             }
         );
     }
@@ -378,10 +378,10 @@ mod tests {
         let second = reference(2, 1);
         let selection = Selection { references: vec![first, second] };
         assert_eq!(
-            BatchProgress::default().finish(&selection, Some(TerrainEditorError::MarkMissing { requested: first })),
-            TerrainCommandResult::Rejected {
+            BatchProgress::default().finish(&selection, Some(TerraError::MarkMissing { requested: first })),
+            TerraCommandResult::Rejected {
                 selection: vec![first, second],
-                error: TerrainEditorError::MarkMissing { requested: first },
+                error: TerraError::MarkMissing { requested: first },
             }
         );
 
@@ -389,12 +389,12 @@ mod tests {
         let mut progress = BatchProgress::default();
         progress.record_delete(&mut selection, first);
         assert_eq!(
-            progress.finish(&selection, Some(TerrainEditorError::MarkMissing { requested: second })),
-            TerrainCommandResult::PartiallyApplied {
+            progress.finish(&selection, Some(TerraError::MarkMissing { requested: second })),
+            TerraCommandResult::PartiallyApplied {
                 selection: vec![second],
                 changed: Vec::new(),
                 deleted: vec![first],
-                error: TerrainEditorError::MarkMissing { requested: second },
+                error: TerraError::MarkMissing { requested: second },
             }
         );
     }

--- a/crates/aether-kit/tests/terra_scenario.rs
+++ b/crates/aether-kit/tests/terra_scenario.rs
@@ -1,4 +1,4 @@
-//! Strict typed terrain-editor flow through two real wasm components.
+//! Strict typed terra flow through two real wasm components.
 
 use std::fs;
 use std::path::Path;
@@ -8,10 +8,9 @@ use aether_kinds::{LoadComponent, LoadResult};
 use aether_kit::mark::{
     Mark, MarkCreate, MarkCreateResult, MarkGeometry, MarkGet, MarkGetResult, MarkRef, MarkUpdate, MarkUpdateResult,
 };
-use aether_kit::terrain_editor::{
-    CreateTerrainMark, DeleteTerrainSelection, MoveTerrainSelection, RelabelTerrainSelection, SetTerrainSelection,
-    TerrainCommandResult, TerrainEditorConfig, TerrainEditorError, TerrainEditorQuery, TerrainEditorQueryResult,
-    WorldDelta,
+use aether_kit::terra::{
+    CreateTerraMark, DeleteTerraSelection, MoveTerraSelection, RelabelTerraSelection, SetTerraSelection,
+    TerraCommandResult, TerraConfig, TerraError, TerraQuery, TerraQueryResult, WorldDelta,
 };
 use aether_kit::world::WorldPoint;
 use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
@@ -20,7 +19,7 @@ use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::requ
 use aether_kit as _;
 
 const MARK_COMPONENT_NAME: &str = "terrain-marks";
-const EDITOR_COMPONENT_NAME: &str = "terrain-editor";
+const TERRA_COMPONENT_NAME: &str = "terra";
 
 fn component_address(name: &str) -> String {
     format!("aether.component/{}:{name}", aether_capabilities::WasmTrampoline::NAMESPACE)
@@ -50,27 +49,27 @@ fn load_mark_book(bench: &mut TestBench, wasm_path: &Path) -> aether_data::Mailb
     }
 }
 
-fn load_editor(bench: &mut TestBench, wasm_path: &Path, mark_book_mailbox: aether_data::MailboxId) {
-    let config = TerrainEditorConfig { mark_book_mailbox };
+fn load_terra(bench: &mut TestBench, wasm_path: &Path, mark_book_mailbox: aether_data::MailboxId) {
+    let config = TerraConfig { mark_book_mailbox };
     let loaded = bench
         .execute(vec![(
-            "load_editor",
+            "load_terra",
             BenchOp::send_and_await(
                 "aether.component",
                 &LoadComponent {
-                    wasm: fs::read(wasm_path).expect("read kit wasm for editor"),
-                    name: Some(EDITOR_COMPONENT_NAME.to_owned()),
+                    wasm: fs::read(wasm_path).expect("read kit wasm for terra"),
+                    name: Some(TERRA_COMPONENT_NAME.to_owned()),
                     config: config.encode_into_bytes(),
-                    export: Some("aether.kit.terrain_editor".to_owned()),
+                    export: Some("aether.kit.terra".to_owned()),
                 },
             ),
         )])
-        .expect("load editor sequence");
-    match loaded.reply::<LoadResult>("load_editor").expect("decode editor LoadResult") {
+        .expect("load terra sequence");
+    match loaded.reply::<LoadResult>("load_terra").expect("decode terra LoadResult") {
         LoadResult::Ok { name, .. } => {
-            assert_eq!(name, component_address(EDITOR_COMPONENT_NAME));
+            assert_eq!(name, component_address(TERRA_COMPONENT_NAME));
         }
-        LoadResult::Err { error } => panic!("load terrain editor: {error}"),
+        LoadResult::Err { error } => panic!("load terra: {error}"),
     }
 }
 
@@ -97,37 +96,36 @@ struct AppliedCommand {
     deleted: Vec<MarkRef>,
 }
 
-fn expect_applied(result: TerrainCommandResult) -> AppliedCommand {
+fn expect_applied(result: TerraCommandResult) -> AppliedCommand {
     match result {
-        TerrainCommandResult::Applied { selection, changed, deleted } => AppliedCommand { selection, changed, deleted },
-        other => panic!("expected applied terrain command, got {other:?}"),
+        TerraCommandResult::Applied { selection, changed, deleted } => AppliedCommand { selection, changed, deleted },
+        other => panic!("expected applied terra command, got {other:?}"),
     }
 }
 
 #[test]
 #[allow(clippy::too_many_lines)]
-fn editor_selection_semantics_and_preflight_run_through_real_wasm() {
+fn terra_selection_semantics_and_preflight_run_through_real_wasm() {
     let Some(wasm_path) = require_runtime("aether_kit") else {
         return;
     };
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     let mark_mailbox = load_mark_book(&mut bench, &wasm_path);
-    load_editor(&mut bench, &wasm_path, mark_mailbox);
+    load_terra(&mut bench, &wasm_path, mark_mailbox);
     let mark_address = component_address(MARK_COMPONENT_NAME);
-    let editor_address = component_address(EDITOR_COMPONENT_NAME);
+    let terra_address = component_address(TERRA_COMPONENT_NAME);
 
     let created_point = bench
         .execute(vec![(
-            "editor_create",
+            "terra_create",
             BenchOp::send_and_await(
-                &editor_address,
-                &CreateTerrainMark { geometry: MarkGeometry::Point(WorldPoint::new(10, 20)), label: "camp".to_owned() },
+                &terra_address,
+                &CreateTerraMark { geometry: MarkGeometry::Point(WorldPoint::new(10, 20)), label: "camp".to_owned() },
             ),
         )])
-        .expect("editor create sequence");
-    let created_point = expect_applied(
-        created_point.reply::<TerrainCommandResult>("editor_create").expect("decode editor create result"),
-    );
+        .expect("terra create sequence");
+    let created_point =
+        expect_applied(created_point.reply::<TerraCommandResult>("terra_create").expect("decode terra create result"));
     assert_eq!(created_point.selection, created_point.changed);
     assert_eq!(created_point.changed.len(), 1);
     assert!(created_point.deleted.is_empty());
@@ -157,29 +155,29 @@ fn editor_selection_semantics_and_preflight_run_through_real_wasm() {
     let ordered = vec![area, point, path];
     let selected = bench
         .execute(vec![
-            ("set", BenchOp::send_and_await(&editor_address, &SetTerrainSelection { references: ordered.clone() })),
-            ("query", BenchOp::send_and_await(&editor_address, &TerrainEditorQuery)),
+            ("set", BenchOp::send_and_await(&terra_address, &SetTerraSelection { references: ordered.clone() })),
+            ("query", BenchOp::send_and_await(&terra_address, &TerraQuery)),
         ])
         .expect("set and query sequence");
-    let set = expect_applied(selected.reply::<TerrainCommandResult>("set").expect("decode set result"));
+    let set = expect_applied(selected.reply::<TerraCommandResult>("set").expect("decode set result"));
     assert_eq!(set.selection, ordered);
     assert!(set.changed.is_empty());
     assert!(set.deleted.is_empty());
     assert_eq!(
-        selected.reply::<TerrainEditorQueryResult>("query").expect("decode query result"),
-        TerrainEditorQueryResult { selection: ordered, busy: false }
+        selected.reply::<TerraQueryResult>("query").expect("decode query result"),
+        TerraQueryResult { selection: ordered, busy: false }
     );
 
     let moved = bench
         .execute(vec![(
             "move",
             BenchOp::send_and_await(
-                &editor_address,
-                &MoveTerrainSelection { delta: WorldDelta { x_octimeters: 3, z_octimeters: -2 } },
+                &terra_address,
+                &MoveTerraSelection { delta: WorldDelta { x_octimeters: 3, z_octimeters: -2 } },
             ),
         )])
         .expect("move sequence");
-    let moved = expect_applied(moved.reply::<TerrainCommandResult>("move").expect("decode move result"));
+    let moved = expect_applied(moved.reply::<TerraCommandResult>("move").expect("decode move result"));
     assert_eq!(moved.selection, moved.changed);
     assert_eq!(moved.changed.len(), 3);
     assert!(moved.deleted.is_empty());
@@ -214,10 +212,10 @@ fn editor_selection_semantics_and_preflight_run_through_real_wasm() {
     let relabeled = bench
         .execute(vec![(
             "relabel",
-            BenchOp::send_and_await(&editor_address, &RelabelTerrainSelection { label: "ridge".to_owned() }),
+            BenchOp::send_and_await(&terra_address, &RelabelTerraSelection { label: "ridge".to_owned() }),
         )])
         .expect("relabel sequence");
-    let relabeled = expect_applied(relabeled.reply::<TerrainCommandResult>("relabel").expect("decode relabel result"));
+    let relabeled = expect_applied(relabeled.reply::<TerraCommandResult>("relabel").expect("decode relabel result"));
     assert_eq!(relabeled.selection, relabeled.changed);
     assert!(relabeled.deleted.is_empty());
     for reference in &relabeled.selection {
@@ -254,16 +252,16 @@ fn editor_selection_semantics_and_preflight_run_through_real_wasm() {
         .execute(vec![(
             "stale_move",
             BenchOp::send_and_await(
-                &editor_address,
-                &MoveTerrainSelection { delta: WorldDelta { x_octimeters: 100, z_octimeters: 100 } },
+                &terra_address,
+                &MoveTerraSelection { delta: WorldDelta { x_octimeters: 100, z_octimeters: 100 } },
             ),
         )])
         .expect("stale move sequence");
     assert_eq!(
-        stale_move.reply::<TerrainCommandResult>("stale_move").expect("decode stale move result"),
-        TerrainCommandResult::Rejected {
+        stale_move.reply::<TerraCommandResult>("stale_move").expect("decode stale move result"),
+        TerraCommandResult::Rejected {
             selection: relabeled.selection.clone(),
-            error: TerrainEditorError::StaleReference {
+            error: TerraError::StaleReference {
                 requested: relabeled.selection[stale_index],
                 current: externally_changed,
             },
@@ -286,22 +284,22 @@ fn editor_selection_semantics_and_preflight_run_through_real_wasm() {
         .execute(vec![
             (
                 "set_fresh",
-                BenchOp::send_and_await(&editor_address, &SetTerrainSelection { references: fresh_selection.clone() }),
+                BenchOp::send_and_await(&terra_address, &SetTerraSelection { references: fresh_selection.clone() }),
             ),
-            ("delete", BenchOp::send_and_await(&editor_address, &DeleteTerrainSelection)),
-            ("query", BenchOp::send_and_await(&editor_address, &TerrainEditorQuery)),
+            ("delete", BenchOp::send_and_await(&terra_address, &DeleteTerraSelection)),
+            ("query", BenchOp::send_and_await(&terra_address, &TerraQuery)),
         ])
         .expect("fresh selection and delete sequence");
     assert_eq!(
-        expect_applied(deleted.reply::<TerrainCommandResult>("set_fresh").expect("decode fresh set result")).selection,
+        expect_applied(deleted.reply::<TerraCommandResult>("set_fresh").expect("decode fresh set result")).selection,
         fresh_selection
     );
-    let deleted_result = expect_applied(deleted.reply::<TerrainCommandResult>("delete").expect("decode delete result"));
+    let deleted_result = expect_applied(deleted.reply::<TerraCommandResult>("delete").expect("decode delete result"));
     assert!(deleted_result.selection.is_empty());
     assert!(deleted_result.changed.is_empty());
     assert_eq!(deleted_result.deleted, fresh_selection);
     assert_eq!(
-        deleted.reply::<TerrainEditorQueryResult>("query").expect("decode final query result"),
-        TerrainEditorQueryResult { selection: Vec::new(), busy: false }
+        deleted.reply::<TerraQueryResult>("query").expect("decode final query result"),
+        TerraQueryResult { selection: Vec::new(), busy: false }
     );
 }


### PR DESCRIPTION
Closes #3026

## Summary

- rename the `terrain_editor` module and scenario to `terra`
- move the actor namespace, all 12 wire kinds, Rust editor types, selector, exports, and docs to the Terra vocabulary
- preserve `aether.kit.mark`, `aether.kit.world.pick_terrain`, and the world-geometry `Terrain*` types unchanged

## Verification

- no `terrain_editor` or `TerrainEditor` references remain under `crates/aether-kit`
- `cargo build -p aether-kit`
- `cargo test -p aether-kit` (330 unit tests plus all scenarios, including `terra_scenario`)
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`

Generated by the Aether implement workflow.