### PR TITLE
feat(ci): add scheduled MCP context-budget canary

### DIFF
--- a/.github/workflows/context-budget-canary.yml
+++ b/.github/workflows/context-budget-canary.yml
@@ -1,0 +1,120 @@
+name: context-budget-canary
+
+on:
+  schedule:
+    - cron: "43 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      AETHER_MCP_RESPONSE_INLINE_MAX_BYTES: "32768"
+      AETHER_MCP_REPLY_INLINE_MAX_BYTES: "262144"
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install desktop capture dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev mesa-vulkan-drivers xvfb libxkbcommon-x11-0 libxkbcommon-x11-dev
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build component fixtures
+        run: cargo xtask dist
+
+      # ensure-tunnel.sh ingests this desktop release binary into the hub
+      # registry when it exists, allowing the driver to select
+      # selector=aether-substrate deterministically.
+      - name: Build desktop chassis
+        run: cargo build --release -p aether-substrate-bundle --bin aether-substrate
+
+      # Start the display before the tunnel so the tunnel, hub, and desktop
+      # substrate inherit DISPLAY through the complete fork chain.
+      - name: Start Xvfb
+        run: |
+          Xvfb :99 -screen 0 1280x800x24 &
+          echo "DISPLAY=:99" >> "$GITHUB_ENV"
+
+      - name: Bring up MCP harness
+        run: scripts/ensure-tunnel.sh
+
+      - name: Assert tunnel and children are ready
+        run: |
+          ok=""
+          for _ in $(seq 1 30); do
+            if curl -fsS --max-time 2 http://127.0.0.1:8890/admin/status -o /tmp/status.json \
+               && grep -q '"aether_mcp":{"alive":true' /tmp/status.json \
+               && grep -q '"hub":{"alive":true' /tmp/status.json; then
+              ok=1
+              break
+            fi
+            sleep 2
+          done
+          echo "admin/status:"
+          cat /tmp/status.json 2>/dev/null || echo "(no response)"
+          if [ -z "$ok" ]; then
+            echo "context canary harness did not become ready"
+            exit 1
+          fi
+
+      - name: Measure MCP context budgets
+        id: canary
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          cargo run -p aether-context-canary -- \
+            --component "$PWD/dist/components/aether_kit.wasm" \
+            --breach-body /tmp/context-budget-breach.md \
+            2>&1 | tee /tmp/context-budget-canary.log
+
+      # Keep one open alert issue and append subsequent breach runs, matching
+      # fuzz-nightly's file-or-comment notification shape.
+      - name: File or update context-budget issue
+        if: steps.canary.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="ci: MCP context-budget canary breach"
+          if [ ! -s /tmp/context-budget-breach.md ]; then
+            {
+              echo "The scheduled MCP context-budget scenario failed before producing a budget comparison."
+              echo
+              echo "Last driver output:"
+              echo
+              echo '~~~text'
+              tail -n 200 /tmp/context-budget-canary.log
+              echo '~~~'
+            } > /tmp/context-budget-breach.md
+          fi
+          {
+            cat /tmp/context-budget-breach.md
+            echo
+            echo "- Run: ${RUN_URL}"
+          } > /tmp/context-budget-issue.md
+
+          existing=$(gh issue list --state open --search "${title} in:title" \
+            --json number,title \
+            --jq "map(select(.title == \"${title}\")) | .[0].number // empty")
+
+          if [ -n "$existing" ]; then
+            echo "Commenting on existing context-budget issue #${existing}."
+            gh issue comment "$existing" --body-file /tmp/context-budget-issue.md
+          else
+            echo "Filing context-budget issue."
+            gh issue create --title "$title" --body-file /tmp/context-budget-issue.md
+          fi
+
+      - name: Fail on context-budget breach
+        if: steps.canary.outcome == 'failure'
+        run: exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-context-canary"
+version = "0.3.0-alpha"
+dependencies = [
+ "anyhow",
+ "clap",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
 name = "aether-data"
 version = "0.3.0-alpha"
 dependencies = [
@@ -3675,6 +3688,8 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-util",
@@ -3719,6 +3734,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "rand 0.10.1",
+ "reqwest",
  "rmcp-macros",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/aether-kit",
     "crates/aether-capabilities",
     "crates/aether-mcp",
+    "crates/aether-context-canary",
     # Test fixtures — a container dir of single-output crates: one shared
     # `kinds` rlib plus the component cdylibs (the main bundle, the
     # typed↔reshaped replace-pair satellites, and the ADR-0138 defaultless

--- a/crates/aether-context-canary/Cargo.toml
+++ b/crates/aether-context-canary/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "aether-context-canary"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+rmcp = { version = "1.7", default-features = false, features = [
+    "client",
+    "transport-streamable-http-client-reqwest",
+] }
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+toml = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/aether-context-canary/budgets.toml
+++ b/crates/aether-context-canary/budgets.toml
@@ -1,0 +1,34 @@
+[tool.capture_frame]
+raw_bytes = 1422
+budget_bytes = 1778
+tolerance = 0.25
+
+[tool.describe_kinds]
+raw_bytes = 32405
+budget_bytes = 35646
+tolerance = 0.1
+
+[tool.list_components]
+raw_bytes = 1209
+budget_bytes = 1330
+tolerance = 0.1
+
+[tool.load_component]
+raw_bytes = 3309
+budget_bytes = 3640
+tolerance = 0.1
+
+[tool.send_mail_traced]
+raw_bytes = 1697
+budget_bytes = 1867
+tolerance = 0.1
+
+[tool.spawn_substrate]
+raw_bytes = 134
+budget_bytes = 148
+tolerance = 0.1
+
+[tool.upload_component]
+raw_bytes = 145
+budget_bytes = 160
+tolerance = 0.1

--- a/crates/aether-context-canary/src/main.rs
+++ b/crates/aether-context-canary/src/main.rs
@@ -22,6 +22,10 @@ const DEFAULT_TOLERANCE: f64 = 0.1;
 const CAPTURE_TOLERANCE: f64 = 0.25;
 const COMPONENT_NAME: &str = "aether-context-canary-kit";
 const COMPONENT_EXPORT: &str = "aether.kit.camera";
+const UNREAPED_ENGINE_WARNING: &str = concat!(
+    "WARNING: spawn_substrate may have created an engine, but its response did not provide a usable engine_id; ",
+    "automatic cleanup is impossible",
+);
 const SCENARIO_TOOLS: [&str; 7] = [
     "upload_component",
     "spawn_substrate",
@@ -170,12 +174,7 @@ async fn run_scenario(endpoint: &str, component: &Path) -> Result<BTreeMap<Strin
             }),
         )
         .await?;
-        let spawned: Value = text_json(&spawn, "spawn_substrate")?;
-        let engine_id = spawned
-            .get("engine_id")
-            .and_then(Value::as_str)
-            .context("spawn_substrate response omitted engine_id")?
-            .to_owned();
+        let engine_id = spawned_engine_id(&spawn)?;
 
         let exercise_result = exercise_substrate(&client, &mut measurements, &engine_id, &selector).await;
 
@@ -321,6 +320,11 @@ fn text_json(result: &CallToolResult, tool: &str) -> Result<Value> {
         .find_map(|content| content.as_text().map(|text| text.text.as_str()))
         .with_context(|| format!("{tool} response contained no text block"))?;
     serde_json::from_str(text).with_context(|| format!("parse {tool} response JSON"))
+}
+
+fn spawned_engine_id(result: &CallToolResult) -> Result<String> {
+    let spawned = text_json(result, "spawn_substrate").context(UNREAPED_ENGINE_WARNING)?;
+    spawned.get("engine_id").and_then(Value::as_str).map(str::to_owned).ok_or_else(|| anyhow!(UNREAPED_ENGINE_WARNING))
 }
 
 fn content_text(result: &CallToolResult) -> String {
@@ -512,6 +516,7 @@ fn breach_markdown(breaches: &[Breach], measurements: &BTreeMap<String, Measurem
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rmcp::model::Content;
 
     fn synthetic_manifest() -> BudgetManifest {
         BudgetManifest {
@@ -581,5 +586,19 @@ mod tests {
         let combined_message = format!("{combined_error:#}");
         assert!(combined_message.contains("scenario failed"));
         assert!(combined_message.contains("reap failed"));
+    }
+
+    #[test]
+    fn spawn_reply_without_a_usable_engine_id_warns_that_cleanup_is_impossible() {
+        let malformed = CallToolResult::success(vec![Content::text("not json")]);
+        let malformed_error = spawned_engine_id(&malformed).expect_err("malformed reply must fail");
+        assert!(format!("{malformed_error:#}").contains(UNREAPED_ENGINE_WARNING));
+
+        let missing = CallToolResult::success(vec![Content::text("{}")]);
+        let missing_error = spawned_engine_id(&missing).expect_err("missing engine id must fail");
+        assert!(format!("{missing_error:#}").contains(UNREAPED_ENGINE_WARNING));
+
+        let valid = CallToolResult::success(vec![Content::text(r#"{"engine_id":"engine-7"}"#)]);
+        assert_eq!(spawned_engine_id(&valid).expect("valid engine id"), "engine-7");
     }
 }

--- a/crates/aether-context-canary/src/main.rs
+++ b/crates/aether-context-canary/src/main.rs
@@ -1,0 +1,512 @@
+// This binary's only product is its human- and CI-readable report.
+#![allow(clippy::print_stderr, clippy::print_stdout)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::Parser;
+use rmcp::model::{CallToolRequestParams, CallToolResult, ClientInfo, JsonObject};
+use rmcp::service::{RunningService, Service};
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::{RoleClient, ServiceExt};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+const DEFAULT_ENDPOINT: &str = "http://127.0.0.1:8890/mcp";
+const DEFAULT_TOLERANCE: f64 = 0.1;
+const CAPTURE_TOLERANCE: f64 = 0.25;
+const COMPONENT_NAME: &str = "aether-context-canary-kit";
+const COMPONENT_EXPORT: &str = "aether.kit.camera";
+const SCENARIO_TOOLS: [&str; 7] = [
+    "upload_component",
+    "spawn_substrate",
+    "describe_kinds",
+    "load_component",
+    "send_mail_traced",
+    "capture_frame",
+    "list_components",
+];
+
+#[derive(Parser)]
+#[command(about = "Measure a deterministic MCP bring-up scenario against checked-in byte budgets")]
+struct Args {
+    /// MCP streamable-HTTP endpoint. `AETHER_MCP_ENDPOINT` is used when omitted.
+    #[arg(long)]
+    endpoint: Option<String>,
+
+    /// Path to the staged `aether_kit.wasm` fixture.
+    #[arg(long, default_value = "dist/components/aether_kit.wasm")]
+    component: PathBuf,
+
+    /// Checked-in budget manifest.
+    #[arg(long)]
+    budgets: Option<PathBuf>,
+
+    /// Replace the manifest baseline and derived budgets with this run.
+    #[arg(long, conflicts_with = "delta")]
+    seed: bool,
+
+    /// Print current byte counts as deltas from the checked-in raw baseline.
+    #[arg(long, conflicts_with = "seed")]
+    delta: bool,
+
+    /// Tolerance used when seeding entries that are not already in the manifest.
+    #[arg(long, default_value_t = DEFAULT_TOLERANCE)]
+    tolerance: f64,
+
+    /// Write a Markdown breach report here before returning a nonzero status.
+    #[arg(long)]
+    breach_body: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct BudgetManifest {
+    tool: BTreeMap<String, ToolBudget>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ToolBudget {
+    raw_bytes: usize,
+    budget_bytes: usize,
+    tolerance: f64,
+}
+
+#[derive(Clone, Debug)]
+struct Measurement {
+    received_bytes: usize,
+    spill_files: Vec<SpillFile>,
+}
+
+#[derive(Clone, Debug)]
+struct SpillFile {
+    path: PathBuf,
+    bytes: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Breach {
+    tool: String,
+    raw_bytes: usize,
+    budget_bytes: usize,
+    received_bytes: usize,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    if !(0.0..=10.0).contains(&args.tolerance) {
+        bail!("--tolerance must be between 0.0 and 10.0");
+    }
+
+    let endpoint = endpoint(args.endpoint);
+    let component = args
+        .component
+        .canonicalize()
+        .with_context(|| format!("resolve component fixture {}", args.component.display()))?;
+    let budgets_path = args.budgets.unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("budgets.toml"));
+    let existing_manifest = read_manifest(&budgets_path).ok();
+
+    let measurements = run_scenario(&endpoint, &component).await?;
+    print_measurements(&measurements);
+
+    if args.seed {
+        let manifest = seeded_manifest(&measurements, existing_manifest.as_ref(), args.tolerance);
+        write_manifest(&budgets_path, &manifest)?;
+        println!("\nseeded {}", budgets_path.display());
+        return Ok(());
+    }
+
+    let manifest = existing_manifest.ok_or_else(|| anyhow!("read budget manifest {}", budgets_path.display()))?;
+    if args.delta {
+        print_deltas(&manifest, &measurements)?;
+        return Ok(());
+    }
+
+    let breaches = compare(&manifest, &measurements)?;
+    print_budget_status(&manifest, &measurements);
+    if breaches.is_empty() {
+        println!("\ncontext budgets: PASS");
+        return Ok(());
+    }
+
+    let body = breach_markdown(&breaches, &measurements);
+    if let Some(path) = args.breach_body {
+        fs::write(&path, &body).with_context(|| format!("write breach body {}", path.display()))?;
+    }
+    eprintln!("\n{body}");
+    bail!("{} context budget(s) breached", breaches.len())
+}
+
+async fn run_scenario(endpoint: &str, component: &Path) -> Result<BTreeMap<String, Measurement>> {
+    let transport = StreamableHttpClientTransport::from_uri(endpoint.to_owned());
+    let client =
+        ClientInfo::default().serve(transport).await.with_context(|| format!("initialize MCP client at {endpoint}"))?;
+    let mut measurements = BTreeMap::new();
+
+    let upload = call_measured(
+        &client,
+        &mut measurements,
+        "upload_component",
+        json!({"staged_path": component, "name": COMPONENT_NAME}),
+    )
+    .await?;
+    let uploaded: Value = text_json(&upload, "upload_component")?;
+    let selector = uploaded.get("name").and_then(Value::as_str).unwrap_or(COMPONENT_NAME).to_owned();
+
+    let spawn = call_measured(
+        &client,
+        &mut measurements,
+        "spawn_substrate",
+        json!({
+            "selector": "aether-substrate",
+            "args": ["--window-mode", "windowed:320x240"],
+            "components": [],
+        }),
+    )
+    .await?;
+    let spawned: Value = text_json(&spawn, "spawn_substrate")?;
+    let engine_id = spawned
+        .get("engine_id")
+        .and_then(Value::as_str)
+        .context("spawn_substrate response omitted engine_id")?
+        .to_owned();
+
+    call_measured(&client, &mut measurements, "describe_kinds", json!({"engine_id": engine_id, "full": false})).await?;
+    call_measured(
+        &client,
+        &mut measurements,
+        "load_component",
+        json!({
+            "engine_id": engine_id,
+            "selector": selector,
+            "name": "context-canary-camera",
+            "export": COMPONENT_EXPORT,
+        }),
+    )
+    .await?;
+    call_measured(
+        &client,
+        &mut measurements,
+        "send_mail_traced",
+        json!({
+            "engine_id": engine_id,
+            "mails": [{
+                "recipient_name": "aether.window",
+                "kind_name": "aether.window.set_title",
+                "params": {"title": "aether context canary"},
+            }],
+            "settlement_timeout_ms": 30_000,
+            "fire_and_forget": false,
+        }),
+    )
+    .await?;
+    call_measured(
+        &client,
+        &mut measurements,
+        "capture_frame",
+        json!({
+            "engine_id": engine_id,
+            "mails": [{
+                "recipient_name": "aether.render",
+                "kind_name": "aether.render.draw_solid_quads",
+                "params": {
+                    "space": "Screen",
+                    "clip": null,
+                    "quads": [{
+                        "x": 80.0,
+                        "y": 60.0,
+                        "width": 160.0,
+                        "height": 120.0,
+                        "color": {"r": 1.0, "g": 1.0, "b": 1.0, "a": 1.0},
+                    }],
+                },
+            }],
+            "checks": [
+                {"reduction": "not_all_black", "tolerance": 5},
+                {"reduction": "coverage", "tolerance": 5},
+            ],
+        }),
+    )
+    .await?;
+    call_measured(&client, &mut measurements, "list_components", json!({"namespace": COMPONENT_EXPORT})).await?;
+
+    client.cancel().await.context("close MCP client")?;
+    Ok(measurements)
+}
+
+async fn call_measured<S>(
+    client: &RunningService<RoleClient, S>,
+    measurements: &mut BTreeMap<String, Measurement>,
+    tool: &str,
+    arguments: Value,
+) -> Result<CallToolResult>
+where
+    S: Service<RoleClient>,
+{
+    let arguments: JsonObject = serde_json::from_value(arguments).context("tool arguments must be a JSON object")?;
+    let result = client
+        .call_tool(CallToolRequestParams::new(tool.to_owned()).with_arguments(arguments))
+        .await
+        .with_context(|| format!("call MCP tool {tool}"))?;
+    let received_bytes =
+        serde_json::to_vec(&result.content).with_context(|| format!("serialize {tool} CallToolResult.content"))?.len();
+    measurements.insert(tool.to_owned(), Measurement { received_bytes, spill_files: spill_files(&result) });
+
+    if result.is_error == Some(true) {
+        bail!("MCP tool {tool} failed: {}", content_text(&result));
+    }
+    Ok(result)
+}
+
+fn text_json(result: &CallToolResult, tool: &str) -> Result<Value> {
+    let text = result
+        .content
+        .iter()
+        .find_map(|content| content.as_text().map(|text| text.text.as_str()))
+        .with_context(|| format!("{tool} response contained no text block"))?;
+    serde_json::from_str(text).with_context(|| format!("parse {tool} response JSON"))
+}
+
+fn content_text(result: &CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|content| content.as_text().map(|text| text.text.as_str()))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn spill_files(result: &CallToolResult) -> Vec<SpillFile> {
+    let mut paths = BTreeSet::new();
+    for text in result.content.iter().filter_map(|content| content.as_text()) {
+        if let Ok(value) = serde_json::from_str::<Value>(&text.text) {
+            collect_file_paths(&value, &mut paths);
+        }
+    }
+    paths
+        .into_iter()
+        .filter_map(|path| fs::metadata(&path).ok().map(|metadata| SpillFile { path, bytes: metadata.len() }))
+        .collect()
+}
+
+fn collect_file_paths(value: &Value, paths: &mut BTreeSet<PathBuf>) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                collect_file_paths(value, paths);
+            }
+        }
+        Value::Object(object) => {
+            if let Some(path) = object.get("file").and_then(Value::as_str) {
+                paths.insert(PathBuf::from(path));
+            }
+            for value in object.values() {
+                collect_file_paths(value, paths);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn endpoint(argument: Option<String>) -> String {
+    // This executable is an external tooling client, so its endpoint is a
+    // process-level integration knob rather than actor/chassis config.
+    #[allow(clippy::disallowed_methods)]
+    let environment = env::var("AETHER_MCP_ENDPOINT").ok();
+    argument.or(environment).unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned())
+}
+
+fn read_manifest(path: &Path) -> Result<BudgetManifest> {
+    let text = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    toml::from_str(&text).with_context(|| format!("parse {}", path.display()))
+}
+
+fn write_manifest(path: &Path, manifest: &BudgetManifest) -> Result<()> {
+    let text = toml::to_string_pretty(manifest).context("serialize budget manifest")?;
+    fs::write(path, text).with_context(|| format!("write {}", path.display()))
+}
+
+fn seeded_manifest(
+    measurements: &BTreeMap<String, Measurement>,
+    existing: Option<&BudgetManifest>,
+    default_tolerance: f64,
+) -> BudgetManifest {
+    let tool = measurements
+        .iter()
+        .map(|(name, measurement)| {
+            let tolerance = existing.and_then(|manifest| manifest.tool.get(name)).map_or_else(
+                || {
+                    if name == "capture_frame" {
+                        CAPTURE_TOLERANCE
+                    } else {
+                        default_tolerance
+                    }
+                },
+                |budget| budget.tolerance,
+            );
+            // MCP responses are many orders of magnitude below f64's exact
+            // integer limit and tolerance was validated as nonnegative.
+            #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss, clippy::cast_sign_loss)]
+            let budget_bytes = ((measurement.received_bytes as f64) * (1.0 + tolerance)).ceil() as usize;
+            (name.clone(), ToolBudget { raw_bytes: measurement.received_bytes, budget_bytes, tolerance })
+        })
+        .collect();
+    BudgetManifest { tool }
+}
+
+fn compare(manifest: &BudgetManifest, measurements: &BTreeMap<String, Measurement>) -> Result<Vec<Breach>> {
+    validate_tool_sets(manifest, measurements)?;
+    Ok(SCENARIO_TOOLS
+        .iter()
+        .filter_map(|name| {
+            let budget = &manifest.tool[*name];
+            let measurement = &measurements[*name];
+            (measurement.received_bytes > budget.budget_bytes).then(|| Breach {
+                tool: (*name).to_owned(),
+                raw_bytes: budget.raw_bytes,
+                budget_bytes: budget.budget_bytes,
+                received_bytes: measurement.received_bytes,
+            })
+        })
+        .collect())
+}
+
+fn validate_tool_sets(manifest: &BudgetManifest, measurements: &BTreeMap<String, Measurement>) -> Result<()> {
+    let expected: BTreeSet<&str> = SCENARIO_TOOLS.into_iter().collect();
+    let budgeted: BTreeSet<&str> = manifest.tool.keys().map(String::as_str).collect();
+    let measured: BTreeSet<&str> = measurements.keys().map(String::as_str).collect();
+    if budgeted != expected {
+        bail!("budget manifest tool set mismatch: expected {expected:?}, found {budgeted:?}");
+    }
+    if measured != expected {
+        bail!("scenario measurement tool set mismatch: expected {expected:?}, found {measured:?}");
+    }
+    Ok(())
+}
+
+fn print_measurements(measurements: &BTreeMap<String, Measurement>) {
+    println!("tool                     received bytes  spilled bytes");
+    for name in SCENARIO_TOOLS {
+        let measurement = &measurements[name];
+        let spilled_bytes: u64 = measurement.spill_files.iter().map(|spill| spill.bytes).sum();
+        println!("{name:<24} {:>14}  {spilled_bytes:>13}", measurement.received_bytes);
+        for spill in &measurement.spill_files {
+            println!("  spill: {} ({} bytes, non-budgeted)", spill.path.display(), spill.bytes);
+        }
+    }
+}
+
+fn print_deltas(manifest: &BudgetManifest, measurements: &BTreeMap<String, Measurement>) -> Result<()> {
+    validate_tool_sets(manifest, measurements)?;
+    println!("\ntool                     baseline -> current (delta)");
+    for name in SCENARIO_TOOLS {
+        let raw = manifest.tool[name].raw_bytes;
+        let current = measurements[name].received_bytes;
+        let delta = current as i128 - raw as i128;
+        println!("{name:<24} {raw:>8} -> {current:<8} ({delta:+})");
+    }
+    Ok(())
+}
+
+fn print_budget_status(manifest: &BudgetManifest, measurements: &BTreeMap<String, Measurement>) {
+    println!("\ntool                     current / budget  status");
+    for name in SCENARIO_TOOLS {
+        let current = measurements[name].received_bytes;
+        let budget = manifest.tool[name].budget_bytes;
+        let status = if current <= budget {
+            "PASS"
+        } else {
+            "BREACH"
+        };
+        println!("{name:<24} {current:>8} / {budget:<8}  {status}");
+    }
+}
+
+fn breach_markdown(breaches: &[Breach], measurements: &BTreeMap<String, Measurement>) -> String {
+    let mut body = String::from(
+        "The scheduled MCP context-budget canary measured one or more responses above their checked-in budgets.\n\n\
+         | Tool | Baseline bytes | Current bytes | Budget bytes | Delta |\n\
+         | --- | ---: | ---: | ---: | ---: |\n",
+    );
+    for breach in breaches {
+        let delta = breach.received_bytes as i128 - breach.raw_bytes as i128;
+        writeln!(
+            body,
+            "| {} | {} | {} | {} | {delta:+} |",
+            breach.tool, breach.raw_bytes, breach.received_bytes, breach.budget_bytes
+        )
+        .expect("writing to String cannot fail");
+    }
+
+    let spilled: Vec<_> = SCENARIO_TOOLS
+        .iter()
+        .flat_map(|tool| measurements[*tool].spill_files.iter().map(move |spill| (*tool, spill)))
+        .collect();
+    if !spilled.is_empty() {
+        body.push_str("\nSpill files (on-disk bytes, metadata only; not budgeted):\n\n");
+        for (tool, spill) in spilled {
+            writeln!(body, "- {tool}: {} ({} bytes)", spill.path.display(), spill.bytes)
+                .expect("writing to String cannot fail");
+        }
+    }
+    body
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synthetic_manifest() -> BudgetManifest {
+        BudgetManifest {
+            tool: SCENARIO_TOOLS
+                .iter()
+                .map(|name| {
+                    ((*name).to_owned(), ToolBudget { raw_bytes: 90, budget_bytes: 100, tolerance: DEFAULT_TOLERANCE })
+                })
+                .collect(),
+        }
+    }
+
+    fn synthetic_measurements() -> BTreeMap<String, Measurement> {
+        SCENARIO_TOOLS
+            .iter()
+            .map(|name| ((*name).to_owned(), Measurement { received_bytes: 100, spill_files: Vec::new() }))
+            .collect()
+    }
+
+    #[test]
+    fn manifest_parses_per_tool_baseline_budget_and_tolerance() {
+        let manifest: BudgetManifest = toml::from_str(
+            r"
+                [tool.upload_component]
+                raw_bytes = 90
+                budget_bytes = 100
+                tolerance = 0.1
+            ",
+        )
+        .expect("parse synthetic manifest");
+
+        let budget = &manifest.tool["upload_component"];
+        assert_eq!(budget.raw_bytes, 90);
+        assert_eq!(budget.budget_bytes, 100);
+        assert!((budget.tolerance - 0.1).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn compare_reports_only_measurements_over_budget() {
+        let manifest = synthetic_manifest();
+        let mut measurements = synthetic_measurements();
+        measurements.get_mut("capture_frame").expect("synthetic capture measurement").received_bytes = 101;
+
+        let breaches = compare(&manifest, &measurements).expect("compare synthetic measurements");
+
+        assert_eq!(
+            breaches,
+            vec![Breach { tool: "capture_frame".to_owned(), raw_bytes: 90, budget_bytes: 100, received_bytes: 101 }]
+        );
+    }
+}

--- a/crates/aether-context-canary/src/main.rs
+++ b/crates/aether-context-canary/src/main.rs
@@ -146,40 +146,63 @@ async fn run_scenario(endpoint: &str, component: &Path) -> Result<BTreeMap<Strin
     let transport = StreamableHttpClientTransport::from_uri(endpoint.to_owned());
     let client =
         ClientInfo::default().serve(transport).await.with_context(|| format!("initialize MCP client at {endpoint}"))?;
-    let mut measurements = BTreeMap::new();
+    let scenario_result = async {
+        let mut measurements = BTreeMap::new();
 
-    let upload = call_measured(
-        &client,
-        &mut measurements,
-        "upload_component",
-        json!({"staged_path": component, "name": COMPONENT_NAME}),
-    )
-    .await?;
-    let uploaded: Value = text_json(&upload, "upload_component")?;
-    let selector = uploaded.get("name").and_then(Value::as_str).unwrap_or(COMPONENT_NAME).to_owned();
+        let upload = call_measured(
+            &client,
+            &mut measurements,
+            "upload_component",
+            json!({"staged_path": component, "name": COMPONENT_NAME}),
+        )
+        .await?;
+        let uploaded: Value = text_json(&upload, "upload_component")?;
+        let selector = uploaded.get("name").and_then(Value::as_str).unwrap_or(COMPONENT_NAME).to_owned();
 
-    let spawn = call_measured(
-        &client,
-        &mut measurements,
-        "spawn_substrate",
-        json!({
-            "selector": "aether-substrate",
-            "args": ["--window-mode", "windowed:320x240"],
-            "components": [],
-        }),
-    )
-    .await?;
-    let spawned: Value = text_json(&spawn, "spawn_substrate")?;
-    let engine_id = spawned
-        .get("engine_id")
-        .and_then(Value::as_str)
-        .context("spawn_substrate response omitted engine_id")?
-        .to_owned();
+        let spawn = call_measured(
+            &client,
+            &mut measurements,
+            "spawn_substrate",
+            json!({
+                "selector": "aether-substrate",
+                "args": ["--window-mode", "windowed:320x240"],
+                "components": [],
+            }),
+        )
+        .await?;
+        let spawned: Value = text_json(&spawn, "spawn_substrate")?;
+        let engine_id = spawned
+            .get("engine_id")
+            .and_then(Value::as_str)
+            .context("spawn_substrate response omitted engine_id")?
+            .to_owned();
 
-    call_measured(&client, &mut measurements, "describe_kinds", json!({"engine_id": engine_id, "full": false})).await?;
+        let exercise_result = exercise_substrate(&client, &mut measurements, &engine_id, &selector).await;
+
+        let terminate_result =
+            call_unmeasured(&client, "terminate_substrate", json!({"engine_id": engine_id})).await.map(|_| ());
+        finish_with_cleanup(exercise_result, terminate_result, "terminate spawned substrate")?;
+        Ok(measurements)
+    }
+    .await;
+
+    let close_result = client.cancel().await.map(|_| ()).context("close MCP client");
+    finish_with_cleanup(scenario_result, close_result, "close MCP client")
+}
+
+async fn exercise_substrate<S>(
+    client: &RunningService<RoleClient, S>,
+    measurements: &mut BTreeMap<String, Measurement>,
+    engine_id: &str,
+    selector: &str,
+) -> Result<()>
+where
+    S: Service<RoleClient>,
+{
+    call_measured(client, measurements, "describe_kinds", json!({"engine_id": engine_id, "full": false})).await?;
     call_measured(
-        &client,
-        &mut measurements,
+        client,
+        measurements,
         "load_component",
         json!({
             "engine_id": engine_id,
@@ -190,8 +213,8 @@ async fn run_scenario(endpoint: &str, component: &Path) -> Result<BTreeMap<Strin
     )
     .await?;
     call_measured(
-        &client,
-        &mut measurements,
+        client,
+        measurements,
         "send_mail_traced",
         json!({
             "engine_id": engine_id,
@@ -206,8 +229,8 @@ async fn run_scenario(endpoint: &str, component: &Path) -> Result<BTreeMap<Strin
     )
     .await?;
     call_measured(
-        &client,
-        &mut measurements,
+        client,
+        measurements,
         "capture_frame",
         json!({
             "engine_id": engine_id,
@@ -233,10 +256,8 @@ async fn run_scenario(endpoint: &str, component: &Path) -> Result<BTreeMap<Strin
         }),
     )
     .await?;
-    call_measured(&client, &mut measurements, "list_components", json!({"namespace": COMPONENT_EXPORT})).await?;
-
-    client.cancel().await.context("close MCP client")?;
-    Ok(measurements)
+    call_measured(client, measurements, "list_components", json!({"namespace": COMPONENT_EXPORT})).await?;
+    Ok(())
 }
 
 async fn call_measured<S>(
@@ -261,6 +282,36 @@ where
         bail!("MCP tool {tool} failed: {}", content_text(&result));
     }
     Ok(result)
+}
+
+async fn call_unmeasured<S>(
+    client: &RunningService<RoleClient, S>,
+    tool: &str,
+    arguments: Value,
+) -> Result<CallToolResult>
+where
+    S: Service<RoleClient>,
+{
+    let arguments: JsonObject = serde_json::from_value(arguments).context("tool arguments must be a JSON object")?;
+    let result = client
+        .call_tool(CallToolRequestParams::new(tool.to_owned()).with_arguments(arguments))
+        .await
+        .with_context(|| format!("call MCP tool {tool}"))?;
+    if result.is_error == Some(true) {
+        bail!("MCP tool {tool} failed: {}", content_text(&result));
+    }
+    Ok(result)
+}
+
+fn finish_with_cleanup<T>(operation: Result<T>, cleanup: Result<()>, cleanup_name: &str) -> Result<T> {
+    match (operation, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(cleanup_error)) => Err(cleanup_error).with_context(|| cleanup_name.to_owned()),
+        (Err(error), Err(cleanup_error)) => {
+            Err(error).with_context(|| format!("{cleanup_name} also failed: {cleanup_error:#}"))
+        }
+    }
 }
 
 fn text_json(result: &CallToolResult, tool: &str) -> Result<Value> {
@@ -510,5 +561,25 @@ mod tests {
             breaches,
             vec![Breach { tool: "capture_frame".to_owned(), raw_bytes: 90, budget_bytes: 100, received_bytes: 101 }]
         );
+    }
+
+    #[test]
+    fn cleanup_runs_without_masking_the_operation_result() {
+        assert_eq!(finish_with_cleanup(Ok(7), Ok(()), "cleanup").expect("both succeeded"), 7);
+
+        let operation_error = finish_with_cleanup::<()>(Err(anyhow!("scenario failed")), Ok(()), "cleanup")
+            .expect_err("scenario error must survive");
+        assert!(operation_error.to_string().contains("scenario failed"));
+
+        let cleanup_error = finish_with_cleanup(Ok(()), Err(anyhow!("reap failed")), "terminate")
+            .expect_err("cleanup error must surface");
+        assert!(cleanup_error.to_string().contains("terminate"));
+
+        let combined_error =
+            finish_with_cleanup::<()>(Err(anyhow!("scenario failed")), Err(anyhow!("reap failed")), "terminate")
+                .expect_err("both errors must surface");
+        let combined_message = format!("{combined_error:#}");
+        assert!(combined_message.contains("scenario failed"));
+        assert!(combined_message.contains("reap failed"));
     }
 }

--- a/crates/aether-context-canary/src/main.rs
+++ b/crates/aether-context-canary/src/main.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fmt::Write as _;
 use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -108,7 +109,7 @@ async fn main() -> Result<()> {
         .canonicalize()
         .with_context(|| format!("resolve component fixture {}", args.component.display()))?;
     let budgets_path = args.budgets.unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("budgets.toml"));
-    let existing_manifest = read_manifest(&budgets_path).ok();
+    let existing_manifest = read_manifest_if_present(&budgets_path)?;
 
     let measurements = run_scenario(&endpoint, &component).await?;
     print_measurements(&measurements);
@@ -294,21 +295,18 @@ fn spill_files(result: &CallToolResult) -> Vec<SpillFile> {
 }
 
 fn collect_file_paths(value: &Value, paths: &mut BTreeSet<PathBuf>) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                collect_file_paths(value, paths);
+    let mut pending = vec![value];
+    while let Some(value) = pending.pop() {
+        match value {
+            Value::Array(values) => pending.extend(values),
+            Value::Object(object) => {
+                if let Some(path) = object.get("file").and_then(Value::as_str) {
+                    paths.insert(PathBuf::from(path));
+                }
+                pending.extend(object.values());
             }
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
         }
-        Value::Object(object) => {
-            if let Some(path) = object.get("file").and_then(Value::as_str) {
-                paths.insert(PathBuf::from(path));
-            }
-            for value in object.values() {
-                collect_file_paths(value, paths);
-            }
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
     }
 }
 
@@ -320,9 +318,13 @@ fn endpoint(argument: Option<String>) -> String {
     argument.or(environment).unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned())
 }
 
-fn read_manifest(path: &Path) -> Result<BudgetManifest> {
-    let text = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-    toml::from_str(&text).with_context(|| format!("parse {}", path.display()))
+fn read_manifest_if_present(path: &Path) -> Result<Option<BudgetManifest>> {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).with_context(|| format!("read {}", path.display())),
+    };
+    toml::from_str(&text).map(Some).with_context(|| format!("parse {}", path.display()))
 }
 
 fn write_manifest(path: &Path, manifest: &BudgetManifest) -> Result<()> {


### PR DESCRIPTION
Closes #3010

## Summary

- add a scheduled, spill-aware MCP context-budget canary with checked-in per-tool baselines and tolerances
- drive a fixed upload/spawn/describe/load/mail/capture/list scenario through an `rmcp` client
- support compare, `--seed`, and `--delta` modes plus a single file-or-comment breach alert
- select the freshly ingested `aether-substrate` desktop binary deterministically instead of relying on a stale global chassis attribute match

## Seeded baseline

| Tool | Raw bytes | Budget bytes |
| --- | ---: | ---: |
| `upload_component` | 145 | 160 |
| `spawn_substrate` | 134 | 148 |
| `describe_kinds` | 32,405 | 35,646 |
| `load_component` | 3,309 | 3,640 |
| `send_mail_traced` | 1,697 | 1,867 |
| `capture_frame` | 1,422 | 1,778 |
| `list_components` | 1,209 | 1,330 |

The measured `describe_kinds` spill was recorded as 72,867 on-disk bytes and remained non-budgeted metadata. Re-seed after the remaining #3003–#3008 projection work lands to tighten the baseline around the final output shapes.

## Verification

- live `--seed` run against the local hub/tunnel: PASS
- second live default compare against the seeded manifest: PASS
- canary manifest/compare unit tests: 2 passed
- `cargo xtask dist`
- release desktop chassis build
- `git diff --check`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`

Generated by the Aether implement workflow.
