### PR TITLE
fix(workflow): deep wish pass correctness gaps

### DIFF
--- a/.claude/skills/wish/SKILL.md
+++ b/.claude/skills/wish/SKILL.md
@@ -173,7 +173,7 @@ Minimal frontmatter, then free-form prose. No internal `##` headers — the pros
 ```markdown
 ---
 wish: I wish I could <X> so that I could <Y>.
-adversity: data | empathy
+adversity: data | empathy | parent-absence # non-root: the parent's unresolved absence
 parent: ../wish.md                # omit if root
 supports:                           # optional, only if branch-overlap with memory
   - "[[memory-entry-name]]"
@@ -257,7 +257,7 @@ A global best-first priority frontier of scored nodes, seeded from the roots the
 
 ### Adversarial terminality
 
-When a driller claims `producible: true`, an adversarial skeptic agent gates the claim against one bar: is there a hidden unknown that is itself **wish-worthy** — a genuine production-blocking gap, not a decision the driller could resolve inline by picking an obvious default? A wish-worthy unknown is a surface the driller assumed without grep-confirming it (and the skeptic cannot confirm either), a step not writable within current resources, or a "known mean" that is really another wish. Whether a struct carries some field, what a parameter defaults to, what something is named, or that a parent is not built yet (true of every node above a leaf) are inline decisions the driller records in its own `wish.md`, never children. The default is terminal: the skeptic returns no unknown unless it can point at a specific production-blocking gap, because there is always some unverified nit and a nit is not a wish. When it does find a wish-worthy unknown, that becomes a child and the node keeps drilling — the mechanism that kills the "good enough" shortcut without manufacturing children out of trivia. The same bar lives on the driller contract, since the skeptic only ever sees a `producible: true` claim: a driller that emits trivial children directly is held to the wish-worthy rule in its own prompt, closing the second source of the spiral.
+When a driller claims `producible: true`, an adversarial skeptic agent gates the claim against one bar: is there a hidden unknown that is itself **wish-worthy** — a genuine production-blocking gap, not a decision the driller could resolve inline by picking an obvious default? A wish-worthy unknown is a surface the driller assumed without grep-confirming it (and the skeptic cannot confirm either), a step not writable within current resources, or a "known mean" that is really another wish. Whether a struct carries some field, what a parameter defaults to, what something is named, or that a parent is not built yet (true of every node above a leaf) are inline decisions the driller records in its own `wish.md`, never children. The default is terminal: the skeptic returns no unknown unless it can point at a specific production-blocking gap, because there is always some unverified nit and a nit is not a wish. When it does find a wish-worthy unknown, the node is demoted and the branch continues through that pushed child; the demoted node itself is not re-drilled. This is the mechanism that kills the "good enough" shortcut without manufacturing children out of trivia. The same bar lives on the driller contract, since the skeptic only ever sees a `producible: true` claim: a driller that emits trivial children directly is held to the wish-worthy rule in its own prompt, closing the second source of the spiral.
 
 ### Synthesis
 
@@ -311,12 +311,13 @@ For each root, recursively:
 On `--deep`, run steps 1 (pre-load adversity) and 2 (generate roots) inline in the main context — the judgment-and-memory-bound front of the pass — then hand drilling to the `wish` workflow instead of recursing inline. The hand-off:
 
 1. **Score each root.** For every root from step 2, assign an initial `doors_opened` (leverage, 1-5) and `unresolvedness` (distance-from-plan, 1-5). These seed the frontier's scoring.
-2. **Compute `wishDir`.** The absolute path to `wishes/<YYYY-MM-DD>-<theme-slug>/`. Create the directory so the drillers have a place to write.
+2. **Compute `wishDir`.** Resolve the main working checkout as the first entry of `git worktree list`, then append `/wishes/<YYYY-MM-DD>-<theme-slug>/` to that absolute path. Never use the current session/agent worktree. Create the directory so the drillers have a durable place to write even when the invoking worktree is later swept.
 3. **Gather `groundingNotes`.** The grep-confirmed engine surfaces from step 1, as a short shared block, so the drillers extend the grounding rather than each re-deriving it.
-4. **Call the workflow.** `Workflow({name: "wish", args: {theme, role, beam, budget, roots, wishDir, groundingNotes}})` — `roots` is `[{slug, wish, doors_opened, unresolvedness}]`; `beam` and `budget` come from the flags (defaults 3 and 40); `role` is null if not given. The workflow holds the best-first frontier, spawns the parallel drillers + the skeptic gate + the synthesis writer, and the agents write every `wish.md` and `index.md` themselves.
-5. **Report from the returned stats.** On completion the workflow returns `{rootCount, totalNodes, leafCount, maxDepth, skepticDemotions, undrilled, ...}`. Print the deep-mode report (step 8) from those, and surface that the tree is on disk and resumable.
+4. **Gather `existingWork`.** Build a compact digest of open-issue titles plus the recent ADR and commit mechanisms already scanned in step 1, matching the sources used by step 4's existing-work filter. The synthesis agent uses this once, after drilling, to identify duplicated terminal leaves.
+5. **Call the workflow.** `Workflow({name: "wish", args: {theme, role, beam, budget, roots, wishDir, groundingNotes, existingWork}})` — `roots` is `[{slug, wish, doors_opened, unresolvedness}]`; `beam` and `budget` come from the flags (defaults 3 and 40); `role` is null if not given. The workflow holds the best-first frontier, spawns the parallel drillers + the read-only skeptic gate + demotion-time reconcile writers + the synthesis writer, and the agents write every `wish.md` and `index.md` themselves.
+6. **Report from the returned stats.** On completion the workflow returns `{rootCount, totalNodes, leafCount, maxDepth, skepticDemotions, undrilled, ...}`. Print the deep-mode report (step 8) from those, and surface that the tree is on disk and resumable.
 
-Deep mode does not run steps 4-7 inline — filtering and the on-disk write are the drillers' and synthesis agent's job inside the workflow. Step 8's report template has a deep-mode variant.
+Deep mode gathers step 4's existing-work inputs inline but leaves leaf deduplication to synthesis; it does not run the remainder of steps 4-7 inline. The driller, reconcile, and synthesis agents own the on-disk writes inside the workflow. Step 8's report template has a deep-mode variant.
 
 ### 4. Filter against existing work (tree-aware)
 
@@ -386,10 +387,10 @@ Deep mode (`--deep`) reports from the workflow's returned stats instead:
   Theme: <theme>[, as <role>]   (deep mode — beam <N>, budget <M>)
   Tree: <rootCount> roots, <totalNodes> nodes drilled, max depth <maxDepth>
   Plans (leaves): <leafCount>     Skeptic demotions: <skepticDemotions> (caught "good enough")
-  Frontier left undrilled (budget-bounded stubs): <undrilled>
+  Resumable undrilled (budget-bounded frontier + diminishing-returns stubs): <undrilled>
   Index: wishes/<date>-<theme>/index.md
 
-Weighted sketches (<leafCount> leaves):
+Weighted sketches (<sketches.length> non-duplicate leaves):
   - [<slug-chain>] (<weight: S|M|L|XL>) <wish> — <recommendation>
   ... (one line per leaf from sketches array)
 

--- a/.claude/workflows/wish.js
+++ b/.claude/workflows/wish.js
@@ -22,8 +22,9 @@ export const meta = {
 //   beam,            number  — fan-out width per round (default 3); the depth-vs-breadth knob
 //   budget,          number  — max driller agents the loop spawns (default 40); the size knob
 //   roots,           [{ slug, wish, doors_opened, unresolvedness }]  — generated inline by the skill
-//   wishDir,         string  — ABSOLUTE path to wishes/<date>-<theme>/ (agents write here)
+//   wishDir,         string  — ABSOLUTE path to the main worktree's wishes/<date>-<theme>/ (agents write here)
 //   groundingNotes,  string  — shared grep-confirmed engine surfaces from the skill's step-1 scan
+//   existingWork,    string  — digest of open-issue titles plus recent ADR/commit mechanisms
 // }
 //
 // NOTE on the name `budget`: the harness injects a per-turn TOKEN budget as a
@@ -39,6 +40,7 @@ const beam = Math.max(1, Number.isFinite(A.beam) ? A.beam : 3)
 const drillBudget = Math.max(1, Number.isFinite(A.budget) ? A.budget : 40)
 const wishDir = A.wishDir || ''
 const groundingNotes = A.groundingNotes || ''
+const existingWork = A.existingWork || ''
 const roots = Array.isArray(A.roots) ? A.roots : []
 
 if (!theme || !wishDir || roots.length === 0) {
@@ -79,7 +81,7 @@ const DRILL_SCHEMA = {
 
 // The synthesis agent returns per-leaf weights so the workflow can build a
 // structured sketches array without a second agent pass. One entry per terminal
-// leaf (producible:true && no children). Weight follows the /scope Size rubric:
+// leaf (producible:true && no children) not dropped as duplicate existing work. Weight follows the /scope Size rubric:
 // skinny = S/M/L (one focused PR), fat = XL (multi-PR arc, decompose first).
 const SKETCH_SCHEMA = {
   type: 'object',
@@ -88,7 +90,7 @@ const SKETCH_SCHEMA = {
   properties: {
     sketches: {
       type: 'array',
-      description: 'one entry per terminal leaf (producible && no children), in slug-chain order',
+      description: 'one entry per non-duplicate terminal leaf (producible && no children), in slug-chain order',
       items: {
         type: 'object',
         additionalProperties: false,
@@ -106,7 +108,7 @@ const SKETCH_SCHEMA = {
 
 // A skeptic runs ONLY on a producible:true claim. It must FAIL to find a hidden
 // unknown before the node counts terminal. A found unknown re-enters the frontier
-// as a child and the node keeps drilling — this is what kills "good enough".
+// as a child, so the branch continues through that child while the demoted node is not re-drilled.
 const SKEPTIC_SCHEMA = {
   type: 'object',
   additionalProperties: false,
@@ -136,7 +138,7 @@ const WISH_MD_SHAPE =
   '```\n' +
   '---\n' +
   'wish: I wish I could <X> so that I could <Y>.\n' +
-  'adversity: data | empathy\n' +
+  'adversity: data | empathy | parent-absence # non-root: the parent\'s unresolved absence\n' +
   'parent: ../wish.md            # omit if this node is a root\n' +
   'producible: true | false      # true means this wish IS a plan\n' +
   'grounded_surfaces:             # re-greppable `identifier` — crates/aether-*/src/path citations\n' +
@@ -219,25 +221,39 @@ const skepticPrompt = (node, res) =>
   'Otherwise — every leaned-on surface checks out and what remains is inline decisions — ' +
   'return hidden_unknown_found:false and unknown:null with a rationale naming what you verified.\n\nStructured output only.'
 
-const synthPrompt = (indexPath, nodeBlock, stubBlock, leafBlock, stats) =>
+const reconcilePrompt = ({ file, node, unknown }) =>
+  '## Reconcile a skeptic-demoted wish\n\n' +
+  'A read-only skeptic found a production-blocking absence after the driller wrote this node as producible. ' +
+  'Edit the existing wish.md at this EXACT path:\n  ' + file + '\n\n' +
+  'Wish: ' + node.wish + '\n' +
+  'Newly surfaced child: ' + unknown.wish + '\n\n' +
+  'Make only these two changes: set the frontmatter `producible: true` value to `producible: false`, and append ' +
+  'one prose paragraph (no header) naming the newly surfaced child wish as the production-blocking absence. ' +
+  'Preserve every other frontmatter field and all existing prose. You MUST edit the wish.md file.'
+
+const synthPrompt = ({ indexPath, nodeBlock, frontierBlock, stubBlock, leafBlock, stats, existingWork }) =>
   '## Wish-tree synthesis — write the index\n\n' +
   'A /wish --deep pass drilled this tree node by node; each node below is one bounded summary (the fan-out spent ' +
   'the cross-branch coherence, your job is to recover it). Theme: ' + theme + (role ? ' (as ' + role + ')' : '') + '.\n\n' +
   '## Nodes (path · producible · wish · summary)\n' + nodeBlock + '\n\n' +
+  '## Existing work (flag any duplicated terminal leaf in considered-and-dropped)\n' +
+  (existingWork || '(none provided)') + '\n\n' +
+  '## Budget-bounded frontier (undrilled; resumable via /wish --under)\n' + frontierBlock + '\n\n' +
   '## Diminishing-returns stubs (recorded undrilled — score collapsed below half the parent past depth 3; resumable via /wish --under)\n' + stubBlock + '\n\n' +
   '## Terminal leaves to weigh (producible plans — assign skinny/fat weight)\n' + leafBlock + '\n\n' +
   '## Stats\n' +
   'roots: ' + stats.rootCount + '  ·  drilled nodes: ' + stats.totalNodes + '  ·  plans (leaves): ' + stats.leafCount +
   '  ·  max depth: ' + stats.maxDepth + '  ·  skeptic demotions: ' + stats.skepticDemotions +
-  '  ·  named-but-undrilled (budget-bounded): ' + stats.undrilled + '\n\n' +
+  '  ·  named-but-undrilled (frontier + stubs): ' + stats.undrilled + '\n\n' +
   '## Task\nWrite index.md to the EXACT path:\n  ' + indexPath + '\n' +
   'It is the navigation surface, not a duplicate of the wish bodies. Include: date, theme, role; the list of root ' +
   'wishes with one-line summaries; the deep-spine map (which high-leverage branches drilled deep vs which stayed ' +
   'stubs, and WHY — the cross-branch coherence); the skeptic-demoted nodes (where "good enough" was caught); the ' +
-  'diminishing-returns stub list above (collapsing-score branches that self-terminated, resumable via /wish --under); the ' +
-  'stats above; and a short notes paragraph.\n\n' +
+  'budget-bounded frontier and diminishing-returns stub lists above as two distinct categories, both resumable via ' +
+  '/wish --under; a considered-and-dropped entry for every terminal leaf that duplicates the existing-work digest ' +
+  '(omit those duplicate leaves from weighted sketches); the stats above; and a short notes paragraph.\n\n' +
   'Additionally, write a ## Weighted sketches section at the end of index.md — one bullet per terminal leaf ' +
-  '(the leaves listed in "Terminal leaves to weigh" above). Each bullet: `- [slug-path] (WEIGHT) wish-text — recommendation`. ' +
+  'not dropped as duplicate existing work. Each bullet: `- [slug-path] (WEIGHT) wish-text — recommendation`. ' +
   'Assign weight using the /scope Size rubric: S = single-file/concept change (one small PR); M = single-crate/multiple files; ' +
   'L = cross-crate or architectural change; XL = multi-PR arc that must be decomposed before scoping. ' +
   'S/M/L = skinny (one focused PR, ready for /sketch then /scope). XL = fat (decompose first via /wish --under or file fat for sweep fat). ' +
@@ -287,9 +303,10 @@ const drillNode = async (node) => {
   if (producible) {
     const sk = await agent(skepticPrompt(node, res), { label: 'skeptic:' + node.slug, phase: 'Drill', schema: SKEPTIC_SCHEMA, agentType: 'Explore' })
     if (sk && sk.hidden_unknown_found && sk.unknown) {
-      producible = false   // demoted — the node keeps drilling
+      producible = false   // demoted — the branch continues through the pushed child; this node is not re-drilled
       demoted = true
       children.push(sk.unknown)
+      await agent(reconcilePrompt({ file, node, unknown: sk.unknown }), { label: 'reconcile:' + node.slug, phase: 'Drill' })
       log('skeptic demoted [' + node.slug + ']: ' + sk.unknown.slug)
     }
   }
@@ -367,6 +384,14 @@ const nodeBlock = summaries
   .map(s => '- [' + s.slugChain.join('/') + '] (' + (s.producible ? 'plan' : 'wish') + ') ' + s.wish + '\n    ' + s.summary)
   .join('\n')
 
+const frontierBlock = frontier.length
+  ? frontier
+      .slice()
+      .sort((a, b) => a.slugChain.join('/').localeCompare(b.slugChain.join('/')))
+      .map(node => '- [' + node.slugChain.join('/') + '] (frontier · score ' + node.score + ') ' + node.wish)
+      .join('\n')
+  : '(none)'
+
 const stubBlock = stubs.length
   ? stubs
       .slice()
@@ -390,7 +415,15 @@ const leafBlock = leaves.length
   : '(no terminal leaves — all nodes still have children or all were stubs)'
 
 const indexPath = wishDir + '/index.md'
-const synth = await agent(synthPrompt(indexPath, nodeBlock, stubBlock, leafBlock, stats), { label: 'synthesize', phase: 'Synthesize', schema: SKETCH_SCHEMA })
+const synth = await agent(synthPrompt({
+  indexPath,
+  nodeBlock,
+  frontierBlock,
+  stubBlock,
+  leafBlock,
+  stats,
+  existingWork,
+}), { label: 'synthesize', phase: 'Synthesize', schema: SKETCH_SCHEMA })
 
 // Build the sketches array from the synth agent's structured output.
 // If the agent did not return a conforming schema (e.g. no leaves), fall back to an empty array.


### PR DESCRIPTION
Closes #3054

## Summary

- anchor deep wish trees to the main worktree so session-worktree sweeps cannot strand them
- pass an existing-work digest to synthesis and drop duplicate terminal leaves from weighted sketches
- reconcile skeptic-demoted `wish.md` files through a write-capable agent while keeping the skeptic read-only
- distinguish budget-bounded frontier nodes from diminishing-return stubs and surface both as resumable
- correct demotion language, deep-mode step references, and the non-root `parent-absence` adversity shape

## Verification

- `node --check .claude/workflows/wish.js`
- scoped anchor/coherence greps
- `git diff --check`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- clean worktree after commit

Dogfood is N/A for this workflow/skill-text change and was not run inline.

Generated by the Aether implement workflow.
