### PR TITLE
fix(ci): record rollupless dogfood attempts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,14 +69,14 @@ jobs:
       - run: cargo fmt --all -- --check
 
   dogfood-token-table:
-    name: Dogfood token table
+    name: Dogfood contracts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: node --test scripts/dogfood-token-table.test.mjs
+      - run: node --test scripts/dogfood-token-table.test.mjs scripts/post-dogfood-rollup.test.mjs scripts/dogfood-action-contract.test.mjs
 
   clippy:
     name: Clippy

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -5,7 +5,8 @@ name: Dogfood
 # task through that surface alone (the dogfood workflow, .claude/workflows/
 # dogfood.js), and grade the friction it hit plus the rendered artifact. The
 # trial runs unattended on a Runs-On ephemeral box; a separate post job pushes
-# the evidence, upserts the PR/issue comment, and enforces the retry cap.
+# the evidence, records every completed attempt, upserts the PR/issue comment,
+# and enforces the retry cap for actionable attempts.
 #
 # GATE STACK (each predicate must hold, in order — this is the terminal stage
 # of the PR gate chain, so it fires only when everything upstream is green):
@@ -50,8 +51,11 @@ name: Dogfood
 # the `trial` job executes the resolved code (build + headless Claude with
 # --dangerously-skip-permissions on the ephemeral box) and holds `contents:
 # read` and nothing else; only the `post` job, which never runs branch code
-# (it checks out main), carries the write scopes. The trial job currently runs
-# WITHOUT an egress firewall: the first default-drop attempt broke the runner's
+# (it checks out main), carries the write scopes. The no-rollup post path emits
+# only a compact marker pointing to the Actions run; it never executes branch
+# code or interprets a branch-produced result as a trusted rollup. The trial
+# job currently runs WITHOUT an egress firewall: the first default-drop attempt
+# broke the runner's
 # own control plane and then cargo's CDN-backed downloads (IP pinning cannot
 # track CDN rotation), so it was pulled by owner call; issue 3063 tracks the
 # domain-scoped restoration. Until then the OAuth token's exposure rests on the
@@ -482,9 +486,12 @@ jobs:
           Monitor on the rollup path is useless because that file only appears when YOU write it. Do
           NOT stop the workflow task, and NEVER treat the status note as the end of the job. When the
           completion notification arrives, read the workflow's returned { rollup, task } value (from
-          the task output file if the notification truncates it) and write the ROLLUP object as JSON
-          verbatim to exactly ${GITHUB_WORKSPACE}/dogfood-rollup.json (that absolute path — the rollup
-          object, not the { rollup, task } wrapper). The file NEVER appears on its own — YOU write it.
+          the task output file if the notification truncates it). If it contains a rollup, write the
+          ROLLUP object as JSON verbatim to exactly ${GITHUB_WORKSPACE}/dogfood-rollup.json (that
+          absolute path — the rollup object, not the { rollup, task } wrapper). The file NEVER appears
+          on its own — YOU write it. If the workflow reports an error or no rollup, do NOT fabricate a
+          replacement file or claim success: leave the failure in the session transcript so the action
+          can record an actionable no-rollup attempt for diagnosis and re-trial.
 
           EVIDENCE (absolute paths only — ${GITHUB_WORKSPACE}/dogfood-run/ already exists):
           - If the task's expectedArtifact is not null the run RENDERS. Ensure a live engine is showing
@@ -495,7 +502,7 @@ jobs:
             copy it into ${GITHUB_WORKSPACE}/dogfood-run/solution/ so the author/build-layer artifact
             rides in the evidence (best effort — skip if it is not reachable from here).
 
-          Do not push to git or touch GitHub. Print exactly DOGFOOD-DONE once the rollup file is written.
+          Do not push to git or touch GitHub. Print exactly DOGFOOD-DONE only once the rollup file is written.
           EOF
 
           claude -p "$(cat /tmp/dogfood-prompt.md)" \
@@ -548,11 +555,12 @@ jobs:
           echo "staged run directory:"
           ls -la "$GITHUB_WORKSPACE/dogfood-run" || true
 
-      # Whether the run produced a rollup gates the `post` job. A missing rollup
-      # after the trial actually ran (token present) is a FAILURE, not a quiet
-      # skip — the session exiting with the workflow still in flight is the exact
-      # bug the mechanical wait contract exists to prevent (#2979/#2986). The
-      # quiet-skip path exists only for the absent-secret case.
+      # A missing rollup after the trial actually ran (token present) is a
+      # FAILURE, not a quiet skip — the session exiting with the workflow still
+      # in flight is the exact bug the mechanical wait contract exists to
+      # prevent (#2979/#2986). Its failed trial result lets `post` record a
+      # first-class actionable attempt; the quiet-skip path exists only for the
+      # absent-secret case.
       - name: Note whether a rollup was produced
         id: rollup
         if: always()
@@ -600,15 +608,19 @@ jobs:
           fi
 
   post:
-    name: Post dogfood rollup
+    name: Post dogfood attempt
     needs: [resolve, trial]
-    # No-op when the trial produced no rollup (token absent or the trial
-    # failed). Mirrors review.yml's needs-output gate.
-    if: needs.trial.outputs.rollup_produced == 'true'
+    # A produced rollup follows the normal path. A failed trial with no rollup
+    # still needs a durable, actionable attempt; the absent-secret case remains
+    # a success and therefore stays a no-op. Never schedule this writer if the
+    # read-only resolve job failed.
+    if: always() && needs.resolve.result == 'success' && (needs.trial.outputs.rollup_produced == 'true' || needs.trial.result == 'failure')
     runs-on: ubuntu-latest
     # The only job with write scopes, and it never executes branch code: the
     # default checkout is the base repo (main), so the evidence + poster
-    # scripts are the trusted versions — the PR head is only ever read as data.
+    # scripts are the trusted versions. A failed trial's no-rollup comment
+    # points to the Actions run rather than consuming branch artifacts; the PR
+    # head is never executed here.
     permissions:
       contents: write
       issues: write
@@ -621,9 +633,11 @@ jobs:
       ATTEMPT: ${{ needs.resolve.outputs.attempt }}
       DOGFOOD_RUN_ID: ${{ github.run_id }}-${{ needs.resolve.outputs.attempt }}
       VIEWER_BASE: https://iamacoffeepot.github.io/aether/evidence/
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
+        if: needs.trial.outputs.rollup_produced == 'true'
         with:
           name: dogfood-run
           path: dogfood-run
@@ -631,43 +645,52 @@ jobs:
       # The trusted helper from main enriches the downloaded trial data before
       # either reporting sink consumes it. PR code is never executed here.
       - name: Account MCP tool tokens
+        if: needs.trial.outputs.rollup_produced == 'true'
         run: node scripts/dogfood-token-table.mjs dogfood-run/transcript.jsonl dogfood-run/rollup.json
 
       # Commit this attempt's run directory to the orphan dogfood/evidence
       # branch at evidence/<issue>/<run-id>/ (the script pushes with retries).
       - name: Push the run to the evidence branch
+        if: needs.trial.outputs.rollup_produced == 'true'
         run: scripts/dogfood-evidence.sh dogfood-run "$ISSUE" "$DOGFOOD_RUN_ID"
 
       # Upsert the living marker comment on the issue and set/clear the advisory
       # dogfood:unresolved label on the PR. The marker carries attempts/verdict
-      # so the next green event's resolve gate can read the retry state back.
-      - name: Post the rollup comment + label
+      # so the next green event's resolve gate can read the retry state back. A
+      # failed run without a rollup gets a synthetic, actionable poster record.
+      - name: Post the dogfood attempt comment + label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           RUN_REF: ${{ needs.resolve.outputs.issue }}/${{ github.run_id }}-${{ needs.resolve.outputs.attempt }}
-          ROLLUP_PATH: dogfood-run/rollup.json
         run: |
-          HAS_FRAME=0
-          [ -f dogfood-run/frame.png ] && HAS_FRAME=1
-          HAS_FRAME="$HAS_FRAME" node scripts/post-dogfood-rollup.mjs
+          if [ "${{ needs.trial.outputs.rollup_produced }}" = "true" ]; then
+            HAS_FRAME=0
+            [ -f dogfood-run/frame.png ] && HAS_FRAME=1
+            ROLLUP_PATH=dogfood-run/rollup.json HAS_FRAME="$HAS_FRAME" node scripts/post-dogfood-rollup.mjs
+          else
+            node scripts/post-dogfood-rollup.mjs
+          fi
 
       # Cap-bounce: a persistently-failing feature (an actionable trial at the
       # attempt cap) bounces the CLOSING ISSUE to the user for review rather than
-      # looping forever. The actionability predicate mirrors the poster's — a
-      # failed attempt, a wrong artifact, a soft-hold, or a blocker /
-      # missing-primitive finding. The PR keeps its evidence comment + label;
-      # the issue's phase:bounced is the review surface.
+      # looping forever. A no-rollup failure is actionable by definition; a
+      # rollup uses the poster's normal predicate. The PR keeps its evidence
+      # comment + label; the issue's phase:bounced is the review surface.
       - name: Bounce the issue at the attempt cap
         run: |
           set -euo pipefail
-          actionable="$(jq -r '(.rollup // .) as $r
-            | (($r.succeeded == false)
-               or ($r.artifact.verdict == "wrong")
-               or ((($r.softHolds // []) | length) > 0)
-               or ((($r.friction.blocker // []) | length) > 0)
-               or ((($r.friction["missing-primitive"] // []) | length) > 0))' \
-            dogfood-run/rollup.json)"
+          if [ "${{ needs.trial.outputs.rollup_produced }}" = "true" ]; then
+            actionable="$(jq -r '(.rollup // .) as $r
+              | (($r.succeeded == false)
+                 or ($r.artifact.verdict == "wrong")
+                 or ((($r.softHolds // []) | length) > 0)
+                 or ((($r.friction.blocker // []) | length) > 0)
+                 or ((($r.friction["missing-primitive"] // []) | length) > 0))' \
+              dogfood-run/rollup.json)"
+          else
+            actionable=true
+          fi
           echo "attempt=${ATTEMPT} cap=${DOGFOOD_MAX_ATTEMPTS} actionable=${actionable}"
           if [ "$actionable" != "true" ] || [ "$ATTEMPT" -lt "$DOGFOOD_MAX_ATTEMPTS" ]; then
             echo "not bouncing (either clean or below the cap)."
@@ -701,9 +724,10 @@ jobs:
 
           The dogfood trial for this feature failed **${DOGFOOD_MAX_ATTEMPTS}** times (the retry cap) without going green, so it is bounced here for your review rather than retrying forever.
 
-          The PR (#${PR}) keeps its living dogfood comment and its \`dogfood:unresolved\` label; this issue now carries \`phase:bounced\`. Every attempt's evidence:
+          The PR (#${PR}) keeps its living dogfood comment and its \`dogfood:unresolved\` label; this issue now carries \`phase:bounced\`. Evidence from rollup-producing attempts:
 
           ${links}
+          A no-rollup attempt links to its Actions run from the living dogfood comment.
           Clear it by fixing the feature (or the brief) and re-running the trial via \`workflow_dispatch\` on the Dogfood workflow with this PR number.
           EOF
           gh api -X POST "repos/${REPO}/issues/${ISSUE}/comments" -f body="$(cat /tmp/bounce-body.md)"

--- a/scripts/dogfood-action-contract.test.mjs
+++ b/scripts/dogfood-action-contract.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const DOGFOOD_WORKFLOW = new URL('../.github/workflows/dogfood.yml', import.meta.url)
+
+test('a failed no-rollup trial reaches the writer only after resolve succeeds', async () => {
+  const workflow = await readFile(DOGFOOD_WORKFLOW, 'utf8')
+
+  assert.match(
+    workflow,
+    /if: always\(\) && needs\.resolve\.result == 'success' && \(needs\.trial\.outputs\.rollup_produced == 'true' \|\| needs\.trial\.result == 'failure'\)/,
+  )
+  assert.match(
+    workflow,
+    /- name: Account MCP tool tokens\n        if: needs\.trial\.outputs\.rollup_produced == 'true'/,
+  )
+  assert.match(workflow, /else\n            node scripts\/post-dogfood-rollup\.mjs/)
+  assert.match(workflow, /ROLLUP_PATH=dogfood-run\/rollup\.json HAS_FRAME="\$HAS_FRAME"/)
+  assert.match(workflow, /RUN_URL: \$\{\{ github\.server_url \}\}\/\$\{\{ github\.repository \}\}\/actions\/runs\/\$\{\{ github\.run_id \}\}/)
+  assert.match(workflow, /do NOT fabricate a\n          replacement file or claim success/)
+  assert.match(
+    workflow,
+    /- name: Push the run to the evidence branch\n        if: needs\.trial\.outputs\.rollup_produced == 'true'/,
+  )
+  assert.match(workflow, /else\n            actionable=true/)
+  assert.doesNotMatch(workflow, /- name: Bounce the issue at the attempt cap\n        if:/)
+  assert.doesNotMatch(workflow, /Record a no-rollup failure/)
+})
+
+test('a produced rollup keeps the existing evidence, token, and poster path', async () => {
+  const workflow = await readFile(DOGFOOD_WORKFLOW, 'utf8')
+
+  assert.match(
+    workflow,
+    /- uses: actions\/download-artifact@v4\n        if: needs\.trial\.outputs\.rollup_produced == 'true'\n        with:\n          name: dogfood-run/,
+  )
+  assert.match(workflow, /node scripts\/dogfood-token-table\.mjs dogfood-run\/transcript\.jsonl dogfood-run\/rollup\.json/)
+  assert.match(workflow, /HAS_FRAME="\$HAS_FRAME" node scripts\/post-dogfood-rollup\.mjs/)
+})

--- a/scripts/post-dogfood-rollup.mjs
+++ b/scripts/post-dogfood-rollup.mjs
@@ -27,7 +27,9 @@
 //   ISSUE               the feature issue to comment on (required)
 //   PR                  the PR to carry the label (optional; defaults to ISSUE)
 //   RUN_REF             <issue>/<run-id> — the evidence-branch path segment
-//   ROLLUP_PATH         rollup.json (the workflow's returned rollup)
+//   RUN_URL             Actions URL for a no-rollup attempt's transcript
+//   ROLLUP_PATH         rollup.json (the workflow's returned rollup); unset or
+//                       unreadable records a no-rollup attempt
 //   ATTEMPT             this trial's attempt number, baked into the marker
 //                       (optional; defaults to 1)
 //   HAS_FRAME           "1"/"true" when the staged run dir held a frame.png
@@ -36,14 +38,7 @@
 // No external deps — Node built-ins + global fetch only.
 
 import { readFile } from 'node:fs/promises'
-
-const TOKEN = requireEnv('GITHUB_TOKEN')
-const REPO = requireEnv('GITHUB_REPOSITORY')
-const ISSUE = Number(requireEnv('ISSUE'))
-const PR = process.env.PR ? Number(process.env.PR) : ISSUE
-const RUN_REF = requireEnv('RUN_REF')
-const ROLLUP_PATH = process.env.ROLLUP_PATH || 'rollup.json'
-const ATTEMPT = process.env.ATTEMPT ? Number(process.env.ATTEMPT) : 1
+import { pathToFileURL } from 'node:url'
 
 // The bare prefix is the upsert anchor — it matches both the old
 // `<!-- aether-dogfood -->` comment and the extended
@@ -61,11 +56,25 @@ function requireEnv(name) {
   return v
 }
 
-async function api(method, path, body) {
+function environment() {
+  const issue = Number(requireEnv('ISSUE'))
+  return {
+    token: requireEnv('GITHUB_TOKEN'),
+    repo: requireEnv('GITHUB_REPOSITORY'),
+    issue,
+    pr: process.env.PR ? Number(process.env.PR) : issue,
+    runRef: process.env.RUN_REF || '',
+    runUrl: process.env.RUN_URL || '',
+    rollupPath: process.env.ROLLUP_PATH || '',
+    attempt: process.env.ATTEMPT ? Number(process.env.ATTEMPT) : 1,
+  }
+}
+
+async function api(token, method, path, body) {
   const res = await fetch(`${API}/${path}`, {
     method,
     headers: {
-      authorization: `Bearer ${TOKEN}`,
+      authorization: `Bearer ${token}`,
       accept: 'application/vnd.github+json',
       'x-github-api-version': '2022-11-28',
       'content-type': 'application/json',
@@ -83,13 +92,13 @@ function safeJson(t) {
 }
 
 // Paginate a GitHub list endpoint via the Link header.
-async function apiList(path) {
+async function apiList(token, path) {
   const out = []
   let url = `${API}/${path}${path.includes('?') ? '&' : '?'}per_page=100`
   while (url) {
     const res = await fetch(url, {
       headers: {
-        authorization: `Bearer ${TOKEN}`,
+        authorization: `Bearer ${token}`,
         accept: 'application/vnd.github+json',
         'x-github-api-version': '2022-11-28',
         'user-agent': 'aether-dogfood-poster',
@@ -186,29 +195,40 @@ function softHoldLines(softHolds) {
 // with anything actionable (a failed attempt, a wrong artifact, a
 // soft-hold, a blocker / missing-primitive finding) is `failed`, else
 // `green`. `green` is terminal for the auto-retry loop.
-function markerVerdict(rollup) {
+export function markerVerdict(rollup) {
   return isActionable(rollup) || rollup.succeeded === false ? 'failed' : 'green'
 }
 
-function markerLine(rollup) {
-  return `${MARKER_PREFIX} attempts=${ATTEMPT} verdict=${markerVerdict(rollup)} -->`
+export function markerLine(rollup, attempt = 1, verdict = markerVerdict(rollup)) {
+  return `${MARKER_PREFIX} attempts=${attempt} verdict=${verdict} -->`
 }
 
-function renderComment(rollup, hasFrame) {
-  const lines = [markerLine(rollup), '## Dogfood trial', '']
+export function renderComment(rollup, hasFrame, { attempt = 1, runRef = '' } = {}) {
+  const lines = [markerLine(rollup, attempt), '## Dogfood trial', '']
   lines.push(...verdictLines(rollup))
   lines.push('', '### Friction')
   lines.push(...frictionLines(rollup.friction))
   lines.push(...softHoldLines(rollup.softHolds))
   lines.push(...tokenTableLines(rollup.tokensPerTool))
   if (hasFrame) {
-    lines.push('', '### Judged frame', '', `![judged frame](${RAW_BASE}/${RUN_REF}/frame.png)`)
+    lines.push('', '### Judged frame', '', `![judged frame](${RAW_BASE}/${runRef}/frame.png)`)
   }
-  lines.push('', `[Full run in the evidence viewer](${VIEWER_BASE}?run=${encodeURIComponent(RUN_REF)})`)
+  lines.push('', `[Full run in the evidence viewer](${VIEWER_BASE}?run=${encodeURIComponent(runRef)})`)
   return lines.join('\n')
 }
 
-function isActionable(rollup) {
+export function renderNoRollupComment({ attempt = 1, runUrl } = {}) {
+  return [
+    markerLine(null, attempt, 'failed'),
+    '## Dogfood trial',
+    '',
+    '- **Attempt:** did not succeed',
+    '',
+    `The trial ended without its required rollup. [Open the Actions run](${runUrl}) to inspect the \`dogfood-session-transcript\` artifact and runner log.`,
+  ].join('\n')
+}
+
+export function isActionable(rollup) {
   if (rollup.succeeded === false) return true
   if (rollup.artifact && rollup.artifact.verdict === 'wrong') return true
   if (Array.isArray(rollup.softHolds) && rollup.softHolds.length) return true
@@ -219,10 +239,20 @@ function isActionable(rollup) {
   return false
 }
 
+export async function readRollup(path) {
+  if (!path) return null
+  try {
+    return JSON.parse(await readFile(path, 'utf8'))
+  } catch (error) {
+    if (error instanceof SyntaxError) throw error
+    return null
+  }
+}
+
 // Create the label if it does not exist yet. An already-exists 422 is a
 // clean success — the label is present, which is all we need.
-async function ensureLabel() {
-  const res = await api('POST', `repos/${REPO}/labels`, {
+async function ensureLabel({ token, repo }) {
+  const res = await api(token, 'POST', `repos/${repo}/labels`, {
     name: LABEL,
     color: 'd93f0b',
     description: 'A dogfood trial surfaced something actionable',
@@ -232,48 +262,52 @@ async function ensureLabel() {
 }
 
 async function main() {
-  const raw = JSON.parse(await readFile(ROLLUP_PATH, 'utf8'))
+  const env = environment()
+  const raw = await readRollup(env.rollupPath)
+  const noRollup = raw === null
   // Accept either the bare rollup or the workflow's full { rollup, task }.
   const rollup = raw && raw.rollup ? raw.rollup : raw
-
-  const hasFrame = process.env.HAS_FRAME
+  const hasFrame = !noRollup && (process.env.HAS_FRAME
     ? /^(1|true)$/i.test(process.env.HAS_FRAME)
-    : rollup.artifact != null
-
-  const body = renderComment(rollup, hasFrame)
+    : rollup.artifact != null)
+  const body = noRollup
+    ? renderNoRollupComment({ ...env, runUrl: requireEnv('RUN_URL') })
+    : renderComment(rollup, hasFrame, { ...env, runRef: requireEnv('RUN_REF') })
 
   // Upsert the marker-anchored living comment — edit if present, create
   // otherwise. The evidence branch keeps per-run history, so the comment
   // shows latest-state.
-  const issueComments = await apiList(`repos/${REPO}/issues/${ISSUE}/comments`)
+  const issueComments = await apiList(env.token, `repos/${env.repo}/issues/${env.issue}/comments`)
   const existing = issueComments.find((c) => String(c.body || '').includes(MARKER_PREFIX))
   if (existing) {
-    const res = await api('PATCH', `repos/${REPO}/issues/comments/${existing.id}`, { body })
+    const res = await api(env.token, 'PATCH', `repos/${env.repo}/issues/comments/${existing.id}`, { body })
     if (!res.ok) console.error(`update comment failed: ${res.status} ${res.text}`)
     else console.log('updated dogfood comment')
   } else {
-    const res = await api('POST', `repos/${REPO}/issues/${ISSUE}/comments`, { body })
+    const res = await api(env.token, 'POST', `repos/${env.repo}/issues/${env.issue}/comments`, { body })
     if (!res.ok) console.error(`post comment failed: ${res.status} ${res.text}`)
     else console.log('posted dogfood comment')
   }
 
   // Advisory label on the PR when passed (that is where /land reads),
   // else on the issue. Set when actionable, cleared clean.
-  const target = PR
-  if (isActionable(rollup)) {
-    await ensureLabel()
-    const res = await api('POST', `repos/${REPO}/issues/${target}/labels`, { labels: [LABEL] })
+  const target = env.pr
+  if (noRollup || isActionable(rollup)) {
+    await ensureLabel(env)
+    const res = await api(env.token, 'POST', `repos/${env.repo}/issues/${target}/labels`, { labels: [LABEL] })
     if (!res.ok) console.error(`add label failed: ${res.status} ${res.text}`)
     else console.log(`set ${LABEL} on #${target}`)
   } else {
-    const res = await api('DELETE', `repos/${REPO}/issues/${target}/labels/${encodeURIComponent(LABEL)}`)
+    const res = await api(env.token, 'DELETE', `repos/${env.repo}/issues/${target}/labels/${encodeURIComponent(LABEL)}`)
     // 404 = the label was not present; a clean no-op.
     if (res.ok || res.status === 404) console.log(`cleared ${LABEL} on #${target}`)
     else console.error(`remove label failed: ${res.status} ${res.text}`)
   }
 }
 
-main().catch((err) => {
-  console.error(err)
-  process.exit(1)
-})
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/scripts/post-dogfood-rollup.test.mjs
+++ b/scripts/post-dogfood-rollup.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import {
+  isActionable,
+  markerVerdict,
+  readRollup,
+  renderComment,
+  renderNoRollupComment,
+} from './post-dogfood-rollup.mjs'
+
+test('an unset or unreadable rollup path selects no-rollup mode', async () => {
+  assert.equal(await readRollup(''), null)
+  const directory = await mkdtemp(join(tmpdir(), 'aether-no-rollup-'))
+  try {
+    assert.equal(await readRollup(join(directory, 'missing.json')), null)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('no-rollup mode records an actionable failed attempt', () => {
+  const comment = renderNoRollupComment({
+    attempt: 2,
+    runUrl: 'https://github.com/iamacoffeepot/aether/actions/runs/12345',
+  })
+
+  assert.match(
+    comment,
+    /<!-- aether-dogfood attempts=2 verdict=failed -->/,
+  )
+  assert.match(
+    comment,
+    /\[Open the Actions run\]\(https:\/\/github\.com\/iamacoffeepot\/aether\/actions\/runs\/12345\)/,
+  )
+  assert.doesNotMatch(comment, /evidence viewer|frame\.png/)
+})
+
+test('a clean rollup remains green and non-actionable', () => {
+  const rollup = {
+    succeeded: true,
+    buildGreen: true,
+    summary: 'The consumer completed the task.',
+    artifact: { verdict: 'correct', rationale: 'The frame matches the expected artifact.' },
+    friction: { blocker: [], 'missing-primitive': [], papercut: [], 'doc-gap': [] },
+    softHolds: [],
+  }
+
+  assert.equal(isActionable(rollup), false)
+  assert.equal(markerVerdict(rollup), 'green')
+  assert.match(
+    renderComment(rollup, false, { attempt: 3, runRef: '3088/12345-3' }),
+    /<!-- aether-dogfood attempts=3 verdict=green -->/,
+  )
+})


### PR DESCRIPTION
Closes #3088.

## Summary

- run the trusted post job for genuine trial failures that produced no rollup, while retaining the resolve-success and cancelled/absent-secret guards
- record a compact failed attempt marker and `dogfood:unresolved` label linking the Actions run and transcript artifact
- keep token accounting and evidence-branch pushes restricted to real rollups, while treating no-rollup attempts as actionable for the retry cap
- add workflow and poster contracts to CI for both no-rollup and existing clean-rollup paths

## Verification

- `node --test scripts/dogfood-token-table.test.mjs scripts/post-dogfood-rollup.test.mjs scripts/dogfood-action-contract.test.mjs` (8 passed)
- Node syntax check and Ruby YAML parse for both changed workflows
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`

## Generated by

`/implement` — Terra execution of scoped issue #3088, followed by parent contract review.
