### PR TITLE
perf(aether-text): batch widget text draws

### DIFF
--- a/crates/aether-capabilities/src/text/kinds.rs
+++ b/crates/aether-capabilities/src/text/kinds.rs
@@ -88,6 +88,16 @@ pub struct DrawText {
     pub clip: Option<ClipRect>,
 }
 
+/// `aether.text.draw_batch` — the batched form of [`DrawText`]. Every item
+/// follows the same immediate-mode contract; the capability preserves vector
+/// order while coalescing adjacent compatible glyph quad runs. Fire-and-
+/// forget; no reply.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.text.draw_batch")]
+pub struct DrawTextBatch {
+    pub items: Vec<DrawText>,
+}
+
 /// Names the font a `FontMetricsRequest` measures: by the
 /// session-scoped `font_id` a prior `LoadFont` (or metrics grab)
 /// assigned, or by the `aether.fs` `namespace` / `path` of its TTF —

--- a/crates/aether-capabilities/src/text/runtime/mod.rs
+++ b/crates/aether-capabilities/src/text/runtime/mod.rs
@@ -220,6 +220,126 @@ impl TextCapabilityState {
         };
         ctx.actor::<RenderCapability>().send(&update);
     }
+
+    /// Resolve a text item's font and reject invalid pixel sizes. An unknown
+    /// font follows the established warn-drop behavior for `DrawText`.
+    fn font_for_draw(&self, item: &DrawText) -> Option<Arc<fontdue::Font>> {
+        let Some(font) = self.fonts.get(&item.font_id).cloned() else {
+            tracing::warn!(
+                target: "aether_substrate::text",
+                font_id = item.font_id,
+                "draw for unknown font_id; dropping",
+            );
+            return None;
+        };
+        if !(item.size_pixels.is_finite() && item.size_pixels > 0.0) {
+            return None;
+        }
+        Some(font)
+    }
+
+    /// Return the live atlas texture, lazily creating it when needed and
+    /// resetting a saturated atlas before the caller lays out its items.
+    fn atlas_texture_for_draw(&mut self, ctx: &mut NativeCtx<'_>) -> Option<u32> {
+        let Some(texture_id) = self.atlas_texture_id else {
+            // No atlas texture yet — kick off creation; immediate mode
+            // resends this draw next frame once the id lands.
+            self.ensure_atlas_texture(ctx);
+            return None;
+        };
+
+        // Reset the atlas when full so the frame's glyphs can re-pack
+        // from a clean slate. The render cap's staged buffer is re-synced
+        // with one full-rect upload; per-glyph uploads follow as cache
+        // misses. This costs one frame of partial text (the overflow
+        // glyphs missing on the saturating frame) and then fully recovers.
+        if self.atlas.is_full() {
+            tracing::info!(
+                target: "aether_substrate::text",
+                "glyph atlas full; resetting for next frame",
+            );
+            self.atlas.reset();
+            self.resync_atlas(ctx, texture_id);
+        }
+
+        Some(texture_id)
+    }
+
+    /// Lay out one text item, returning newly-rasterized atlas entries so the
+    /// caller can preserve upload-before-use ordering at its send site.
+    fn layout_text_item(&mut self, font: &fontdue::Font, item: &DrawText) -> (Vec<TexturedQuad>, Vec<AtlasEntry>) {
+        let size = item.size_pixels;
+        // Quantize the size for the glyph cache key — two draws at the
+        // same nominal size share one raster.
+        let size_key = quantize_size(size);
+        let baseline = font.horizontal_line_metrics(size).map_or(size, |line| line.ascent);
+
+        let mut pen_x = 0.0f32;
+        let mut quads: Vec<TexturedQuad> = Vec::new();
+        let mut uploads: Vec<AtlasEntry> = Vec::new();
+
+        for ch in item.text.chars() {
+            let glyph_index = font.lookup_glyph_index(ch);
+            let metrics = font.metrics(ch, size);
+            let key = GlyphKey { font_id: item.font_id, glyph_index, size_pixels: size_key };
+            let (glyph_width, glyph_height) = glyph_dimensions(&metrics);
+
+            // Rasterize only on a cache miss.
+            let slot = if let Some(hit) = self.atlas.cached(&key) {
+                hit
+            } else {
+                let (_m, coverage) = font.rasterize(ch, size);
+                self.atlas.get_or_insert(key, glyph_width, glyph_height, &coverage)
+            };
+
+            match slot {
+                GlyphSlot::Placed { entry, uploaded } => {
+                    if uploaded {
+                        uploads.push(entry);
+                    }
+                    quads.push(glyph_quad(&metrics, pen_x, baseline, &entry, item.color));
+                }
+                // Empty: no pixels, just advance the pen.
+                // Full: the atlas saturated during this frame's layout pass;
+                // the reset fires at the top of the next draw so this
+                // glyph will re-pack and render then.
+                GlyphSlot::Empty | GlyphSlot::Full => {}
+            }
+            pen_x += metrics.advance_width;
+        }
+
+        if matches!(&item.space, QuadSpace::World { .. }) {
+            // World quads carry pixel offsets relative to the anchor, not
+            // absolute screen positions. Center the string horizontally and
+            // shift so the baseline sits at y=0 — the anchor is the baseline
+            // point, and text appears above it (negative y in screen y-down
+            // convention = above the anchor in world space).
+            let half_width = pen_x / 2.0;
+            for quad in &mut quads {
+                quad.x -= half_width;
+                quad.y -= baseline;
+            }
+        } else {
+            // Screen quads flow from the top-left of the window by default
+            // (pen starts at 0,0). Apply the caller's origin offset so a
+            // string can sit at an arbitrary screen pixel.
+            let [origin_x, origin_y] = item.origin;
+            for quad in &mut quads {
+                quad.x += origin_x;
+                quad.y += origin_y;
+            }
+        }
+
+        (quads, uploads)
+    }
+}
+
+/// One pending contiguous text quad run. Its key is the projection plus
+/// framebuffer clip; the atlas texture is shared by the text capability.
+struct TextQuadRun {
+    space: QuadSpace,
+    clip: Option<aether_kinds::ClipRect>,
+    quads: Vec<TexturedQuad>,
 }
 
 // The cap mail kinds (`LoadFont`, `DrawText`, …) plus the layout helpers the
@@ -227,7 +347,9 @@ impl TextCapabilityState {
 // runtime surface for the struct-hosted identity in the parent.
 use self::layout::{build_font_metrics, emit_draw, font_name_from_path, glyph_dimensions, glyph_quad, quantize_size};
 use super::TextCapability;
-use super::kinds::{DrawText, FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontBytes, LoadFontResult};
+use super::kinds::{
+    DrawText, DrawTextBatch, FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontBytes, LoadFontResult,
+};
 use aether_actor::runtime;
 
 fn parse_font_bytes(bytes: Vec<u8>) -> FontParseOutput {
@@ -447,105 +569,60 @@ impl NativeActor for TextCapability {
     /// resend every frame (immediate-mode contract).
     #[handler::single]
     fn on_draw_text(state: &mut Self::State, ctx: &mut NativeCtx<'_>, mail: DrawText) {
-        let Some(font) = state.fonts.get(&mail.font_id).cloned() else {
-            tracing::warn!(
-                target: "aether_substrate::text",
-                font_id = mail.font_id,
-                "draw for unknown font_id; dropping",
-            );
+        let Some(font) = state.font_for_draw(&mail) else {
             return;
         };
-        if !(mail.size_pixels.is_finite() && mail.size_pixels > 0.0) {
-            return;
-        }
-        let Some(texture_id) = state.atlas_texture_id else {
-            // No atlas texture yet — kick off creation; immediate mode
-            // resends this draw next frame once the id lands.
-            state.ensure_atlas_texture(ctx);
+        let Some(texture_id) = state.atlas_texture_for_draw(ctx) else {
             return;
         };
-
-        // Reset the atlas when full so the frame's glyphs can re-pack
-        // from a clean slate. The render cap's staged buffer is re-synced
-        // with one full-rect upload; per-glyph uploads follow as cache
-        // misses. This costs one frame of partial text (the overflow
-        // glyphs missing on the saturating frame) and then fully recovers.
-        if state.atlas.is_full() {
-            tracing::info!(
-                target: "aether_substrate::text",
-                "glyph atlas full; resetting for next frame",
-            );
-            state.atlas.reset();
-            state.resync_atlas(ctx, texture_id);
-        }
-
-        let size = mail.size_pixels;
-        // Quantize the size for the glyph cache key — two draws at the
-        // same nominal size share one raster.
-        let size_key = quantize_size(size);
-        let baseline = font.horizontal_line_metrics(size).map_or(size, |line| line.ascent);
-
-        let mut pen_x = 0.0f32;
-        let mut quads: Vec<TexturedQuad> = Vec::new();
-        let mut uploads: Vec<AtlasEntry> = Vec::new();
-
-        for ch in mail.text.chars() {
-            let glyph_index = font.lookup_glyph_index(ch);
-            let metrics = font.metrics(ch, size);
-            let key = GlyphKey { font_id: mail.font_id, glyph_index, size_pixels: size_key };
-            let (glyph_width, glyph_height) = glyph_dimensions(&metrics);
-
-            // Rasterize only on a cache miss.
-            let slot = if let Some(hit) = state.atlas.cached(&key) {
-                hit
-            } else {
-                let (_m, coverage) = font.rasterize(ch, size);
-                state.atlas.get_or_insert(key, glyph_width, glyph_height, &coverage)
-            };
-
-            match slot {
-                GlyphSlot::Placed { entry, uploaded } => {
-                    if uploaded {
-                        uploads.push(entry);
-                    }
-                    quads.push(glyph_quad(&metrics, pen_x, baseline, &entry, mail.color));
-                }
-                // Empty: no pixels, just advance the pen.
-                // Full: the atlas saturated during this frame's layout pass;
-                // the reset fires at the top of the next draw so this
-                // glyph will re-pack and render then.
-                GlyphSlot::Empty | GlyphSlot::Full => {}
-            }
-            pen_x += metrics.advance_width;
-        }
-
+        let (quads, uploads) = state.layout_text_item(&font, &mail);
         for entry in uploads {
             state.upload_glyph(ctx, texture_id, &entry);
         }
         if !quads.is_empty() {
-            if matches!(mail.space, QuadSpace::World { .. }) {
-                // World quads carry pixel offsets relative to the
-                // anchor, not absolute screen positions. Center the
-                // string horizontally and shift so the baseline sits
-                // at y=0 — the anchor is the baseline point, and text
-                // appears above it (negative y in screen y-down
-                // convention = above the anchor in world space).
-                let half_width = pen_x / 2.0;
-                for q in &mut quads {
-                    q.x -= half_width;
-                    q.y -= baseline;
-                }
-            } else {
-                // Screen quads flow from the top-left of the window by
-                // default (pen starts at 0,0). Apply the caller's origin
-                // offset so a string can sit at an arbitrary screen pixel.
-                let [ox, oy] = mail.origin;
-                for q in &mut quads {
-                    q.x += ox;
-                    q.y += oy;
-                }
-            }
             emit_draw(ctx, texture_id, mail.space, mail.clip, quads);
+        }
+    }
+
+    /// Lay out and draw an authored sequence of text items in immediate mode.
+    /// Adjacent items with the same projection and clip share one textured-quad
+    /// send; every other transition preserves the authored order as a separate
+    /// run. Each item's glyph uploads are sent before any subsequent run
+    /// flush, preserving `aether.render` FIFO upload-before-use ordering.
+    #[handler::single]
+    fn on_draw_batch(state: &mut Self::State, ctx: &mut NativeCtx<'_>, mail: DrawTextBatch) {
+        let Some(texture_id) = state.atlas_texture_for_draw(ctx) else {
+            return;
+        };
+
+        let mut pending: Option<TextQuadRun> = None;
+        for item in &mail.items {
+            let Some(font) = state.font_for_draw(item) else {
+                continue;
+            };
+            let (quads, uploads) = state.layout_text_item(&font, item);
+            for entry in uploads {
+                state.upload_glyph(ctx, texture_id, &entry);
+            }
+            if quads.is_empty() {
+                continue;
+            }
+
+            if let Some(run) = &mut pending
+                && run.space == item.space
+                && run.clip == item.clip
+            {
+                run.quads.extend(quads);
+            } else {
+                if let Some(run) = pending.take() {
+                    emit_draw(ctx, texture_id, run.space, run.clip, run.quads);
+                }
+                pending = Some(TextQuadRun { space: item.space.clone(), clip: item.clip.clone(), quads });
+            }
+        }
+
+        if let Some(run) = pending {
+            emit_draw(ctx, texture_id, run.space, run.clip, run.quads);
         }
     }
 }
@@ -603,6 +680,23 @@ mod tests {
                 clip: None,
             },
         );
+    }
+
+    fn draw_batch(state: &mut TextCapabilityState, binding: &Arc<NativeBinding>, items: Vec<DrawText>) {
+        let mut ctx = NativeCtx::new(binding, session_sender(), MailId::NONE, MailId::NONE);
+        TextCapability::on_draw_batch(state, &mut ctx, DrawTextBatch { items });
+    }
+
+    fn screen_text_item(text: &str, origin: [f32; 2], clip: Option<aether_kinds::ClipRect>) -> DrawText {
+        DrawText {
+            font_id: 0,
+            text: text.to_owned(),
+            size_pixels: 24.0,
+            color: Rgba::new(1.0, 1.0, 1.0, 1.0),
+            origin,
+            space: QuadSpace::Screen,
+            clip,
+        }
     }
 
     #[test]
@@ -872,6 +966,74 @@ mod tests {
         assert_next_send_kind::<DrawTexturedQuads>(&binding, &rx);
     }
 
+    #[test]
+    fn draw_batch_coalesces_same_key_screen_items_into_one_quad_send() {
+        let mut state = TextCapabilityState::new();
+        state.fonts.insert(0, Arc::new(test_font()));
+        state.atlas_texture_id = Some(1);
+        let (binding, rx) = ctx_binding();
+
+        draw_batch(
+            &mut state,
+            &binding,
+            vec![screen_text_item("A", [0.0, 0.0], None), screen_text_item("B", [24.0, 0.0], None)],
+        );
+
+        let batches = collect_draw_textured_quad_batches(&binding, &rx);
+        assert_eq!(batches.len(), 1, "two same-key text items emit one DrawTexturedQuads");
+        assert_eq!(batches[0].space, QuadSpace::Screen);
+        assert_eq!(batches[0].clip, None);
+        assert_eq!(batches[0].quads.len(), 2);
+        assert!(batches[0].quads[0].x < batches[0].quads[1].x, "glyph quads retain item order");
+    }
+
+    #[test]
+    fn draw_batch_preserves_noncontiguous_clip_runs() {
+        let mut state = TextCapabilityState::new();
+        state.fonts.insert(0, Arc::new(test_font()));
+        state.atlas_texture_id = Some(1);
+        let (binding, rx) = ctx_binding();
+        let left_clip = aether_kinds::ClipRect { x: 0.0, y: 0.0, width: 20.0, height: 20.0 };
+        let right_clip = aether_kinds::ClipRect { x: 20.0, y: 0.0, width: 20.0, height: 20.0 };
+
+        draw_batch(
+            &mut state,
+            &binding,
+            vec![
+                screen_text_item("A", [0.0, 0.0], Some(left_clip.clone())),
+                screen_text_item("B", [24.0, 0.0], Some(right_clip.clone())),
+                screen_text_item("C", [48.0, 0.0], Some(left_clip.clone())),
+            ],
+        );
+
+        let batches = collect_draw_textured_quad_batches(&binding, &rx);
+        assert_eq!(batches.len(), 3, "noncontiguous equal clips remain separate authored-order runs");
+        assert_eq!(batches[0].clip, Some(left_clip.clone()));
+        assert_eq!(batches[1].clip, Some(right_clip));
+        assert_eq!(batches[2].clip, Some(left_clip));
+    }
+
+    #[test]
+    fn draw_batch_drops_an_unknown_font_without_losing_surrounding_items() {
+        let mut state = TextCapabilityState::new();
+        state.fonts.insert(0, Arc::new(test_font()));
+        state.atlas_texture_id = Some(1);
+        let (binding, rx) = ctx_binding();
+        let mut unknown = screen_text_item("ignored", [24.0, 0.0], None);
+        unknown.font_id = 99;
+
+        draw_batch(
+            &mut state,
+            &binding,
+            vec![screen_text_item("A", [0.0, 0.0], None), unknown, screen_text_item("B", [48.0, 0.0], None)],
+        );
+
+        let batches = collect_draw_textured_quad_batches(&binding, &rx);
+        assert_eq!(batches.len(), 1, "valid items on either side share their run");
+        assert_eq!(batches[0].quads.len(), 2, "the unknown-font item alone is dropped");
+        assert!(batches[0].quads[0].x < batches[0].quads[1].x, "surviving items retain authored order");
+    }
+
     /// `Screen` draws at a non-zero `origin` shift every glyph quad by
     /// that offset. Draw the same string twice — once at `[0,0]` and once
     /// at `[ox, oy]` — and assert each quad in the offset batch sits
@@ -920,6 +1082,27 @@ mod tests {
                     .expect("test: DrawTexturedQuads payload decodes");
             }
         }
+    }
+
+    fn collect_draw_textured_quad_batches(
+        binding: &NativeBinding,
+        rx: &Receiver<EgressEvent>,
+    ) -> Vec<DrawTexturedQuads> {
+        binding.flush_outbound();
+        rx.try_iter()
+            .filter_map(|event| {
+                if let EgressEvent::UnresolvedMail { kind_id, payload, .. } = event
+                    && kind_id == DrawTexturedQuads::ID
+                {
+                    Some(
+                        DrawTexturedQuads::decode_from_bytes(&payload)
+                            .expect("test: DrawTexturedQuads payload decodes"),
+                    )
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     /// A tiny real font for the draw-path tests — the workspace's

--- a/crates/aether-kit/src/widget/mod.rs
+++ b/crates/aether-kit/src/widget/mod.rs
@@ -15,7 +15,7 @@
 //!   each `Tick`, resets its [`Composite`], appends its own chrome, and
 //!   sends [`Collect`] to each child in layout order. When its slots close
 //!   it emits the whole subtree as contiguous compatible solid/textured
-//!   runs (plus one `DrawText` per glyph run) to `aether.render` /
+//!   runs plus one `DrawTextBatch` to `aether.render` /
 //!   `aether.text`, remaining the cluster's only render sender.
 //! - An **interior** node does the same on each inbound [`Collect`], but
 //!   instead of emitting it replies its flattened composite up to its
@@ -56,7 +56,7 @@ pub use scroll::ScrollWidget;
 use aether_actor::{ActorInitError, Addressable, Manual, Subname, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::render::{DrawSolidQuads, DrawTexturedQuads, SolidQuad, TexturedQuad as RenderTexturedQuad};
-use aether_capabilities::text::DrawText;
+use aether_capabilities::text::{DrawText, DrawTextBatch};
 use aether_capabilities::{LifecycleCapability, RenderCapability, TextCapability};
 use aether_data::Kind;
 use aether_kinds::{ClipRect, QuadSpace, Tick};
@@ -320,10 +320,34 @@ fn framebuffer_clip(rect: WidgetClipRect) -> ClipRect {
     ClipRect { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
 }
 
+/// Collect the filtered text subsequence into authored-order text items.
+/// Invalid clips omit their items before the root converts the remaining clips
+/// into framebuffer coordinates.
+fn text_items(list: &WidgetDrawList) -> Vec<DrawText> {
+    let mut items: Vec<DrawText> = Vec::new();
+    for item in &list.items {
+        if let WidgetDrawItem::Text { x, y, font_id, text, size_pixels, color, .. } = item {
+            let Some(clip) = PreparedClip::for_item(item) else {
+                continue;
+            };
+            items.push(DrawText {
+                font_id: *font_id,
+                text: text.clone(),
+                size_pixels: *size_pixels,
+                color: *color,
+                origin: [*x, *y],
+                space: QuadSpace::Screen,
+                clip: clip.framebuffer(),
+            });
+        }
+    }
+    items
+}
+
 /// Emit a flattened subtree as the cluster's single render + text sender.
 /// Compatible solid/textured runs preserve authored non-text order through
-/// same-recipient FIFO, then one `DrawText` is sent per glyph run. Text's extra
-/// hop through the text cap keeps the established later lane.
+/// same-recipient FIFO, then one authored-order `DrawTextBatch` reaches the
+/// text cap. Text's extra hop keeps the established later lane.
 pub(crate) fn emit(ctx: &mut WasmCtx<'_, Manual>, list: &WidgetDrawList) {
     for run in direct_runs(list) {
         match run {
@@ -344,21 +368,9 @@ pub(crate) fn emit(ctx: &mut WasmCtx<'_, Manual>, list: &WidgetDrawList) {
             }
         }
     }
-    for item in &list.items {
-        if let WidgetDrawItem::Text { x, y, font_id, text, size_pixels, color, .. } = item {
-            let Some(clip) = PreparedClip::for_item(item) else {
-                continue;
-            };
-            ctx.actor::<TextCapability>().send(&DrawText {
-                font_id: *font_id,
-                text: text.clone(),
-                size_pixels: *size_pixels,
-                color: *color,
-                origin: [*x, *y],
-                space: QuadSpace::Screen,
-                clip: clip.framebuffer(),
-            });
-        }
+    let items = text_items(list);
+    if !items.is_empty() {
+        ctx.actor::<TextCapability>().send(&DrawTextBatch { items });
     }
 }
 
@@ -371,16 +383,8 @@ mod tests {
         WidgetDrawItem::Quad { x, y: 0.0, width: 1.0, height: 1.0, color: Rgba::WHITE, clip }
     }
 
-    fn text(clip: Option<WidgetClipRect>) -> WidgetDrawItem {
-        WidgetDrawItem::Text {
-            x: 0.0,
-            y: 0.0,
-            font_id: 1,
-            text: "text".into(),
-            size_pixels: 12.0,
-            color: Rgba::WHITE,
-            clip,
-        }
+    fn text(x: f32, label: &str, clip: Option<WidgetClipRect>) -> WidgetDrawItem {
+        WidgetDrawItem::Text { x, y: 0.0, font_id: 1, text: label.into(), size_pixels: 12.0, color: Rgba::WHITE, clip }
     }
 
     fn textured(texture_id: u32, x: f32, clip: Option<WidgetClipRect>) -> WidgetDrawItem {
@@ -409,7 +413,7 @@ mod tests {
             items: vec![
                 quad(0.0, Some(a)),
                 textured(7, 1.0, Some(a)),
-                text(Some(b)),
+                text(0.0, "text", Some(b)),
                 textured(7, 2.0, Some(a)),
                 textured(8, 3.0, Some(a)),
                 textured(7, 4.0, Some(a)),
@@ -488,6 +492,26 @@ mod tests {
             DirectRun::Solid { clip: PreparedClip::Unbounded, quads }
                 if quads.iter().map(|quad| quad.x).eq([1.0, 3.0])
         ));
+    }
+
+    #[test]
+    fn text_items_preserve_authored_order_and_omit_clipped_out_items() {
+        let invalid = WidgetClipRect { x: 0.0, y: 0.0, width: -1.0, height: 2.0 };
+        let list = WidgetDrawList {
+            intrinsic: None,
+            items: vec![
+                text(10.0, "first", None),
+                quad(0.0, None),
+                text(20.0, "second", None),
+                text(30.0, "skipped", Some(invalid)),
+                text(40.0, "third", None),
+            ],
+        };
+
+        let items = text_items(&list);
+        assert_eq!(items.len(), 3, "three valid text items survive filtering");
+        assert!(items.iter().map(|item| item.text.as_str()).eq(["first", "second", "third"]));
+        assert!(items.iter().map(|item| item.origin[0]).eq([10.0, 20.0, 40.0]));
     }
 
     #[test]

--- a/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
+++ b/crates/aether-substrate-bundle/tests/widget_render_interaction.rs
@@ -642,11 +642,16 @@ fn assert_virtual_list_rows(
 
 fn assert_five_virtual_list_glyph_rows(snapshot: &[DrawTexturedQuads]) {
     let clip = virtual_list_clip();
-    let glyph_quads: Vec<_> = snapshot
+    let glyph_batches: Vec<_> = snapshot
         .iter()
         .filter(|batch| batch.texture_id != WHITE_TEXTURE_ID && batch.clip.as_ref() == Some(&clip))
-        .flat_map(|batch| &batch.quads)
         .collect();
+    assert_eq!(
+        glyph_batches.len(),
+        1,
+        "five virtual-list text rows must arrive in one glyph batch; snapshot: {snapshot:?}",
+    );
+    let glyph_quads = &glyph_batches[0].quads;
     assert_eq!(glyph_quads.len(), 15, "five three-digit labels, and no off-window labels, should be resident");
     for row_offset in 0..5usize {
         let row_top = PANEL_Y + row_offset as f32 * ROW_HEIGHT;


### PR DESCRIPTION
Closes #3080.

## Summary

- add `aether.text.draw_batch` as `DrawTextBatch { items: Vec<DrawText> }`, reusing the existing public text payload
- share the single-item layout path and coalesce only contiguous `(space, clip)` runs
- preserve per-item guard behavior and upload-before-use ordering
- collapse widget text emission to one batch mail and assert one render glyph batch for five virtual-list rows

## Test plan

- `cargo test -p aether-capabilities --features text-runtime draw_batch` (3/3)
- `cargo test -p aether-kit text_items_preserve_authored_order_and_omit_clipped_out_items` (1/1)
- strict `widget_render_interaction` TestBench run (scoped virtual-list tripwire passed; 14/15 initially passed, then the sole missing-fixture precondition was built and its test passed)
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`

FleetBench is not applicable: this batching path remains inside one widget/text/render substrate and does not exercise cross-substrate routing or fleet lifecycle.

## Generated by

`/implement` — Terra execution of [scoped issue #3080](https://github.com/iamacoffeepot/aether/issues/3080), followed by parent API and TestBench review.
