### PR TITLE
chore(qodana): clear tolerated PR findings

### DIFF
--- a/crates/aether-capabilities/src/engine/proxy/connect.rs
+++ b/crates/aether-capabilities/src/engine/proxy/connect.rs
@@ -106,8 +106,7 @@ pub fn connect_proxy(
     // retrying once `d` has elapsed.
     let deadline = budget.map(|d| Instant::now() + d);
     #[cfg(test)]
-    let reader_wake =
-        WAIT_FOR_READER_WAKE.with(|wait| wait.replace(false)).then(|| Arc::new((Mutex::new(false), Condvar::new())));
+    let reader_wake = WAIT_FOR_READER_WAKE.replace(false).then(|| Arc::new((Mutex::new(false), Condvar::new())));
     loop {
         // The reader sidecar fires `RpcInboundReady` at the proxy's
         // own mailbox after every inbound frame so

--- a/crates/aether-kit/src/camera/controller/mod.rs
+++ b/crates/aether-kit/src/camera/controller/mod.rs
@@ -70,7 +70,7 @@ const CAMERA_COMPONENT: &str = "aether.kit.camera";
 const SEED_TARGET: [f32; 3] = [0.0, 0.0, 0.0];
 const SEED_DISTANCE: f32 = 12.0;
 /// Negative pitch places the eye above the target looking down (see
-/// [`OrbitParams::pitch`](crate::camera::OrbitParams)); ~-63° is a legible
+/// [`OrbitParams::pitch`]); ~-63° is a legible
 /// three-quarter angle well inside the `±π/2` pole.
 const SEED_PITCH: f32 = -1.1;
 const SEED_YAW: f32 = 0.0;

--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -34,7 +34,7 @@
 //! - [`mover::WorldMover`] — the input-driven body that walks the painted
 //!   world, selected by the `aether_kit@aether.kit.mover` export. Its
 //!   `aether.kit.mover.teleport` placement kind lives in [`mover`].
-//! - [`sim::TurnSim`] — the deterministic fixed-tick reference simulation,
+//! - [`TurnSim`] — the deterministic fixed-tick reference simulation,
 //!   selected by the `aether_kit@aether.kit.sim` export. Its tick-native
 //!   intent, trajectory, summary, and catch-up vocabulary lives in [`sim`].
 //! - [`widget::Widget`] — the widget-compositing node (ADR-0117), selected
@@ -42,7 +42,7 @@
 //!   [`widget::WidgetPanel`] and the concrete [`widget::set`] widgets. The
 //!   widget-compositing vocabulary lives in [`widget`] and the visual tokens
 //!   in [`widget::theme`].
-//! - [`widget::EditorShell`] — the input-only arbiter between independently
+//! - [`EditorShell`] — the input-only arbiter between independently
 //!   rooted editor regions (ADR-0141).
 //!
 //! `export!` (below) packs the actors into one cdylib (ADR-0096 multi-actor

--- a/crates/aether-kit/src/widget/routing.rs
+++ b/crates/aether-kit/src/widget/routing.rs
@@ -326,7 +326,7 @@ mod tests {
 
     fn region(target: u64, rect: EditorRegionRect, keyboard: bool, input_lanes: RegionInputLanes) -> RegionSpec {
         RegionSpec {
-            name: alloc::format!("region-{target}"),
+            name: format!("region-{target}"),
             rect,
             target: MailboxId(target),
             keyboard_focus_eligible: keyboard,

--- a/crates/aether-kit/src/widget/set/button.rs
+++ b/crates/aether-kit/src/widget/set/button.rs
@@ -36,12 +36,6 @@ pub struct ButtonWidget {
 }
 
 impl ButtonWidget {
-    /// Arm the button if the press landed inside. Owned state-machine step —
-    /// unit-tested.
-    fn press_at(&mut self, x: f32, y: f32) {
-        self.arms.press_pointer(&self.frame, self.state.is_available(), x, y);
-    }
-
     /// Resolve a release: returns `true` (a click fired) only if the button
     /// was armed and the release landed back inside. Disarms either way.
     fn release_at(&mut self, x: f32, y: f32) -> bool {
@@ -156,9 +150,7 @@ impl WasmActor for ButtonWidget {
     /// A left press inside arms the button.
     #[handler::single]
     fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, press: MouseButton) {
-        if press.button == mouse_button::LEFT {
-            self.press_at(press.x, press.y);
-        }
+        self.arms.press_mouse_button(&self.frame, self.state.is_available(), press);
     }
 
     /// A left release fires the click if it lands back inside while armed.
@@ -246,7 +238,7 @@ mod tests {
     #[test]
     fn press_inside_then_release_inside_clicks() {
         let mut b = button();
-        b.press_at(20.0, 20.0);
+        b.arms.press_pointer(&b.frame, b.state.is_available(), 20.0, 20.0);
         assert!(b.arms.pointer_pressed);
         assert!(b.release_at(30.0, 25.0), "press-inside then release-inside is a click");
         assert!(!b.arms.pointer_pressed, "disarmed after release");
@@ -255,7 +247,7 @@ mod tests {
     #[test]
     fn press_inside_then_release_outside_cancels() {
         let mut b = button();
-        b.press_at(20.0, 20.0);
+        b.arms.press_pointer(&b.frame, b.state.is_available(), 20.0, 20.0);
         assert!(!b.release_at(200.0, 200.0), "a release that drifts off the button does not click");
         assert!(!b.arms.pointer_pressed, "disarmed even on a cancel");
     }
@@ -263,7 +255,7 @@ mod tests {
     #[test]
     fn press_outside_never_arms() {
         let mut b = button();
-        b.press_at(200.0, 200.0);
+        b.arms.press_pointer(&b.frame, b.state.is_available(), 200.0, 200.0);
         assert!(!b.arms.pointer_pressed);
         assert!(!b.release_at(20.0, 20.0), "a release with no prior inside-press does not click");
     }

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -59,7 +59,7 @@ use aether_actor::WasmCtx;
 use aether_capabilities::TextCapability;
 use aether_capabilities::text::{FontMetricsRequest, FontRef};
 use aether_kinds::keycode::{KEY_ENTER, KEY_SPACE};
-use aether_kinds::{Modifiers, MouseButtonRelease, mouse_button};
+use aether_kinds::{Modifiers, MouseButton, MouseButtonRelease, mouse_button};
 use aether_math::Rgba;
 
 use crate::widget::state::{InteractionState, emit_state_changed};
@@ -87,6 +87,12 @@ impl ActivationArms {
     fn press_pointer(&mut self, frame: &WidgetFrame, eligible: bool, x: f32, y: f32) {
         if eligible && Self::contains(frame, x, y) {
             self.pointer_pressed = true;
+        }
+    }
+
+    fn press_mouse_button(&mut self, frame: &WidgetFrame, eligible: bool, press: MouseButton) {
+        if press.button == mouse_button::LEFT {
+            self.press_pointer(frame, eligible, press.x, press.y);
         }
     }
 

--- a/crates/aether-kit/src/widget/set/toggle.rs
+++ b/crates/aether-kit/src/widget/set/toggle.rs
@@ -47,10 +47,6 @@ impl ToggleWidget {
         self.on
     }
 
-    fn press_at(&mut self, x: f32, y: f32) {
-        self.arms.press_pointer(&self.frame, self.state.can_mutate(), x, y);
-    }
-
     fn release_at(&mut self, x: f32, y: f32) -> Option<bool> {
         self.arms.release_pointer(&self.frame, self.state.can_mutate(), x, y).then(|| self.toggle())
     }
@@ -151,9 +147,7 @@ impl WasmActor for ToggleWidget {
 
     #[handler::single]
     fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, press: MouseButton) {
-        if press.button == mouse_button::LEFT {
-            self.press_at(press.x, press.y);
-        }
+        self.arms.press_mouse_button(&self.frame, self.state.can_mutate(), press);
     }
 
     #[handler::single]
@@ -254,11 +248,11 @@ mod tests {
     #[test]
     fn pointer_activation_toggles_once_and_release_outside_cancels() {
         let mut toggle = toggle();
-        toggle.press_at(20.0, 30.0);
+        toggle.arms.press_pointer(&toggle.frame, toggle.state.can_mutate(), 20.0, 30.0);
         assert_eq!(toggle.release_at(20.0, 30.0), Some(true));
         assert_eq!(toggle.release_at(20.0, 30.0), None, "an unarmed release cannot toggle twice");
 
-        toggle.press_at(20.0, 30.0);
+        toggle.arms.press_pointer(&toggle.frame, toggle.state.can_mutate(), 20.0, 30.0);
         assert_eq!(toggle.release_at(200.0, 30.0), None);
         assert!(toggle.on, "release outside preserves the prior value");
     }
@@ -278,7 +272,7 @@ mod tests {
     #[test]
     fn read_only_or_unavailable_state_cancels_live_arms_and_blocks_mutation() {
         let mut toggle = toggle();
-        toggle.press_at(20.0, 30.0);
+        toggle.arms.press_pointer(&toggle.frame, toggle.state.can_mutate(), 20.0, 30.0);
         toggle.press_key(KEY_SPACE);
         let read_only = WidgetControlState { read_only: true, ..WidgetControlState::default() };
         assert!(toggle.adopt_control_state(read_only));
@@ -289,7 +283,7 @@ mod tests {
 
         let disabled = WidgetControlState { enabled: false, ..WidgetControlState::default() };
         assert!(toggle.adopt_control_state(disabled));
-        toggle.press_at(20.0, 30.0);
+        toggle.arms.press_pointer(&toggle.frame, toggle.state.can_mutate(), 20.0, 30.0);
         assert!(!toggle.arms.pointer_pressed);
     }
 }


### PR DESCRIPTION
Sweeps the six findings tolerated by final Qodana scans in the recently merged code PR queue: four unnecessary qualifications, one stable thread-local API replacement, and one duplicated widget handler. Dependency-version update nags remain excluded and unchanged.

Local verification:
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test -p aether-kit --lib
- cargo test -p aether-capabilities engine::proxy