### PR TITLE
chore(qodana): clear concrete main findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,6 @@ dependencies = [
  "confique",
  "crossbeam-channel",
  "crossbeam-deque",
- "dirs",
  "libc",
  "png",
  "proptest",
@@ -356,7 +355,6 @@ dependencies = [
  "aether-kinds",
  "aether-math",
  "aether-test-fixtures-kinds",
- "bytemuck",
  "serde",
  "tracing",
 ]

--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -381,8 +381,6 @@ impl Subscriber for ForwardingSubscriber {
 
     fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
     fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
-    fn enter(&self, _: &span::Id) {}
-    fn exit(&self, _: &span::Id) {}
 
     fn event(&self, event: &Event<'_>) {
         if let Some(sink) = current_sink() {
@@ -390,6 +388,9 @@ impl Subscriber for ForwardingSubscriber {
             sink(level, &target, &message);
         }
     }
+
+    fn enter(&self, _: &span::Id) {}
+    fn exit(&self, _: &span::Id) {}
 }
 
 static SUBSCRIBER_INSTALLED: AtomicBool = AtomicBool::new(false);

--- a/crates/aether-actor/src/wasm/mailbox.rs
+++ b/crates/aether-actor/src/wasm/mailbox.rs
@@ -43,7 +43,7 @@ use crate::wasm::inline::{ChainMode, Registry, RouteDecision};
 #[allow(clippy::module_name_repetitions)]
 pub struct WasmActorMailbox<'a, R> {
     mailbox: u64,
-    /// The resolving actor's own folded [`aether_data::MailboxId`] raw value —
+    /// The resolving actor's own folded [`MailboxId`] raw value —
     /// the "from" half threaded onto every send so the recipient's
     /// `ctx.source_mailbox()` resolves who sent it, and so the host stamps the
     /// correct origin without an ambient per-receive cell (issue 1987). Set by

--- a/crates/aether-capabilities/src/anthropic/kinds.rs
+++ b/crates/aether-capabilities/src/anthropic/kinds.rs
@@ -1,7 +1,7 @@
 //! Wire kinds for the `aether.anthropic` capability (ADR-0050, ADR-0121).
 //!
 //! The seven anthropic-specific types moved here from `aether-kinds` so the
-//! capability owns its mail vocabulary. [`aether_kinds::Usage`] stays central
+//! capability owns its mail vocabulary. [`Usage`] stays central
 //! — it is shared with the `aether.gemini` result kinds, so moving it here
 //! would force gemini to reach across capabilities.
 

--- a/crates/aether-capabilities/src/engine/server/runtime.rs
+++ b/crates/aether-capabilities/src/engine/server/runtime.rs
@@ -345,7 +345,7 @@ impl NativeActor for EngineServer {
                 )
                 .finish();
 
-            match result {
+            return match result {
                 Ok(proxy_mailbox) => {
                     state.engines.insert(
                         engine_id,
@@ -357,7 +357,7 @@ impl NativeActor for EngineServer {
                             last_alive: Instant::now(),
                         },
                     );
-                    return SpawnEngineResult::Ok { engine_id: engine_id.0.to_string(), rpc_port };
+                    SpawnEngineResult::Ok { engine_id: engine_id.0.to_string(), rpc_port }
                 }
                 Err(e) => {
                     last_error = format!("proxy failed to connect to the spawned substrate: {e:?}");
@@ -376,9 +376,9 @@ impl NativeActor for EngineServer {
                         );
                         continue;
                     }
-                    return state.fail_spawn(engine_id, rpc_port, last_error);
+                    state.fail_spawn(engine_id, rpc_port, last_error)
                 }
-            }
+            };
         }
 
         // Only reached if `attempts` is 0, which `spawn_attempts()`

--- a/crates/aether-capabilities/src/engine/store/eviction.rs
+++ b/crates/aether-capabilities/src/engine/store/eviction.rs
@@ -1,4 +1,4 @@
-//! LRU disk-budget eviction for [`super::ArtifactStore`].
+//! LRU disk-budget eviction for [`ArtifactStore`].
 
 use std::collections::HashSet;
 use std::fs;

--- a/crates/aether-capabilities/src/engine/store/persistence.rs
+++ b/crates/aether-capabilities/src/engine/store/persistence.rs
@@ -100,7 +100,7 @@ pub fn ensure_root(root: &Path) -> PathBuf {
 }
 
 /// Best-effort `lock.pid` acquisition (ADR-0115). Delegates to
-/// [`aether_substrate::pid_lock::acquire_lock_pid`] for the shared
+/// [`acquire_lock_pid`] for the shared
 /// read → classify → reclaim → write protocol. A stale (dead-pid) or
 /// garbage lock is reclaimed; a live holder or a write failure leaves
 /// the store unlocked (returns `None`) but still operating, since a

--- a/crates/aether-capabilities/src/fs/registry.rs
+++ b/crates/aether-capabilities/src/fs/registry.rs
@@ -1,6 +1,6 @@
 //! The fs namespace registry + its boot config. [`AdapterRegistry`]
 //! maps a namespace short name (`"save"`, `"assets"`, `"config"`) to
-//! the [`FileAdapter`](super::FileAdapter) backing it; [`NamespaceRoots`]
+//! the [`FileAdapter`] backing it; [`NamespaceRoots`]
 //! is the ADR-0090 derive-`Config` struct chassis mains resolve at boot
 //! and hand to `with_actor::<FsCapability>(roots)`; [`build_registry`]
 //! wires the three ADR-0041 namespaces into a populated registry.

--- a/crates/aether-capabilities/src/http/server/runtime/types.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/types.rs
@@ -29,7 +29,7 @@ pub struct ReaderShared {
 /// (ADR-0135): the shard's sidecar channel (receiver consumed at `init`,
 /// sender cloned into every reader the shard spawns), the shared route
 /// table + live-connection count, and the per-connection tuning copied
-/// from [`HttpServerConfig`](crate::http::server::HttpServerConfig).
+/// from [`HttpServerConfig`].
 pub struct HttpShardSeed {
     /// The shard's inbound event channel; `Some` exactly until the shard's
     /// `init` takes it (the `TcpSessionConfig::stream` consume pattern).
@@ -51,7 +51,7 @@ pub struct HttpShardSeed {
     pub response_stream_window: u32,
     pub request_stream_window: u32,
     /// Cap-global stream-id source (ADR-0135) — see
-    /// [`HttpShardState::next_stream_id`](super::HttpShardState).
+    /// [`HttpShardState::next_stream_id`].
     pub next_stream_id: Arc<AtomicU64>,
 }
 

--- a/crates/aether-capabilities/src/http/stream.rs
+++ b/crates/aether-capabilities/src/http/stream.rs
@@ -22,7 +22,7 @@
 //! gets it without the native runtime.
 //!
 //! [`HttpServerCapability`]: super::HttpServerCapability
-//! [`MailboxId`]: aether_data::MailboxId
+//! [`MailboxId`]: MailboxId
 
 use aether_actor::{MailSender, OutboundReply};
 use aether_data::MailboxId;

--- a/crates/aether-capabilities/src/rpc/server/test_echo.rs
+++ b/crates/aether-capabilities/src/rpc/server/test_echo.rs
@@ -112,7 +112,7 @@ pub struct DeferredEchoReply {
 }
 
 /// Test-only actor that answers [`DeferredEchoRequest`] off-thread via the
-/// ADR-0093 hold-until-resolve dispatch ([`crate::shared::contentgen::TaskQueue`]
+/// ADR-0093 hold-until-resolve dispatch ([`TaskQueue`]
 /// over `ctx.dispatch_blocking`), reproducing the production content-gen
 /// caps' deferred-reply shape (submit -> spawned worker -> completion wake
 /// -> re-reply). The whole point is that the reply happens *after* the

--- a/crates/aether-codec/src/proptest_roundtrip.rs
+++ b/crates/aether-codec/src/proptest_roundtrip.rs
@@ -284,7 +284,7 @@ fn value_for_map(key_schema: &SchemaType, value_schema: &SchemaType) -> BoxedStr
         SchemaType::Scalar(p) => {
             prop::collection::btree_map(arb_int_key(*p), value_strat, 0..=MAX_WIDTH).prop_map(stringify_keys).boxed()
         }
-        other => unreachable!("arb_map_key_schema never yields {other:?} as a map key"),
+        other => unreachable!("arb_map_key_schema never yields {:?} as a map key", other),
     }
 }
 
@@ -308,7 +308,7 @@ fn arb_int_key(p: Primitive) -> BoxedStrategy<i128> {
         Primitive::I16 => (i128::from(i16::MIN)..=i128::from(i16::MAX)).boxed(),
         Primitive::I32 => (i128::from(i32::MIN)..=i128::from(i32::MAX)).boxed(),
         Primitive::I64 => (i128::from(i64::MIN)..=i128::from(i64::MAX)).boxed(),
-        other => unreachable!("arb_int_key called with non-integer primitive {other:?}"),
+        other => unreachable!("arb_int_key called with non-integer primitive {:?}", other),
     }
 }
 

--- a/crates/aether-kit/src/mark/mod.rs
+++ b/crates/aether-kit/src/mark/mod.rs
@@ -110,7 +110,7 @@ fn validate_geometry(geometry: &MarkGeometry) -> Result<(), MarkMutationError> {
     };
     if !(minimum..=MAX_STAMP_VERTICES).contains(&length) {
         return Err(MarkMutationError::InvalidGeometry {
-            reason: alloc::format!("{kind} requires {minimum}..={MAX_STAMP_VERTICES} world points; got {length}"),
+            reason: format!("{kind} requires {minimum}..={MAX_STAMP_VERTICES} world points; got {length}"),
         });
     }
     Ok(())

--- a/crates/aether-kit/src/world/mod.rs
+++ b/crates/aether-kit/src/world/mod.rs
@@ -656,7 +656,7 @@ mod tests {
             id: MarkId::new(id),
             revision,
             geometry: MarkGeometry::Point(WorldPoint::new(128, 128)),
-            label: alloc::format!("mark-{id}"),
+            label: format!("mark-{id}"),
         }
     }
 

--- a/crates/aether-kit/src/world/overlay.rs
+++ b/crates/aether-kit/src/world/overlay.rs
@@ -257,7 +257,7 @@ mod tests {
     }
 
     fn mark(id: u32, geometry: MarkGeometry) -> Mark {
-        Mark { id: MarkId::new(id), revision: 1, geometry, label: alloc::format!("mark-{id}") }
+        Mark { id: MarkId::new(id), revision: 1, geometry, label: format!("mark-{id}") }
     }
 
     fn assert_finite(triangles: &[DrawTriangle]) {

--- a/crates/aether-mcp/src/tools/bytes.rs
+++ b/crates/aether-mcp/src/tools/bytes.rs
@@ -1,4 +1,4 @@
-use super::{EnumVariant, SchemaType, Uuid};
+use super::{EnumVariant, SchemaType};
 use aether_data::NamedField;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD;
@@ -441,7 +441,7 @@ pub(super) fn spill_reply_bytes(dir: &Path, bytes: &[u8]) -> io::Result<PathBuf>
     // `std::fs`, not the module's `tokio::fs`: this write is blocking by design
     // (the MCP front handling a tool reply is not latency-critical).
     use std::fs as std_fs;
-    let path = dir.join(format!("aether-reply-{}.bin", Uuid::new_v4()));
+    let path = dir.join(format!("aether-reply-{}.bin", uuid::Uuid::new_v4()));
     std_fs::write(&path, bytes)?;
     Ok(path)
 }

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -55,9 +55,6 @@ bytemuck = { workspace = true }
 # but default-on), so this is a plain dep, not feature-gated like the
 # capabilities crate's confique.
 confique = { workspace = true }
-# ADR-0049 on-disk handle store: resolve the default persistence root
-# (`dirs::data_dir()/aether/handles`). Same crate the fs cap uses.
-dirs = "6"
 serde = { workspace = true, features = ["derive", "std"] }
 # ADR-0081 §4 crash dump: serialize the panicking actor's ring as
 # JSONL on a panic-hook write path. Read-side consumers (operator

--- a/crates/aether-substrate/src/capture.rs
+++ b/crates/aether-substrate/src/capture.rs
@@ -112,7 +112,6 @@ impl CaptureQueue {
     /// # Panics
     /// Panics if the slot `Mutex` is poisoned — fail-fast per ADR-0063:
     /// a poisoned mutex means a prior holder panicked under the guard.
-    #[must_use = "a rejected request still owns its inbound guard; reply through it before it drops"]
     pub fn request(&self, pending: PendingCapture) -> Result<(), Box<PendingCapture>> {
         let mut slot = self.slot.lock().expect("capture slot mutex poisoned; fail-fast per ADR-0063");
         if slot.is_some() {

--- a/crates/aether-substrate/src/chassis/settlement_table.rs
+++ b/crates/aether-substrate/src/chassis/settlement_table.rs
@@ -119,7 +119,7 @@ struct Slot {
     /// `(version << 2) | state`. A fresh `AtomicU64::new(0)` is
     /// `(version 0, STATE_EMPTY)` — the correct initial state.
     sv: AtomicU64,
-    /// Key hi: the root's `sender` [`aether_data::MailboxId`] word.
+    /// Key hi: the root's `sender` [`MailboxId`] word.
     sender: AtomicU64,
     /// Key lo: the root's `correlation_id`.
     correlation: AtomicU64,

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/Cargo.toml
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/Cargo.toml
@@ -25,7 +25,6 @@ aether-data = { path = "../../aether-data", features = ["derive"] }
 aether-kinds = { path = "../../aether-kinds" }
 aether-math = { path = "../../aether-math" }
 aether-test-fixtures-kinds = { path = "../aether-test-fixtures-kinds" }
-bytemuck = { workspace = true, default-features = false, features = ["derive"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }
 # Issue #581: the probe emits `tracing::info!` on the first tick; the
 # actor-aware subscriber installed by `export!()` buffers + drains it to

--- a/crates/aether-test-fixtures/aether-test-fixtures-split-cap/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-split-cap/src/lib.rs
@@ -59,6 +59,8 @@ fn assert_identity_present() {
 #[cfg(test)]
 mod tests {
     use super::SplitCap;
+    #[cfg(feature = "runtime")]
+    use super::runtime;
     use aether_actor::Addressable;
 
     // Runs in both feature configs (the test lib compiles ungated). Proves the

--- a/crates/aether-test-fixtures/aether-test-fixtures-split-cap/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-split-cap/src/lib.rs
@@ -58,7 +58,7 @@ fn assert_identity_present() {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::SplitCap;
     use aether_actor::Addressable;
 
     // Runs in both feature configs (the test lib compiles ungated). Proves the

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -28,13 +28,15 @@ exclude:
   # container builds under path remapping, so local_file() returns None and
   # the ADR-0123-recorded hard-error fallback fires, producing an
   # RsCompileErrorMacro finding on every #[actor] invocation in this crate.
-  # Real cargo paths (clippy / nextest / doc / CI) compile every cap cleanly
-  # — the error is Qodana-container-only. Scoped to aether-capabilities (the
-  # only crate hosting the struct-hosted form) so genuine macro compile errors
-  # remain active everywhere else, including aether-actor-derive itself.
+  # Real cargo paths (clippy / nextest / doc / CI) compile every cap and the
+  # dedicated split-cap fixture cleanly — the error is Qodana-container-only.
+  # Scoped to the production capability crate and that one proof fixture so
+  # genuine macro compile errors remain active everywhere else, including
+  # aether-actor-derive itself.
   - name: RsCompileErrorMacro
     paths:
       - crates/aether-capabilities
+      - crates/aether-test-fixtures/aether-test-fixtures-split-cap
   - name: All
     paths:
       - target


### PR DESCRIPTION
Clears 23 of the 62 findings in the repository-wide Qodana report for main: unused dependencies, Rust inspection findings, unnecessary qualifications, and the verified split-cap analyzer false positive. Dependency-version update inspections remain excluded and no dependency versions change.

The tcp/listener qualification finding is intentionally deferred until PR #3109 lands to avoid overlapping that contributor branch.

Local verification:
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- CI rustdoc lint command with redundant, broken, and private intra-doc links denied