### PR TITLE
refactor(aether-kit): consolidate widget implementations

### DIFF
--- a/crates/aether-kit/src/console/mod.rs
+++ b/crates/aether-kit/src/console/mod.rs
@@ -581,11 +581,10 @@ fn f32_floor_to_usize(value: f32) -> usize {
 mod tests {
     use super::*;
 
-    #[test]
-    fn visible_rows_reserve_input_band() {
-        let overlay = ConsoleOverlay {
-            config: ConsoleConfig { panel_height: 100.0, font_size: 10.0, ..ConsoleConfig::default() },
-            state: ConsoleState::new(&ConsoleConfig::default()),
+    fn overlay(config: ConsoleConfig) -> ConsoleOverlay {
+        ConsoleOverlay {
+            state: ConsoleState::new(&config),
+            config,
             window_size: [100, 100],
             font_id: None,
             metrics: None,
@@ -593,7 +592,12 @@ mod tests {
             override_font_failed: false,
             backspace_held: false,
             backspace_ticks: 0,
-        };
+        }
+    }
+
+    #[test]
+    fn visible_rows_reserve_input_band() {
+        let overlay = overlay(ConsoleConfig { panel_height: 100.0, font_size: 10.0, ..ConsoleConfig::default() });
 
         assert_eq!(overlay.visible_rows(), 4);
     }
@@ -610,17 +614,7 @@ mod tests {
 
     #[test]
     fn activation_text_matches_single_activation_character_only() {
-        let overlay = ConsoleOverlay {
-            config: ConsoleConfig::default(),
-            state: ConsoleState::new(&ConsoleConfig::default()),
-            window_size: [100, 100],
-            font_id: None,
-            metrics: None,
-            embedded_font_requested: false,
-            override_font_failed: false,
-            backspace_held: false,
-            backspace_ticks: 0,
-        };
+        let overlay = overlay(ConsoleConfig::default());
 
         assert!(ConsoleOverlay::is_activation_text("`", overlay.config.activation_key_code));
         assert!(!ConsoleOverlay::is_activation_text("``", overlay.config.activation_key_code));
@@ -629,17 +623,7 @@ mod tests {
 
     #[test]
     fn held_backspace_repeats_after_initial_delay() {
-        let mut overlay = ConsoleOverlay {
-            config: ConsoleConfig::default(),
-            state: ConsoleState::new(&ConsoleConfig::default()),
-            window_size: [100, 100],
-            font_id: None,
-            metrics: None,
-            embedded_font_requested: false,
-            override_font_failed: false,
-            backspace_held: false,
-            backspace_ticks: 0,
-        };
+        let mut overlay = overlay(ConsoleConfig::default());
         overlay.state.open = true;
         overlay.state.insert_text("abcd");
 
@@ -658,17 +642,7 @@ mod tests {
 
     #[test]
     fn markdown_tones_map_to_explicit_theme_fields() {
-        let overlay = ConsoleOverlay {
-            config: ConsoleConfig::default(),
-            state: ConsoleState::new(&ConsoleConfig::default()),
-            window_size: [100, 100],
-            font_id: None,
-            metrics: None,
-            embedded_font_requested: false,
-            override_font_failed: false,
-            backspace_held: false,
-            backspace_ticks: 0,
-        };
+        let overlay = overlay(ConsoleConfig::default());
         let markdown = overlay.config.theme.markdown;
 
         assert_eq!(overlay.markdown_color(LineStyle::Output, MarkdownTone::Heading), markdown.heading_color);

--- a/crates/aether-kit/src/widget/mod.rs
+++ b/crates/aether-kit/src/widget/mod.rs
@@ -615,6 +615,7 @@ impl WasmActor for Widget {
     /// # Agent
     /// A child's reply; not useful to send manually.
     #[handler::manual]
+    //noinspection DuplicatedCode -- actor macros require one draw-list handler per composite owner type.
     fn on_draw_list(&mut self, ctx: &mut WasmCtx<'_, Manual>, list: WidgetDrawList) {
         if accept_open_child_list(&self.frame_discharge, &mut self.composite, ctx, list) {
             self.finish(ctx);

--- a/crates/aether-kit/src/widget/mod.rs
+++ b/crates/aether-kit/src/widget/mod.rs
@@ -233,6 +233,15 @@ pub(crate) fn accept_child_list(
     composite.is_complete()
 }
 
+fn accept_open_child_list(
+    discharge: &FrameDischarge,
+    composite: &mut Composite,
+    ctx: &mut WasmCtx<'_, Manual>,
+    list: WidgetDrawList,
+) -> bool {
+    !discharge.is_closed() && accept_child_list(composite, ctx, list)
+}
+
 /// One contiguous run of non-text widget draws with one render capability
 /// shape. Text is filtered before planning and remains on its later lane.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -607,10 +616,7 @@ impl WasmActor for Widget {
     /// A child's reply; not useful to send manually.
     #[handler::manual]
     fn on_draw_list(&mut self, ctx: &mut WasmCtx<'_, Manual>, list: WidgetDrawList) {
-        if self.frame_discharge.is_closed() {
-            return;
-        }
-        if accept_child_list(&mut self.composite, ctx, list) {
+        if accept_open_child_list(&self.frame_discharge, &mut self.composite, ctx, list) {
             self.finish(ctx);
         }
     }

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -72,7 +72,7 @@ use crate::widget::{
     WidgetChildSpec, WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame, WidgetKind, WidgetStateChanged,
 };
 use crate::widget::{FrameDischarge, decode_nested_widget_config};
-use crate::widget::{accept_child_list, emit, flush_membership};
+use crate::widget::{accept_open_child_list, emit, flush_membership};
 
 /// One spawned child's alias plus the logical name the panel attributes its
 /// value-up events under (for the map-editor translation / logging) — the
@@ -944,10 +944,7 @@ impl WasmActor for WidgetPanel {
     /// A child's reply; not useful to send manually.
     #[handler::manual]
     fn on_draw_list(&mut self, ctx: &mut WasmCtx<'_, Manual>, list: WidgetDrawList) {
-        if self.frame_discharge.is_closed() {
-            return;
-        }
-        if accept_child_list(&mut self.composite, ctx, list) {
+        if accept_open_child_list(&self.frame_discharge, &mut self.composite, ctx, list) {
             self.finish(ctx);
         }
     }

--- a/crates/aether-kit/src/widget/scroll.rs
+++ b/crates/aether-kit/src/widget/scroll.rs
@@ -24,7 +24,7 @@ use crate::widget::{
     Collect, ScrollConfig, ScrollDelta, ScrollExtent, ScrollOffset, ScrollOutcome, ScrollResidual, WidgetChildSpec,
     WidgetClipRect, WidgetControlState, WidgetDrawList, WidgetFrame,
 };
-use crate::widget::{FrameDischarge, accept_child_list, flush_membership};
+use crate::widget::{FrameDischarge, accept_open_child_list, flush_membership};
 
 struct ScrollContent {
     id: MailboxId,
@@ -332,10 +332,7 @@ impl WasmActor for ScrollWidget {
 
     #[handler::manual]
     fn on_draw_list(&mut self, ctx: &mut WasmCtx<'_, Manual>, list: WidgetDrawList) {
-        if self.frame_discharge.is_closed() {
-            return;
-        }
-        if accept_child_list(&mut self.composite, ctx, list) {
+        if accept_open_child_list(&self.frame_discharge, &mut self.composite, ctx, list) {
             self.finish(ctx);
         }
     }

--- a/crates/aether-kit/src/widget/set/image.rs
+++ b/crates/aether-kit/src/widget/set/image.rs
@@ -15,6 +15,7 @@ use alloc::vec::Vec;
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_math::Rgba;
 
+use crate::widget::set::apply_static_control_state;
 use crate::widget::state::{InteractionState, emit_state_changed};
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{Collect, ImageConfig, ImageFit, SetWidgetState, WidgetDrawItem, WidgetDrawList, WidgetFrame};
@@ -263,9 +264,7 @@ impl WasmActor for ImageWidget {
     /// Update external availability without changing image presentation.
     #[handler::single]
     fn on_set_widget_state(&mut self, ctx: &mut WasmCtx<'_>, set: SetWidgetState) {
-        if self.state.replace(set.state) {
-            emit_state_changed(ctx, &self.state);
-        }
+        apply_static_control_state(ctx, &mut self.state, set.state);
     }
 
     /// Restyle disabled presentation.

--- a/crates/aether-kit/src/widget/set/label.rs
+++ b/crates/aether-kit/src/widget/set/label.rs
@@ -13,7 +13,7 @@ use alloc::vec::Vec;
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 
-use crate::widget::set::{reply_if_hidden, text_origin_y};
+use crate::widget::set::{apply_static_control_state, reply_if_hidden, text_origin_y};
 use crate::widget::state::{InteractionState, emit_state_changed};
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{Collect, LabelConfig, SetWidgetState, WidgetDrawItem, WidgetDrawList, WidgetFrame};
@@ -61,9 +61,7 @@ impl WasmActor for LabelWidget {
     /// Update external availability without changing the label or theme.
     #[handler::single]
     fn on_set_widget_state(&mut self, ctx: &mut WasmCtx<'_>, set: SetWidgetState) {
-        if self.state.replace(set.state) {
-            emit_state_changed(ctx, &self.state);
-        }
+        apply_static_control_state(ctx, &mut self.state, set.state);
     }
 
     /// Restyle: adopt the fanned theme.

--- a/crates/aether-kit/src/widget/set/mod.rs
+++ b/crates/aether-kit/src/widget/set/mod.rs
@@ -59,11 +59,11 @@ use aether_actor::WasmCtx;
 use aether_capabilities::TextCapability;
 use aether_capabilities::text::{FontMetricsRequest, FontRef};
 use aether_kinds::keycode::{KEY_ENTER, KEY_SPACE};
-use aether_kinds::{Modifiers, MouseButton, MouseButtonRelease, mouse_button};
+use aether_kinds::{CachedFontMetrics, Modifiers, MouseButton, MouseButtonRelease, mouse_button};
 use aether_math::Rgba;
 
 use crate::widget::state::{InteractionState, emit_state_changed};
-use crate::widget::text_edit::{FontMetricsAdapter, TextEditState};
+use crate::widget::text_edit::{DisplayedEdit, FontMetricsAdapter, SingleLineLayout, TextEditState};
 use crate::widget::theme::{Theme, ThemeState};
 use crate::widget::{WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame};
 
@@ -181,15 +181,37 @@ fn apply_text_theme(ctx: &mut WasmCtx<'_>, font_metrics: &mut FontMetricsAdapter
     pump_text_font_metrics(ctx, font_metrics);
 }
 
-fn release_text_drag(dragging: &mut bool, release: MouseButtonRelease) {
+fn release_left<T>(pressed: &mut T, released: T, release: MouseButtonRelease) {
     if release.button == mouse_button::LEFT {
-        *dragging = false;
+        *pressed = released;
     }
+}
+
+fn arm_text_drag(state: &InteractionState, dragging: &mut bool, press: MouseButton) -> Option<f32> {
+    if press.button != mouse_button::LEFT || !state.is_available() {
+        return None;
+    }
+    *dragging = true;
+    Some(press.x)
 }
 
 fn update_text_modifiers(state: &InteractionState, modifiers: &mut Modifiers, next: Modifiers) {
     if state.is_available() {
         *modifiers = next;
+    }
+}
+
+fn apply_static_control_state(ctx: &WasmCtx<'_>, state: &mut InteractionState, next: WidgetControlState) {
+    if state.replace(next) {
+        emit_state_changed(ctx, state);
+    }
+}
+
+fn clamp_option_index(index: u32, len: usize) -> usize {
+    if len == 0 {
+        0
+    } else {
+        (index as usize).min(len - 1)
     }
 }
 
@@ -204,6 +226,19 @@ pub(super) fn reply_if_hidden(ctx: &WasmCtx<'_>, state: &InteractionState) -> bo
         parent.send(&WidgetDrawList { intrinsic: None, items: Vec::new() });
     }
     true
+}
+
+fn reply_with_draw_items(
+    ctx: &WasmCtx<'_>,
+    state: &InteractionState,
+    draw_items: impl FnOnce() -> Vec<WidgetDrawItem>,
+) {
+    if reply_if_hidden(ctx, state) {
+        return;
+    }
+    if let Some(parent) = ctx.parent() {
+        parent.send(&WidgetDrawList { intrinsic: None, items: draw_items() });
+    }
 }
 
 /// A flat-colored quad in a widget's own local coordinates — the shared
@@ -283,6 +318,82 @@ pub(crate) fn approx_text_width(char_count: usize, size_pixels: f32) -> f32 {
     #[allow(clippy::cast_precision_loss)]
     let count = char_count as f32;
     count * size_pixels * APPROX_ADVANCE_RATIO
+}
+
+fn single_line_hit_byte(text: &str, metrics: Option<&CachedFontMetrics>, size_pixels: f32, local_x: f32) -> usize {
+    if let Some(metrics) = metrics {
+        return SingleLineLayout::build(text, metrics, size_pixels).hit_test(local_x);
+    }
+    let advance = (size_pixels * APPROX_ADVANCE_RATIO).max(1.0);
+    let index = if local_x <= 0.0 {
+        0
+    } else {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let rounded = (local_x / advance + 0.5) as usize;
+        rounded.min(text.chars().count())
+    };
+    text.char_indices().nth(index).map_or(text.len(), |(byte, _)| byte)
+}
+
+fn single_line_edit_draw_items(
+    displayed: &DisplayedEdit,
+    metrics: Option<&CachedFontMetrics>,
+    theme: &Theme,
+    state: &InteractionState,
+    theme_state: ThemeState,
+    width: f32,
+    height: f32,
+) -> Vec<WidgetDrawItem> {
+    let pad = theme.pad;
+    let size = theme.value_size_pixels;
+    let text_y = text_origin_y(0.0, height, size);
+    let caret_height = pad.mul_add(-2.0, height).max(1.0);
+    let layout = metrics.map(|metrics| SingleLineLayout::build(&displayed.text, metrics, size));
+    let prefix_width = |byte: usize| {
+        layout.as_ref().map_or_else(
+            || approx_text_width(displayed.text[..byte].chars().count(), size),
+            |layout| layout.caret_x(byte),
+        )
+    };
+
+    let mut items = Vec::new();
+    items.push(quad(0.0, 0.0, width, height, theme.fill(theme.surface_raised, theme_state)));
+    if let Some(span) = displayed.selection_span {
+        let x0 = pad + prefix_width(span.start_byte);
+        let x1 = pad + prefix_width(span.end_byte);
+        items.push(quad(x0, pad, (x1 - x0).max(1.0), caret_height, theme.accent));
+    }
+    if let Some(span) = displayed.preedit_cursor_span.filter(|span| !span.is_collapsed()) {
+        let x0 = pad + prefix_width(span.start_byte);
+        let x1 = pad + prefix_width(span.end_byte);
+        items.push(quad(x0, pad, (x1 - x0).max(1.0), caret_height, theme.accent));
+    }
+    if !displayed.text.is_empty() {
+        items.push(WidgetDrawItem::Text {
+            x: pad,
+            y: text_y,
+            font_id: theme.font_id,
+            text: displayed.text.clone(),
+            size_pixels: size,
+            color: theme.fill(theme.text_primary, theme_state),
+            clip: None,
+        });
+    }
+    if let Some(span) = displayed.preedit_span {
+        let x0 = pad + prefix_width(span.start_byte);
+        let x1 = pad + prefix_width(span.end_byte);
+        items.push(quad(x0, text_y + size, (x1 - x0).max(1.0), 1.0, theme.accent));
+        if let Some(cursor) = displayed.preedit_cursor_span.filter(|cursor| cursor.is_collapsed()) {
+            let cursor_x = pad + prefix_width(cursor.end_byte);
+            items.push(quad(cursor_x, pad, 1.0, caret_height, theme.accent));
+        }
+    }
+    if state.focused() && !displayed.composing {
+        let caret_x = pad + prefix_width(displayed.caret_byte);
+        items.push(quad(caret_x, pad, 1.0, caret_height, theme.accent));
+    }
+    push_control_outlines(&mut items, width, height, state, theme);
+    items
 }
 
 /// The `Screen`-space `DrawText` origin y that vertically centers a single

--- a/crates/aether-kit/src/widget/set/numeric.rs
+++ b/crates/aether-kit/src/widget/set/numeric.rs
@@ -464,6 +464,7 @@ impl WasmActor for NumericWidget {
     }
 
     #[handler::single]
+    //noinspection DuplicatedCode -- actor macros require one pointer handler per concrete widget type.
     fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, press: MouseButton) {
         let Some(event_x) = arm_text_drag(&self.state, &mut self.dragging, press) else {
             return;

--- a/crates/aether-kit/src/widget/set/numeric.rs
+++ b/crates/aether-kit/src/widget/set/numeric.rs
@@ -11,9 +11,6 @@
 //! reverts. Up/Down step and commit immediately. Clipboard edits use the same
 //! selection and parse paths as typed edits.
 
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
-
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::clipboard::{GetClipboardTextResult, SetClipboardTextResult};
 use aether_capabilities::text::{FontMetricsRequest, FontMetricsResult, FontRef};
@@ -22,18 +19,19 @@ use aether_kinds::keycode::{
     KEY_A, KEY_BACKSPACE, KEY_C, KEY_DOWN, KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_UP, KEY_V, KEY_X,
 };
 use aether_kinds::{
-    CachedFontMetrics, ImePreedit, Key, Modifiers, MouseButton, MouseButtonRelease, MouseMove, TextInput, mouse_button,
+    CachedFontMetrics, ImePreedit, Key, Modifiers, MouseButton, MouseButtonRelease, MouseMove, TextInput,
 };
+use alloc::string::{String, ToString};
 
 use crate::widget::set::{
-    APPROX_ADVANCE_RATIO, approx_text_width, push_control_outlines, quad, reply_if_hidden, text_origin_y,
+    arm_text_drag, release_left, reply_with_draw_items, single_line_edit_draw_items, single_line_hit_byte,
 };
 use crate::widget::state::{InteractionState, emit_state_changed};
-use crate::widget::text_edit::{EditPolicy, SingleLineLayout, TextEditState, TextSpan};
+use crate::widget::text_edit::{EditPolicy, TextEditState, TextSpan};
 use crate::widget::theme::{SetTheme, Theme, ThemeState};
 use crate::widget::{
     Collect, FocusGained, FocusLost, HoverGained, HoverLost, NumericChanged, NumericConfig, SetWidgetState,
-    WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+    WidgetControlState, WidgetFrame,
 };
 
 /// Retained edit-buffer bound; comfortably exceeds every canonical finite
@@ -82,15 +80,6 @@ enum StepDirection {
 struct CutEdit {
     copied: String,
     emission: Option<NumericEmission>,
-}
-
-struct DisplayedNumeric {
-    text: String,
-    caret_byte: usize,
-    selection_span: Option<TextSpan>,
-    preedit_span: Option<TextSpan>,
-    preedit_cursor_span: Option<TextSpan>,
-    composing: bool,
 }
 
 /// A single-line numeric editor with an independent display buffer and
@@ -310,53 +299,12 @@ impl NumericWidget {
     }
 
     fn hit_byte(&self, event_x: f32) -> usize {
-        let size = self.theme.value_size_pixels;
-        let local_x = event_x - self.frame.x - self.theme.pad;
-        let text = self.edit.value();
-        if let Some(metrics) = self.resolved_metrics() {
-            return SingleLineLayout::build(text, metrics, size).hit_test(local_x);
-        }
-        let advance = (size * APPROX_ADVANCE_RATIO).max(1.0);
-        let index = if local_x <= 0.0 {
-            0
-        } else {
-            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            let rounded = (local_x / advance + 0.5) as usize;
-            rounded.min(text.chars().count())
-        };
-        text.char_indices().nth(index).map_or(text.len(), |(byte, _)| byte)
-    }
-
-    fn displayed(&self) -> DisplayedNumeric {
-        let selection = self.edit.selection();
-        if self.edit.preedit().is_empty() {
-            return DisplayedNumeric {
-                text: String::from(self.edit.value()),
-                caret_byte: self.edit.caret(),
-                selection_span: (!selection.is_collapsed()).then_some(selection),
-                preedit_span: None,
-                preedit_cursor_span: None,
-                composing: false,
-            };
-        }
-        let preedit = self.edit.preedit();
-        let mut text = String::with_capacity(self.edit.value().len() + preedit.len());
-        text.push_str(&self.edit.value()[..selection.start_byte]);
-        text.push_str(preedit);
-        text.push_str(&self.edit.value()[selection.end_byte..]);
-        let end = selection.start_byte + preedit.len();
-        let cursor = self.edit.preedit_cursor().unwrap_or_else(|| TextSpan::new(preedit.len(), preedit.len()));
-        DisplayedNumeric {
-            text,
-            caret_byte: end,
-            selection_span: None,
-            preedit_span: Some(TextSpan::new(selection.start_byte, end)),
-            preedit_cursor_span: Some(TextSpan::new(
-                selection.start_byte + cursor.start_byte,
-                selection.start_byte + cursor.end_byte,
-            )),
-            composing: true,
-        }
+        single_line_hit_byte(
+            self.edit.value(),
+            self.resolved_metrics(),
+            self.theme.value_size_pixels,
+            event_x - self.frame.x - self.theme.pad,
+        )
     }
 
     fn theme_state(&self) -> ThemeState {
@@ -517,12 +465,10 @@ impl WasmActor for NumericWidget {
 
     #[handler::single]
     fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, press: MouseButton) {
-        if press.button != mouse_button::LEFT || !self.state.is_available() {
+        let Some(event_x) = arm_text_drag(&self.state, &mut self.dragging, press) else {
             return;
-        }
-        self.dragging = true;
-        let byte = self.hit_byte(press.x);
-        self.edit.place_caret(byte);
+        };
+        self.edit.place_caret(self.hit_byte(event_x));
     }
 
     #[handler::single]
@@ -535,9 +481,7 @@ impl WasmActor for NumericWidget {
 
     #[handler::single]
     fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
-        if release.button == mouse_button::LEFT {
-            self.dragging = false;
-        }
+        release_left(&mut self.dragging, false, release);
     }
 
     #[handler::single]
@@ -602,66 +546,17 @@ impl WasmActor for NumericWidget {
 
     #[handler::single]
     fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
-        if reply_if_hidden(ctx, &self.state) {
-            return;
-        }
-        let Some(parent) = ctx.parent() else {
-            return;
-        };
-        let width = self.frame.width;
-        let height = self.frame.height;
-        let pad = self.theme.pad;
-        let size = self.theme.value_size_pixels;
-        let text_y = text_origin_y(0.0, height, size);
-        let caret_height = pad.mul_add(-2.0, height).max(1.0);
-        let theme_state = self.theme_state();
-        let displayed = self.displayed();
-        let layout = self.resolved_metrics().map(|metrics| SingleLineLayout::build(&displayed.text, metrics, size));
-        let prefix_width = |byte: usize| {
-            layout.as_ref().map_or_else(
-                || approx_text_width(displayed.text[..byte].chars().count(), size),
-                |layout| layout.caret_x(byte),
+        reply_with_draw_items(ctx, &self.state, || {
+            single_line_edit_draw_items(
+                &self.edit.displayed(),
+                self.resolved_metrics(),
+                &self.theme,
+                &self.state,
+                self.theme_state(),
+                self.frame.width,
+                self.frame.height,
             )
-        };
-
-        let mut items = Vec::new();
-        items.push(quad(0.0, 0.0, width, height, self.theme.fill(self.theme.surface_raised, theme_state)));
-        if let Some(span) = displayed.selection_span {
-            let x0 = pad + prefix_width(span.start_byte);
-            let x1 = pad + prefix_width(span.end_byte);
-            items.push(quad(x0, pad, (x1 - x0).max(1.0), caret_height, self.theme.accent));
-        }
-        if let Some(span) = displayed.preedit_cursor_span.filter(|span| !span.is_collapsed()) {
-            let x0 = pad + prefix_width(span.start_byte);
-            let x1 = pad + prefix_width(span.end_byte);
-            items.push(quad(x0, pad, (x1 - x0).max(1.0), caret_height, self.theme.accent));
-        }
-        if !displayed.text.is_empty() {
-            items.push(WidgetDrawItem::Text {
-                x: pad,
-                y: text_y,
-                font_id: self.theme.font_id,
-                text: displayed.text.clone(),
-                size_pixels: size,
-                color: self.theme.fill(self.theme.text_primary, theme_state),
-                clip: None,
-            });
-        }
-        if let Some(span) = displayed.preedit_span {
-            let x0 = pad + prefix_width(span.start_byte);
-            let x1 = pad + prefix_width(span.end_byte);
-            items.push(quad(x0, text_y + size, (x1 - x0).max(1.0), 1.0, self.theme.accent));
-            if let Some(cursor) = displayed.preedit_cursor_span.filter(|cursor| cursor.is_collapsed()) {
-                let cursor_x = pad + prefix_width(cursor.end_byte);
-                items.push(quad(cursor_x, pad, 1.0, caret_height, self.theme.accent));
-            }
-        }
-        if self.state.focused() && !displayed.composing {
-            let caret_x = pad + prefix_width(displayed.caret_byte);
-            items.push(quad(caret_x, pad, 1.0, caret_height, self.theme.accent));
-        }
-        push_control_outlines(&mut items, width, height, &self.state, &self.theme);
-        parent.send(&WidgetDrawList { intrinsic: None, items });
+        });
     }
 }
 

--- a/crates/aether-kit/src/widget/set/radio.rs
+++ b/crates/aether-kit/src/widget/set/radio.rs
@@ -17,7 +17,9 @@ use aether_kinds::keycode::{KEY_DOWN, KEY_UP};
 use aether_kinds::mouse_button;
 use aether_kinds::{Key, MouseButton, MouseButtonRelease};
 
-use crate::widget::set::{push_control_outlines, quad, reply_if_hidden, text_origin_y};
+use crate::widget::set::{
+    clamp_option_index, push_control_outlines, quad, release_left, reply_if_hidden, text_origin_y,
+};
 use crate::widget::state::{InteractionState, emit_state_changed};
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{
@@ -80,7 +82,7 @@ impl WasmActor for RadioGroupWidget {
     const NAMESPACE: &'static str = "aether.kit.widget.radio";
 
     fn init(config: RadioConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
-        let selected = clamp_index(config.initial_index, config.options.len());
+        let selected = clamp_option_index(config.initial_index, config.options.len());
         Ok(RadioGroupWidget {
             options: config.options,
             selected,
@@ -94,7 +96,7 @@ impl WasmActor for RadioGroupWidget {
     /// Replace the options / theme in place, re-clamping the selection.
     #[handler::single]
     fn on_config(&mut self, ctx: &mut WasmCtx<'_>, config: RadioConfig) {
-        self.selected = clamp_index(config.initial_index, config.options.len());
+        self.selected = clamp_option_index(config.initial_index, config.options.len());
         self.options = config.options;
         self.theme = config.theme;
         self.apply_control_state(ctx, config.state);
@@ -157,9 +159,7 @@ impl WasmActor for RadioGroupWidget {
 
     #[handler::single]
     fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
-        if release.button == mouse_button::LEFT {
-            self.pressed = false;
-        }
+        release_left(&mut self.pressed, false, release);
     }
 
     /// Up / Down move the selection while focused (clamped at the ends).
@@ -226,16 +226,6 @@ impl WasmActor for RadioGroupWidget {
     }
 }
 
-/// Clamp a 1-past-the-end initial index down to the last option (or `0` for an
-/// empty group).
-fn clamp_index(index: u32, len: usize) -> usize {
-    if len == 0 {
-        0
-    } else {
-        (index as usize).min(len - 1)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,9 +255,9 @@ mod tests {
 
     #[test]
     fn clamp_index_pins_an_over_range_initial() {
-        assert_eq!(clamp_index(0, 3), 0);
-        assert_eq!(clamp_index(5, 3), 2, "past the end clamps to the last option");
-        assert_eq!(clamp_index(1, 0), 0, "an empty group clamps to 0");
+        assert_eq!(clamp_option_index(0, 3), 0);
+        assert_eq!(clamp_option_index(5, 3), 2, "past the end clamps to the last option");
+        assert_eq!(clamp_option_index(1, 0), 0, "an empty group clamps to 0");
     }
 
     #[test]

--- a/crates/aether-kit/src/widget/set/segmented.rs
+++ b/crates/aether-kit/src/widget/set/segmented.rs
@@ -12,7 +12,9 @@ use aether_kinds::keycode::{KEY_LEFT, KEY_RIGHT};
 use aether_kinds::mouse_button;
 use aether_kinds::{Key, MouseButton, MouseButtonRelease, MouseMove};
 
-use crate::widget::set::{push_control_outlines, quad, reply_if_hidden, text_origin_y};
+use crate::widget::set::{
+    clamp_option_index, push_control_outlines, quad, release_left, reply_if_hidden, text_origin_y,
+};
 use crate::widget::state::{InteractionState, emit_state_changed};
 use crate::widget::theme::{SetTheme, Theme, ThemeState};
 use crate::widget::{
@@ -122,7 +124,7 @@ impl WasmActor for SegmentedWidget {
     const NAMESPACE: &'static str = "aether.kit.widget.segmented";
 
     fn init(config: SegmentedConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
-        let selected = clamp_index(config.initial_index, config.options.len());
+        let selected = clamp_option_index(config.initial_index, config.options.len());
         Ok(Self {
             options: config.options,
             selected,
@@ -136,7 +138,7 @@ impl WasmActor for SegmentedWidget {
 
     #[handler::single]
     fn on_config(&mut self, ctx: &mut WasmCtx<'_>, config: SegmentedConfig) {
-        self.selected = clamp_index(config.initial_index, config.options.len());
+        self.selected = clamp_option_index(config.initial_index, config.options.len());
         self.options = config.options;
         self.theme = config.theme;
         self.pressed_segment = None;
@@ -192,9 +194,7 @@ impl WasmActor for SegmentedWidget {
 
     #[handler::single]
     fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
-        if release.button == mouse_button::LEFT {
-            self.pressed_segment = None;
-        }
+        release_left(&mut self.pressed_segment, None, release);
     }
 
     #[handler::single]
@@ -275,14 +275,6 @@ impl WasmActor for SegmentedWidget {
     }
 }
 
-fn clamp_index(index: u32, len: usize) -> usize {
-    if len == 0 {
-        0
-    } else {
-        (index as usize).min(len - 1)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -322,8 +314,8 @@ mod tests {
 
     #[test]
     fn initial_index_clamps_for_nonempty_and_empty_options() {
-        assert_eq!(clamp_index(9, 3), 2);
-        assert_eq!(clamp_index(9, 0), 0);
+        assert_eq!(clamp_option_index(9, 3), 2);
+        assert_eq!(clamp_option_index(9, 0), 0);
     }
 
     #[test]

--- a/crates/aether-kit/src/widget/set/text_area.rs
+++ b/crates/aether-kit/src/widget/set/text_area.rs
@@ -515,6 +515,7 @@ impl WasmActor for TextAreaWidget {
     }
 
     #[handler::single]
+    //noinspection DuplicatedCode -- actor macros require one collect handler per concrete widget type.
     fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
         reply_with_draw_items(ctx, &self.state, || self.draw_items());
     }

--- a/crates/aether-kit/src/widget/set/text_area.rs
+++ b/crates/aether-kit/src/widget/set/text_area.rs
@@ -15,15 +15,15 @@ use aether_kinds::{
 };
 
 use crate::widget::set::{
-    apply_text_control_state, apply_text_theme, pump_text_font_metrics, push_control_outlines, quad, release_text_drag,
-    reply_if_hidden, text_control_theme_state, text_origin_y, update_text_modifiers,
+    apply_text_control_state, apply_text_theme, pump_text_font_metrics, push_control_outlines, quad, release_left,
+    reply_with_draw_items, text_control_theme_state, text_origin_y, update_text_modifiers,
 };
 use crate::widget::state::InteractionState;
 use crate::widget::text_edit::{EditPolicy, FontMetricsAdapter, SingleLineLayout, TextEditState, TextSpan};
 use crate::widget::theme::{SetTheme, Theme, ThemeState};
 use crate::widget::{
     Collect, FocusGained, FocusLost, HoverGained, HoverLost, SetWidgetState, TextAreaConfig, TextCommitted,
-    WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+    WidgetControlState, WidgetDrawItem, WidgetFrame,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -368,6 +368,7 @@ impl WasmActor for TextAreaWidget {
     }
 
     #[handler::single]
+    //noinspection DuplicatedCode -- actor macros require one handler per type; the implementation is shared.
     fn on_set_theme(&mut self, ctx: &mut WasmCtx<'_>, set: SetTheme) {
         apply_text_theme(ctx, &mut self.font_metrics, &mut self.theme, set.theme);
     }
@@ -478,7 +479,7 @@ impl WasmActor for TextAreaWidget {
 
     #[handler::single]
     fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
-        release_text_drag(&mut self.dragging, release);
+        release_left(&mut self.dragging, false, release);
     }
 
     #[handler::single]
@@ -515,12 +516,7 @@ impl WasmActor for TextAreaWidget {
 
     #[handler::single]
     fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
-        if reply_if_hidden(ctx, &self.state) {
-            return;
-        }
-        if let Some(parent) = ctx.parent() {
-            parent.send(&WidgetDrawList { intrinsic: None, items: self.draw_items() });
-        }
+        reply_with_draw_items(ctx, &self.state, || self.draw_items());
     }
 }
 

--- a/crates/aether-kit/src/widget/set/text_field.rs
+++ b/crates/aether-kit/src/widget/set/text_field.rs
@@ -25,27 +25,25 @@
 //! and Page Down. `TextFieldWidget` does not yet implement behavior for those
 //! keys.
 
-use alloc::string::String;
-use alloc::vec::Vec;
-
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::text::FontMetricsResult;
 use aether_kinds::keycode::{KEY_BACKSPACE, KEY_ENTER, KEY_LEFT, KEY_RIGHT};
 use aether_kinds::{
-    CachedFontMetrics, ImePreedit, Key, Modifiers, MouseButton, MouseButtonRelease, MouseMove, TextInput, mouse_button,
+    CachedFontMetrics, ImePreedit, Key, Modifiers, MouseButton, MouseButtonRelease, MouseMove, TextInput,
 };
+use alloc::string::String;
 
 use crate::widget::set::{
-    APPROX_ADVANCE_RATIO, apply_text_control_state, apply_text_theme, approx_text_width, pump_text_font_metrics,
-    push_control_outlines, quad, release_text_drag, reply_if_hidden, text_control_theme_state, text_origin_y,
+    apply_text_control_state, apply_text_theme, arm_text_drag, pump_text_font_metrics, release_left,
+    reply_with_draw_items, single_line_edit_draw_items, single_line_hit_byte, text_control_theme_state,
     update_text_modifiers,
 };
 use crate::widget::state::InteractionState;
-use crate::widget::text_edit::{EditPolicy, FontMetricsAdapter, SingleLineLayout, TextEditState, TextSpan};
+use crate::widget::text_edit::{EditPolicy, FontMetricsAdapter, TextEditState, TextSpan};
 use crate::widget::theme::{SetTheme, Theme, ThemeState};
 use crate::widget::{
     Collect, FocusGained, FocusLost, HoverGained, HoverLost, SetWidgetState, TextCommitted, TextFieldConfig,
-    WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+    WidgetControlState, WidgetFrame,
 };
 
 /// A single-line editable string. Holds the reusable editing state, the
@@ -83,21 +81,12 @@ impl TextFieldWidget {
     /// exact against the metric table when resolved, else the proportional
     /// approximation.
     fn hit_byte(&self, event_x: f32) -> usize {
-        let size = self.theme.value_size_pixels;
-        let local_x = event_x - self.frame.x - self.theme.pad;
-        let text = self.edit.value();
-        if let Some(metrics) = self.font_metrics.resolved() {
-            return SingleLineLayout::build(text, metrics, size).hit_test(local_x);
-        }
-        let advance = (size * APPROX_ADVANCE_RATIO).max(1.0);
-        let index = if local_x <= 0.0 {
-            0
-        } else {
-            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            let rounded = (local_x / advance + 0.5) as usize;
-            rounded.min(text.chars().count())
-        };
-        text.char_indices().nth(index).map_or(text.len(), |(byte, _)| byte)
+        single_line_hit_byte(
+            self.edit.value(),
+            self.font_metrics.resolved(),
+            self.theme.value_size_pixels,
+            event_x - self.frame.x - self.theme.pad,
+        )
     }
 
     fn theme_state(&self) -> ThemeState {
@@ -230,12 +219,10 @@ impl WasmActor for TextFieldWidget {
     /// buttons are ignored.
     #[handler::single]
     fn on_mouse_button(&mut self, _ctx: &mut WasmCtx<'_>, press: MouseButton) {
-        if press.button != mouse_button::LEFT || !self.state.is_available() {
+        let Some(event_x) = arm_text_drag(&self.state, &mut self.dragging, press) else {
             return;
-        }
-        self.dragging = true;
-        let byte = self.hit_byte(press.x);
-        self.edit.place_caret(byte);
+        };
+        self.edit.place_caret(self.hit_byte(event_x));
     }
 
     /// A move during a live drag extends the selection to the pointer.
@@ -251,7 +238,7 @@ impl WasmActor for TextFieldWidget {
     /// A left release ends the drag.
     #[handler::single]
     fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
-        release_text_drag(&mut self.dragging, release);
+        release_left(&mut self.dragging, false, release);
     }
 
     /// Cache the latest modifier state (Ctrl / Shift / …) so Shift-extended
@@ -299,72 +286,17 @@ impl WasmActor for TextFieldWidget {
     /// The panel root's per-frame poll; not useful to send manually.
     #[handler::single]
     fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
-        if reply_if_hidden(ctx, &self.state) {
-            return;
-        }
-        let Some(parent) = ctx.parent() else {
-            return;
-        };
-        let width = self.frame.width;
-        let height = self.frame.height;
-        let pad = self.theme.pad;
-        let size = self.theme.value_size_pixels;
-        let text_y = text_origin_y(0.0, height, size);
-        let caret_height = pad.mul_add(-2.0, height).max(1.0);
-        let theme_state = self.theme_state();
-
-        let displayed = self.edit.displayed();
-
-        // One measured layout per rendered string. Every geometry lookup below
-        // reads this table; the warm-up fallback remains character-count based
-        // only until the desired font's metrics settle.
-        let layout =
-            self.font_metrics.resolved().map(|metrics| SingleLineLayout::build(&displayed.text, metrics, size));
-        let prefix_width = |byte: usize| {
-            layout.as_ref().map_or_else(
-                || approx_text_width(displayed.text[..byte].chars().count(), size),
-                |layout| layout.caret_x(byte),
+        reply_with_draw_items(ctx, &self.state, || {
+            single_line_edit_draw_items(
+                &self.edit.displayed(),
+                self.font_metrics.resolved(),
+                &self.theme,
+                &self.state,
+                self.theme_state(),
+                self.frame.width,
+                self.frame.height,
             )
-        };
-
-        let mut items: Vec<WidgetDrawItem> = Vec::new();
-        items.push(quad(0.0, 0.0, width, height, self.theme.fill(self.theme.surface_raised, theme_state)));
-        if let Some(span) = displayed.selection_span {
-            let x0 = pad + prefix_width(span.start_byte);
-            let x1 = pad + prefix_width(span.end_byte);
-            items.push(quad(x0, pad, (x1 - x0).max(1.0), caret_height, self.theme.accent));
-        }
-        if let Some(span) = displayed.preedit_cursor_span.filter(|span| !span.is_collapsed()) {
-            let x0 = pad + prefix_width(span.start_byte);
-            let x1 = pad + prefix_width(span.end_byte);
-            items.push(quad(x0, pad, (x1 - x0).max(1.0), caret_height, self.theme.accent));
-        }
-        if !displayed.text.is_empty() {
-            items.push(WidgetDrawItem::Text {
-                x: pad,
-                y: text_y,
-                font_id: self.theme.font_id,
-                text: displayed.text.clone(),
-                size_pixels: size,
-                color: self.theme.fill(self.theme.text_primary, theme_state),
-                clip: None,
-            });
-        }
-        if let Some(span) = displayed.preedit_span {
-            let x0 = pad + prefix_width(span.start_byte);
-            let x1 = pad + prefix_width(span.end_byte);
-            items.push(quad(x0, text_y + size, (x1 - x0).max(1.0), 1.0, self.theme.accent));
-            if let Some(cursor) = displayed.preedit_cursor_span.filter(|cursor| cursor.is_collapsed()) {
-                let cursor_x = pad + prefix_width(cursor.end_byte);
-                items.push(quad(cursor_x, pad, 1.0, caret_height, self.theme.accent));
-            }
-        }
-        if self.state.focused() && !displayed.composing {
-            let caret_x = pad + prefix_width(displayed.caret_byte);
-            items.push(quad(caret_x, pad, 1.0, caret_height, self.theme.accent));
-        }
-        push_control_outlines(&mut items, width, height, &self.state, &self.theme);
-        parent.send(&WidgetDrawList { intrinsic: None, items });
+        });
     }
 }
 

--- a/crates/aether-kit/src/widget/set/virtual_list.rs
+++ b/crates/aether-kit/src/widget/set/virtual_list.rs
@@ -17,12 +17,12 @@ use aether_kinds::keycode::{KEY_DOWN, KEY_PAGE_DOWN, KEY_PAGE_UP, KEY_UP};
 use aether_kinds::mouse_button;
 use aether_kinds::{Key, MouseButton, MouseButtonRelease};
 
-use crate::widget::set::{push_control_outlines, quad, reply_if_hidden, text_origin_y};
+use crate::widget::set::{push_control_outlines, quad, release_left, reply_with_draw_items, text_origin_y};
 use crate::widget::state::{InteractionState, emit_state_changed};
 use crate::widget::theme::{SetTheme, Theme};
 use crate::widget::{
     Collect, FocusGained, FocusLost, HoverGained, HoverLost, SetWidgetState, VirtualListConfig, VirtualListSelected,
-    WidgetControlState, WidgetDrawItem, WidgetDrawList, WidgetFrame,
+    WidgetControlState, WidgetDrawItem, WidgetFrame,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -281,9 +281,7 @@ impl WasmActor for VirtualListWidget {
 
     #[handler::single]
     fn on_mouse_button_release(&mut self, _ctx: &mut WasmCtx<'_>, release: MouseButtonRelease) {
-        if release.button == mouse_button::LEFT {
-            self.pressed = false;
-        }
+        release_left(&mut self.pressed, false, release);
     }
 
     #[handler::single]
@@ -305,12 +303,7 @@ impl WasmActor for VirtualListWidget {
 
     #[handler::single]
     fn on_collect(&mut self, ctx: &mut WasmCtx<'_>, _collect: Collect) {
-        if reply_if_hidden(ctx, &self.state) {
-            return;
-        }
-        if let Some(parent) = ctx.parent() {
-            parent.send(&WidgetDrawList { intrinsic: None, items: self.draw_items() });
-        }
+        reply_with_draw_items(ctx, &self.state, || self.draw_items());
     }
 }
 

--- a/crates/aether-kit/src/world/mesher/contour.rs
+++ b/crates/aether-kit/src/world/mesher/contour.rs
@@ -68,6 +68,12 @@ fn covered(sample: u8) -> bool {
     scalar_coverage_is_inside(f32::from(sample))
 }
 
+const ORTHOGONAL_OFFSETS: [(i32, i32); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
+
+fn orthogonal_match_count(grid: &[u8], width: usize, height: usize, x: i32, z: i32, expected: bool) -> usize {
+    ORTHOGONAL_OFFSETS.iter().filter(|(dx, dz)| in_mask(grid, width, height, x + dx, z + dz, expected)).count()
+}
+
 fn binary_coverage(sample: u8) -> bool {
     sample == 0 || sample == u8::MAX
 }
@@ -310,10 +316,7 @@ fn prune_one_wide_artifacts(
                 }
                 let sample = grid[gz as usize * gw + gx as usize];
                 let m = covered(sample);
-                let orth_covered = [(-1, 0), (1, 0), (0, -1), (0, 1)]
-                    .iter()
-                    .filter(|(dx, dz)| in_mask(&grid, gw, gh, gx + dx, gz + dz, m))
-                    .count();
+                let orth_covered = orthogonal_match_count(&grid, gw, gh, gx, gz, m);
                 if (m && orth_covered <= 1) || (!m && orth_covered >= 3) {
                     next[gz as usize * gw + gx as usize] = if m {
                         0
@@ -1320,10 +1323,7 @@ mod tests {
         for gz in 0..gh as i32 {
             for gx in 0..gw as i32 {
                 let m = covered(grid[gz as usize * gw + gx as usize]);
-                let orth_covered = [(-1, 0), (1, 0), (0, -1), (0, 1)]
-                    .iter()
-                    .filter(|(dx, dz)| in_mask(&grid, gw, gh, gx + dx, gz + dz, m))
-                    .count();
+                let orth_covered = orthogonal_match_count(&grid, gw, gh, gx, gz, m);
                 if m {
                     assert!(orth_covered >= 2, "one-wide bump survived at ({gx}, {gz})");
                 } else {


### PR DESCRIPTION
## Summary

- consolidate the shared single-line edit projection, hit-testing, drawing, and pointer-release paths used by Numeric and TextField
- share widget option clamping, static state propagation, draw-list replies, and composite frame acceptance
- replace repeated console fixtures and contour neighbor counting with focused helpers
- narrowly suppress actor-macro SetTheme boilerplate whose implementation already delegates to the shared theme helper

This addresses the 17 aether-kit duplicate-code groups in the full main Qodana baseline.

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test -p aether-kit --lib (338 passed)