### PR TITLE
refactor: consolidate core duplicate helpers

### DIFF
--- a/crates/aether-actor-derive/src/manifest.rs
+++ b/crates/aether-actor-derive/src/manifest.rs
@@ -4,6 +4,7 @@ use syn::Type;
 
 use crate::handler_parse::{FallbackFn, HandlerClass, HandlerFn};
 
+//noinspection DuplicatedCode -- proc-macro crates intentionally do not depend on one another for this leaf helper.
 fn to_screaming_snake_case(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 4);
     for (i, ch) in s.chars().enumerate() {

--- a/crates/aether-math/src/color.rs
+++ b/crates/aether-math/src/color.rs
@@ -83,6 +83,7 @@ impl Rgb {
 
     #[inline]
     #[must_use]
+    //noinspection DuplicatedCode -- color and vector constructors are independent public const APIs.
     pub const fn from_array(a: [f32; 3]) -> Self {
         Self::new(a[0], a[1], a[2])
     }
@@ -136,6 +137,7 @@ impl Rgba {
 
     #[inline]
     #[must_use]
+    //noinspection DuplicatedCode -- color and vector constructors are independent public const APIs.
     pub const fn from_array(a: [f32; 4]) -> Self {
         Self::new(a[0], a[1], a[2], a[3])
     }

--- a/crates/aether-substrate-bundle/src/bundle_pack.rs
+++ b/crates/aether-substrate-bundle/src/bundle_pack.rs
@@ -349,6 +349,14 @@ impl<'a> Cursor<'a> {
         let s = str::from_utf8(bytes).map_err(|_| PackError::BadUtf8)?;
         Ok(Some(s.to_owned()))
     }
+
+    fn take_opt_u32(&mut self) -> Result<Option<u32>, PackError> {
+        if self.take_byte()? == 0 {
+            return Ok(None);
+        }
+        let raw = self.take(4)?;
+        Ok(Some(u32::from_le_bytes(raw.try_into().expect("4-byte slice"))))
+    }
 }
 
 /// Decode a pack blob produced by [`encode_pack`].
@@ -369,12 +377,7 @@ pub fn decode_pack(bytes: &[u8]) -> Result<Pack, PackError> {
     }
     let title = cursor.take_opt_string()?;
     let window_mode = cursor.take_opt_string()?;
-    let tick_hz = if cursor.take_byte()? == 0 {
-        None
-    } else {
-        let raw = cursor.take(4)?;
-        Some(u32::from_le_bytes(raw.try_into().expect("4-byte slice")))
-    };
+    let tick_hz = cursor.take_opt_u32()?;
     let count = cursor.take_short_len()?;
     let mut components = Vec::new();
     for _ in 0..count {
@@ -382,12 +385,7 @@ pub fn decode_pack(bytes: &[u8]) -> Result<Pack, PackError> {
         let config = cursor.take_bytes_long()?;
         let name = cursor.take_opt_string()?;
         let export = cursor.take_opt_string()?;
-        let replicas = if cursor.take_byte()? == 0 {
-            None
-        } else {
-            let raw = cursor.take(4)?;
-            Some(u32::from_le_bytes(raw.try_into().expect("4-byte slice")))
-        };
+        let replicas = cursor.take_opt_u32()?;
         components.push(PackedComponent { wasm, config, name, export, replicas });
     }
     Ok(Pack { chassis: ChassisSettings { title, window_mode, tick_hz }, components })

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -617,22 +617,7 @@ mod tests {
     /// reach the actor's per-actor `Local<T>` rings.
     #[test]
     fn claim_mailbox_returns_stampable_actor_slots() {
-        let registry = Arc::new(Registry::new());
-        for d in descriptors::all() {
-            let _ = registry.register_kind_with_descriptor(d);
-        }
-        let mailer = Arc::new(Mailer::new(Arc::clone(&registry)));
-        let aborter: Arc<dyn FatalAborter> = Arc::new(PanicAborter);
-        let actor_registry = Arc::new(ActorRegistry::new());
-        let pool = Pool::start(PoolConfig::default(), Arc::clone(&aborter));
-        let spawner = Arc::new(crate::Spawner::new(
-            Arc::clone(&registry),
-            actor_registry,
-            Arc::clone(&mailer),
-            Arc::clone(&aborter),
-            pool.wake_sink(),
-            RingCapacities::default(),
-        ));
+        let (registry, mailer, spawner, aborter, _pool) = test_infra();
         let mut fallback: Option<FallbackRouter> = None;
         let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
         let mut ctx =

--- a/crates/aether-substrate/src/render/material.rs
+++ b/crates/aether-substrate/src/render/material.rs
@@ -170,14 +170,11 @@ fn material_params_bind_group(
 }
 
 fn material_vertex_layout() -> wgpu::VertexBufferLayout<'static> {
-    wgpu::VertexBufferLayout {
-        array_stride: MATERIAL_VERTEX_STRIDE,
-        step_mode: wgpu::VertexStepMode::Vertex,
-        attributes: &[
-            wgpu::VertexAttribute { offset: 0, shader_location: 0, format: wgpu::VertexFormat::Float32x3 },
-            wgpu::VertexAttribute { offset: 12, shader_location: 1, format: wgpu::VertexFormat::Float32x2 },
-        ],
-    }
+    const ATTRIBUTES: &[wgpu::VertexAttribute] = &[
+        wgpu::VertexAttribute { offset: 0, shader_location: 0, format: wgpu::VertexFormat::Float32x3 },
+        wgpu::VertexAttribute { offset: 12, shader_location: 1, format: wgpu::VertexFormat::Float32x2 },
+    ];
+    super::vertex_layout(MATERIAL_VERTEX_STRIDE, ATTRIBUTES)
 }
 
 fn material_pipeline(
@@ -189,6 +186,7 @@ fn material_pipeline(
     fragment_entry: &'static str,
     vertex_layout: &wgpu::VertexBufferLayout<'_>,
 ) -> wgpu::RenderPipeline {
+    let fragment_targets = [Some(super::color_target_state(color_format, wgpu::BlendState::ALPHA_BLENDING))];
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: Some(label),
         layout: Some(layout),
@@ -198,16 +196,7 @@ fn material_pipeline(
             compilation_options: wgpu::PipelineCompilationOptions::default(),
             buffers: slice::from_ref(vertex_layout),
         },
-        fragment: Some(wgpu::FragmentState {
-            module: shader,
-            entry_point: Some(fragment_entry),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            targets: &[Some(wgpu::ColorTargetState {
-                format: color_format,
-                blend: Some(wgpu::BlendState::ALPHA_BLENDING),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-        }),
+        fragment: Some(super::fragment_state(shader, fragment_entry, &fragment_targets)),
         primitive: wgpu::PrimitiveState {
             topology: wgpu::PrimitiveTopology::TriangleList,
             strip_index_format: None,

--- a/crates/aether-substrate/src/render/mod.rs
+++ b/crates/aether-substrate/src/render/mod.rs
@@ -78,20 +78,38 @@ pub const IDENTITY_VIEW_PROJ: [f32; 16] = [
     0.0, 0.0, 0.0, 1.0, //
 ];
 
+fn vertex_layout(array_stride: u64, attributes: &'static [wgpu::VertexAttribute]) -> wgpu::VertexBufferLayout<'static> {
+    wgpu::VertexBufferLayout { array_stride, step_mode: wgpu::VertexStepMode::Vertex, attributes }
+}
+
+fn color_target_state(format: wgpu::TextureFormat, blend: wgpu::BlendState) -> wgpu::ColorTargetState {
+    wgpu::ColorTargetState { format, blend: Some(blend), write_mask: wgpu::ColorWrites::ALL }
+}
+
+fn fragment_state<'a>(
+    shader: &'a wgpu::ShaderModule,
+    entry_point: &'a str,
+    targets: &'a [Option<wgpu::ColorTargetState>],
+) -> wgpu::FragmentState<'a> {
+    wgpu::FragmentState {
+        module: shader,
+        entry_point: Some(entry_point),
+        compilation_options: wgpu::PipelineCompilationOptions::default(),
+        targets,
+    }
+}
+
 /// `pos vec3 + color vec3` interleaved vertex layout the shared
 /// pipeline expects. Exposed so chassis-side helpers building extra
 /// pipelines (e.g. desktop's wireframe overlay) can match the layout
 /// without re-deriving offsets.
 #[must_use]
 pub fn vertex_buffer_layout() -> wgpu::VertexBufferLayout<'static> {
-    wgpu::VertexBufferLayout {
-        array_stride: VERTEX_STRIDE,
-        step_mode: wgpu::VertexStepMode::Vertex,
-        attributes: &[
-            wgpu::VertexAttribute { offset: 0, shader_location: 0, format: wgpu::VertexFormat::Float32x3 },
-            wgpu::VertexAttribute { offset: 12, shader_location: 1, format: wgpu::VertexFormat::Float32x3 },
-        ],
-    }
+    const ATTRIBUTES: &[wgpu::VertexAttribute] = &[
+        wgpu::VertexAttribute { offset: 0, shader_location: 0, format: wgpu::VertexFormat::Float32x3 },
+        wgpu::VertexAttribute { offset: 12, shader_location: 1, format: wgpu::VertexFormat::Float32x3 },
+    ];
+    vertex_layout(VERTEX_STRIDE, ATTRIBUTES)
 }
 
 /// Single-entry vertex-stage uniform-buffer bind group layout — the

--- a/crates/aether-substrate/src/render/pipeline.rs
+++ b/crates/aether-substrate/src/render/pipeline.rs
@@ -96,6 +96,7 @@ pub fn build_main_pipeline(
     });
 
     let vertex_layout = vertex_buffer_layout();
+    let fragment_targets = [Some(super::color_target_state(color_format, wgpu::BlendState::REPLACE))];
     let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: Some("aether main pipeline"),
         layout: Some(&pipeline_layout),
@@ -105,16 +106,7 @@ pub fn build_main_pipeline(
             compilation_options: wgpu::PipelineCompilationOptions::default(),
             buffers: slice::from_ref(&vertex_layout),
         },
-        fragment: Some(wgpu::FragmentState {
-            module: &shader,
-            entry_point: Some("fs_main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            targets: &[Some(wgpu::ColorTargetState {
-                format: color_format,
-                blend: Some(wgpu::BlendState::REPLACE),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-        }),
+        fragment: Some(super::fragment_state(&shader, "fs_main", &fragment_targets)),
         primitive: wgpu::PrimitiveState {
             topology: wgpu::PrimitiveTopology::TriangleList,
             strip_index_format: None,

--- a/crates/aether-substrate/src/render/quad.rs
+++ b/crates/aether-substrate/src/render/quad.rs
@@ -192,6 +192,7 @@ pub fn build_quad_pipeline(
         ],
     };
 
+    let fragment_targets = [Some(super::color_target_state(color_format, wgpu::BlendState::ALPHA_BLENDING))];
     let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: Some("aether quad pipeline"),
         layout: Some(&pipeline_layout),
@@ -201,16 +202,7 @@ pub fn build_quad_pipeline(
             compilation_options: wgpu::PipelineCompilationOptions::default(),
             buffers: slice::from_ref(&vertex_layout),
         },
-        fragment: Some(wgpu::FragmentState {
-            module: &shader,
-            entry_point: Some("fs_main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            targets: &[Some(wgpu::ColorTargetState {
-                format: color_format,
-                blend: Some(wgpu::BlendState::ALPHA_BLENDING),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-        }),
+        fragment: Some(super::fragment_state(&shader, "fs_main", &fragment_targets)),
         primitive: wgpu::PrimitiveState {
             topology: wgpu::PrimitiveTopology::TriangleList,
             strip_index_format: None,


### PR DESCRIPTION
## Summary

- share render vertex-layout, fragment-state, and color-target descriptor construction without changing the ADR-0140 pass contracts
- decode optional pack u32 fields through one cursor helper
- reuse the chassis test infrastructure constructor
- narrowly document unavoidable duplicate leaf helpers across independent color/vector APIs and proc-macro crates

This addresses seven low-level duplicate-code groups in the full main Qodana baseline.

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test -p aether-math --lib (71 passed)
- cargo test -p aether-substrate-bundle bundle_pack (7 passed)
- cargo test -p aether-substrate --features test-support claim_mailbox_returns_stampable_actor_slots