### PR TITLE
refactor(aether-capabilities): consolidate http runtime helpers

### DIFF
--- a/crates/aether-capabilities/src/http/server/runtime/mod.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/mod.rs
@@ -38,6 +38,7 @@ pub use aether_data::{Kind, KindId, MailboxId};
 pub use aether_substrate::actor::native::envelope::Envelope;
 pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
 pub use aether_substrate::chassis::error::BootError;
+pub use aether_substrate::mail::MailId;
 pub use aether_substrate::mail::mailer::Mailer;
 pub use aether_substrate::mail::registry::{MailboxEntry, Registry};
 

--- a/crates/aether-capabilities/src/http/server/runtime/routing.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/routing.rs
@@ -70,6 +70,7 @@ pub fn normalize_prefix(raw: &str) -> Result<String, String> {
 /// private runtime module, so the five-line check is mirrored rather
 /// than imported). The host-stamped `_self` forms skip it: the stamp
 /// already names a live in-process mailbox.
+//noinspection DuplicatedCode -- intentionally mirrored from the input cap without coupling private runtimes.
 pub fn validate_route_mailbox(registry: &Registry, id: MailboxId) -> Result<(), String> {
     match registry.entry(id) {
         Some(MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_)) => Ok(()),

--- a/crates/aether-capabilities/src/http/server/runtime/state.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/state.rs
@@ -293,7 +293,7 @@ impl HttpSupervisorState {
 }
 
 impl HttpShardState {
-    pub(super) fn wake_sink(&self) -> WakeSink {
+    pub fn wake_sink(&self) -> WakeSink {
         WakeSink {
             inbound_tx: self.inbound_tx.clone(),
             mailer: Arc::clone(&self.mailer),
@@ -303,7 +303,7 @@ impl HttpShardState {
         }
     }
 
-    pub(super) fn subscribe_settlement(&self, mail_id: MailId) {
+    pub fn subscribe_settlement(&self, mail_id: MailId) {
         if let Some(registry) = self.mailer.settlement_registry() {
             registry.subscribe_settlement_mail(
                 mail_id,

--- a/crates/aether-capabilities/src/http/server/runtime/state.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/state.rs
@@ -293,6 +293,27 @@ impl HttpSupervisorState {
 }
 
 impl HttpShardState {
+    pub(super) fn wake_sink(&self) -> WakeSink {
+        WakeSink {
+            inbound_tx: self.inbound_tx.clone(),
+            mailer: Arc::clone(&self.mailer),
+            self_id: self.self_mailbox,
+            wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
+            dirty: Arc::clone(&self.wake_dirty),
+        }
+    }
+
+    pub(super) fn subscribe_settlement(&self, mail_id: MailId) {
+        if let Some(registry) = self.mailer.settlement_registry() {
+            registry.subscribe_settlement_mail(
+                mail_id,
+                self.self_mailbox,
+                <Settled as Kind>::ID,
+                Arc::clone(&self.mailer),
+            );
+        }
+    }
+
     /// Release this connection's slot in the global live count (ADR-0135).
     /// Paired with the supervisor's assignment-time increment; called
     /// exactly once per assigned connection — on close, or on an adoption
@@ -342,13 +363,7 @@ impl HttpShardState {
         // into the thread.
         let (control_tx, control_rx) = mpsc::channel::<ReaderControl>();
 
-        let sink = WakeSink {
-            inbound_tx: self.inbound_tx.clone(),
-            mailer: Arc::clone(&self.mailer),
-            self_id: self.self_mailbox,
-            wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
-            dirty: Arc::clone(&self.wake_dirty),
-        };
+        let sink = self.wake_sink();
         let tuning = ReaderTuning {
             request_timeout: self.request_timeout,
             idle_timeout: self.keep_alive_timeout,
@@ -432,14 +447,7 @@ impl HttpShardState {
         // Safety net (ADR-0108 §5): if the chain settles with no
         // response, `on_settled` answers `502`. Best-effort — a chassis
         // without the settlement registry still serves the reply path.
-        if let Some(registry) = self.mailer.settlement_registry() {
-            registry.subscribe_settlement_mail(
-                mail_id,
-                self.self_mailbox,
-                <Settled as Kind>::ID,
-                Arc::clone(&self.mailer),
-            );
-        }
+        self.subscribe_settlement(mail_id);
         self.in_flight.insert(mail_id.correlation_id, PendingRequest { conn_id, method, keep_alive, handler });
     }
 

--- a/crates/aether-capabilities/src/http/server/runtime/streaming.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/streaming.rs
@@ -67,14 +67,7 @@ impl HttpShardState {
         };
         let payload = HttpRequestStreamEnd { stream_id }.encode_into_bytes();
         let mail_id = ctx.send_envelope_detached(stream.handler, <HttpRequestStreamEnd as Kind>::ID, &payload);
-        if let Some(registry) = self.mailer.settlement_registry() {
-            registry.subscribe_settlement_mail(
-                mail_id,
-                self.self_mailbox,
-                <Settled as Kind>::ID,
-                Arc::clone(&self.mailer),
-            );
-        }
+        self.subscribe_settlement(mail_id);
         self.in_flight.insert(
             mail_id.correlation_id,
             PendingRequest { conn_id, method: stream.method, keep_alive: stream.keep_alive, handler: stream.handler },
@@ -137,13 +130,7 @@ impl HttpShardState {
 
         let window = self.response_stream_window.max(1);
         let (tx, rx) = mpsc::sync_channel::<WriterMsg>(window as usize);
-        let sink = WakeSink {
-            inbound_tx: self.inbound_tx.clone(),
-            mailer: Arc::clone(&self.mailer),
-            self_id: self.self_mailbox,
-            wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
-            dirty: Arc::clone(&self.wake_dirty),
-        };
+        let sink = self.wake_sink();
         let idle_deadline = self.request_timeout;
 
         // Per-connection writer below the mail layer, mirroring the reader

--- a/crates/aether-capabilities/src/http/server/runtime/websocket.rs
+++ b/crates/aether-capabilities/src/http/server/runtime/websocket.rs
@@ -472,13 +472,7 @@ impl HttpShardState {
         let stream_id = self.next_stream_id.fetch_add(1, Ordering::Relaxed);
         let window = self.response_stream_window.max(1);
         let (tx, rx) = mpsc::sync_channel::<WriterMsg>(window as usize);
-        let sink = WakeSink {
-            inbound_tx: self.inbound_tx.clone(),
-            mailer: Arc::clone(&self.mailer),
-            self_id: self.self_mailbox,
-            wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
-            dirty: Arc::clone(&self.wake_dirty),
-        };
+        let sink = self.wake_sink();
         // The writer's idle deadline is the websocket idle timeout: an upgraded
         // socket with nothing to write for minutes is normal, unlike a stalled
         // response stream.

--- a/crates/aether-capabilities/src/http/server/shard/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/shard/runtime.rs
@@ -63,6 +63,7 @@ impl NativeActor for HttpDispatchShard {
     fn unwire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {
         // Stop every per-connection reader. Shutting the socket down
         // wakes the blocked `read()`; the reader sees the flag and exits.
+        //noinspection DuplicatedCode -- HTTP and RPC own distinct connection state and shutdown semantics.
         for conn in state.connections.values_mut() {
             conn.shutdown.store(true, Ordering::Release);
             let _ = conn.write_half.shutdown(Shutdown::Both);

--- a/crates/aether-capabilities/src/http/stream.rs
+++ b/crates/aether-capabilities/src/http/stream.rs
@@ -120,6 +120,7 @@ impl WebSocketStream {
     /// the cap sends at accept time before any peer traffic (ADR-0132).
     /// `None` when the dispatch has no component source.
     #[must_use]
+    //noinspection DuplicatedCode -- response and websocket handles are distinct public protocol types.
     pub fn from_credit(ctx: &impl OutboundReply, credit: &HttpStreamCredit) -> Option<Self> {
         Some(Self { counterparty: ctx.source_mailbox()?, stream_id: credit.stream_id })
     }


### PR DESCRIPTION
## Summary

- construct HTTP reader, response-writer, and websocket wake sinks through one shard-state helper
- subscribe buffered and streamed request chains through one settlement helper
- narrowly document three intentional mirrors across independent capability/public protocol types

This addresses five capability-runtime duplicate-code groups in the full main Qodana baseline without changing wire shapes, flow-control windows, settlement, or shutdown semantics.

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo check -p aether-capabilities --all-features --all-targets
- cargo test -p aether-capabilities --all-features http (79 passed)