### PR TITLE
test: consolidate duplicate fixtures

### DIFF
--- a/crates/aether-behavior/src/host/actor.rs
+++ b/crates/aether-behavior/src/host/actor.rs
@@ -863,6 +863,7 @@ mod tests {
         runtime_context.reply = Some(reply_handle(77));
         let boot_context = load_context(ScriptLoadOrigin::Boot, "assets", "behavior.wasm");
 
+        //noinspection DuplicatedCode -- the test intentionally compares identical reads under distinct request contexts.
         let (runtime_result, runtime_reply) = host.apply_read_result(
             ReadResult::Ok {
                 namespace: "assets".to_string(),

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -685,6 +685,16 @@ where
         .expect("caps boot")
 }
 
+fn boot_single_shard_fixed_body() -> PassiveChassis<TestChassis> {
+    boot_chassis::<FixedBodyHttpHandler>(HttpServerConfig {
+        bind_addr: "127.0.0.1:0".to_string(),
+        handler_mailbox: <FixedBodyHttpHandler as Addressable>::NAMESPACE.to_string(),
+        request_timeout_millis: 5_000,
+        dispatch_shards: 1,
+        ..HttpServerConfig::default()
+    })
+}
+
 /// [`boot_chassis`] with `H` as its own `handler_mailbox` under a
 /// buffered [`config_for`] config (`max_request_bytes`).
 fn boot_buffered<H>(max_request_bytes: usize) -> PassiveChassis<TestChassis>
@@ -1391,13 +1401,7 @@ fn method_specific_route_beats_agnostic() {
 /// exclusive default keeps the route owned by exactly one instance.
 #[test]
 fn bare_router_stays_exclusive_second_claim_rejected() {
-    let chassis = boot_chassis::<FixedBodyHttpHandler>(HttpServerConfig {
-        bind_addr: "127.0.0.1:0".to_string(),
-        handler_mailbox: <FixedBodyHttpHandler as Addressable>::NAMESPACE.to_string(),
-        request_timeout_millis: 5_000,
-        dispatch_shards: 1,
-        ..HttpServerConfig::default()
-    });
+    let chassis = boot_single_shard_fixed_body();
     chassis
         .spawn_actor::<ExclusiveMacroPoolHandler>(Subname::Named("alpha"), b"excl-macro-alpha")
         .finish()
@@ -1439,13 +1443,7 @@ fn macro_router_shared_opt_in_joins_a_member_set() {
     // Pinned to one dispatch shard, like `shared_route_spreads_across_members`:
     // round-robin state is per-shard, so alternation across a request
     // sequence is only deterministic with a single shard.
-    let chassis = boot_chassis::<FixedBodyHttpHandler>(HttpServerConfig {
-        bind_addr: "127.0.0.1:0".to_string(),
-        handler_mailbox: <FixedBodyHttpHandler as Addressable>::NAMESPACE.to_string(),
-        request_timeout_millis: 5_000,
-        dispatch_shards: 1,
-        ..HttpServerConfig::default()
-    });
+    let chassis = boot_single_shard_fixed_body();
     // Two named instances of the exact same `SharedMacroPoolHandler` type
     // (the accurate replica analog, per the type's own doc comment): each
     // instance's `wire` runs the identical macro-emitted `shared: true`

--- a/crates/aether-capabilities/src/http/server/tests.rs
+++ b/crates/aether-capabilities/src/http/server/tests.rs
@@ -1391,18 +1391,13 @@ fn method_specific_route_beats_agnostic() {
 /// exclusive default keeps the route owned by exactly one instance.
 #[test]
 fn bare_router_stays_exclusive_second_claim_rejected() {
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<HttpServerCapability>(HttpServerConfig {
-            bind_addr: "127.0.0.1:0".to_string(),
-            handler_mailbox: <FixedBodyHttpHandler as Addressable>::NAMESPACE.to_string(),
-            request_timeout_millis: 5_000,
-            dispatch_shards: 1,
-            ..HttpServerConfig::default()
-        })
-        .with_actor::<FixedBodyHttpHandler>(())
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_chassis::<FixedBodyHttpHandler>(HttpServerConfig {
+        bind_addr: "127.0.0.1:0".to_string(),
+        handler_mailbox: <FixedBodyHttpHandler as Addressable>::NAMESPACE.to_string(),
+        request_timeout_millis: 5_000,
+        dispatch_shards: 1,
+        ..HttpServerConfig::default()
+    });
     chassis
         .spawn_actor::<ExclusiveMacroPoolHandler>(Subname::Named("alpha"), b"excl-macro-alpha")
         .finish()
@@ -1444,18 +1439,13 @@ fn macro_router_shared_opt_in_joins_a_member_set() {
     // Pinned to one dispatch shard, like `shared_route_spreads_across_members`:
     // round-robin state is per-shard, so alternation across a request
     // sequence is only deterministic with a single shard.
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<HttpServerCapability>(HttpServerConfig {
-            bind_addr: "127.0.0.1:0".to_string(),
-            handler_mailbox: <FixedBodyHttpHandler as Addressable>::NAMESPACE.to_string(),
-            request_timeout_millis: 5_000,
-            dispatch_shards: 1,
-            ..HttpServerConfig::default()
-        })
-        .with_actor::<FixedBodyHttpHandler>(())
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_chassis::<FixedBodyHttpHandler>(HttpServerConfig {
+        bind_addr: "127.0.0.1:0".to_string(),
+        handler_mailbox: <FixedBodyHttpHandler as Addressable>::NAMESPACE.to_string(),
+        request_timeout_millis: 5_000,
+        dispatch_shards: 1,
+        ..HttpServerConfig::default()
+    });
     // Two named instances of the exact same `SharedMacroPoolHandler` type
     // (the accurate replica analog, per the type's own doc comment): each
     // instance's `wire` runs the identical macro-emitted `shared: true`

--- a/crates/aether-capabilities/src/render/mod.rs
+++ b/crates/aether-capabilities/src/render/mod.rs
@@ -142,7 +142,7 @@ mod tests {
     use aether_kinds::QuadSpace;
     use aether_kinds::trace::Nanos;
     use aether_math::Rgba;
-    use aether_substrate::chassis::builder::Builder;
+    use aether_substrate::chassis::builder::{Builder, PassiveChassis};
     use aether_substrate::mail::MailId;
     use aether_substrate::mail::MailRef;
     use aether_substrate::mail::registry::OwnedDispatch;
@@ -178,6 +178,15 @@ mod tests {
         StagedTexture { width: 2, height: 2, format: TextureFormat::Rgba8, pixels, realized: None, dirty: true }
     }
 
+    fn boot_render(config: RenderConfig) -> (Arc<Registry>, PassiveChassis<TestChassis>) {
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<RenderCapability>(config)
+            .build_passive()
+            .expect("build succeeds");
+        (registry, chassis)
+    }
+
     // ADR-0082 retired the frame-bound pending counter; the
     // DrawTriangle → render dispatch path is now covered end-to-end
     // by the bundle scenario tests (`tick_roundtrip_component_to_sink`
@@ -190,11 +199,7 @@ mod tests {
     fn destroy_texture_removes_registry_entry() {
         let observed = Arc::new(Mutex::new(Vec::<String>::new()));
         let config = RenderConfig { observed_kinds: Some(Arc::clone(&observed)), ..RenderConfig::default() };
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<RenderCapability>(config)
-            .build_passive()
-            .expect("build succeeds");
+        let (registry, chassis) = boot_render(config);
         let handles = chassis.handle::<RenderHandles>().expect("RenderCapability publishes RenderHandles");
         let texture_id = 7;
         {
@@ -225,11 +230,7 @@ mod tests {
     /// warn-drop and leave the registry untouched.
     #[test]
     fn destroy_texture_unknown_and_reserved_ids_leave_registry_untouched() {
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<RenderCapability>(RenderConfig::default())
-            .build_passive()
-            .expect("build succeeds");
+        let (registry, chassis) = boot_render(RenderConfig::default());
         let handles = chassis.handle::<RenderHandles>().expect("RenderCapability publishes RenderHandles");
         let user_texture_id = 3;
         {
@@ -259,11 +260,7 @@ mod tests {
     /// draws through the shared sentinel texel.
     #[test]
     fn update_texture_reserved_id_leaves_white_pixels_untouched() {
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<RenderCapability>(RenderConfig::default())
-            .build_passive()
-            .expect("build succeeds");
+        let (registry, chassis) = boot_render(RenderConfig::default());
         let handles = chassis.handle::<RenderHandles>().expect("RenderCapability publishes RenderHandles");
         {
             let mut textures = handles.textures.lock().expect("textures mutex is not poisoned");
@@ -293,11 +290,7 @@ mod tests {
     fn draw_solid_quads_accumulates_and_observed() {
         let observed = Arc::new(Mutex::new(Vec::<String>::new()));
         let config = RenderConfig { observed_kinds: Some(Arc::clone(&observed)), ..RenderConfig::default() };
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<RenderCapability>(config)
-            .build_passive()
-            .expect("build succeeds");
+        let (registry, chassis) = boot_render(config);
         let handles = chassis.handle::<RenderHandles>().expect("RenderCapability publishes RenderHandles");
 
         let mail = DrawSolidQuads {

--- a/crates/aether-capabilities/src/rpc/server/tests.rs
+++ b/crates/aether-capabilities/src/rpc/server/tests.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::disallowed_methods)]
 use super::*;
 use crate::rpc::{Hello, HelloAck, PeerKind, WIRE_VERSION, WireFrame};
+use crate::trace::TraceDispatchCapability;
 use aether_codec::frame::{read_frame, write_frame};
 use aether_substrate::chassis::builder::Builder;
 use aether_substrate::chassis::builder::PassiveChassis;
@@ -41,7 +42,6 @@ fn boot_with_rpc_server_only(timeout: Duration) -> (PassiveChassis<TestChassis>,
 /// `(chassis, stream)`; both must stay alive for the listener.
 fn boot_with_deferred_echo(timeout: Duration) -> (PassiveChassis<TestChassis>, TcpStream) {
     use crate::rpc::server::test_echo::DeferredEchoActor;
-    use crate::trace::TraceDispatchCapability;
 
     let (registry, mailer) = fresh_substrate();
     let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
@@ -56,6 +56,21 @@ fn boot_with_deferred_echo(timeout: Duration) -> (PassiveChassis<TestChassis>, T
     let mut stream = connect_to_rpc_server(&chassis, timeout);
     complete_handshake(&mut stream);
     (chassis, stream)
+}
+
+fn boot_with_echo_server() -> PassiveChassis<TestChassis> {
+    use crate::rpc::server::test_echo::TestEchoActor;
+
+    let (registry, mailer) = fresh_substrate();
+    Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceDispatchCapability>(())
+        .with_actor::<TestEchoActor>(())
+        .with_actor::<RpcServerCapability>(RpcServerConfig {
+            bind_addr: "127.0.0.1:0".into(),
+            peer_kind: test_peer_kind(),
+        })
+        .build_passive()
+        .expect("caps boot")
 }
 
 /// Lift the published `RpcServerHandle`'s `local_port`, open a
@@ -141,25 +156,10 @@ fn ping_pong_roundtrip() {
 fn call_echo_round_trip_event_then_end() {
     use crate::rpc::server::test_echo::{TestEchoActor, TestEchoReply, TestEchoRequest};
     use crate::rpc::{MailEnvelope, MailboxAddress};
-    use crate::trace::TraceDispatchCapability;
     use aether_actor::Addressable;
     use aether_data::{Kind, mailbox_id_from_name};
 
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        // TraceObserver folds substrate-wide trace events into per-
-        // root counters and fires `Settled { root }` mail at the
-        // chassis-mailbox once a root drains. Without it,
-        // RpcServer's settlement subscription never wakes and
-        // the `Call` never produces a `ReplyEnd`.
-        .with_actor::<TraceDispatchCapability>(())
-        .with_actor::<TestEchoActor>(())
-        .with_actor::<RpcServerCapability>(RpcServerConfig {
-            bind_addr: "127.0.0.1:0".into(),
-            peer_kind: test_peer_kind(),
-        })
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_with_echo_server();
 
     let mut stream = connect_to_rpc_server(&chassis, Duration::from_secs(5));
     complete_handshake(&mut stream);
@@ -221,7 +221,6 @@ fn call_echo_round_trip_event_then_end() {
 #[test]
 fn call_headless_window_set_mode_err_reaches_component_reply() {
     use crate::rpc::{MailEnvelope, MailboxAddress};
-    use crate::trace::TraceDispatchCapability;
     use crate::window::HeadlessWindowCapability;
     use aether_actor::Addressable;
     use aether_data::{Kind, mailbox_id_from_name};
@@ -618,23 +617,10 @@ fn client_peer_kind() -> PeerKind {
 fn call_echo_round_trips_over_the_socket() {
     use crate::rpc::server::test_echo::{TestEchoActor, TestEchoReply, TestEchoRequest};
     use crate::rpc::{MailEnvelope, MailboxAddress, RpcClient};
-    use crate::trace::TraceDispatchCapability;
     use aether_actor::Addressable;
     use aether_data::{Kind, mailbox_id_from_name};
 
-    let (registry, mailer) = fresh_substrate();
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        // TraceObserver fires `Settled { root }` once a dispatched
-        // chain drains; without it RpcServer's settlement
-        // subscription never wakes and no `ReplyEnd` is written.
-        .with_actor::<TraceDispatchCapability>(())
-        .with_actor::<TestEchoActor>(())
-        .with_actor::<RpcServerCapability>(RpcServerConfig {
-            bind_addr: "127.0.0.1:0".into(),
-            peer_kind: test_peer_kind(),
-        })
-        .build_passive()
-        .expect("caps boot");
+    let chassis = boot_with_echo_server();
 
     let port = chassis.handle::<RpcServerHandle>().expect("RpcServerHandle published").local_port;
 

--- a/crates/aether-mcp/src/tools/test_support.rs
+++ b/crates/aether-mcp/src/tools/test_support.rs
@@ -128,6 +128,7 @@ pub(super) fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
     }
     let (outbound, _rx) = HubOutbound::attached_loopback();
     let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
+    //noinspection DuplicatedCode -- the inventory variant deliberately extends this typed builder chain.
     let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
         .with_actor::<TraceDispatchCapability>(())
         .with_actor::<EngineServer>(EngineConfig::default())

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -135,6 +135,7 @@ impl WasmActor for StreamingHttpHandler {
     /// `HttpServerConfig.handler_mailbox` at
     /// `"aether.component/aether.embedded:test.web_stream"`.
     #[handler::single]
+    //noinspection DuplicatedCode -- actor macros require one request handler per fixture actor type.
     fn on_request(&mut self, _ctx: &mut WasmCtx<'_>, _req: HttpServerRequest) -> HttpResponseStreamOpen {
         self.next_index = 0;
         self.ended = false;
@@ -149,6 +150,7 @@ impl WasmActor for StreamingHttpHandler {
     /// window slot; the handler emits at most that many `HttpResponseChunk`s
     /// in response.
     #[handler::manual]
+    //noinspection DuplicatedCode -- actor macros require one credit handler per fixture actor type.
     fn on_credit(&mut self, ctx: &mut WasmCtx<'_, Manual>, credit: HttpStreamCredit) {
         spend_credit(&mut self.stream, &mut self.next_index, &mut self.ended, ctx, &credit);
     }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/http_handler.rs
@@ -134,8 +134,8 @@ impl WasmActor for StreamingHttpHandler {
     /// every inbound request. Route here by pointing
     /// `HttpServerConfig.handler_mailbox` at
     /// `"aether.component/aether.embedded:test.web_stream"`.
-    #[handler::single]
     //noinspection DuplicatedCode -- actor macros require one request handler per fixture actor type.
+    #[handler::single]
     fn on_request(&mut self, _ctx: &mut WasmCtx<'_>, _req: HttpServerRequest) -> HttpResponseStreamOpen {
         self.next_index = 0;
         self.ended = false;
@@ -149,8 +149,8 @@ impl WasmActor for StreamingHttpHandler {
     /// Not sent manually — the cap sends one `HttpStreamCredit` per freed
     /// window slot; the handler emits at most that many `HttpResponseChunk`s
     /// in response.
-    #[handler::manual]
     //noinspection DuplicatedCode -- actor macros require one credit handler per fixture actor type.
+    #[handler::manual]
     fn on_credit(&mut self, ctx: &mut WasmCtx<'_, Manual>, credit: HttpStreamCredit) {
         spend_credit(&mut self.stream, &mut self.next_index, &mut self.ended, ctx, &credit);
     }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/inline_child.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/inline_child.rs
@@ -228,6 +228,7 @@ impl WasmActor for InlineStatefulChild {
     /// Reply with the live counter so a test can read the child's state
     /// across a swap.
     #[handler::manual]
+    //noinspection DuplicatedCode -- actor macros require one query handler per hot-swap fixture type.
     fn on_count_query(&mut self, ctx: &mut WasmCtx<'_, Manual>, _query: CountQuery) {
         if ctx.reply_target().is_some() {
             ctx.reply(&CountReport { count: self.count });


### PR DESCRIPTION
## Summary
- share repeated RPC, HTTP, and render test chassis setup
- document intentional actor-macro and context-comparison fixture mirrors with narrow Qodana suppressions
- leave dependency-version inspections excluded by repository policy

This PR does not modify TCP code.

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo check -p aether-capabilities -p aether-mcp -p aether-behavior -p aether-test-fixtures-bundle --all-features --all-targets
- cargo test -p aether-capabilities --all-features rpc
- cargo test -p aether-capabilities --all-features render
- cargo test -p aether-capabilities --all-features macro_router