### PR TITLE
chore: enforce zero Qodana findings

### DIFF
--- a/crates/aether-behavior/src/host/actor.rs
+++ b/crates/aether-behavior/src/host/actor.rs
@@ -610,6 +610,10 @@ mod tests {
         )
     }
 
+    fn attached_script_read_result() -> ReadResult {
+        ReadResult::Ok { namespace: "assets".to_string(), path: "behavior.wasm".to_string(), bytes: attach_script() }
+    }
+
     fn assert_attach_offered(sink: &RecordingSink) {
         assert_eq!(
             sink.events,
@@ -863,28 +867,12 @@ mod tests {
         runtime_context.reply = Some(reply_handle(77));
         let boot_context = load_context(ScriptLoadOrigin::Boot, "assets", "behavior.wasm");
 
-        //noinspection DuplicatedCode -- the test intentionally compares identical reads under distinct request contexts.
-        let (runtime_result, runtime_reply) = host.apply_read_result(
-            ReadResult::Ok {
-                namespace: "assets".to_string(),
-                path: "behavior.wasm".to_string(),
-                bytes: attach_script(),
-            },
-            runtime_context,
-            |_| {},
-        );
+        let (runtime_result, runtime_reply) =
+            host.apply_read_result(attached_script_read_result(), runtime_context, |_| {});
         assert!(matches!(runtime_result, Ok(_)));
         assert_eq!(runtime_reply.map(ReplyHandle::raw), Some(77));
 
-        let (boot_result, boot_reply) = host.apply_read_result(
-            ReadResult::Ok {
-                namespace: "assets".to_string(),
-                path: "behavior.wasm".to_string(),
-                bytes: attach_script(),
-            },
-            boot_context,
-            |_| {},
-        );
+        let (boot_result, boot_reply) = host.apply_read_result(attached_script_read_result(), boot_context, |_| {});
         assert!(matches!(boot_result, Ok(_)));
         assert!(boot_reply.is_none());
     }

--- a/crates/aether-capabilities/src/http/server/shard/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/shard/runtime.rs
@@ -60,10 +60,10 @@ impl NativeActor for HttpDispatchShard {
         })
     }
 
+    //noinspection DuplicatedCode -- HTTP and RPC own distinct connection state and shutdown semantics.
     fn unwire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {
         // Stop every per-connection reader. Shutting the socket down
         // wakes the blocked `read()`; the reader sees the flag and exits.
-        //noinspection DuplicatedCode -- HTTP and RPC own distinct connection state and shutdown semantics.
         for conn in state.connections.values_mut() {
             conn.shutdown.store(true, Ordering::Release);
             let _ = conn.write_half.shutdown(Shutdown::Both);

--- a/crates/aether-capabilities/src/http/stream.rs
+++ b/crates/aether-capabilities/src/http/stream.rs
@@ -52,6 +52,7 @@ impl ResponseStream {
     /// (broadcast / session / substrate-origin mail cannot open a stream) —
     /// so a handler stores an `Option<ResponseStream>` and sends only once
     /// the first grant has armed it.
+    //noinspection DuplicatedCode -- response and websocket handles are distinct public protocol types.
     #[must_use]
     pub fn from_credit(ctx: &impl OutboundReply, credit: &HttpStreamCredit) -> Option<Self> {
         Some(Self { counterparty: ctx.source_mailbox()?, stream_id: credit.stream_id })
@@ -119,8 +120,8 @@ impl WebSocketStream {
     /// Capture the handle from the first [`HttpStreamCredit`] grant, which
     /// the cap sends at accept time before any peer traffic (ADR-0132).
     /// `None` when the dispatch has no component source.
-    #[must_use]
     //noinspection DuplicatedCode -- response and websocket handles are distinct public protocol types.
+    #[must_use]
     pub fn from_credit(ctx: &impl OutboundReply, credit: &HttpStreamCredit) -> Option<Self> {
         Some(Self { counterparty: ctx.source_mailbox()?, stream_id: credit.stream_id })
     }

--- a/crates/aether-capabilities/src/rpc/server/runtime.rs
+++ b/crates/aether-capabilities/src/rpc/server/runtime.rs
@@ -415,6 +415,7 @@ impl NativeActor for RpcServerCapability {
         })
     }
 
+    //noinspection DuplicatedCode -- RPC and HTTP own distinct connection state and shutdown semantics.
     fn unwire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {
         // Stop the accept thread; self-connect to unblock its blocking
         // `accept()`.

--- a/crates/aether-kit/src/widget/mod.rs
+++ b/crates/aether-kit/src/widget/mod.rs
@@ -614,8 +614,8 @@ impl WasmActor for Widget {
     ///
     /// # Agent
     /// A child's reply; not useful to send manually.
-    #[handler::manual]
     //noinspection DuplicatedCode -- actor macros require one draw-list handler per composite owner type.
+    #[handler::manual]
     fn on_draw_list(&mut self, ctx: &mut WasmCtx<'_, Manual>, list: WidgetDrawList) {
         if accept_open_child_list(&self.frame_discharge, &mut self.composite, ctx, list) {
             self.finish(ctx);

--- a/crates/aether-kit/src/widget/panel.rs
+++ b/crates/aether-kit/src/widget/panel.rs
@@ -942,6 +942,7 @@ impl WasmActor for WidgetPanel {
     ///
     /// # Agent
     /// A child's reply; not useful to send manually.
+    //noinspection DuplicatedCode -- actor macros require one draw-list handler per composite owner type.
     #[handler::manual]
     fn on_draw_list(&mut self, ctx: &mut WasmCtx<'_, Manual>, list: WidgetDrawList) {
         if accept_open_child_list(&self.frame_discharge, &mut self.composite, ctx, list) {

--- a/crates/aether-kit/src/widget/scroll.rs
+++ b/crates/aether-kit/src/widget/scroll.rs
@@ -330,6 +330,7 @@ impl WasmActor for ScrollWidget {
         self.drive_frame(ctx);
     }
 
+    //noinspection DuplicatedCode -- actor macros require one draw-list handler per composite owner type.
     #[handler::manual]
     fn on_draw_list(&mut self, ctx: &mut WasmCtx<'_, Manual>, list: WidgetDrawList) {
         if accept_open_child_list(&self.frame_discharge, &mut self.composite, ctx, list) {

--- a/crates/aether-math/src/color.rs
+++ b/crates/aether-math/src/color.rs
@@ -81,9 +81,9 @@ impl Rgb {
         Self::new(srgb8_channel_to_linear(r), srgb8_channel_to_linear(g), srgb8_channel_to_linear(b))
     }
 
+    //noinspection DuplicatedCode -- color and vector constructors are independent public const APIs.
     #[inline]
     #[must_use]
-    //noinspection DuplicatedCode -- color and vector constructors are independent public const APIs.
     pub const fn from_array(a: [f32; 3]) -> Self {
         Self::new(a[0], a[1], a[2])
     }
@@ -135,9 +135,9 @@ impl Rgba {
         hsl.to_rgba()
     }
 
+    //noinspection DuplicatedCode -- color and vector constructors are independent public const APIs.
     #[inline]
     #[must_use]
-    //noinspection DuplicatedCode -- color and vector constructors are independent public const APIs.
     pub const fn from_array(a: [f32; 4]) -> Self {
         Self::new(a[0], a[1], a[2], a[3])
     }

--- a/crates/aether-math/src/vec.rs
+++ b/crates/aether-math/src/vec.rs
@@ -112,6 +112,7 @@ impl Vec3 {
 
     /// Construct a `Vec3` from a `[f32; 3]`. Mirror of [`Self::to_array`].
     /// Useful when bridging to legacy storage (mesh AST, OBJ, etc.).
+    //noinspection DuplicatedCode -- vector and color constructors are independent public const APIs.
     #[inline]
     #[must_use]
     pub const fn from_array(a: [f32; 3]) -> Self {
@@ -265,6 +266,7 @@ impl Vec4 {
 
     /// Construct a `Vec4` from a `[f32; 4]`. Mirror of
     /// [`Self::to_array`]; the array is `[x, y, z, w]`.
+    //noinspection DuplicatedCode -- vector and color constructors are independent public const APIs.
     #[inline]
     #[must_use]
     pub const fn from_array(a: [f32; 4]) -> Self {

--- a/crates/aether-mcp/src/tools/test_support.rs
+++ b/crates/aether-mcp/src/tools/test_support.rs
@@ -121,6 +121,7 @@ pub(super) fn stage_blob_file(tag: &str, bytes: &[u8]) -> PathBuf {
 /// the `RpcServer`'s local Calls settle and close). Returns the
 /// chassis (kept alive for its dispatcher threads) and the RPC
 /// port an `RpcSession` dials.
+//noinspection DuplicatedCode -- the inventory variant deliberately extends this typed builder chain.
 pub(super) fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
     let registry = Arc::new(Registry::new());
     for d in descriptors::all() {
@@ -128,7 +129,6 @@ pub(super) fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
     }
     let (outbound, _rx) = HubOutbound::attached_loopback();
     let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
-    //noinspection DuplicatedCode -- the inventory variant deliberately extends this typed builder chain.
     let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
         .with_actor::<TraceDispatchCapability>(())
         .with_actor::<EngineServer>(EngineConfig::default())
@@ -166,6 +166,7 @@ pub(super) fn connect_mcp(port: u16) -> Mcp {
 /// `descriptors::all()`. Used by ADR-0091's end-to-end check that
 /// the MCP encode path picks the registered kind up via
 /// `aether.inventory.kinds`.
+//noinspection DuplicatedCode -- this variant extends the base hub with inventory and extra descriptors.
 pub(super) fn boot_hub_with_inventory(extras: &[KindDescriptor]) -> (PassiveChassis<TestChassis>, u16) {
     use aether_capabilities::InventoryCapability;
 

--- a/crates/aether-substrate/src/render/material.rs
+++ b/crates/aether-substrate/src/render/material.rs
@@ -169,6 +169,7 @@ fn material_params_bind_group(
     })
 }
 
+//noinspection DuplicatedCode -- material UVs and the main pipeline's colors require distinct layouts.
 fn material_vertex_layout() -> wgpu::VertexBufferLayout<'static> {
     const ATTRIBUTES: &[wgpu::VertexAttribute] = &[
         wgpu::VertexAttribute { offset: 0, shader_location: 0, format: wgpu::VertexFormat::Float32x3 },

--- a/crates/aether-substrate/src/render/mod.rs
+++ b/crates/aether-substrate/src/render/mod.rs
@@ -103,6 +103,7 @@ fn fragment_state<'a>(
 /// pipeline expects. Exposed so chassis-side helpers building extra
 /// pipelines (e.g. desktop's wireframe overlay) can match the layout
 /// without re-deriving offsets.
+//noinspection DuplicatedCode -- this color layout is distinct from the material pipeline's UV layout.
 #[must_use]
 pub fn vertex_buffer_layout() -> wgpu::VertexBufferLayout<'static> {
     const ATTRIBUTES: &[wgpu::VertexAttribute] = &[

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/inline_child.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/inline_child.rs
@@ -227,8 +227,8 @@ impl WasmActor for InlineStatefulChild {
 
     /// Reply with the live counter so a test can read the child's state
     /// across a swap.
-    #[handler::manual]
     //noinspection DuplicatedCode -- actor macros require one query handler per hot-swap fixture type.
+    #[handler::manual]
     fn on_count_query(&mut self, ctx: &mut WasmCtx<'_, Manual>, _query: CountQuery) {
         if ctx.reply_target().is_some() {
             ctx.reply(&CountReport { count: self.count });
@@ -389,6 +389,7 @@ impl WasmActor for InlineConfiguredChild {
 
     /// Reply with the live counter so a test can read the child's state
     /// across a swap.
+    //noinspection DuplicatedCode -- actor macros require one query handler per hot-swap fixture type.
     #[handler::manual]
     fn on_count_query(&mut self, ctx: &mut WasmCtx<'_, Manual>, _query: CountQuery) {
         if ctx.reply_target().is_some() {

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/stateful_replace.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/stateful_replace.rs
@@ -46,6 +46,7 @@ impl WasmActor for Counter {
     }
 
     /// Reply with the live counter so a test can read it across a swap.
+    //noinspection DuplicatedCode -- actor macros require one query handler per hot-swap fixture type.
     #[handler::manual]
     fn on_count_query(&mut self, ctx: &mut WasmCtx<'_, Manual>, _query: CountQuery) {
         if ctx.reply_target().is_some() {

--- a/crates/aether-test-fixtures/aether-test-fixtures-stateful-reshaped/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-stateful-reshaped/src/lib.rs
@@ -57,6 +57,7 @@ impl WasmActor for Counter {
         self.count += 1;
     }
 
+    //noinspection DuplicatedCode -- actor macros require one query handler per hot-swap fixture type.
     #[handler::manual]
     fn on_count_query(&mut self, ctx: &mut WasmCtx<'_, Manual>, _query: CountQuery) {
         if ctx.reply_target().is_some() {

--- a/crates/aether-test-fixtures/aether-test-fixtures-stateful-typed/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-stateful-typed/src/lib.rs
@@ -68,6 +68,7 @@ impl WasmActor for Counter {
     }
 
     /// Reply with the live counter so a test can read it across a swap.
+    //noinspection DuplicatedCode -- actor macros require one query handler per hot-swap fixture type.
     #[handler::manual]
     fn on_count_query(&mut self, ctx: &mut WasmCtx<'_, Manual>, _query: CountQuery) {
         if ctx.reply_target().is_some() {

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -9,12 +9,10 @@ linter: jetbrains/qodana-rust:2026.1-eap
 profile:
   name: qodana.recommended
 
-# Quality gate: the scan fails when the finding count exceeds this.
-# Bumped 0 -> 2 so a small number of findings get swept at end-of-release
-# rather than blocking each push. Single source of truth — the CI Qodana
-# job reads it (it passes no --fail-threshold CLI override, which would
-# shadow this value).
-failThreshold: 2
+# Quality gate: any in-scope finding fails the scan. Single source of truth —
+# the CI Qodana job passes no --fail-threshold CLI override that would shadow
+# this value.
+failThreshold: 0
 
 # Paths Qodana shouldn't analyse.
 exclude:
@@ -22,6 +20,11 @@ exclude:
   # on a linter's say-so is a supply-chain risk, so version bumps stay a
   # deliberate human decision rather than a quality-gate finding.
   - name: NewCrateVersionAvailable
+  # TCP is maintained and validated on its own assumptions; its current
+  # qualification inspection is intentionally outside this sweep.
+  - name: RsUnnecessaryQualifications
+    paths:
+      - crates/aether-capabilities/src/tcp/listener/runtime.rs
   # Verified false positive scoped to the struct-hosted #[actor] form
   # (ADR-0123). The macro harvests a cap's identity by reading its sibling
   # runtime.rs via proc_macro::Span::local_file(). Qodana's inspection


### PR DESCRIPTION
## Summary
- clear the nine non-TCP duplicate groups from the fresh full-main Qodana artifact
- attach narrow documented suppressions at the declarations Qodana analyzes and deduplicate the behavior read-result fixture
- set Qodana failThreshold to 0 so every future in-scope finding blocks CI
- keep dependency-version inspections excluded as a supply-chain policy and scope the explicitly irrelevant TCP qualification out of this sweep

No TCP source code is modified.

## Verification
- cargo fmt --all -- --check
- cargo test -p aether-behavior --all-features boot_and_runtime_same_path_loads_resolve_to_their_own_contexts
- cargo test -p aether-kit --lib (338 passed)
- cargo clippy --all-targets -- -D warnings