### PR TITLE
feat(dogfood): record the task and agent provenance in every trial rollup

### DIFF
--- a/.claude/workflows/dogfood.js
+++ b/.claude/workflows/dogfood.js
@@ -23,20 +23,35 @@ export const meta = {
 //   authorModel,  string  — model for the Author phase (default 'sonnet').
 //   attemptModel, string  — model for the Attempt (default 'opus' — the consumer does real engineering).
 //   judgeModel,   string  — model for the vision judge (default 'opus').
+//   authorEffort, string  — reasoning effort for the Author (default 'medium').
+//   attemptEffort,string  — reasoning effort for the Attempt (default 'high' — it does real engineering).
+//   judgeEffort,  string  — reasoning effort for the judge (default 'high').
+//   driverModel,  string  — the model of the harness session that INVOKED this workflow. The workflow
+//                           cannot read it, so an unattended caller (the CI action) passes it in purely
+//                           so the rollup can record it. Recorded, never acted on.
 // }
 //
 // returns { proposedTask?, needsApproval?, rollup, task }. For a heavy medium (author / build-layer)
 // authored fresh, the run STOPS after Author and returns { proposedTask, needsApproval:true, rollup:null }
 // — a workflow cannot block on human input, so the caller reviews the task and re-invokes with args.task.
 // A drive task runs straight through. rollup = { totals, succeeded, buildGreen, artifact, friction
-// (grouped papercut|missing-primitive|doc-gap|blocker), softHolds }. softHolds = a wrong artifact verdict
-// or any high-severity blocker — the subset a reviewer clears. friction feeds the flywheel: papercut ->
-// /sketch, missing-primitive -> a build-machinery issue, doc-gap -> a guide edit.
+// (grouped papercut|missing-primitive|doc-gap|blocker), softHolds, task, provenance }. softHolds = a wrong
+// artifact verdict or any high-severity blocker — the subset a reviewer clears. friction feeds the
+// flywheel: papercut -> /sketch, missing-primitive -> a build-machinery issue, doc-gap -> a guide edit.
+//
+// rollup.task and rollup.provenance exist so a trial is DIAGNOSABLE from its evidence alone. A verdict
+// read without the task that produced it, and without the prompt/model/effort of the agent that rendered
+// it, is unfalsifiable: a reader cannot tell a real defect from an agent that was asked the wrong
+// question. They ride inside the rollup (not as a sibling of it) because the rollup is the single file
+// the evidence branch, the viewer, and the issue comment all read.
 
 const A = (typeof args === 'string') ? JSON.parse(args || '{}') : (args || {})
 const AUTHOR_MODEL = A.authorModel || 'sonnet'
 const ATTEMPT_MODEL = A.attemptModel || 'opus'
 const JUDGE_MODEL = A.judgeModel || 'opus'
+const AUTHOR_EFFORT = A.authorEffort || 'medium'
+const ATTEMPT_EFFORT = A.attemptEffort || 'high'
+const JUDGE_EFFORT = A.judgeEffort || 'high'
 
 const MEDIA = ['drive', 'author', 'build-layer']
 // Media whose generated task is expensive to attempt (a scratch crate + compile loop), so a fresh
@@ -193,11 +208,16 @@ Return verdict and rationale.`
 
 // Phase 1 — Author (skipped when a task is supplied). A freshly-authored heavy-medium task is
 // human-gated: the run returns the proposal and stops, because a workflow cannot block on input.
+// Every prompt actually sent is retained verbatim for the rollup's provenance block — the reader of a
+// verdict needs the question the agent was asked, not a reconstruction of it.
+const prompts = { author: null, attempt: null, judge: null }
+
 let task = A.task || null
 if (!task) {
   phase('Author')
-  task = await agent(authorPrompt(A.issue, A.diff, A.surface, A.medium), {
-    label: 'author', phase: 'Author', model: AUTHOR_MODEL, schema: TASK_SCHEMA,
+  prompts.author = authorPrompt(A.issue, A.diff, A.surface, A.medium)
+  task = await agent(prompts.author, {
+    label: 'author', phase: 'Author', model: AUTHOR_MODEL, effort: AUTHOR_EFFORT, schema: TASK_SCHEMA,
   })
   if (!task) throw new Error('dogfood: the Author phase produced no task')
   if (HEAVY.has(task.medium)) {
@@ -210,8 +230,9 @@ if (!task) {
 // Phase 2 — Attempt. A fresh agent, never handed the diff, accomplishes the task through the public
 // surface and logs friction. Heavy media compile a scratch crate, so they get an isolated worktree.
 phase('Attempt')
-const attempt = await agent(attemptPrompt(task), {
-  label: `attempt:${task.medium}`, phase: 'Attempt', model: ATTEMPT_MODEL,
+prompts.attempt = attemptPrompt(task)
+const attempt = await agent(prompts.attempt, {
+  label: `attempt:${task.medium}`, phase: 'Attempt', model: ATTEMPT_MODEL, effort: ATTEMPT_EFFORT,
   agentType: 'general-purpose',
   isolation: HEAVY.has(task.medium) ? 'worktree' : undefined,
   schema: FRICTION_SCHEMA,
@@ -226,8 +247,10 @@ if (!attempt) throw new Error('dogfood: the Attempt agent died with no friction 
 let judge = null
 if (task.expectedArtifact && attempt.engineId) {
   phase('Judge')
-  judge = await agent(judgePrompt(task, attempt.engineId, attempt.replayMails), {
-    label: 'judge', phase: 'Judge', model: JUDGE_MODEL, agentType: 'general-purpose', schema: JUDGE_SCHEMA,
+  prompts.judge = judgePrompt(task, attempt.engineId, attempt.replayMails)
+  judge = await agent(prompts.judge, {
+    label: 'judge', phase: 'Judge', model: JUDGE_MODEL, effort: JUDGE_EFFORT,
+    agentType: 'general-purpose', schema: JUDGE_SCHEMA,
   })
 } else if (task.expectedArtifact && !attempt.engineId) {
   log('dogfood: task expected a render artifact but the Attempt left no live engine — artifact unjudged.')
@@ -252,7 +275,30 @@ const totals = {
   softHolds: softHolds.length,
 }
 
+// What ran, and what it was asked. A phase that did not run (Author on a supplied task, Judge on a
+// non-rendering task) records a null prompt rather than being omitted, so the reader can tell "this phase
+// was skipped" from "this field was never recorded".
+//
+// The stored prompt is clipped: the Author's embeds the entire landed diff, and the rollup is committed
+// to the evidence branch on every trial. The clip is generous enough that the Attempt's and the Judge's
+// prompts — the two a reader actually adjudicates a verdict against — always land whole, and it marks
+// itself when it fires rather than truncating silently.
+const PROMPT_STORE_MAX = 20000
+const storedPrompt = (p) => (p === null || p.length <= PROMPT_STORE_MAX)
+  ? p
+  : `${p.slice(0, PROMPT_STORE_MAX)}\n\n[…clipped ${p.length - PROMPT_STORE_MAX} chars of ${p.length} for the evidence record]`
+
+const provenance = {
+  driver: { model: A.driverModel || null },
+  phases: {
+    author: { model: AUTHOR_MODEL, effort: AUTHOR_EFFORT, agentType: null, prompt: storedPrompt(prompts.author) },
+    attempt: { model: ATTEMPT_MODEL, effort: ATTEMPT_EFFORT, agentType: 'general-purpose', prompt: storedPrompt(prompts.attempt) },
+    judge: { model: JUDGE_MODEL, effort: JUDGE_EFFORT, agentType: 'general-purpose', prompt: storedPrompt(prompts.judge) },
+  },
+}
+
 log(`dogfood [${task.medium}]: succeeded=${attempt.succeeded}${attempt.buildGreen === null ? '' : ` buildGreen=${attempt.buildGreen}`}${judge ? ` artifact=${judge.verdict}` : ''} — ${totals.findings} findings (papercut ${totals.papercut}, missing-primitive ${totals.missingPrimitive}, doc-gap ${totals.docGap}, blocker ${totals.blocker}), ${softHolds.length} SOFT-HOLD`)
+log(`dogfood provenance: driver=${provenance.driver.model || 'unrecorded'} attempt=${ATTEMPT_MODEL}/${ATTEMPT_EFFORT} judge=${JUDGE_MODEL}/${JUDGE_EFFORT}`)
 
 return {
   rollup: {
@@ -263,6 +309,8 @@ return {
     artifact: judge ? { verdict: judge.verdict, rationale: judge.rationale } : null,
     friction: byCategory,
     softHolds,
+    task,
+    provenance,
   },
   task,
 }

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -302,6 +302,12 @@ jobs:
       DOGFOOD_RUN_ID: ${{ github.run_id }}-${{ needs.resolve.outputs.attempt }}
       EXPECTED_ARTIFACT: ${{ needs.resolve.outputs.expected_artifact }}
       ISSUE: ${{ needs.resolve.outputs.issue }}
+      # The model driving the headless harness session that launches the
+      # workflow — NOT the models the workflow's own Author/Attempt/Judge agents
+      # run on (those are dogfood.js's, and it records them itself). One knob so
+      # the auth preflight, the trial, and the provenance the rollup reports can
+      # never disagree about what actually ran.
+      DRIVER_MODEL: claude-sonnet-5
     outputs:
       rollup_produced: ${{ steps.rollup.outputs.produced }}
     steps:
@@ -411,7 +417,7 @@ jobs:
         if: env.CLAUDE_CODE_OAUTH_TOKEN != ''
         run: |
           claude -p "Reply with exactly: AUTH-OK" \
-            --model claude-sonnet-5 \
+            --model "$DRIVER_MODEL" \
             --max-turns 3 | tee /tmp/auth.log
           grep -q "AUTH-OK" /tmp/auth.log
 
@@ -453,16 +459,20 @@ jobs:
           set -euo pipefail
           mkdir -p "$GITHUB_WORKSPACE/dogfood-run"
 
-          # Build the args.task JSON with jq so a brief value carrying quotes,
+          # Build the whole args object with jq so a brief value carrying quotes,
           # backticks, or $ is escaped correctly. `none` maps to a null
           # expectedArtifact (the workflow's "nothing renders" sentinel).
-          task_json="$(jq -nc \
+          # driverModel rides along so the rollup's provenance can record which
+          # model drove this session — the workflow cannot read it otherwise.
+          args_json="$(jq -nc \
             --arg medium "$BRIEF_MEDIUM" \
             --arg prompt "$BRIEF_PROMPT" \
             --arg surface "$BRIEF_SURFACE" \
             --arg artifact "$BRIEF_ARTIFACT" \
-            '{medium: $medium, prompt: $prompt, surfaceUnderTest: $surface,
-              expectedArtifact: (if $artifact == "none" or $artifact == "" then null else $artifact end)}')"
+            --arg driver "$DRIVER_MODEL" \
+            '{task: {medium: $medium, prompt: $prompt, surfaceUnderTest: $surface,
+                     expectedArtifact: (if $artifact == "none" or $artifact == "" then null else $artifact end)},
+              driverModel: $driver}')"
 
           # Assemble the prompt in a quoted heredoc so the interpolated JSON is
           # inserted verbatim (no shell re-parsing of its contents).
@@ -476,7 +486,7 @@ jobs:
           the Workflow/Skill tooling, passing args set to EXACTLY this JSON object. Supplying args.task
           SKIPS the Author phase and its human approval stop — that is what makes this run unattended:
 
-          { "task": ${task_json} }
+          ${args_json}
 
           THE WAIT CONTRACT (load-bearing — headless runs die on this): the Workflow tool runs in the
           BACKGROUND. Launch it, then end your turn with a one-line status note — nothing else. The
@@ -508,7 +518,7 @@ jobs:
           claude -p "$(cat /tmp/dogfood-prompt.md)" \
             --mcp-config .mcp.json \
             --dangerously-skip-permissions \
-            --model claude-sonnet-5 \
+            --model "$DRIVER_MODEL" \
             --max-turns 120 \
             --output-format stream-json --verbose \
             | tee /tmp/dogfood-session.jsonl \

--- a/docs/evidence-viewer/index.html
+++ b/docs/evidence-viewer/index.html
@@ -132,6 +132,27 @@
     border-radius: 4px;
     padding: 0.1rem 0.35rem;
   }
+  /* A prompt is long-form text, not code: wrap it rather than sending the page
+     into a horizontal scroll. */
+  pre {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.75rem;
+    margin: 0.4rem 0 1rem;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font-size: 0.85rem;
+    line-height: 1.45;
+  }
+  details {
+    margin: 0.5rem 0;
+  }
+  summary {
+    cursor: pointer;
+    color: var(--link);
+  }
 </style>
 </head>
 <body>
@@ -415,6 +436,97 @@
     return String(value);
   }
 
+  // The task and the provenance are what make a verdict falsifiable: without the
+  // prompt the consumer was handed and the artifact the judge was told to expect,
+  // a "wrong" is unreadable — you cannot tell a real defect from an agent that was
+  // asked the wrong question. Everything is set via textContent, never innerHTML.
+  function labelled(label, value) {
+    var p = el("p");
+    var strong = el("strong", { text: label + ": " });
+    p.appendChild(strong);
+    p.appendChild(document.createTextNode(fieldText(value) || "—"));
+    return p;
+  }
+
+  function renderTask(task) {
+    var section = el("div", { className: "card" });
+    if (!task || typeof task !== "object") {
+      section.appendChild(el("p", {
+        className: "muted",
+        text: "This run predates task capture — the rollup does not record what the consumer was asked.",
+      }));
+      return section;
+    }
+    section.appendChild(labelled("Medium", task.medium));
+    section.appendChild(labelled("Surface under test", task.surfaceUnderTest));
+
+    section.appendChild(el("div", { className: "category-heading", text: "Handed verbatim to the consumer" }));
+    section.appendChild(el("pre", { text: fieldText(task.prompt) || "—" }));
+
+    section.appendChild(el("div", {
+      className: "category-heading",
+      text: "Expected artifact (the judge grades against this; the consumer never sees it)",
+    }));
+    section.appendChild(el("pre", {
+      text: task.expectedArtifact ? fieldText(task.expectedArtifact) : "(none — nothing renders, so no artifact was judged)",
+    }));
+    return section;
+  }
+
+  function renderProvenance(provenance) {
+    var wrap = document.createDocumentFragment();
+    if (!provenance || typeof provenance !== "object") {
+      wrap.appendChild(el("p", {
+        className: "muted",
+        text: "This run predates provenance capture — the models, effort, and prompts it ran with were not recorded.",
+      }));
+      return wrap;
+    }
+
+    var table = el("table");
+    var thead = el("thead");
+    var headRow = el("tr");
+    ["phase", "model", "effort", "agent type"].forEach(function (heading) {
+      headRow.appendChild(el("th", { text: heading }));
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+
+    var tbody = el("tbody");
+    var driverRow = el("tr");
+    driverRow.appendChild(el("td", { text: "driver (harness session)" }));
+    driverRow.appendChild(el("td", { text: fieldText(provenance.driver && provenance.driver.model) || "—" }));
+    driverRow.appendChild(el("td", { text: "—" }));
+    driverRow.appendChild(el("td", { text: "—" }));
+    tbody.appendChild(driverRow);
+
+    var phases = provenance.phases || {};
+    var order = ["author", "attempt", "judge"];
+    order.forEach(function (name) {
+      var phase = phases[name];
+      if (!phase) return;
+      var tr = el("tr");
+      tr.appendChild(el("td", { text: phase.prompt ? name : name + " (did not run)" }));
+      tr.appendChild(el("td", { text: fieldText(phase.model) || "—" }));
+      tr.appendChild(el("td", { text: fieldText(phase.effort) || "—" }));
+      tr.appendChild(el("td", { text: fieldText(phase.agentType) || "—" }));
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    wrap.appendChild(table);
+
+    order.forEach(function (name) {
+      var phase = phases[name];
+      if (!phase || !phase.prompt) return;
+      var details = el("details");
+      details.appendChild(el("summary", { text: "The " + name + " prompt, as sent" }));
+      details.appendChild(el("pre", { text: fieldText(phase.prompt) }));
+      wrap.appendChild(details);
+    });
+
+    return wrap;
+  }
+
   function renderFrictionTable(friction) {
     var wrap = document.createDocumentFragment();
     if (!friction || typeof friction !== "object") return wrap;
@@ -555,6 +667,9 @@
     app.appendChild(el("h1", { text: "Evidence: " + run.joined }));
     app.appendChild(renderVerdictHeader(rollup));
 
+    app.appendChild(el("h2", { text: "The task" }));
+    app.appendChild(renderTask(rollup.task));
+
     app.appendChild(el("h2", { text: "Friction" }));
     app.appendChild(renderFrictionTable(rollup.friction));
 
@@ -569,6 +684,9 @@
 
     app.appendChild(el("h2", { text: "Media & artifacts" }));
     app.appendChild(renderMedia(run));
+
+    app.appendChild(el("h2", { text: "Provenance" }));
+    app.appendChild(renderProvenance(rollup.provenance));
   }
 
   function main() {

--- a/scripts/post-dogfood-rollup.mjs
+++ b/scripts/post-dogfood-rollup.mjs
@@ -137,6 +137,67 @@ function verdictLines(rollup) {
   return lines
 }
 
+// A verdict is only readable against the question that produced it. `wrong` on a
+// frame says nothing until you can see the task the consumer was handed and the
+// artifact the judge was told to expect — those two disagreeing is itself the
+// most common way a trial goes bad. So they lead, ahead of the friction table.
+function taskLines(task) {
+  if (!task) return []
+  const lines = ['', '### The task', '']
+  lines.push(`- **Medium:** ${cell(task.medium)}`)
+  lines.push(`- **Surface under test:** ${cell(task.surfaceUnderTest)}`)
+  if (task.prompt) lines.push('', '**Handed verbatim to the consumer:**', '', blockquote(task.prompt))
+  lines.push(
+    '',
+    '**Expected artifact** — the judge grades against this; the consumer is not shown it:',
+    '',
+    task.expectedArtifact ? blockquote(task.expectedArtifact) : '> _(none — nothing renders, so no artifact was judged)_',
+  )
+  return lines
+}
+
+// Prompts are long and only wanted when a verdict is being contested, so they
+// collapse. The clip is the GitHub comment budget, not the evidence budget — the
+// rollup on the evidence branch keeps the fuller text, and the viewer shows it.
+const COMMENT_PROMPT_MAX = 4000
+
+function provenanceLines(provenance) {
+  if (!provenance) return []
+  const phases = provenance.phases || {}
+  const lines = ['', '### Provenance', '', '| phase | model | effort |', '| --- | --- | --- |']
+  const driver = (provenance.driver && provenance.driver.model) || null
+  lines.push(`| driver (harness session) | ${cell(driver)} | ${cell(null)} |`)
+  for (const name of ['author', 'attempt', 'judge']) {
+    const p = phases[name]
+    if (!p) continue
+    const ran = p.prompt ? '' : ' _(did not run)_'
+    lines.push(`| ${name}${ran} | ${cell(p.model)} | ${cell(p.effort)} |`)
+  }
+  for (const name of ['author', 'attempt', 'judge']) {
+    const p = phases[name]
+    if (!p || !p.prompt) continue
+    const text = p.prompt.length > COMMENT_PROMPT_MAX
+      ? `${p.prompt.slice(0, COMMENT_PROMPT_MAX)}\n\n[…clipped — full prompt in the evidence viewer]`
+      : p.prompt
+    lines.push(
+      '',
+      `<details><summary>The <code>${name}</code> prompt, as sent</summary>`,
+      '',
+      '```',
+      // A fence inside the prompt would otherwise close this one early.
+      text.replace(/```/g, "'''"),
+      '```',
+      '',
+      '</details>',
+    )
+  }
+  return lines
+}
+
+function blockquote(text) {
+  return String(text).split(/\r?\n/).map((l) => `> ${l}`).join('\n')
+}
+
 const CATEGORIES = ['blocker', 'missing-primitive', 'papercut', 'doc-gap']
 
 function frictionLines(friction) {
@@ -206,6 +267,7 @@ export function markerLine(rollup, attempt = 1, verdict = markerVerdict(rollup))
 export function renderComment(rollup, hasFrame, { attempt = 1, runRef = '' } = {}) {
   const lines = [markerLine(rollup, attempt), '## Dogfood trial', '']
   lines.push(...verdictLines(rollup))
+  lines.push(...taskLines(rollup.task))
   lines.push('', '### Friction')
   lines.push(...frictionLines(rollup.friction))
   lines.push(...softHoldLines(rollup.softHolds))
@@ -213,6 +275,7 @@ export function renderComment(rollup, hasFrame, { attempt = 1, runRef = '' } = {
   if (hasFrame) {
     lines.push('', '### Judged frame', '', `![judged frame](${RAW_BASE}/${runRef}/frame.png)`)
   }
+  lines.push(...provenanceLines(rollup.provenance))
   lines.push('', `[Full run in the evidence viewer](${VIEWER_BASE}?run=${encodeURIComponent(runRef)})`)
   return lines.join('\n')
 }

--- a/scripts/post-dogfood-rollup.test.mjs
+++ b/scripts/post-dogfood-rollup.test.mjs
@@ -56,3 +56,95 @@ test('a clean rollup remains green and non-actionable', () => {
     /<!-- aether-dogfood attempts=3 verdict=green -->/,
   )
 })
+
+// The trial that motivated task + provenance capture (run 29155032950): the judge
+// ruled `wrong` against a rubric describing a three-frame comparison it could never
+// have made from one capture, and the posted comment showed neither the task nor the
+// rubric — so the verdict could not be checked by the human reading it. A comment
+// that carries a verdict must carry the question that produced it.
+const GROUNDED_ROLLUP = {
+  succeeded: true,
+  buildGreen: null,
+  summary: 'Drove the proposal lifecycle over MCP.',
+  artifact: { verdict: 'wrong', rationale: 'No terrain surface in the frame.' },
+  friction: { blocker: [], 'missing-primitive': [], papercut: [], 'doc-gap': [] },
+  softHolds: [],
+  task: {
+    medium: 'drive',
+    prompt: 'Load `aether.kit.world` and stage a cross-chunk proposal.',
+    surfaceUnderTest: '`aether.kit.world.{propose,commit_proposal}`',
+    expectedArtifact: 'a preview frame that visibly differs from the committed baseline',
+  },
+  provenance: {
+    driver: { model: 'claude-sonnet-5' },
+    phases: {
+      author: { model: 'sonnet', effort: 'medium', agentType: null, prompt: null },
+      attempt: { model: 'opus', effort: 'high', agentType: 'general-purpose', prompt: 'You are a FRESH consumer.' },
+      judge: { model: 'opus', effort: 'high', agentType: 'general-purpose', prompt: 'You are a vision judge.' },
+    },
+  },
+}
+
+test('a rollup carrying a task renders the prompt and the rubric the judge graded against', () => {
+  const comment = renderComment(GROUNDED_ROLLUP, true, { attempt: 1, runRef: '3088/12345-1' })
+
+  assert.match(comment, /### The task/)
+  assert.match(comment, /\*\*Medium:\*\* drive/)
+  assert.match(comment, /> Load `aether\.kit\.world` and stage a cross-chunk proposal\./)
+  // The pass bar must be visible next to the verdict it produced, and labelled as
+  // something the consumer was never shown — that asymmetry is the bug it exposes.
+  assert.match(comment, /\*\*Expected artifact\*\*.*the consumer is not shown it/)
+  assert.match(comment, /> a preview frame that visibly differs from the committed baseline/)
+})
+
+test('provenance reports every phase model and effort, and flags the phase that did not run', () => {
+  const comment = renderComment(GROUNDED_ROLLUP, false, { attempt: 1, runRef: '3088/12345-1' })
+
+  assert.match(comment, /### Provenance/)
+  assert.match(comment, /\| driver \(harness session\) \| claude-sonnet-5 \|/)
+  assert.match(comment, /\| attempt \| opus \| high \|/)
+  assert.match(comment, /\| judge \| opus \| high \|/)
+  // Author is skipped whenever CI supplies the task, which is every unattended run.
+  // Reporting its model without saying it never ran would misdescribe the trial.
+  assert.match(comment, /\| author _\(did not run\)_ \| sonnet \| medium \|/)
+  assert.match(comment, /<details><summary>The <code>attempt<\/code> prompt, as sent<\/summary>/)
+  assert.doesNotMatch(comment, /<summary>The <code>author<\/code> prompt/)
+})
+
+test('a fenced prompt cannot break out of the collapsible that contains it', () => {
+  const rollup = {
+    ...GROUNDED_ROLLUP,
+    provenance: {
+      driver: { model: 'claude-sonnet-5' },
+      phases: {
+        attempt: {
+          model: 'opus',
+          effort: 'high',
+          agentType: 'general-purpose',
+          prompt: 'Run this:\n```bash\necho hi\n```\nthen stop.',
+        },
+      },
+    },
+  }
+
+  const comment = renderComment(rollup, false, { attempt: 1, runRef: '3088/12345-1' })
+  const details = comment.slice(comment.indexOf('<details>'))
+  // Exactly the one opening fence and the one closing fence this renderer emits.
+  assert.equal(details.match(/```/g).length, 2)
+  assert.match(details, /'''bash/)
+})
+
+test('a rollup predating task and provenance capture still renders', () => {
+  const legacy = {
+    succeeded: true,
+    buildGreen: null,
+    summary: 'An older trial.',
+    artifact: null,
+    friction: { blocker: [], 'missing-primitive': [], papercut: [], 'doc-gap': [] },
+    softHolds: [],
+  }
+
+  const comment = renderComment(legacy, false, { attempt: 1, runRef: '3088/12345-1' })
+  assert.doesNotMatch(comment, /### The task|### Provenance/)
+  assert.match(comment, /## Dogfood trial/)
+})


### PR DESCRIPTION
## Why

A dogfood verdict was unreadable on its own. The posted rollup carried the judge's ruling but not the task the consumer was handed, not the artifact the judge was told to expect, and nothing about which model, effort, or prompt produced any of it.

That is not academic. Auditing the last 23 trials, the `wrong` artifact verdict — the only verdict that raises a soft-hold — has a false-positive rate around 60–80%. Run `29155032950` ruled a terrain feature visibly broken because the frame showed "no terrain grid, no editable surface." The frame was correct. The world starts empty, the consumer stamped a band, and the band is what a correct render looks like. The judge invented a landscape from the word "terrain" in the brief and graded against that. Nobody reading the comment could have caught it, because the comment showed neither the task nor the rubric.

## What

The rollup now carries `task` and `provenance`, and both surfaces that read it — the issue comment and the evidence viewer — render them.

- **`task`** — medium, surface under test, the prompt handed verbatim to the consumer, and the `expectedArtifact` the judge grades against. The rubric sits next to the verdict it produced and is labelled as something the consumer was never shown.
- **`provenance`** — per phase (author / attempt / judge): model, effort, agent type, and the prompt as sent. Plus the driver model of the harness session that launched the workflow, which the workflow cannot read for itself, so the action passes it in.
- **Effort is now explicit** — attempt and judge at `high`, author at `medium`. It was previously unset and unreported, so two trials could run at different effort with nothing in the record to say so.
- **`DRIVER_MODEL`** is a single job-level knob feeding the auth preflight, the trial, and the recorded provenance, so they cannot disagree about what ran.

Rendered against run `29155032950`'s real archived rollup, the bad verdict now indicts itself on sight: the rubric visibly demands a three-frame comparison the judge could never have made from one capture, and never mentions a terrain grid at all.

## Notes

- Stored prompts clip at 20k chars — the author's embeds the whole landed diff, and the rollup is committed to the evidence branch on every trial. The clip marks itself when it fires; the attempt and judge prompts always land whole.
- Rollups predating this change render exactly as before (both sections omitted). Covered by a test.
- This is observability only. It changes no verdict logic. The judge fixes it makes diagnosable — grounding the judge in the task, letting it return `insufficient-evidence`, and having it grade the consumer's saved frames instead of re-capturing a stale engine — are a follow-up, gated on a replay probe over the archived corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)