### PR TITLE
fix(dogfood): ground the vision judge and let it decline an unanswerable rubric

### DIFF
--- a/.claude/workflows/dogfood.js
+++ b/.claude/workflows/dogfood.js
@@ -29,6 +29,9 @@ export const meta = {
 //   driverModel,  string  — the model of the harness session that INVOKED this workflow. The workflow
 //                           cannot read it, so an unattended caller (the CI action) passes it in purely
 //                           so the rollup can record it. Recorded, never acted on.
+//   judgeFramePath, string — absolute path the JUDGE saves the frame it actually grades to. The evidence
+//                           image was previously a later re-capture by the caller, which can disagree with
+//                           what the judge saw; this makes the verdict auditable against its own pixels.
 // }
 //
 // returns { proposedTask?, needsApproval?, rollup, task }. For a heavy medium (author / build-layer)
@@ -118,8 +121,12 @@ const JUDGE_SCHEMA = {
   additionalProperties: false,
   required: ['verdict', 'rationale'],
   properties: {
-    verdict: { type: 'string', enum: ['correct', 'wrong', 'n-a'], description: 'correct = the captured frame matches the expected artifact; wrong = it does not (use-visible defect); n-a = nothing renderable to judge' },
-    rationale: { type: 'string', description: 'what the frame showed vs what was expected — the concrete visual discrepancy for a wrong verdict' },
+    verdict: {
+      type: 'string',
+      enum: ['correct', 'wrong', 'insufficient-evidence', 'n-a'],
+      description: 'correct = the frame satisfies the rubric; wrong = it contradicts the rubric (use-visible defect); insufficient-evidence = the rubric cannot be settled from the evidence given (a comparison with no baseline, a claim about bytes or dimensions, a state not visible in this frame); n-a = nothing renderable to judge',
+    },
+    rationale: { type: 'string', description: 'what the frame showed vs what was expected — the concrete visual discrepancy for a wrong verdict, or exactly which evidence was missing for insufficient-evidence' },
   },
 }
 
@@ -183,23 +190,61 @@ THE IMMEDIATE-MODE RULE (load-bearing — the judge grades a frame it captures i
 Return succeeded, summary, engineId, replayMails, buildGreen, and findings (every friction point — category, severity, where, what, suggested). An empty findings array means the surface was friction-free; be honest, not generous.`
 }
 
-function judgePrompt(task, engineId, replayMails) {
+// The judge is the only agent in the pipeline with authority to call a landed feature visibly broken, and
+// it was the only one given nothing to go on. It received the rubric and an engine id — not the task, not
+// what the consumer says it did, and no baseline — so on a rubric it could not settle it filled the gap
+// with a prior about what the domain "ought" to look like and reported the gap as a defect. Replaying the
+// shipped prompt over ten archived frames scored 24/30 against hand labels, with three false `wrong`
+// verdicts; the text below scored 30/30 with none. Both were perfectly self-consistent across three
+// samples, so the failure was never noise — it was a question the judge could not answer being posed as
+// one it had to. Re-score against the frame corpus before editing this prompt.
+function judgePrompt(task, engineId, replayMails, attemptSummary, framePath) {
   const replay = (replayMails && replayMails.length)
     ? `The engine's render surface is immediate mode — the consumer's draws cleared the frame after they were sent, so a bare capture would come back blank. Pass this bundle as capture_frame's \`mails\` (it fires before readback, putting the picture back on screen for the frame you read):
 
 ${JSON.stringify(replayMails, null, 2)}`
     : `The consumer reported no replay bundle — the visual state redraws itself every tick — so a plain capture (no \`mails\`) shows it.`
-  return `You are a vision judge for a dogfood trial. A consumer agent drove an engine to produce a visual result and left it alive for you. Capture it yourself and rule whether it is use-visibly correct.
 
-EXPECTED ARTIFACT (what the frame should show):
+  // The frame the judge graded was never archived: the evidence image is a LATER re-capture by the CI
+  // driver, and the two have been observed to disagree (a `wrong` verdict posted directly above a frame
+  // that plainly satisfies its rubric). Saving the judged frame makes the verdict auditable against the
+  // pixels that produced it, rather than against a different picture of the same engine.
+  const save = framePath
+    ? `\n- \`save_path\`: "${framePath}" — persist the exact frame you grade, so the verdict can be audited against the pixels that produced it.`
+    : ''
+
+  return `You are a vision judge for a dogfood trial. A consumer agent drove the aether engine to produce a visual result and left it alive for you. Your job is to rule whether the frame it produced is use-visibly correct.
+
+THE TASK THE CONSUMER WAS HANDED:
+${task.prompt}
+
+WHAT THE CONSUMER REPORTS IT DID (its own account — treat as context, not as proof):
+${attemptSummary}
+
+EXPECTED ARTIFACT (the rubric — grade against THIS TEXT and nothing else):
 ${task.expectedArtifact}
 
 ${replay}
 
-Call capture_frame on engine_id "${engineId}" (ToolSearch for mcp__aether-hub__capture_frame). The PNG returns inline — look at it. Compare what you SEE against the expected artifact above. Rule:
-- verdict 'correct' if the frame matches the expectation.
-- verdict 'wrong' if it does not — name the concrete visual discrepancy (this is a use-visible defect the producer's tests missed).
-- verdict 'n-a' only if nothing renderable came back.
+Call capture_frame on engine_id "${engineId}" (ToolSearch for mcp__aether-hub__capture_frame). The PNG returns inline — LOOK at it.${save}
+
+HOW TO RULE:
+- Grade ONLY against the rubric as written. Do NOT import an assumption about what this kind of scene
+  "ought" to look like. If the rubric says an authored region should differ from a baseline, a bare shape
+  on an empty background may be exactly that — the engine renders only what the consumer put there, and a
+  scene that starts empty stays empty. A noun in the task (terrain, panel, list) is not a promise of
+  scenery you have priors about.
+- THE SINGLE-FRAME RULE (load-bearing): you have ONE image. If the rubric asks you to compare states — a
+  preview versus a baseline, a before versus an after, several captures at different scales, pixel
+  dimensions across images — you CANNOT settle that from one frame. Do not guess, and do not resolve the
+  gap by assuming the missing frame was wrong. Return 'insufficient-evidence' and name exactly which
+  evidence you were not given.
+- verdict 'correct' — the frame satisfies what the rubric actually asks, on the evidence you have.
+- verdict 'wrong' — the frame contradicts the rubric: the thing that was supposed to render is absent or
+  visibly malformed. Name the concrete visual discrepancy.
+- verdict 'insufficient-evidence' — the rubric cannot be settled from what you were given. This is a real
+  verdict, not a hedge: use it when it is true, and do not use it to avoid a call you CAN make.
+- verdict 'n-a' — nothing renderable came back at all.
 
 After you have judged, terminate_substrate engine_id "${engineId}" to free the fleet.
 
@@ -247,7 +292,7 @@ if (!attempt) throw new Error('dogfood: the Attempt agent died with no friction 
 let judge = null
 if (task.expectedArtifact && attempt.engineId) {
   phase('Judge')
-  prompts.judge = judgePrompt(task, attempt.engineId, attempt.replayMails)
+  prompts.judge = judgePrompt(task, attempt.engineId, attempt.replayMails, attempt.summary, A.judgeFramePath)
   judge = await agent(prompts.judge, {
     label: 'judge', phase: 'Judge', model: JUDGE_MODEL, effort: JUDGE_EFFORT,
     agentType: 'general-purpose', schema: JUDGE_SCHEMA,

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -470,9 +470,10 @@ jobs:
             --arg surface "$BRIEF_SURFACE" \
             --arg artifact "$BRIEF_ARTIFACT" \
             --arg driver "$DRIVER_MODEL" \
+            --arg judgeframe "$GITHUB_WORKSPACE/dogfood-run/judged-frame.png" \
             '{task: {medium: $medium, prompt: $prompt, surfaceUnderTest: $surface,
                      expectedArtifact: (if $artifact == "none" or $artifact == "" then null else $artifact end)},
-              driverModel: $driver}')"
+              driverModel: $driver, judgeFramePath: $judgeframe}')"
 
           # Assemble the prompt in a quoted heredoc so the interpolated JSON is
           # inserted verbatim (no shell re-parsing of its contents).
@@ -504,10 +505,13 @@ jobs:
           can record an actionable no-rollup attempt for diagnosis and re-trial.
 
           EVIDENCE (absolute paths only — ${GITHUB_WORKSPACE}/dogfood-run/ already exists):
-          - If the task's expectedArtifact is not null the run RENDERS. Ensure a live engine is showing
-            the expected state (re-spawn + re-drive it if the workflow's judge already terminated the
-            render engine), then call capture_frame with save_path set to EXACTLY
-            ${GITHUB_WORKSPACE}/dogfood-run/frame.png so the judged frame is persisted for the record.
+          - The JUDGE saves the frame it actually graded, to dogfood-run/judged-frame.png. That file is
+            the evidence image and you must NOT produce it yourself. Do NOT re-spawn, re-drive, or
+            re-capture the render engine to manufacture a frame: a picture taken later, from a re-driven
+            engine, is a DIFFERENT frame than the one the verdict was formed against, and posting it as
+            the judged frame is how a verdict came to sit under a screenshot that contradicts it.
+          - If judged-frame.png is absent (the judge did not run, or the task does not render), leave it
+            absent. An absent frame is a true statement about the trial; a substitute frame is not.
           - If the medium was author or build-layer and you can locate the Attempt's scratch crate,
             copy it into ${GITHUB_WORKSPACE}/dogfood-run/solution/ so the author/build-layer artifact
             rides in the evidence (best effort — skip if it is not reachable from here).
@@ -676,7 +680,7 @@ jobs:
         run: |
           if [ "${{ needs.trial.outputs.rollup_produced }}" = "true" ]; then
             HAS_FRAME=0
-            [ -f dogfood-run/frame.png ] && HAS_FRAME=1
+            [ -f dogfood-run/judged-frame.png ] && HAS_FRAME=1
             ROLLUP_PATH=dogfood-run/rollup.json HAS_FRAME="$HAS_FRAME" node scripts/post-dogfood-rollup.mjs
           else
             node scripts/post-dogfood-rollup.mjs

--- a/docs/evidence-viewer/index.html
+++ b/docs/evidence-viewer/index.html
@@ -625,13 +625,18 @@
   function renderMedia(run) {
     var wrap = document.createDocumentFragment();
 
+    // judged-frame.png is the frame the JUDGE graded. Runs archived before the judge
+    // saved its own capture only have frame.png — a LATER re-capture by the CI driver,
+    // which is not necessarily the picture the verdict was formed against. Prefer the
+    // judged frame; fall back to the old path so historical runs still show something.
     var img = el("img", {
       className: "frame",
-      attrs: { alt: "judged frame for run " + run.joined },
+      attrs: { alt: "the frame the judge graded, run " + run.joined },
     });
-    img.src = BRANCH_BASE + run.joined + "/frame.png";
+    img.src = BRANCH_BASE + run.joined + "/judged-frame.png";
     img.onerror = function () {
-      img.style.display = "none";
+      img.onerror = function () { img.style.display = "none"; };
+      img.src = BRANCH_BASE + run.joined + "/frame.png";
     };
     wrap.appendChild(img);
 

--- a/scripts/post-dogfood-rollup.mjs
+++ b/scripts/post-dogfood-rollup.mjs
@@ -32,7 +32,7 @@
 //                       unreadable records a no-rollup attempt
 //   ATTEMPT             this trial's attempt number, baked into the marker
 //                       (optional; defaults to 1)
-//   HAS_FRAME           "1"/"true" when the staged run dir held a frame.png
+//   HAS_FRAME           "1"/"true" when the staged run dir held a judged-frame.png
 //                       (falls back to rollup.artifact != null when unset)
 //
 // No external deps — Node built-ins + global fetch only.
@@ -273,7 +273,8 @@ export function renderComment(rollup, hasFrame, { attempt = 1, runRef = '' } = {
   lines.push(...softHoldLines(rollup.softHolds))
   lines.push(...tokenTableLines(rollup.tokensPerTool))
   if (hasFrame) {
-    lines.push('', '### Judged frame', '', `![judged frame](${RAW_BASE}/${runRef}/frame.png)`)
+    // The frame the JUDGE graded — not a later re-capture. The two used to differ.
+    lines.push('', '### The frame the judge graded', '', `![the frame the judge graded](${RAW_BASE}/${runRef}/judged-frame.png)`)
   }
   lines.push(...provenanceLines(rollup.provenance))
   lines.push('', `[Full run in the evidence viewer](${VIEWER_BASE}?run=${encodeURIComponent(runRef)})`)
@@ -294,6 +295,11 @@ export function renderNoRollupComment({ attempt = 1, runUrl } = {}) {
 export function isActionable(rollup) {
   if (rollup.succeeded === false) return true
   if (rollup.artifact && rollup.artifact.verdict === 'wrong') return true
+  // A rubric the judge could not settle is not a pass. It raises no soft-hold — an
+  // unjudgeable artifact is not a claim that the feature is broken — but it must not
+  // read as green either, because nothing was actually verified. Actionable routes it
+  // to a re-trial and, at the attempt cap, to a human.
+  if (rollup.artifact && rollup.artifact.verdict === 'insufficient-evidence') return true
   if (Array.isArray(rollup.softHolds) && rollup.softHolds.length) return true
   const friction = rollup.friction || {}
   for (const category of ['blocker', 'missing-primitive']) {

--- a/scripts/post-dogfood-rollup.test.mjs
+++ b/scripts/post-dogfood-rollup.test.mjs
@@ -148,3 +148,63 @@ test('a rollup predating task and provenance capture still renders', () => {
   assert.doesNotMatch(comment, /### The task|### Provenance/)
   assert.match(comment, /## Dogfood trial/)
 })
+
+// Replaying the shipped judge prompt over ten archived frames scored 24/30 against hand
+// labels; every miss was a rubric the judge could not settle from one capture (a
+// preview-vs-baseline comparison, a claim about pixel dimensions across three images) and
+// had no way to decline. Two of those became `wrong` — a soft-hold asserting a landed
+// feature was visibly broken, on no evidence. `insufficient-evidence` is that escape hatch.
+test('an unjudgeable artifact is not a pass, and does not claim the feature is broken', () => {
+  const rollup = {
+    succeeded: true,
+    buildGreen: null,
+    summary: 'Drove the proposal lifecycle.',
+    artifact: {
+      verdict: 'insufficient-evidence',
+      rationale: 'The rubric compares a preview frame against a committed baseline; only one frame was captured and no baseline was supplied.',
+    },
+    friction: { blocker: [], 'missing-primitive': [], papercut: [], 'doc-gap': [] },
+    softHolds: [],
+  }
+
+  // Not green: nothing was actually verified, so it must not read as a clean trial.
+  assert.equal(isActionable(rollup), true)
+  assert.equal(markerVerdict(rollup), 'failed')
+  // But no soft-hold — "I could not tell" is not "the feature is broken".
+  const comment = renderComment(rollup, false, { attempt: 1, runRef: '3088/12345-1' })
+  assert.doesNotMatch(comment, /use-visible-incorrect/)
+  assert.match(comment, /\*\*Artifact:\*\* insufficient-evidence/)
+})
+
+test('a wrong verdict still soft-holds', () => {
+  const rollup = {
+    succeeded: true,
+    buildGreen: null,
+    summary: 'Drove the widgets.',
+    artifact: { verdict: 'wrong', rationale: 'None of the three controls rendered.' },
+    friction: { blocker: [], 'missing-primitive': [], papercut: [], 'doc-gap': [] },
+    softHolds: [{ kind: 'use-visible-incorrect', detail: 'None of the three controls rendered.' }],
+  }
+
+  assert.equal(isActionable(rollup), true)
+  assert.equal(markerVerdict(rollup), 'failed')
+  assert.match(renderComment(rollup, false, { attempt: 1, runRef: '3088/12345-1' }), /use-visible-incorrect/)
+})
+
+test('the evidence image is the frame the judge graded, not a re-capture', () => {
+  const rollup = {
+    succeeded: true,
+    buildGreen: null,
+    summary: 'Rendered the text panel.',
+    artifact: { verdict: 'correct', rationale: 'Six legible rows.' },
+    friction: { blocker: [], 'missing-primitive': [], papercut: [], 'doc-gap': [] },
+    softHolds: [],
+  }
+
+  const comment = renderComment(rollup, true, { attempt: 1, runRef: '3088/12345-1' })
+  assert.match(comment, /### The frame the judge graded/)
+  assert.match(comment, /!\[the frame the judge graded\]\(.*\/3088\/12345-1\/judged-frame\.png\)/)
+  // The old path was a later re-capture of a re-driven engine, and was observed
+  // contradicting the verdict printed directly above it.
+  assert.doesNotMatch(comment, /\/frame\.png/)
+})


### PR DESCRIPTION
## The bug

The vision judge is the only agent in the dogfood pipeline with authority to declare a landed feature visibly broken, and it was the only one given nothing to go on. It received the rubric and an engine id — not the task the consumer was handed, not the consumer's account of what it did, and no baseline frame. So when a rubric asked a question one capture could not answer, it filled the gap with a prior about what the domain *ought* to look like, and reported the gap as a defect.

Run `29155032950` ruled a terrain feature broken because the frame showed "no terrain grid, no editable surface." The frame was correct — the world starts empty, the consumer stamped a band, and a band is what a correct render looks like. The word "terrain" in the brief did the rest.

## Measured, not assumed

I replayed the shipped judge prompt against the ten archived render frames, scored versus hand labels, three independent samples each:

| | accuracy | false `wrong` (bogus soft-holds) | samples disagreeing |
|---|---|---|---|
| shipped prompt | **24/30** | **3** | 0/10 |
| this prompt | **30/30** | **0** | 0/10 |

Both prompts were perfectly self-consistent across samples. The failure was never noise — it was an unanswerable question posed as an answerable one. **A judge panel would have bought three identical wrong answers at 3× the cost**, which is why this PR does not add one.

## What changed

- The judge receives the task and the Attempt's summary, and is told to grade **only** against the rubric as written. A noun in the task (terrain, panel, list) is not a promise of scenery it has priors about.
- New **`insufficient-evidence`** verdict. One frame cannot settle a rubric that compares a preview to a baseline, or asserts pixel dimensions across three captures. Saying so is now a real verdict rather than a hedge it had no way to express.
- `insufficient-evidence` is **actionable** (nothing was verified, so it is not a pass) but raises **no soft-hold** — "I could not tell" is not "this is broken."
- Dropped the `this is a use-visible defect the producer's tests missed` clause, which presupposed the defect it was asking the judge to find.

## The evidence image was lying

The judge now saves the frame it actually grades. The posted evidence image used to be a **later re-capture by the CI driver**, off a re-spawned and re-driven engine — a different frame than the verdict was formed against. Run `29148288739` posted a `wrong` verdict directly above a screenshot showing six perfectly legible text rows, exactly as its rubric demanded. The driver is now told not to manufacture that image, and an absent frame stays absent.

This also opens the door to the remaining unexplained result: replaying the **old** prompt over the archived frames correctly rules all three widget runs `wrong`, yet production shipped them `correct`. The prompt is exonerated, so the production judge must have been looking at different pixels — three features passed their visual gate on evidence that contradicts the verdict. That is a capture-path bug I cannot diagnose until the judged frame is archived, which is what this PR starts doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)