### PR TITLE
perf(tcp): add FleetBench load harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,14 @@ jobs:
           path: target/test-bench-artifacts/**
           if-no-files-found: ignore
           retention-days: 7
+      - name: Upload FleetBench TCP load metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fleetbench-tcp-load-metrics
+          path: target/fleetbench-metrics/tcp-load.json
+          if-no-files-found: ignore
+          retention-days: 7
       # Hit-rate visibility while the S3 backend beds in; harmless to
       # keep once it does.
       - name: sccache stats

--- a/crates/aether-capabilities/src/tcp/kinds.rs
+++ b/crates/aether-capabilities/src/tcp/kinds.rs
@@ -104,8 +104,9 @@ pub struct UnbindListener {
 /// Reply to `UnbindListener`. `Ok` once the listener has
 /// tombstoned (the cap waited on `MonitorNotice` before
 /// replying). `Err` for unknown listener names, listeners
-/// already tombstoned at the time of the unbind request, or
-/// fan-out failures.
+/// already tombstoned at the time of the unbind request,
+/// duplicate requests while an unbind is in progress, or fan-out
+/// failures.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.tcp.unbind_listener_result")]
 pub enum UnbindListenerResult {

--- a/crates/aether-capabilities/src/tcp/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/runtime.rs
@@ -93,6 +93,7 @@ pub struct ListenerEntry {
 
 pub struct PendingUnbind {
     pub sender: aether_data::Source,
+    pub hold: SettlementHold,
     pub listener_name: String,
 }
 
@@ -346,9 +347,14 @@ impl NativeActor for TcpCapability {
         // Park the reply target keyed on listener_id. The cap's
         // already-registered monitor (set at spawn time) fires
         // MonitorNotice on close, which drives the reply.
-        state
-            .pending_unbinds
-            .insert(listener_id, PendingUnbind { sender: ctx.reply_target(), listener_name: mail.listener_name });
+        state.pending_unbinds.insert(
+            listener_id,
+            PendingUnbind {
+                sender: ctx.reply_target(),
+                hold: ctx.acquire_settlement_hold(),
+                listener_name: mail.listener_name,
+            },
+        );
         // Mail Close to the listener by its stored id. ADR-0099 §3:
         // the listener is a spawned child, so its id is the lineage
         // fold, not `hash(NAMESPACE:name)` — re-resolving by name
@@ -387,9 +393,9 @@ impl NativeActor for TcpCapability {
         // forward-index drain.
         let _entry = state.listeners.remove(&notice.target);
         // Fire the parked unbind reply if one was waiting.
-        let parked = state.pending_unbinds.remove(&notice.target);
-        if let Some(parked) = parked {
-            ctx.reply_to(parked.sender, &UnbindListenerResult::Ok { listener_name: parked.listener_name });
+        if let Some(PendingUnbind { sender, hold, listener_name }) = state.pending_unbinds.remove(&notice.target) {
+            ctx.reply_to_target(sender, &UnbindListenerResult::Ok { listener_name }, hold.root(), None);
+            drop(hold);
         }
         // Else: notice came from a non-unbind close (chassis
         // shutdown, future trap). Nothing to reply to; the

--- a/crates/aether-capabilities/src/tcp/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/runtime.rs
@@ -8,6 +8,7 @@
 //! `use runtime::*` glob in the parent.
 
 pub use std::collections::HashMap;
+pub use std::collections::hash_map::Entry;
 pub use std::net::{TcpListener, TcpStream};
 pub use std::sync::Arc;
 pub use std::sync::mpsc;
@@ -346,15 +347,22 @@ impl NativeActor for TcpCapability {
         };
         // Park the reply target keyed on listener_id. The cap's
         // already-registered monitor (set at spawn time) fires
-        // MonitorNotice on close, which drives the reply.
-        state.pending_unbinds.insert(
-            listener_id,
-            PendingUnbind {
-                sender: ctx.reply_target(),
-                hold: ctx.acquire_settlement_hold(),
+        // MonitorNotice on close, which drives the reply. Preserve
+        // the first caller when a duplicate request arrives while
+        // that close is still in flight; replacing it would drop the
+        // original settlement hold without ever replying.
+        let Entry::Vacant(pending) = state.pending_unbinds.entry(listener_id) else {
+            ctx.reply(&UnbindListenerResult::Err {
                 listener_name: mail.listener_name,
-            },
-        );
+                reason: "unbind already in progress".into(),
+            });
+            return;
+        };
+        pending.insert(PendingUnbind {
+            sender: ctx.reply_target(),
+            hold: ctx.acquire_settlement_hold(),
+            listener_name: mail.listener_name,
+        });
         // Mail Close to the listener by its stored id. ADR-0099 §3:
         // the listener is a spawned child, so its id is the lineage
         // fold, not `hash(NAMESPACE:name)` — re-resolving by name

--- a/crates/aether-capabilities/src/tcp/tests.rs
+++ b/crates/aether-capabilities/src/tcp/tests.rs
@@ -204,6 +204,74 @@ fn bind_then_list_then_unbind_roundtrip() {
     assert!(list_reply.listeners.is_empty(), "list should drop the unbound listener");
 }
 
+/// Issue 3051: asynchronous unbind retains the originating settlement root
+/// until `MonitorNotice` sends exactly one result to the parked caller. The
+/// reply keeps the original session/correlation and the root settles only
+/// after that deferred reply has been emitted.
+#[test]
+fn unbind_monitor_reply_releases_the_originating_settlement_hold() {
+    let (registry, mailer, rx, chassis) = boot_tcp_substrate();
+    let bind_reply: BindListenerResult = drive_and_decode(
+        &registry,
+        &rx,
+        TcpCapability::NAMESPACE,
+        &BindListener { addr: "127.0.0.1:0".into(), name: Some("held-unbind".into()), consumer: None },
+    );
+    let listener_name = match bind_reply {
+        BindListenerResult::Ok { listener_name, .. } => listener_name,
+        BindListenerResult::Err { reason, .. } => panic!("bind failed: {reason}"),
+    };
+
+    let session = SessionToken(Uuid::from_u128(0x3051));
+    let correlation_id = 0x3051;
+    let root = MailId::new(MailboxId(0x3051), correlation_id);
+    let settled = chassis.settlement_registry().subscribe_settlement(root);
+    let cap_id = registry.lookup(TcpCapability::NAMESPACE).expect("cap mailbox registered");
+    mailer.record_sent(root, root, None, root.sender, cap_id, UnbindListener::ID);
+    let MailboxEntry::Inbox { handler, .. } = registry.entry(cap_id).expect("cap entry") else {
+        panic!("expected cap inbox");
+    };
+    let unbind = UnbindListener { listener_name: listener_name.clone() };
+    handler.enqueue(OwnedDispatch::disarmed(
+        UnbindListener::ID,
+        UnbindListener::NAME.to_owned(),
+        None,
+        Source::with_correlation(SourceAddr::Session(session), correlation_id),
+        MailRef::from(unbind.encode_into_bytes()),
+        1,
+        root,
+        root,
+        None,
+        Nanos(0),
+        0,
+        cap_id,
+    ));
+
+    let event = rx.recv_timeout(Duration::from_secs(2)).expect("deferred unbind reply arrives before deadline");
+    let EgressEvent::ToSession {
+        session: reply_session, kind_name, payload, correlation_id: reply_correlation_id, ..
+    } = event
+    else {
+        panic!("expected deferred unbind reply to the originating session");
+    };
+    assert_eq!(reply_session, session);
+    assert_eq!(reply_correlation_id, correlation_id);
+    assert_eq!(kind_name, UnbindListenerResult::NAME);
+    match UnbindListenerResult::decode_from_bytes(&payload).expect("decode deferred UnbindListenerResult") {
+        UnbindListenerResult::Ok { listener_name: replied_name } => assert_eq!(replied_name, listener_name),
+        UnbindListenerResult::Err { reason, .. } => panic!("unbind failed: {reason}"),
+    }
+
+    settled.recv_timeout(Duration::from_secs(2)).expect("originating root settles after deferred reply");
+    assert!(
+        matches!(rx.recv_timeout(Duration::from_millis(50)), Err(mpsc::RecvTimeoutError::Timeout)),
+        "deferred unbind emits exactly one result",
+    );
+    let listeners: ListListenersResult =
+        drive_and_decode(&registry, &rx, TcpCapability::NAMESPACE, &ListListeners::default());
+    assert!(listeners.listeners.is_empty(), "monitor cleanup removes the unbound listener");
+}
+
 /// Tripwire: an outbound dial must correlate its parked reply to the
 /// spawned cap-child session, and the connect-session lineage helper
 /// must route `SessionWrite` to that actor rather than the accepted-

--- a/crates/aether-capabilities/src/tcp/tests.rs
+++ b/crates/aether-capabilities/src/tcp/tests.rs
@@ -272,6 +272,70 @@ fn unbind_monitor_reply_releases_the_originating_settlement_hold() {
     assert!(listeners.listeners.is_empty(), "monitor cleanup removes the unbound listener");
 }
 
+#[test]
+fn duplicate_unbind_preserves_the_first_parked_reply() {
+    let (registry, _mailer, rx, _chassis) = boot_tcp_substrate();
+    let bind_reply: BindListenerResult = drive_and_decode(
+        &registry,
+        &rx,
+        TcpCapability::NAMESPACE,
+        &BindListener { addr: "127.0.0.1:0".into(), name: Some("duplicate-unbind".into()), consumer: None },
+    );
+    let listener_name = match bind_reply {
+        BindListenerResult::Ok { listener_name, .. } => listener_name,
+        BindListenerResult::Err { reason, .. } => panic!("bind failed: {reason}"),
+    };
+
+    let first_session = SessionToken(Uuid::from_u128(0x3051_0001));
+    let duplicate_session = SessionToken(Uuid::from_u128(0x3051_0002));
+    let unbind = UnbindListener { listener_name: listener_name.clone() };
+    enqueue(
+        &registry,
+        TcpCapability::NAMESPACE,
+        &unbind,
+        Source::with_correlation(SourceAddr::Session(first_session), 1),
+        MailId::NONE,
+    );
+    enqueue(
+        &registry,
+        TcpCapability::NAMESPACE,
+        &unbind,
+        Source::with_correlation(SourceAddr::Session(duplicate_session), 2),
+        MailId::NONE,
+    );
+
+    let mut first_reply = None;
+    let mut duplicate_reply = None;
+    for _ in 0..2 {
+        let event = rx.recv_timeout(Duration::from_secs(2)).expect("both unbind callers receive a reply");
+        let EgressEvent::ToSession { session, kind_name, payload, .. } = event else {
+            panic!("expected unbind reply to a session");
+        };
+        assert_eq!(kind_name, UnbindListenerResult::NAME);
+        let reply = UnbindListenerResult::decode_from_bytes(&payload).expect("decode UnbindListenerResult");
+        if session == first_session {
+            first_reply = Some(reply);
+        } else if session == duplicate_session {
+            duplicate_reply = Some(reply);
+        } else {
+            panic!("unbind replied to unexpected session {session:?}");
+        }
+    }
+
+    assert!(
+        matches!(first_reply, Some(UnbindListenerResult::Ok { listener_name: ref name }) if name == &listener_name),
+        "the first caller retains the parked success reply: {first_reply:?}",
+    );
+    assert!(
+        matches!(
+            duplicate_reply,
+            Some(UnbindListenerResult::Err { listener_name: ref name, ref reason })
+                if name == &listener_name && reason == "unbind already in progress"
+        ),
+        "the duplicate caller receives the in-progress error: {duplicate_reply:?}",
+    );
+}
+
 /// Tripwire: an outbound dial must correlate its parked reply to the
 /// spawned cap-child session, and the connect-session lineage helper
 /// must route `SessionWrite` to that actor rather than the accepted-

--- a/crates/aether-substrate-bundle/tests/fleetbench_tcp_load.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_tcp_load.rs
@@ -1,0 +1,876 @@
+//! Real-process load and churn coverage for both `aether.tcp` session
+//! lineages. Correctness is exact; timing and handler-cost values are emitted
+//! only as diagnostics in `target/fleetbench-metrics/tcp-load.json`.
+
+mod fleetbench;
+
+mod tests {
+    use std::collections::BTreeSet;
+    use std::env::{self, VarError};
+    use std::fs;
+    use std::io::{Read, Write};
+    use std::net::{Shutdown, TcpListener, TcpStream};
+    use std::path::Path;
+    use std::process::Command;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use aether_capabilities::tcp::{
+        BindListener, BindListenerResult, ListListeners, ListListenersResult, SessionDataReady, SessionWrite,
+        UnbindListener, UnbindListenerResult,
+    };
+    use aether_codec::frame::max_frame_size;
+    use aether_data::{EngineId, Kind};
+    use aether_kinds::{CostRow, CostTail, CostTailResult};
+    use aether_test_fixtures_kinds::{
+        CollectTcpLoadSnapshot, ConfigureTcpLoadProbe, StartTcpConnectLoad, TcpLoadSessionSnapshot, TcpLoadSnapshot,
+        TcpLoadTopology,
+    };
+    use serde::Serialize;
+
+    use crate::fleetbench::{FleetBench, dist_component_available, poll_until};
+
+    const FIXTURE_STEM: &str = "aether_test_fixtures_bundle";
+    const FIXTURE_EXPORT: &str = "test.tcp_load_probe";
+    const LISTENER_NAME: &str = "fleetbench-tcp-load";
+
+    const DEFAULT_CONNECTIONS: usize = 3;
+    const DEFAULT_FRAMES_PER_CONNECTION: usize = 8;
+    const DEFAULT_FRAME_BYTES: usize = 256;
+    const DEFAULT_CHURN_ROUNDS: usize = 2;
+    const DEFAULT_COMPLETION_TIMEOUT_MILLIS: u64 = 15_000;
+
+    const MAX_CONNECTIONS: usize = 32;
+    const MAX_FRAMES_PER_CONNECTION: usize = 1_024;
+    const MAX_FRAME_BYTES: usize = 1024 * 1024;
+    const MAX_CHURN_ROUNDS: usize = 16;
+    const MAX_COMPLETION_TIMEOUT_MILLIS: u64 = 120_000;
+    const MAX_TOTAL_FRAMES: usize = 100_000;
+    const MAX_TOTAL_PAYLOAD_BYTES: usize = 128 * 1024 * 1024;
+
+    #[derive(Clone, Debug, Serialize)]
+    struct TcpLoadProfile {
+        connections: usize,
+        frames_per_connection: usize,
+        frame_bytes: usize,
+        churn_rounds: usize,
+        completion_timeout_millis: u64,
+    }
+
+    impl TcpLoadProfile {
+        fn resolve() -> Self {
+            let profile = Self {
+                connections: strict_usize("AETHER_TCP_LOAD_CONNECTIONS", DEFAULT_CONNECTIONS, MAX_CONNECTIONS),
+                frames_per_connection: strict_usize(
+                    "AETHER_TCP_LOAD_FRAMES_PER_CONNECTION",
+                    DEFAULT_FRAMES_PER_CONNECTION,
+                    MAX_FRAMES_PER_CONNECTION,
+                ),
+                frame_bytes: strict_usize("AETHER_TCP_LOAD_FRAME_BYTES", DEFAULT_FRAME_BYTES, MAX_FRAME_BYTES),
+                churn_rounds: strict_usize("AETHER_TCP_LOAD_CHURN_ROUNDS", DEFAULT_CHURN_ROUNDS, MAX_CHURN_ROUNDS),
+                completion_timeout_millis: strict_u64(
+                    "AETHER_TCP_LOAD_COMPLETION_TIMEOUT_MILLIS",
+                    DEFAULT_COMPLETION_TIMEOUT_MILLIS,
+                    MAX_COMPLETION_TIMEOUT_MILLIS,
+                ),
+            };
+            assert!(
+                profile.frame_bytes < max_frame_size(),
+                "AETHER_TCP_LOAD_FRAME_BYTES={} must remain below the active AETHER_MAX_FRAME_SIZE={} cap",
+                profile.frame_bytes,
+                max_frame_size(),
+            );
+
+            let throughput_frames = profile
+                .connections
+                .checked_mul(profile.frames_per_connection)
+                .and_then(|value| value.checked_mul(2))
+                .expect("tcp load throughput frame total overflowed usize");
+            let churn_frames = profile
+                .connections
+                .checked_mul(profile.churn_rounds)
+                .and_then(|value| value.checked_mul(2))
+                .expect("tcp load churn frame total overflowed usize");
+            let total_frames =
+                throughput_frames.checked_add(churn_frames).expect("tcp load total frame count overflowed usize");
+            assert!(
+                total_frames <= MAX_TOTAL_FRAMES,
+                "resolved tcp load profile requests {total_frames} total frames; maximum is {MAX_TOTAL_FRAMES}",
+            );
+            let total_payload_bytes =
+                total_frames.checked_mul(profile.frame_bytes).expect("tcp load total payload bytes overflowed usize");
+            assert!(
+                total_payload_bytes <= MAX_TOTAL_PAYLOAD_BYTES,
+                "resolved tcp load profile requests {total_payload_bytes} payload bytes; maximum is \
+                 {MAX_TOTAL_PAYLOAD_BYTES}",
+            );
+            profile
+        }
+
+        fn timeout(&self) -> Duration {
+            Duration::from_millis(self.completion_timeout_millis)
+        }
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    fn strict_usize(name: &str, default: usize, maximum: usize) -> usize {
+        match env::var(name) {
+            Ok(raw) => {
+                let value =
+                    raw.parse::<usize>().unwrap_or_else(|_| panic!("{name} must be a positive integer, got {raw:?}"));
+                assert!(value > 0, "{name} must be greater than zero");
+                assert!(value <= maximum, "{name}={value} exceeds the maximum {maximum}");
+                value
+            }
+            Err(VarError::NotPresent) => default,
+            Err(error) => panic!("{name} could not be read: {error}"),
+        }
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    fn strict_u64(name: &str, default: u64, maximum: u64) -> u64 {
+        match env::var(name) {
+            Ok(raw) => {
+                let value =
+                    raw.parse::<u64>().unwrap_or_else(|_| panic!("{name} must be a positive integer, got {raw:?}"));
+                assert!(value > 0, "{name} must be greater than zero");
+                assert!(value <= maximum, "{name}={value} exceeds the maximum {maximum}");
+                value
+            }
+            Err(VarError::NotPresent) => default,
+            Err(error) => panic!("{name} could not be read: {error}"),
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum SocketWorkerTopology {
+        Accepted,
+        Outbound,
+    }
+
+    impl SocketWorkerTopology {
+        const fn marker(self) -> u8 {
+            match self {
+                Self::Accepted => 0xA5,
+                Self::Outbound => 0x5A,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct SocketWorkerTraffic {
+        connection_index: usize,
+        successful_frame_count: usize,
+        successful_payload_bytes: usize,
+        round_trip_micros: Vec<u64>,
+    }
+
+    #[derive(Debug)]
+    struct SocketWorkerResult {
+        traffic: SocketWorkerTraffic,
+        socket_eof: bool,
+    }
+
+    struct RunningSocketWorkers {
+        ready_rx: mpsc::Receiver<SocketWorkerTraffic>,
+        release: Vec<mpsc::Sender<()>>,
+        joins: Vec<thread::JoinHandle<SocketWorkerResult>>,
+    }
+
+    impl RunningSocketWorkers {
+        fn await_traffic(&self, connection_count: usize, timeout: Duration) -> Vec<SocketWorkerTraffic> {
+            let deadline = Instant::now() + timeout;
+            let mut traffic = Vec::with_capacity(connection_count);
+            while traffic.len() < connection_count {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                traffic.push(
+                    self.ready_rx.recv_timeout(remaining).unwrap_or_else(|error| {
+                        panic!("socket workers did not finish traffic before deadline: {error}")
+                    }),
+                );
+            }
+            traffic.sort_by_key(|result| result.connection_index);
+            traffic
+        }
+
+        fn close_and_join(self) -> Vec<SocketWorkerResult> {
+            for release in self.release {
+                release.send(()).expect("socket worker remains live until close release");
+            }
+            self.joins.into_iter().map(|join| join.join().expect("socket worker completes without panic")).collect()
+        }
+    }
+
+    fn connect_accepted_streams(port: u16, connection_count: usize) -> Vec<TcpStream> {
+        (0..connection_count)
+            .map(|_| TcpStream::connect(("127.0.0.1", port)).expect("connect accepted worker"))
+            .collect()
+    }
+
+    fn start_outbound_workers(
+        listener: &TcpListener,
+        connection_count: usize,
+        frame_count: usize,
+        frame_bytes: usize,
+        timeout: Duration,
+    ) -> RunningSocketWorkers {
+        let streams = (0..connection_count).map(|_| listener.accept().expect("accept outbound probe connection").0);
+        start_workers(streams, SocketWorkerTopology::Outbound, frame_count, frame_bytes, timeout)
+    }
+
+    #[allow(clippy::disallowed_methods, reason = "test-owned blocking loopback peers run outside the actor runtime")]
+    fn start_workers(
+        streams: impl Iterator<Item = TcpStream>,
+        topology: SocketWorkerTopology,
+        frame_count: usize,
+        frame_bytes: usize,
+        timeout: Duration,
+    ) -> RunningSocketWorkers {
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let mut release = Vec::new();
+        let mut joins = Vec::new();
+        for (connection_index, stream) in streams.enumerate() {
+            let (release_tx, release_rx) = mpsc::channel();
+            release.push(release_tx);
+            let ready_tx = ready_tx.clone();
+            joins.push(thread::spawn(move || {
+                run_socket_worker(
+                    stream,
+                    topology,
+                    connection_index,
+                    frame_count,
+                    frame_bytes,
+                    timeout,
+                    &ready_tx,
+                    &release_rx,
+                )
+            }));
+        }
+        drop(ready_tx);
+        RunningSocketWorkers { ready_rx, release, joins }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_socket_worker(
+        mut stream: TcpStream,
+        topology: SocketWorkerTopology,
+        connection_index: usize,
+        frame_count: usize,
+        frame_bytes: usize,
+        timeout: Duration,
+        ready_tx: &mpsc::Sender<SocketWorkerTraffic>,
+        release_rx: &mpsc::Receiver<()>,
+    ) -> SocketWorkerResult {
+        stream.set_read_timeout(Some(timeout)).expect("set socket worker read timeout");
+        stream.set_write_timeout(Some(timeout)).expect("set socket worker write timeout");
+        stream.set_nodelay(true).expect("disable loopback Nagle delay");
+
+        let mut round_trip_micros = Vec::with_capacity(frame_count);
+        for frame_index in 0..frame_count {
+            let body = frame_body(topology, connection_index, frame_index, frame_bytes);
+            let started = Instant::now();
+            write_body_frame(&mut stream, &body);
+            let echoed = read_body_frame(&mut stream);
+            round_trip_micros.push(micros(started.elapsed()));
+            assert_eq!(echoed, body, "socket worker receives the exact body it sent");
+        }
+
+        let traffic = SocketWorkerTraffic {
+            connection_index,
+            successful_frame_count: frame_count,
+            successful_payload_bytes: frame_count
+                .checked_mul(frame_bytes)
+                .expect("per-worker payload total fits usize"),
+            round_trip_micros,
+        };
+        ready_tx.send(traffic.clone()).expect("load scenario waits for worker traffic");
+        release_rx.recv_timeout(timeout).expect("load scenario releases worker before timeout");
+
+        stream.shutdown(Shutdown::Write).expect("worker half-closes its write side");
+        let mut trailing = [0_u8; 1];
+        let socket_eof = stream.read(&mut trailing).expect("worker observes peer close") == 0;
+        SocketWorkerResult { traffic, socket_eof }
+    }
+
+    fn frame_body(
+        topology: SocketWorkerTopology,
+        connection_index: usize,
+        frame_index: usize,
+        frame_bytes: usize,
+    ) -> Vec<u8> {
+        let connection = u64::try_from(connection_index).expect("connection index fits u64").to_le_bytes();
+        let frame = u64::try_from(frame_index).expect("frame index fits u64").to_le_bytes();
+        let mut body = Vec::with_capacity(frame_bytes);
+        body.push(topology.marker());
+        body.extend_from_slice(&connection);
+        body.extend_from_slice(&frame);
+        body.truncate(frame_bytes);
+        while body.len() < frame_bytes {
+            let offset = u8::try_from(body.len() % 251).expect("modulo result fits u8");
+            body.push(topology.marker().wrapping_add(offset));
+        }
+        body
+    }
+
+    fn write_body_frame(stream: &mut TcpStream, body: &[u8]) {
+        let frame_bytes = u32::try_from(body.len()).expect("tcp load body fits four-byte prefix");
+        stream.write_all(&frame_bytes.to_le_bytes()).expect("write tcp load frame prefix");
+        stream.write_all(body).expect("write tcp load frame body");
+    }
+
+    fn read_body_frame(stream: &mut TcpStream) -> Vec<u8> {
+        let mut prefix = [0_u8; 4];
+        stream.read_exact(&mut prefix).expect("read echoed frame prefix");
+        let frame_bytes = u32::from_le_bytes(prefix) as usize;
+        assert!(frame_bytes < max_frame_size(), "echoed frame remains below the active cap");
+        let mut body = vec![0_u8; frame_bytes];
+        stream.read_exact(&mut body).expect("read echoed frame body");
+        body
+    }
+
+    fn micros(duration: Duration) -> u64 {
+        u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
+    }
+
+    #[derive(Clone, Copy, Debug, Serialize)]
+    enum TcpLoadMetricPhase {
+        AcceptedThroughput,
+        OutboundThroughput,
+        Churn,
+    }
+
+    #[derive(Clone, Debug, Serialize)]
+    #[allow(clippy::struct_field_names, reason = "serialized diagnostic fields spell their microsecond unit")]
+    struct RoundTripLatencyMicros {
+        minimum_micros: u64,
+        median_micros: u64,
+        p95_micros: u64,
+        maximum_micros: u64,
+    }
+
+    #[derive(Clone, Debug, Serialize)]
+    struct TcpHandlerCostMetrics {
+        session_path: String,
+        kind_name: String,
+        mean_nanos: u64,
+        mad_nanos: u64,
+        samples: u64,
+    }
+
+    #[derive(Clone, Debug, Serialize)]
+    struct TcpLoadPhaseMetrics {
+        phase: TcpLoadMetricPhase,
+        successful_connection_count: usize,
+        successful_frame_count: usize,
+        successful_payload_bytes: usize,
+        elapsed_micros: u64,
+        payload_bytes_per_second: f64,
+        connections_per_second: f64,
+        round_trip_latency_micros: RoundTripLatencyMicros,
+        handler_costs: Vec<TcpHandlerCostMetrics>,
+    }
+
+    impl TcpLoadPhaseMetrics {
+        fn from_traffic(
+            phase: TcpLoadMetricPhase,
+            elapsed: Duration,
+            traffic: &[SocketWorkerTraffic],
+            handler_costs: Vec<TcpHandlerCostMetrics>,
+        ) -> Self {
+            let successful_frame_count = traffic.iter().map(|worker| worker.successful_frame_count).sum();
+            let successful_payload_bytes = traffic.iter().map(|worker| worker.successful_payload_bytes).sum();
+            let round_trip_micros =
+                traffic.iter().flat_map(|worker| worker.round_trip_micros.iter().copied()).collect::<Vec<_>>();
+            let elapsed_seconds = elapsed.as_secs_f64().max(f64::EPSILON);
+            Self {
+                phase,
+                successful_connection_count: traffic.len(),
+                successful_frame_count,
+                successful_payload_bytes,
+                elapsed_micros: micros(elapsed),
+                payload_bytes_per_second: f64::from(
+                    u32::try_from(successful_payload_bytes).expect("bounded payload total fits u32"),
+                ) / elapsed_seconds,
+                connections_per_second: f64::from(
+                    u32::try_from(traffic.len()).expect("bounded connection count fits u32"),
+                ) / elapsed_seconds,
+                round_trip_latency_micros: latency_summary(round_trip_micros),
+                handler_costs,
+            }
+        }
+    }
+
+    fn latency_summary(mut samples_micros: Vec<u64>) -> RoundTripLatencyMicros {
+        assert!(!samples_micros.is_empty(), "every load phase records round-trip samples");
+        samples_micros.sort_unstable();
+        let p95_index = (samples_micros.len() * 95).div_ceil(100).saturating_sub(1);
+        RoundTripLatencyMicros {
+            minimum_micros: samples_micros[0],
+            median_micros: samples_micros[samples_micros.len() / 2],
+            p95_micros: samples_micros[p95_index],
+            maximum_micros: *samples_micros.last().expect("samples are non-empty"),
+        }
+    }
+
+    #[derive(Debug, Serialize)]
+    struct TcpLoadReport {
+        build_revision: String,
+        profile: TcpLoadProfile,
+        phases: Vec<TcpLoadPhaseMetrics>,
+    }
+
+    fn snapshot(bench: &mut FleetBench, engine: EngineId, probe_addr: &str) -> TcpLoadSnapshot {
+        let replies = bench.send(engine, probe_addr, &CollectTcpLoadSnapshot);
+        let reply = match replies.as_slice() {
+            [reply] => reply,
+            other => panic!("CollectTcpLoadSnapshot expected one reply, got {}", other.len()),
+        };
+        assert_eq!(reply.kind, TcpLoadSnapshot::ID, "snapshot query replies with TcpLoadSnapshot");
+        TcpLoadSnapshot::decode_from_bytes(&reply.payload).expect("decode TcpLoadSnapshot")
+    }
+
+    #[allow(clippy::too_many_arguments, reason = "phase assertion keeps its independent exact dimensions explicit")]
+    fn wait_for_sessions(
+        bench: &mut FleetBench,
+        engine: EngineId,
+        probe_addr: &str,
+        topology: TcpLoadTopology,
+        previous_names: &BTreeSet<String>,
+        connection_count: usize,
+        frame_count: usize,
+        frame_bytes: usize,
+    ) -> Vec<TcpLoadSessionSnapshot> {
+        let expected_payload_bytes =
+            u64::try_from(frame_count.checked_mul(frame_bytes).expect("expected per-session payload total fits usize"))
+                .expect("expected per-session payload total fits u64");
+        let expected_frames = u64::try_from(frame_count).expect("frame count fits u64");
+        let mut matched = None;
+        assert!(
+            poll_until(|| {
+                let current = snapshot(bench, engine, probe_addr);
+                assert!(
+                    current.connect_failures.is_empty(),
+                    "outbound connect failures: {:?}",
+                    current.connect_failures
+                );
+                let sessions = current
+                    .sessions
+                    .into_iter()
+                    .filter(|session| session.topology == topology && !previous_names.contains(&session.session_name))
+                    .collect::<Vec<_>>();
+                if sessions.len() == connection_count
+                    && sessions.iter().all(|session| {
+                        session.established
+                            && session.received_frame_count == expected_frames
+                            && session.received_payload_bytes == expected_payload_bytes
+                    })
+                {
+                    matched = Some(sessions);
+                    true
+                } else {
+                    false
+                }
+            }),
+            "probe did not report the exact {topology:?} session/frame/byte totals",
+        );
+        matched.expect("successful poll captured matching sessions")
+    }
+
+    fn session_names(snapshot: &TcpLoadSnapshot, topology: TcpLoadTopology) -> BTreeSet<String> {
+        snapshot
+            .sessions
+            .iter()
+            .filter(|session| session.topology == topology)
+            .map(|session| session.session_name.clone())
+            .collect()
+    }
+
+    fn next_accepted_index(snapshot: &TcpLoadSnapshot) -> u64 {
+        snapshot
+            .sessions
+            .iter()
+            .filter(|session| session.topology == TcpLoadTopology::Accepted)
+            .filter_map(|session| session.session_name.strip_prefix("conn-")?.parse::<u64>().ok())
+            .max()
+            .map_or(0, |index| index + 1)
+    }
+
+    fn wait_for_live_accepted_paths(
+        bench: &mut FleetBench,
+        engine: EngineId,
+        first_index: u64,
+        connection_count: usize,
+    ) {
+        assert!(
+            poll_until(|| {
+                (0..connection_count).all(|offset| {
+                    let offset = u64::try_from(offset).expect("connection offset fits u64");
+                    let path = accepted_path(&format!("conn-{}", first_index + offset));
+                    let replies = bench.send(engine, &path, &CostTail { kind: None });
+                    matches!(replies.as_slice(), [reply] if reply.kind == CostTailResult::ID)
+                })
+            }),
+            "accepted session paths did not become live before traffic release",
+        );
+    }
+
+    fn accepted_path(session_name: &str) -> String {
+        format!("aether.tcp/aether.tcp.listener:{LISTENER_NAME}/aether.tcp.session:{session_name}")
+    }
+
+    fn outbound_path(session_name: &str) -> String {
+        format!("aether.tcp/aether.tcp.session:{session_name}")
+    }
+
+    fn sample_live_session(bench: &mut FleetBench, engine: EngineId, path: &str) -> Vec<TcpHandlerCostMetrics> {
+        let replies = bench.send(engine, path, &CostTail { kind: None });
+        let reply = match replies.as_slice() {
+            [reply] => reply,
+            other => panic!("live CostTail at {path:?} expected one reply, got {}", other.len()),
+        };
+        assert_eq!(reply.kind, CostTailResult::ID, "live CostTail replies with CostTailResult");
+        let rows = match CostTailResult::decode_from_bytes(&reply.payload).expect("decode live CostTailResult") {
+            CostTailResult::Ok { rows } => rows,
+            CostTailResult::Err { error } => panic!("CostTail at {path:?} failed: {error}"),
+        };
+        [SessionDataReady::ID, SessionWrite::ID].into_iter().map(|kind| required_cost_row(&rows, kind, path)).collect()
+    }
+
+    fn required_cost_row(rows: &[CostRow], kind: aether_data::KindId, path: &str) -> TcpHandlerCostMetrics {
+        let row = rows
+            .iter()
+            .find(|row| row.kind_id == kind)
+            .unwrap_or_else(|| panic!("CostTail at {path:?} omitted required handler {kind:?}; rows: {rows:?}"));
+        assert!(row.samples > 0, "CostTail handler {kind:?} at {path:?} must have executed");
+        TcpHandlerCostMetrics {
+            session_path: path.to_owned(),
+            kind_name: row.kind_name.clone().unwrap_or_else(|| format!("kind-{}", kind.0)),
+            mean_nanos: row.mean_nanos,
+            mad_nanos: row.mad_nanos,
+            samples: row.samples,
+        }
+    }
+
+    fn assert_sessions_closed(
+        bench: &mut FleetBench,
+        engine: EngineId,
+        probe_addr: &str,
+        sessions: &[TcpLoadSessionSnapshot],
+    ) {
+        let names = sessions.iter().map(|session| session.session_name.clone()).collect::<BTreeSet<_>>();
+        assert!(
+            poll_until(|| {
+                snapshot(bench, engine, probe_addr)
+                    .sessions
+                    .iter()
+                    .filter(|session| names.contains(&session.session_name))
+                    .all(|session| session.closed)
+            }),
+            "probe did not record one close transition for every released session",
+        );
+    }
+
+    fn assert_tombstoned(bench: &mut FleetBench, engine: EngineId, path: &str) {
+        let replies = bench.send(engine, path, &CostTail { kind: None });
+        assert!(
+            replies.is_empty(),
+            "CostTail at formerly-live tombstoned path {path:?} must settle with zero replies, got {}",
+            replies.len(),
+        );
+    }
+
+    fn assert_worker_close(results: &[SocketWorkerResult], expected_frames: usize, expected_bytes: usize) {
+        assert!(results.iter().all(|result| result.socket_eof), "every released peer observes socket EOF");
+        assert!(
+            results.iter().all(|result| {
+                result.traffic.successful_frame_count == expected_frames
+                    && result.traffic.successful_payload_bytes == expected_bytes
+            }),
+            "every worker reports exact completed frames and bytes",
+        );
+    }
+
+    fn bind_listener(bench: &mut FleetBench, engine: EngineId, consumer: aether_data::MailboxId) -> u16 {
+        let replies = bench.send(
+            engine,
+            "aether.tcp",
+            &BindListener {
+                addr: "127.0.0.1:0".to_owned(),
+                name: Some(LISTENER_NAME.to_owned()),
+                consumer: Some(consumer),
+            },
+        );
+        let reply = match replies.as_slice() {
+            [reply] => reply,
+            other => panic!("BindListener expected one reply, got {}", other.len()),
+        };
+        match BindListenerResult::decode_from_bytes(&reply.payload).expect("decode BindListenerResult") {
+            BindListenerResult::Ok { listener_name, local_port, .. } => {
+                assert_eq!(listener_name, LISTENER_NAME);
+                local_port
+            }
+            BindListenerResult::Err { reason, .. } => panic!("BindListener failed: {reason}"),
+        }
+    }
+
+    fn list_listeners(bench: &mut FleetBench, engine: EngineId) -> ListListenersResult {
+        let replies = bench.send(engine, "aether.tcp", &ListListeners::default());
+        let reply = match replies.as_slice() {
+            [reply] => reply,
+            other => panic!("ListListeners expected one reply, got {}", other.len()),
+        };
+        ListListenersResult::decode_from_bytes(&reply.payload).expect("decode ListListenersResult")
+    }
+
+    fn unbind_listener(bench: &mut FleetBench, engine: EngineId) {
+        let replies = bench.send(engine, "aether.tcp", &UnbindListener { listener_name: LISTENER_NAME.to_owned() });
+        let reply = match replies.as_slice() {
+            [reply] => reply,
+            other => panic!("UnbindListener expected one reply, got {}", other.len()),
+        };
+        match UnbindListenerResult::decode_from_bytes(&reply.payload).expect("decode UnbindListenerResult") {
+            UnbindListenerResult::Ok { listener_name } => assert_eq!(listener_name, LISTENER_NAME),
+            UnbindListenerResult::Err { reason, .. } => panic!("UnbindListener failed: {reason}"),
+        }
+    }
+
+    #[allow(clippy::disallowed_methods, reason = "test artifact records the external CI revision when available")]
+    fn build_revision() -> String {
+        env::var("GITHUB_SHA").ok().filter(|revision| !revision.is_empty()).unwrap_or_else(|| {
+            let output =
+                Command::new("git").args(["rev-parse", "HEAD"]).output().expect("read build revision with git");
+            assert!(output.status.success(), "git rev-parse HEAD succeeds");
+            String::from_utf8(output.stdout).expect("git revision is utf8").trim().to_owned()
+        })
+    }
+
+    #[allow(clippy::print_stdout, reason = "the load scenario intentionally prints its structured metrics")]
+    fn write_report(report: &TcpLoadReport) {
+        let json = serde_json::to_string_pretty(report).expect("serialize tcp load metrics");
+        println!("{json}");
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/fleetbench-metrics/tcp-load.json");
+        fs::create_dir_all(path.parent().expect("metrics path has parent")).expect("create fleetbench metrics dir");
+        fs::write(&path, format!("{json}\n")).expect("write tcp load metrics artifact");
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines, reason = "one scenario preserves the accepted/outbound/churn lifecycle ordering")]
+    fn fleetbench_tcp_load_covers_accepted_outbound_and_churn() {
+        if !dist_component_available(FIXTURE_STEM) {
+            return;
+        }
+        let profile = TcpLoadProfile::resolve();
+        let mut bench = FleetBench::start();
+        let engine = bench.spawn_headless();
+        let probe = bench.load_full_export(engine, FIXTURE_STEM, FIXTURE_EXPORT);
+        assert!(list_listeners(&mut bench, engine).listeners.is_empty(), "listener baseline is empty");
+        assert!(
+            bench
+                .send(engine, &probe.addr, &ConfigureTcpLoadProbe { listener_name: LISTENER_NAME.to_owned() },)
+                .is_empty(),
+            "probe configuration is fire-and-settle",
+        );
+        let local_port = bind_listener(&mut bench, engine, probe.mailbox_id);
+
+        let accepted_baseline = snapshot(&mut bench, engine, &probe.addr);
+        let accepted_before = session_names(&accepted_baseline, TcpLoadTopology::Accepted);
+        let accepted_first_index = next_accepted_index(&accepted_baseline);
+        let accepted_started = Instant::now();
+        let accepted_streams = connect_accepted_streams(local_port, profile.connections);
+        wait_for_live_accepted_paths(&mut bench, engine, accepted_first_index, profile.connections);
+        let accepted_workers = start_workers(
+            accepted_streams.into_iter(),
+            SocketWorkerTopology::Accepted,
+            profile.frames_per_connection,
+            profile.frame_bytes,
+            profile.timeout(),
+        );
+        let accepted_traffic = accepted_workers.await_traffic(profile.connections, profile.timeout());
+        let accepted_elapsed = accepted_started.elapsed();
+        let accepted_sessions = wait_for_sessions(
+            &mut bench,
+            engine,
+            &probe.addr,
+            TcpLoadTopology::Accepted,
+            &accepted_before,
+            profile.connections,
+            profile.frames_per_connection,
+            profile.frame_bytes,
+        );
+        let accepted_costs = accepted_sessions
+            .iter()
+            .flat_map(|session| sample_live_session(&mut bench, engine, &accepted_path(&session.session_name)))
+            .collect();
+        let accepted_results = accepted_workers.close_and_join();
+        assert_worker_close(
+            &accepted_results,
+            profile.frames_per_connection,
+            profile.frames_per_connection * profile.frame_bytes,
+        );
+        assert_sessions_closed(&mut bench, engine, &probe.addr, &accepted_sessions);
+        for session in &accepted_sessions {
+            assert_tombstoned(&mut bench, engine, &accepted_path(&session.session_name));
+        }
+
+        let outbound_listener = TcpListener::bind("127.0.0.1:0").expect("bind outbound load listener");
+        let outbound_addr = outbound_listener.local_addr().expect("read outbound listener addr");
+        let outbound_before = session_names(&snapshot(&mut bench, engine, &probe.addr), TcpLoadTopology::Outbound);
+        let outbound_started = Instant::now();
+        assert!(
+            bench
+                .send(
+                    engine,
+                    &probe.addr,
+                    &StartTcpConnectLoad {
+                        addr: outbound_addr.to_string(),
+                        connection_count: u32::try_from(profile.connections).expect("connection count fits u32"),
+                        session_name_prefix: "throughput-outbound".to_owned(),
+                    },
+                )
+                .is_empty(),
+            "outbound load trigger is fire-and-settle",
+        );
+        let outbound_workers = start_outbound_workers(
+            &outbound_listener,
+            profile.connections,
+            profile.frames_per_connection,
+            profile.frame_bytes,
+            profile.timeout(),
+        );
+        let outbound_traffic = outbound_workers.await_traffic(profile.connections, profile.timeout());
+        let outbound_elapsed = outbound_started.elapsed();
+        let outbound_sessions = wait_for_sessions(
+            &mut bench,
+            engine,
+            &probe.addr,
+            TcpLoadTopology::Outbound,
+            &outbound_before,
+            profile.connections,
+            profile.frames_per_connection,
+            profile.frame_bytes,
+        );
+        let outbound_costs = outbound_sessions
+            .iter()
+            .flat_map(|session| sample_live_session(&mut bench, engine, &outbound_path(&session.session_name)))
+            .collect();
+        let outbound_results = outbound_workers.close_and_join();
+        assert_worker_close(
+            &outbound_results,
+            profile.frames_per_connection,
+            profile.frames_per_connection * profile.frame_bytes,
+        );
+        assert_sessions_closed(&mut bench, engine, &probe.addr, &outbound_sessions);
+        for session in &outbound_sessions {
+            assert_tombstoned(&mut bench, engine, &outbound_path(&session.session_name));
+        }
+
+        let churn_started = Instant::now();
+        let mut churn_traffic = Vec::new();
+        let mut churn_costs = Vec::new();
+        for round in 0..profile.churn_rounds {
+            let baseline = snapshot(&mut bench, engine, &probe.addr);
+            let before = session_names(&baseline, TcpLoadTopology::Accepted);
+            let first_index = next_accepted_index(&baseline);
+            let streams = connect_accepted_streams(local_port, profile.connections);
+            wait_for_live_accepted_paths(&mut bench, engine, first_index, profile.connections);
+            let workers = start_workers(
+                streams.into_iter(),
+                SocketWorkerTopology::Accepted,
+                1,
+                profile.frame_bytes,
+                profile.timeout(),
+            );
+            churn_traffic.extend(workers.await_traffic(profile.connections, profile.timeout()));
+            let sessions = wait_for_sessions(
+                &mut bench,
+                engine,
+                &probe.addr,
+                TcpLoadTopology::Accepted,
+                &before,
+                profile.connections,
+                1,
+                profile.frame_bytes,
+            );
+            for session in &sessions {
+                churn_costs.extend(sample_live_session(&mut bench, engine, &accepted_path(&session.session_name)));
+            }
+            let results = workers.close_and_join();
+            assert_worker_close(&results, 1, profile.frame_bytes);
+            assert_sessions_closed(&mut bench, engine, &probe.addr, &sessions);
+            for session in &sessions {
+                assert_tombstoned(&mut bench, engine, &accepted_path(&session.session_name));
+            }
+
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind outbound churn listener");
+            let addr = listener.local_addr().expect("read outbound churn addr");
+            let before = session_names(&snapshot(&mut bench, engine, &probe.addr), TcpLoadTopology::Outbound);
+            let prefix = format!("churn-outbound-{round}");
+            assert!(
+                bench
+                    .send(
+                        engine,
+                        &probe.addr,
+                        &StartTcpConnectLoad {
+                            addr: addr.to_string(),
+                            connection_count: u32::try_from(profile.connections).expect("connection count fits u32"),
+                            session_name_prefix: prefix,
+                        },
+                    )
+                    .is_empty(),
+                "outbound churn trigger is fire-and-settle",
+            );
+            let workers =
+                start_outbound_workers(&listener, profile.connections, 1, profile.frame_bytes, profile.timeout());
+            churn_traffic.extend(workers.await_traffic(profile.connections, profile.timeout()));
+            let sessions = wait_for_sessions(
+                &mut bench,
+                engine,
+                &probe.addr,
+                TcpLoadTopology::Outbound,
+                &before,
+                profile.connections,
+                1,
+                profile.frame_bytes,
+            );
+            for session in &sessions {
+                churn_costs.extend(sample_live_session(&mut bench, engine, &outbound_path(&session.session_name)));
+            }
+            let results = workers.close_and_join();
+            assert_worker_close(&results, 1, profile.frame_bytes);
+            assert_sessions_closed(&mut bench, engine, &probe.addr, &sessions);
+            for session in &sessions {
+                assert_tombstoned(&mut bench, engine, &outbound_path(&session.session_name));
+            }
+        }
+        let churn_elapsed = churn_started.elapsed();
+
+        unbind_listener(&mut bench, engine);
+        assert!(list_listeners(&mut bench, engine).listeners.is_empty(), "listener map returns to its baseline");
+
+        write_report(&TcpLoadReport {
+            build_revision: build_revision(),
+            profile,
+            phases: vec![
+                TcpLoadPhaseMetrics::from_traffic(
+                    TcpLoadMetricPhase::AcceptedThroughput,
+                    accepted_elapsed,
+                    &accepted_traffic,
+                    accepted_costs,
+                ),
+                TcpLoadPhaseMetrics::from_traffic(
+                    TcpLoadMetricPhase::OutboundThroughput,
+                    outbound_elapsed,
+                    &outbound_traffic,
+                    outbound_costs,
+                ),
+                TcpLoadPhaseMetrics::from_traffic(
+                    TcpLoadMetricPhase::Churn,
+                    churn_elapsed,
+                    &churn_traffic,
+                    churn_costs,
+                ),
+            ],
+        });
+    }
+}

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -248,12 +248,11 @@ pub fn dispatch_cost_tail_if_matching_free(
 /// filter.
 ///
 /// The cache is seeded once at actor construction — `WasmTrampoline::init`
-/// for components, the native-cap boot wrap for caps — both inside the
-/// same `with_stamped(&slots, …)` the spawn path opens around `init`
-/// (the stamp binds to the actor's `ActorSlots`, not to a thread, so the
-/// seed runs wherever construction does). Every declared handler's cell
-/// is therefore present before the first dispatch: no lazy first-dispatch
-/// pull, no per-fold lock — just a linear scan over a tiny `Vec`.
+/// for components, the native-cap boot wrap for singleton caps, and
+/// `Spawner::spawn_actor` for native instances — under the actor's stamped
+/// slots. Every declared handler's cell is therefore present before the first
+/// dispatch: no lazy first-dispatch pull, no per-fold lock — just a linear scan
+/// over a tiny `Vec`.
 ///
 /// **No scheduling change** — this only writes the cell.
 pub fn fold_handler_cost(kind: KindId, t_received: Nanos, finished: Nanos) {

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -436,6 +436,11 @@ where
             }
             // Phase 3: unwire hook.
             self.run_close_hook(actor);
+            // iamacoffeepot/aether#3051: the close hook is the last actor
+            // lifecycle phase allowed to observe its handler costs. Once it
+            // returns, remove the finalized mailbox's global rows so native
+            // instance churn cannot retain stale cells.
+            self.mailer.cost_table().drop_mailbox(self.self_id);
             // Phase 4: registry close + monitor fan-out.
             self.finalize_registry();
             actor_guard.take();

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -35,6 +35,7 @@ use crate::chassis::ctx::{MailboxWakeSlot, RelayOutcome, relay_or_transfer};
 use crate::chassis::error::BootError;
 use crate::chassis::settlement::{TerminalDisposition, WaitOutcome, await_internal_signal};
 use crate::config::RingCapacities;
+use crate::mail::cost::CostCells;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::OwnedDispatch;
 use crate::mail::registry::{NameConflict, Registry};
@@ -504,6 +505,18 @@ impl Spawner {
             self.registry.remove_closure(id);
             return Err(SpawnError::SubnameInUse { full_name });
         }
+
+        // iamacoffeepot/aether#3051: seed every declared handler into
+        // the shared cost table and stamp those exact cells into this
+        // spawned actor's local cache. This mirrors singleton native
+        // boot and wasm trampoline construction: registration has
+        // succeeded, but wire and first dispatch have not run yet.
+        let handler_kinds: Vec<KindId> = A::capabilities().handlers.iter().map(|handler| handler.id).collect();
+        let seeded = self.mailer.cost_table().seed(id, &handler_kinds);
+        local::with_stamped(&slots, || {
+            use aether_actor::Local as _;
+            CostCells::try_with_mut(|cells| cells.seed(seeded));
+        });
 
         // Issue 584 Phase 2a (ADR-0079 amended): post-init mail-allowed
         // hook. Sink + actor_registry insert_live above means the

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -508,15 +508,22 @@ impl Spawner {
 
         // iamacoffeepot/aether#3051: seed every declared handler into
         // the shared cost table and stamp those exact cells into this
-        // spawned actor's local cache. This mirrors singleton native
-        // boot and wasm trampoline construction: registration has
-        // succeeded, but wire and first dispatch have not run yet.
-        let handler_kinds: Vec<KindId> = A::capabilities().handlers.iter().map(|handler| handler.id).collect();
-        let seeded = self.mailer.cost_table().seed(id, &handler_kinds);
-        local::with_stamped(&slots, || {
+        // spawned actor's local cache. An actor whose init already installed
+        // a dynamic handler set (notably WasmTrampoline's guest manifest)
+        // keeps that more specific cache instead of being overwritten by the
+        // wrapper actor's static capabilities.
+        let cost_cells_seeded = local::with_stamped(&slots, || {
             use aether_actor::Local as _;
-            CostCells::try_with_mut(|cells| cells.seed(seeded));
+            CostCells::with(|cells| !cells.entries().is_empty())
         });
+        if !cost_cells_seeded {
+            let handler_kinds: Vec<KindId> = A::capabilities().handlers.iter().map(|handler| handler.id).collect();
+            let seeded = self.mailer.cost_table().seed(id, &handler_kinds);
+            local::with_stamped(&slots, || {
+                use aether_actor::Local as _;
+                CostCells::with_mut(|cells| cells.seed(seeded));
+            });
+        }
 
         // Issue 584 Phase 2a (ADR-0079 amended): post-init mail-allowed
         // hook. Sink + actor_registry insert_live above means the

--- a/crates/aether-substrate/src/chassis/builder/tests.rs
+++ b/crates/aether-substrate/src/chassis/builder/tests.rs
@@ -748,6 +748,155 @@ fn ctx_shutdown_marks_dead_runs_unwire_tombstones_id() {
     drop(chassis);
 }
 
+/// Issue 3051: spawned native actors seed their declared handler costs into
+/// both indexes before dispatch, framework kinds remain unseeded, and mailbox
+/// finalization removes the global rows after `unwire`.
+#[test]
+fn spawned_actor_costs_seed_fold_filter_and_drop_on_finalization() {
+    use crate::actor::native::spawn::Subname;
+    use crate::mail::registry::MailboxEntry;
+    use aether_data::{Kind, ReplyContract};
+    use aether_kinds::{ComponentCapabilities, CostTail, CostTailResult, HandlerCapability};
+    use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+    pod_kind!(CostPing { tag: u32 }, "test.spawn_cost.ping", 0xE1E2_E3E4_E5E6_E7E8);
+    pod_kind!(CostQuit { tag: u32 }, "test.spawn_cost.quit", 0xE8E7_E6E5_E4E3_E2E1);
+
+    struct SpawnCostProbe {
+        ping_count: Arc<AtomicU32>,
+    }
+
+    impl Addressable for SpawnCostProbe {
+        const NAMESPACE: &'static str = "test.spawn_cost.probe";
+        type Resolver = aether_actor::Many;
+    }
+
+    impl HandlesKind<CostPing> for SpawnCostProbe {}
+    impl HandlesKind<CostQuit> for SpawnCostProbe {}
+
+    impl aether_actor::Lifecycle<Self> for SpawnCostProbe {
+        type Config = Arc<AtomicU32>;
+        type InitError = BootError;
+        type InitCtx<'a> = NativeInitCtx<'a>;
+        type Ctx<'a> = NativeCtx<'a>;
+
+        fn init(ping_count: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self { ping_count })
+        }
+    }
+
+    impl NativeActor for SpawnCostProbe {
+        type State = Self;
+    }
+
+    impl Dispatch<Self> for SpawnCostProbe {
+        fn dispatch(
+            state: &mut Self,
+            ctx: &mut NativeCtx<'_, crate::Manual>,
+            kind: KindId,
+            payload: &[u8],
+        ) -> Option<()> {
+            if kind == CostPing::ID {
+                let _ = CostPing::decode_from_bytes(payload)?;
+                state.ping_count.fetch_add(1, AtomicOrdering::SeqCst);
+                return Some(());
+            }
+            if kind == CostQuit::ID {
+                let _ = CostQuit::decode_from_bytes(payload)?;
+                ctx.shutdown();
+                return Some(());
+            }
+            None
+        }
+
+        fn capabilities() -> ComponentCapabilities {
+            ComponentCapabilities {
+                handlers: [
+                    HandlerCapability {
+                        id: CostPing::ID,
+                        name: CostPing::NAME.to_owned(),
+                        doc: None,
+                        reply: ReplyContract::None,
+                    },
+                    HandlerCapability {
+                        id: CostQuit::ID,
+                        name: CostQuit::NAME.to_owned(),
+                        doc: None,
+                        reply: ReplyContract::None,
+                    },
+                ]
+                .into(),
+                fallback: None,
+                doc: None,
+                config: None,
+            }
+        }
+    }
+
+    let (registry, mailer) = bare_substrate();
+    let ping_count = Arc::new(AtomicU32::new(0));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .build_passive()
+        .expect("empty chassis boots");
+    let id = chassis
+        .spawn_actor::<SpawnCostProbe>(Subname::Named("measured"), Arc::clone(&ping_count))
+        .finish()
+        .expect("spawn cost probe");
+
+    let CostTailResult::Ok { rows } = mailer.cost_table().tail(id, &CostTail { kind: Some(CostPing::ID) }) else {
+        panic!("spawned actor cost tail succeeds");
+    };
+    assert_eq!(rows.len(), 1, "declared handler has one construction-time neutral row");
+    assert_eq!(rows[0].samples, 0, "declared handler starts at the neutral seed");
+
+    let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("spawned actor inbox registered") else {
+        panic!("expected spawned actor inbox");
+    };
+    let framework = CostTail { kind: None }.encode_into_bytes();
+    handler.enqueue(registry::test_owned_dispatch(CostTail::ID, CostTail::NAME, &framework, 1));
+    let ping = CostPing { tag: 1 }.encode_into_bytes();
+    handler.enqueue(registry::test_owned_dispatch(CostPing::ID, CostPing::NAME, &ping, 1));
+
+    let deadline = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < deadline {
+        let CostTailResult::Ok { rows } = mailer.cost_table().tail(id, &CostTail { kind: Some(CostPing::ID) }) else {
+            panic!("spawned actor cost tail succeeds while awaiting dispatch");
+        };
+        if rows.iter().any(|row| row.samples > 0) {
+            break;
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+    assert_eq!(ping_count.load(AtomicOrdering::SeqCst), 1, "declared handler dispatches exactly once");
+
+    let CostTailResult::Ok { rows } = mailer.cost_table().tail(id, &CostTail { kind: Some(CostPing::ID) }) else {
+        panic!("spawned actor cost tail succeeds after dispatch");
+    };
+    assert_eq!(rows.len(), 1, "filtered tail returns only the declared handler row");
+    assert!(rows[0].samples > 0, "declared handler folds a nonzero sample count");
+    assert!(rows[0].mean_nanos > 0, "declared handler folds a nonzero execution cost");
+
+    let CostTailResult::Ok { rows } = mailer.cost_table().tail(id, &CostTail { kind: Some(CostTail::ID) }) else {
+        panic!("framework-kind cost tail succeeds");
+    };
+    assert!(rows.is_empty(), "framework-handled CostTail never creates a handler-cost row");
+
+    let quit = CostQuit { tag: 1 }.encode_into_bytes();
+    handler.enqueue(registry::test_owned_dispatch(CostQuit::ID, CostQuit::NAME, &quit, 1));
+    let deadline = Instant::now() + Duration::from_millis(500);
+    while chassis.actor_registry().is_live(id) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(5));
+    }
+    assert!(!chassis.actor_registry().is_live(id), "quit finalizes the spawned mailbox");
+
+    let CostTailResult::Ok { rows } = mailer.cost_table().tail(id, &CostTail { kind: None }) else {
+        panic!("finalized actor cost tail succeeds");
+    };
+    assert!(rows.is_empty(), "finalization removes every global cost row for the spawned mailbox");
+
+    drop(chassis);
+}
+
 /// Issue 685: chassis teardown drives `unwire` on every spawned
 /// instanced actor, even those that never received a self-shutdown
 /// trigger. Pre-685 the Pooled spawn path's slot was reachable

--- a/crates/aether-substrate/src/mail/cost.rs
+++ b/crates/aether-substrate/src/mail/cost.rs
@@ -210,9 +210,10 @@ impl CostTable {
     /// `(mailbox, kind)` reuses the prior cell (so a `replace` against
     /// the same handler set keeps its accumulated estimate); a fresh
     /// kind gets a new neutral cell. Called at actor construction
-    /// (`WasmTrampoline::init` / the native-cap boot wrap, both under
-    /// `with_stamped`) and on replace, paired with a `CostCells` cache
-    /// stamp of the returned `Arc`s so both indexes share the cell.
+    /// (`WasmTrampoline::init` / the native-cap boot wrap /
+    /// `Spawner::spawn_actor`, all under `with_stamped`) and on replace,
+    /// paired with a `CostCells` cache stamp of the returned `Arc`s so both
+    /// indexes share the cell.
     ///
     /// # Panics
     /// Panics if the internal lock is poisoned — a poisoned lock means a
@@ -229,8 +230,9 @@ impl CostTable {
             .collect()
     }
 
-    /// Remove every cell for `mailbox`. Called on
-    /// `aether.component.drop` / unload. A no-op for an unknown mailbox.
+    /// Remove every cell for `mailbox`. Called on `aether.component.drop` /
+    /// unload and when a native dispatcher finalizes its mailbox. A no-op for
+    /// an unknown mailbox.
     ///
     /// # Panics
     /// Panics if the internal lock is poisoned (see [`Self::seed`]).

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/lib.rs
@@ -25,6 +25,7 @@ mod multi_actor;
 mod probe;
 mod source_observer;
 mod stateful_replace;
+mod tcp_load_probe;
 mod ui_widget;
 
 pub use cube::Cube;
@@ -43,6 +44,7 @@ pub use multi_actor::{Panel, RootManager};
 pub use probe::{Probe, ProbeWithConfig};
 pub use source_observer::SourceObserver;
 pub use stateful_replace::{Counter, Sidecar};
+pub use tcp_load_probe::TcpLoadProbe;
 pub use ui_widget::UiWidget;
 
 // ADR-0138: `entry = Probe` opts this multi-actor module into `Probe` as
@@ -76,4 +78,5 @@ aether_actor::export!(
     InlineTagParent,
     Counter,
     Sidecar,
+    TcpLoadProbe,
 );

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/tcp_load_probe.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/tcp_load_probe.rs
@@ -1,0 +1,125 @@
+//! Consumer and echo meter for the real-process `aether.tcp` load scenario.
+
+// Handler payloads follow the by-value dispatch ABI even when the body only
+// borrows their fields.
+#![allow(clippy::needless_pass_by_value)]
+
+use aether_actor::{ActorInitError, Manual, OutboundReply, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::tcp::{ConnectResult, SessionClosed, SessionData, TcpCapability, TcpWasmExt};
+use aether_test_fixtures_kinds::{
+    CollectTcpLoadSnapshot, ConfigureTcpLoadProbe, StartTcpConnectLoad, TcpLoadSessionSnapshot, TcpLoadSnapshot,
+    TcpLoadTopology,
+};
+
+#[derive(Default)]
+pub struct TcpLoadProbe {
+    listener_name: Option<String>,
+    sessions: Vec<TcpLoadSessionSnapshot>,
+    connect_failures: Vec<String>,
+}
+
+impl TcpLoadProbe {
+    fn session_index(&self, topology: TcpLoadTopology, session_name: &str) -> Option<usize> {
+        self.sessions.iter().position(|session| session.topology == topology && session.session_name == session_name)
+    }
+
+    fn topology_for(&self, session_name: &str) -> TcpLoadTopology {
+        if self.session_index(TcpLoadTopology::Outbound, session_name).is_some() {
+            TcpLoadTopology::Outbound
+        } else {
+            TcpLoadTopology::Accepted
+        }
+    }
+
+    fn ensure_session(&mut self, topology: TcpLoadTopology, session_name: &str) -> usize {
+        if let Some(index) = self.session_index(topology, session_name) {
+            return index;
+        }
+        self.sessions.push(TcpLoadSessionSnapshot {
+            topology,
+            session_name: session_name.to_owned(),
+            established: topology == TcpLoadTopology::Accepted,
+            received_frame_count: 0,
+            received_payload_bytes: 0,
+            closed: false,
+        });
+        self.sessions.len() - 1
+    }
+}
+
+#[actor]
+impl WasmActor for TcpLoadProbe {
+    const NAMESPACE: &'static str = "test.tcp_load_probe";
+
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Self::default())
+    }
+
+    #[handler::single]
+    fn on_configure(&mut self, _ctx: &mut WasmCtx<'_>, configure: ConfigureTcpLoadProbe) {
+        self.listener_name = Some(configure.listener_name);
+    }
+
+    #[handler::single]
+    fn on_start_connect_load(&mut self, ctx: &mut WasmCtx<'_>, start: StartTcpConnectLoad) {
+        let tcp = ctx.actor::<TcpCapability>();
+        for index in 0..start.connection_count {
+            let session_name = format!("{}-{index}", start.session_name_prefix);
+            self.ensure_session(TcpLoadTopology::Outbound, &session_name);
+            tcp.connect(&start.addr, Some(&session_name), Some(ctx.mailbox_id()));
+        }
+    }
+
+    #[handler::single]
+    fn on_connect_result(&mut self, _ctx: &mut WasmCtx<'_>, result: ConnectResult) {
+        match result {
+            ConnectResult::Ok { session_name, .. } => {
+                let index = self.ensure_session(TcpLoadTopology::Outbound, &session_name);
+                self.sessions[index].established = true;
+            }
+            ConnectResult::Err { addr, reason } => self.connect_failures.push(format!("{addr}: {reason}")),
+        }
+    }
+
+    #[handler::single]
+    fn on_session_data(&mut self, ctx: &mut WasmCtx<'_>, data: SessionData) {
+        let topology = self.topology_for(&data.session_name);
+        let index = self.ensure_session(topology, &data.session_name);
+        self.sessions[index].established = true;
+        self.sessions[index].received_frame_count += 1;
+        self.sessions[index].received_payload_bytes +=
+            u64::try_from(data.bytes.len()).expect("tcp load payload length fits u64");
+
+        let body_bytes = u32::try_from(data.bytes.len()).expect("tcp load frame body fits the four-byte prefix");
+        let mut framed = Vec::with_capacity(4 + data.bytes.len());
+        framed.extend_from_slice(&body_bytes.to_le_bytes());
+        framed.extend_from_slice(&data.bytes);
+
+        let tcp = ctx.actor::<TcpCapability>();
+        match topology {
+            TcpLoadTopology::Accepted => tcp.session_write(
+                self.listener_name.as_deref().expect("tcp load probe configured before accepted traffic"),
+                &data.session_name,
+                &framed,
+            ),
+            TcpLoadTopology::Outbound => tcp.connect_session_write(&data.session_name, &framed),
+        }
+    }
+
+    #[handler::single]
+    fn on_session_closed(&mut self, _ctx: &mut WasmCtx<'_>, closed: SessionClosed) {
+        let topology = self.topology_for(&closed.session_name);
+        let index = self.ensure_session(topology, &closed.session_name);
+        self.sessions[index].closed = true;
+    }
+
+    #[handler::manual]
+    fn on_collect_snapshot(&mut self, ctx: &mut WasmCtx<'_, Manual>, _query: CollectTcpLoadSnapshot) {
+        if ctx.reply_target().is_some() {
+            ctx.reply(&TcpLoadSnapshot {
+                sessions: self.sessions.clone(),
+                connect_failures: self.connect_failures.clone(),
+            });
+        }
+    }
+}

--- a/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-kinds/src/lib.rs
@@ -279,6 +279,58 @@ pub struct FsDemuxReport {
     pub second_matched: bool,
 }
 
+/// Configure the listener lineage used by the TCP load probe when it echoes
+/// frames received from accepted sessions.
+#[derive(aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[kind(name = "aether.test_fixtures.configure_tcp_load_probe")]
+pub struct ConfigureTcpLoadProbe {
+    pub listener_name: String,
+}
+
+/// Ask the TCP load probe to start a bounded batch of outbound connections.
+/// Every session gets a deterministic, unique name below `aether.tcp`.
+#[derive(aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[kind(name = "aether.test_fixtures.start_tcp_connect_load")]
+pub struct StartTcpConnectLoad {
+    pub addr: String,
+    pub connection_count: u32,
+    pub session_name_prefix: String,
+}
+
+/// Query the TCP load probe's exact consumer-side accounting.
+#[derive(aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
+#[kind(name = "aether.test_fixtures.collect_tcp_load_snapshot")]
+pub struct CollectTcpLoadSnapshot;
+
+/// The two distinct TCP session lineages exercised by the load scenario.
+#[derive(aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TcpLoadTopology {
+    /// A cap -> listener -> session accepted by a bound listener.
+    Accepted,
+    /// A cap -> session created by an outbound connect.
+    Outbound,
+}
+
+/// Exact consumer-side state for one accepted or outbound TCP session.
+#[derive(aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct TcpLoadSessionSnapshot {
+    pub topology: TcpLoadTopology,
+    pub session_name: String,
+    pub established: bool,
+    pub received_frame_count: u64,
+    pub received_payload_bytes: u64,
+    pub closed: bool,
+}
+
+/// Reply to [`CollectTcpLoadSnapshot`]. Connect failures are explicit data so
+/// the host never has to infer them from missing sessions or scrape logs.
+#[derive(aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+#[kind(name = "aether.test_fixtures.tcp_load_snapshot")]
+pub struct TcpLoadSnapshot {
+    pub sessions: Vec<TcpLoadSessionSnapshot>,
+    pub connect_failures: Vec<String>,
+}
+
 /// Issue 1977 (ADR-0114 amendment) cluster-addressing matrix driver. Sent to
 /// the `matrix_sweep` fixture's parent over the wire to kick off the sweep:
 /// the parent drives every in-cluster addressing direction (parent → child,


### PR DESCRIPTION
Closes #3051.

## Summary

- seed and retire handler-cost rows for spawned native actors and preserve settlement across asynchronous TCP unbind
- add a MailboxId-bound wasm TCP load probe with semantic fixture snapshots
- add a bounded real-process FleetBench scenario covering accepted, outbound, and churn paths with exact correctness gates and diagnostic metrics artifacts

## Test plan

- `cargo xtask dist --no-bins`
- `cargo test -p aether-substrate --lib spawned_actor_costs_seed_fold_filter_and_drop_on_finalization`
- `cargo test -p aether-capabilities --lib unbind_monitor_reply_releases_the_originating_settlement_hold`
- `cargo test -p aether-codec frame::tests::pop_frame_rejects_oversize_prefix`
- `cargo test -p aether-capabilities --lib tcp::tests`
- `AETHER_REQUIRE_RUNTIME=1 cargo test -p aether-substrate-bundle --test fleetbench_tcp_load -- --nocapture`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`

## Generated by

`/implement` — agent execution of [scoped issue #3051](https://github.com/iamacoffeepot/aether/issues/3051).
