### PR TITLE
feat(aether-kit): add player presentation client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "aether-actor",
  "aether-behavior",
  "aether-capabilities",
+ "aether-codec",
  "aether-data",
  "aether-kinds",
  "aether-math",

--- a/crates/aether-capabilities/src/tcp/session/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/session/runtime.rs
@@ -65,6 +65,7 @@ pub struct TcpSessionState {
     pub read_buffer: Vec<u8>,
     pub write_half: TcpStream,
     pub shutdown: Arc<AtomicBool>,
+    pub read_start: Option<mpsc::Sender<()>>,
     pub read_thread: Option<JoinHandle<()>>,
     pub bytes_rx: mpsc::Receiver<Result<Vec<u8>, String>>,
 }
@@ -94,6 +95,11 @@ impl NativeActor for TcpSessionActor {
         // and turns each item into reassembled SessionData mail (Ok)
         // or SessionClosed mail + ctx.shutdown() (Err).
         let (bytes_tx, bytes_rx) = mpsc::channel::<Result<Vec<u8>, String>>();
+        // The actor mailbox is registered only after `init` returns. Keep
+        // the read sidecar behind a one-shot gate until `wire`, otherwise a
+        // fast peer can make it self-mail `SessionDataReady` to an address
+        // that is not live yet.
+        let (read_start_tx, read_start_rx) = mpsc::channel::<()>();
 
         let mailer_for_thread: Arc<Mailer> = ctx.mailer();
         let self_id = ctx.self_id();
@@ -106,6 +112,9 @@ impl NativeActor for TcpSessionActor {
         let thread = thread::Builder::new()
             .name(thread_name)
             .spawn(move || {
+                if read_start_rx.recv().is_err() {
+                    return;
+                }
                 let mut read_half = read_half;
                 let mut buf = vec![0u8; READ_BUFFER_BYTES];
                 loop {
@@ -168,9 +177,16 @@ impl NativeActor for TcpSessionActor {
             read_buffer: Vec::new(),
             write_half,
             shutdown,
+            read_start: Some(read_start_tx),
             read_thread: Some(thread),
             bytes_rx,
         })
+    }
+
+    fn wire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {
+        if let Some(start) = state.read_start.take() {
+            let _ = start.send(());
+        }
     }
 
     fn unwire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {

--- a/crates/aether-kit/Cargo.toml
+++ b/crates/aether-kit/Cargo.toml
@@ -31,6 +31,7 @@ aether-actor = { path = "../aether-actor" }
 # forwards to turns on exactly the host surface, not the guest `runtime` SDK.
 aether-behavior = { path = "../aether-behavior", default-features = false, optional = true }
 aether-capabilities = { path = "../aether-capabilities", default-features = false, features = ["clipboard", "render", "text"] }
+aether-codec = { path = "../aether-codec" }
 aether-data = { path = "../aether-data", features = ["derive"] }
 aether-kinds = { path = "../aether-kinds" }
 aether-math = { path = "../aether-math" }

--- a/crates/aether-kit/src/client/kinds.rs
+++ b/crates/aether-kit/src/client/kinds.rs
@@ -1,0 +1,34 @@
+//! Typed initialization surface for the player presentation client.
+
+use alloc::string::String;
+
+use aether_capabilities::game::{CellPosition, GridBounds};
+use serde::{Deserialize, Serialize};
+
+/// `aether.kit.client.config` — outbound server and toy-world presentation
+/// configuration for [`PlayerClient`](crate::client::PlayerClient).
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[kind(name = "aether.kit.client.config")]
+#[serde(default)]
+pub struct PlayerClientConfig {
+    /// Socket address passed directly to `aether.tcp.connect`.
+    pub server_addr: String,
+    /// Self-identification included in the initial player `Hello`.
+    pub client_name: String,
+    /// Requested spawn cell. The server replaces the accompanying entity id
+    /// with the identity assigned to this connection.
+    pub spawn_cell: CellPosition,
+    /// Inclusive lattice rendered behind authoritative entity markers.
+    pub grid_bounds: GridBounds,
+}
+
+impl Default for PlayerClientConfig {
+    fn default() -> Self {
+        Self {
+            server_addr: String::from("127.0.0.1:7777"),
+            client_name: String::from("player"),
+            spawn_cell: CellPosition { cell_x: 0, cell_z: 0 },
+            grid_bounds: GridBounds::default(),
+        }
+    }
+}

--- a/crates/aether-kit/src/client/mod.rs
+++ b/crates/aether-kit/src/client/mod.rs
@@ -220,6 +220,15 @@ impl WasmActor for PlayerClient {
         ctx.actor::<TcpCapability>().connect(&self.server_addr, None, Some(ctx.mailbox_id()));
     }
 
+    fn unwire(&mut self, ctx: &mut WasmCtx<'_>) {
+        if self.phase != ConnectionPhase::Closed
+            && let Some(session) = self.session.take()
+        {
+            ctx.actor::<TcpCapability>().connect_session_close(&session.name);
+        }
+        self.phase = ConnectionPhase::Closed;
+    }
+
     #[handler::single]
     fn on_connect_result(&mut self, ctx: &mut WasmCtx<'_>, result: ConnectResult) {
         if self.phase != ConnectionPhase::Connecting || self.session.is_some() {

--- a/crates/aether-kit/src/client/mod.rs
+++ b/crates/aether-kit/src/client/mod.rs
@@ -225,8 +225,11 @@ impl WasmActor for PlayerClient {
         if self.phase != ConnectionPhase::Connecting || self.session.is_some() {
             return;
         }
-        if ctx.source_mailbox() != Some(ctx.actor::<TcpCapability>().mailbox_id()) {
-            self.fail(ctx, "tcp connect result arrived from an unexpected mailbox");
+        // Component replies are source-free. Require the host correlation so
+        // an ordinary peer send cannot impersonate the deferred TCP result;
+        // the one-shot connection phase identifies the only outstanding dial.
+        if ctx.source_mailbox().is_some() || ctx.in_reply_to().is_none() {
+            self.fail(ctx, "tcp connect result was not a correlated component reply");
             return;
         }
         match result {

--- a/crates/aether-kit/src/client/mod.rs
+++ b/crates/aether-kit/src/client/mod.rs
@@ -1,0 +1,585 @@
+// Fixed-point authoritative positions become floats only at the render boundary.
+#![allow(clippy::cast_precision_loss)]
+// `#[handler]` methods take decoded mail by value per the actor ABI.
+#![allow(clippy::needless_pass_by_value)]
+
+//! [`PlayerClient`] — the desktop guest for the authoritative player slice.
+//!
+//! The actor dials a configured game gateway through `aether.tcp`, performs the
+//! recipient-free [`PlayerFrame`] handshake, emits allowlisted player intents,
+//! atomically replaces a named-octimeter scene from authoritative tick bundles,
+//! and draws that scene through `aether.render`. Projection remains owned by a
+//! separately loaded `aether.kit.camera` actor.
+
+mod kinds;
+pub use kinds::*;
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::game::{
+    CellPosition, GridBounds, MoveDirection, MoveIntent, PlayerFrame, Spawn, TickBundle, WIRE_VERSION,
+};
+use aether_capabilities::input::InputMailboxExt;
+use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::render::{DrawTriangle, Vertex};
+use aether_capabilities::tcp::{ConnectResult, SessionClosed, SessionData, TcpWasmExt};
+use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability, TcpCapability};
+use aether_codec::frame::encode_frame;
+use aether_data::{Kind, MailboxId, wire};
+use aether_kinds::{Key, KeyRelease, Render, Tick, keycode};
+use aether_math::Rgb;
+
+use crate::OCTIMETERS_PER_TILE;
+use crate::world::WorldPoint;
+
+const MAX_RENDER_GRID_EDGE: i64 = 32;
+const GRID_INSET_OCTIMETERS: i32 = 8;
+const MARKER_HALF_EXTENT_OCTIMETERS: i32 = 72;
+const GRID_Y_METERS: f32 = 0.0;
+const MARKER_Y_METERS: f32 = 0.025;
+const GRID_EVEN_COLOR: Rgb = Rgb::new(0.08, 0.12, 0.18);
+const GRID_ODD_COLOR: Rgb = Rgb::new(0.11, 0.16, 0.23);
+const ENTITY_COLOR: Rgb = Rgb::new(1.0, 0.0, 1.0);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct EntityId {
+    value: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectionPhase {
+    Connecting,
+    AwaitingHelloAck,
+    Live,
+    Closed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConnectedSession {
+    name: String,
+    id: MailboxId,
+    peer: String,
+}
+
+impl ConnectedSession {
+    fn admits(&self, source: Option<MailboxId>, session_name: &str, peer: &str) -> bool {
+        source == Some(self.id) && self.name == session_name && self.peer == peer
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ServerClock {
+    tick: u64,
+    server_nanos: Option<u64>,
+    interval_nanos: u64,
+}
+
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct HeldDirections {
+    north: bool,
+    east: bool,
+    south: bool,
+    west: bool,
+}
+
+impl HeldDirections {
+    fn set(&mut self, code: u32, held: bool) {
+        match code {
+            keycode::KEY_W => self.north = held,
+            keycode::KEY_D => self.east = held,
+            keycode::KEY_S => self.south = held,
+            keycode::KEY_A => self.west = held,
+            _ => {}
+        }
+    }
+
+    fn resolved(self) -> Option<MoveDirection> {
+        let east_west = i8::from(self.east) - i8::from(self.west);
+        let north_south = i8::from(self.south) - i8::from(self.north);
+        match (east_west, north_south) {
+            (0, -1) => Some(MoveDirection::North),
+            (1, 0) => Some(MoveDirection::East),
+            (0, 1) => Some(MoveDirection::South),
+            (-1, 0) => Some(MoveDirection::West),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct AuthoritativeScene {
+    tick: Option<u64>,
+    superseded_through: u64,
+    entities: BTreeMap<EntityId, WorldPoint>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SceneApply {
+    Committed,
+    IgnoredStale,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SceneApplyError {
+    SummaryTickMismatch { bundle_tick: u64, summary_tick: u64 },
+    ImpossibleWatermark { tick: u64, superseded_through: u64 },
+    DuplicateEntity(EntityId),
+    CellCenterOverflow { entity: EntityId, position: CellPosition },
+}
+
+impl AuthoritativeScene {
+    fn apply(&mut self, bundle: &TickBundle) -> Result<SceneApply, SceneApplyError> {
+        if self.tick.is_some_and(|tick| bundle.tick <= tick) {
+            return Ok(SceneApply::IgnoredStale);
+        }
+        if bundle.summary.tick != bundle.tick {
+            return Err(SceneApplyError::SummaryTickMismatch {
+                bundle_tick: bundle.tick,
+                summary_tick: bundle.summary.tick,
+            });
+        }
+        if bundle.superseded_through > bundle.tick {
+            return Err(SceneApplyError::ImpossibleWatermark {
+                tick: bundle.tick,
+                superseded_through: bundle.superseded_through,
+            });
+        }
+
+        let mut replacement = BTreeMap::new();
+        for entity in &bundle.summary.entities {
+            let entity_id = EntityId { value: entity.entity_id };
+            let position = CellPosition { cell_x: entity.cell_x, cell_z: entity.cell_z };
+            let Some(world_point) = cell_center(position) else {
+                return Err(SceneApplyError::CellCenterOverflow { entity: entity_id, position });
+            };
+            if replacement.insert(entity_id, world_point).is_some() {
+                return Err(SceneApplyError::DuplicateEntity(entity_id));
+            }
+        }
+
+        self.entities = replacement;
+        self.tick = Some(bundle.tick);
+        self.superseded_through = bundle.superseded_through;
+        Ok(SceneApply::Committed)
+    }
+}
+
+fn cell_center(position: CellPosition) -> Option<WorldPoint> {
+    let half_tile = OCTIMETERS_PER_TILE / 2;
+    Some(WorldPoint {
+        x_octimeters: position.cell_x.checked_mul(OCTIMETERS_PER_TILE)?.checked_add(half_tile)?,
+        z_octimeters: position.cell_z.checked_mul(OCTIMETERS_PER_TILE)?.checked_add(half_tile)?,
+    })
+}
+
+/// Outbound player protocol, authoritative scene, input policy, and presentation.
+pub struct PlayerClient {
+    server_addr: String,
+    client_name: String,
+    spawn_cell: CellPosition,
+    grid_bounds: GridBounds,
+    phase: ConnectionPhase,
+    session: Option<ConnectedSession>,
+    session_identity: Option<MailboxId>,
+    server_clock: Option<ServerClock>,
+    held: HeldDirections,
+    scene: AuthoritativeScene,
+}
+
+#[actor]
+impl WasmActor for PlayerClient {
+    type Config = PlayerClientConfig;
+    const NAMESPACE: &'static str = "aether.kit.client";
+
+    fn init(config: PlayerClientConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+        Ok(Self {
+            server_addr: config.server_addr,
+            client_name: config.client_name,
+            spawn_cell: config.spawn_cell,
+            grid_bounds: config.grid_bounds,
+            phase: ConnectionPhase::Connecting,
+            session: None,
+            session_identity: None,
+            server_clock: None,
+            held: HeldDirections::default(),
+            scene: AuthoritativeScene::default(),
+        })
+    }
+
+    fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
+        let input = ctx.actor::<InputCapability>();
+        input.subscribe::<Key>();
+        input.subscribe::<KeyRelease>();
+        let lifecycle = ctx.actor::<LifecycleCapability>();
+        lifecycle.subscribe::<Tick>();
+        lifecycle.subscribe::<Render>();
+        ctx.actor::<TcpCapability>().connect(&self.server_addr, None, Some(ctx.mailbox_id()));
+    }
+
+    #[handler::single]
+    fn on_connect_result(&mut self, ctx: &mut WasmCtx<'_>, result: ConnectResult) {
+        if self.phase != ConnectionPhase::Connecting || self.session.is_some() {
+            return;
+        }
+        if ctx.source_mailbox() != Some(ctx.actor::<TcpCapability>().mailbox_id()) {
+            self.fail(ctx, "tcp connect result arrived from an unexpected mailbox");
+            return;
+        }
+        match result {
+            ConnectResult::Ok { session_name, session_id, peer } => {
+                self.session = Some(ConnectedSession { name: session_name, id: session_id, peer });
+                self.phase = ConnectionPhase::AwaitingHelloAck;
+                self.send_frame(
+                    ctx,
+                    &PlayerFrame::Hello { wire_version: WIRE_VERSION, client_name: self.client_name.clone() },
+                );
+            }
+            ConnectResult::Err { addr, reason } => {
+                self.fail(ctx, &format!("tcp connect to {addr} failed: {reason}"));
+            }
+        }
+    }
+
+    #[handler::single]
+    fn on_session_data(&mut self, ctx: &mut WasmCtx<'_>, mail: SessionData) {
+        if self.phase == ConnectionPhase::Closed {
+            return;
+        }
+        if !self.admits_session(ctx.source_mailbox(), &mail.session_name, &mail.peer) {
+            self.fail(ctx, "tcp session data did not match the retained session mailbox and metadata");
+            return;
+        }
+        let frame = match wire::from_bytes::<PlayerFrame>(&mail.bytes) {
+            Ok(frame) => frame,
+            Err(error) => {
+                self.fail(ctx, &format!("invalid player frame: {error}"));
+                return;
+            }
+        };
+        match self.phase {
+            ConnectionPhase::AwaitingHelloAck => self.handle_hello_ack(ctx, frame),
+            ConnectionPhase::Live => self.handle_live_frame(ctx, frame),
+            ConnectionPhase::Connecting | ConnectionPhase::Closed => {}
+        }
+    }
+
+    #[handler::single]
+    fn on_session_closed(&mut self, ctx: &mut WasmCtx<'_>, mail: SessionClosed) {
+        if self.phase == ConnectionPhase::Closed {
+            return;
+        }
+        if !self.admits_session(ctx.source_mailbox(), &mail.session_name, &mail.peer) {
+            self.fail(ctx, "tcp close notice did not match the retained session mailbox and metadata");
+            return;
+        }
+        tracing::warn!(
+            target: "aether_kit",
+            session = %mail.session_name,
+            peer = %mail.peer,
+            reason = %mail.reason,
+            "player client tcp session closed",
+        );
+        self.phase = ConnectionPhase::Closed;
+    }
+
+    #[handler::single]
+    fn on_tick(&mut self, ctx: &mut WasmCtx<'_>, _tick: Tick) {
+        let (Some(identity), Some(direction)) = (self.session_identity, self.held.resolved()) else {
+            return;
+        };
+        if self.phase == ConnectionPhase::Live {
+            self.send_intent(ctx, &MoveIntent { entity_id: identity.0, direction });
+        }
+    }
+
+    #[handler::single]
+    fn on_render(&mut self, ctx: &mut WasmCtx<'_>, _render: Render) {
+        let triangles = render_triangles(self.grid_bounds, &self.scene.entities);
+        if !triangles.is_empty() {
+            ctx.actor::<RenderCapability>().send_many(&triangles);
+        }
+    }
+
+    #[handler::single]
+    fn on_key(&mut self, _ctx: &mut WasmCtx<'_>, key: Key) {
+        self.held.set(key.code, true);
+    }
+
+    #[handler::single]
+    fn on_key_release(&mut self, _ctx: &mut WasmCtx<'_>, key: KeyRelease) {
+        self.held.set(key.code, false);
+    }
+}
+
+impl PlayerClient {
+    fn admits_session(&self, source: Option<MailboxId>, session_name: &str, peer: &str) -> bool {
+        self.session.as_ref().is_some_and(|session| session.admits(source, session_name, peer))
+    }
+
+    fn handle_hello_ack(&mut self, ctx: &mut WasmCtx<'_>, frame: PlayerFrame) {
+        let PlayerFrame::HelloAck { wire_version, session_identity, tick, interval_nanos } = frame else {
+            self.fail(ctx, "expected HelloAck as first server frame");
+            return;
+        };
+        if wire_version != WIRE_VERSION {
+            self.fail(ctx, &format!("wire_version mismatch: server={wire_version}, client={WIRE_VERSION}"));
+            return;
+        }
+
+        self.session_identity = Some(session_identity);
+        self.server_clock = Some(ServerClock { tick, server_nanos: None, interval_nanos });
+        self.phase = ConnectionPhase::Live;
+        self.send_intent(
+            ctx,
+            &Spawn { entity_id: session_identity.0, cell_x: self.spawn_cell.cell_x, cell_z: self.spawn_cell.cell_z },
+        );
+    }
+
+    fn handle_live_frame(&mut self, ctx: &mut WasmCtx<'_>, frame: PlayerFrame) {
+        match frame {
+            PlayerFrame::Fact { kind, payload } if kind == TickBundle::ID => {
+                let Some(bundle) = TickBundle::decode_from_bytes(&payload) else {
+                    self.fail(ctx, "malformed TickBundle fact payload");
+                    return;
+                };
+                if let Err(error) = self.scene.apply(&bundle) {
+                    self.fail(ctx, &format!("invalid authoritative TickBundle: {error:?}"));
+                }
+            }
+            PlayerFrame::Fact { kind, .. } => {
+                self.fail(ctx, &format!("unexpected player fact kind: {kind}"));
+            }
+            PlayerFrame::Beacon { tick, server_nanos, interval_nanos } => {
+                self.server_clock = Some(ServerClock { tick, server_nanos: Some(server_nanos), interval_nanos });
+            }
+            PlayerFrame::Close { reason } => self.fail(ctx, &format!("server closed player session: {reason}")),
+            PlayerFrame::Hello { .. } | PlayerFrame::HelloAck { .. } | PlayerFrame::Intent { .. } => {
+                self.fail(ctx, "unexpected server player frame direction");
+            }
+        }
+    }
+
+    fn send_intent<K: Kind>(&mut self, ctx: &mut WasmCtx<'_>, intent: &K) {
+        self.send_frame(ctx, &PlayerFrame::Intent { kind: K::ID, payload: intent.encode_into_bytes() });
+    }
+
+    fn send_frame(&mut self, ctx: &mut WasmCtx<'_>, frame: &PlayerFrame) {
+        let bytes = match encode_frame(frame) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                self.fail(ctx, &format!("player frame encode failed: {error}"));
+                return;
+            }
+        };
+        let Some(session) = &self.session else {
+            self.fail(ctx, "player frame send attempted without retained tcp session");
+            return;
+        };
+        ctx.actor::<TcpCapability>().connect_session_write(&session.name, &bytes);
+    }
+
+    fn fail(&mut self, ctx: &mut WasmCtx<'_>, reason: &str) {
+        tracing::warn!(target: "aether_kit", reason, "player client closed");
+        self.phase = ConnectionPhase::Closed;
+        if let Some(session) = &self.session {
+            ctx.actor::<TcpCapability>().connect_session_close(&session.name);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(clippy::struct_field_names)] // Axis fields retain their octimeter unit at the render boundary.
+struct RenderRect {
+    min_x_octimeters: i32,
+    max_x_octimeters: i32,
+    min_z_octimeters: i32,
+    max_z_octimeters: i32,
+}
+
+fn visible_grid(bounds: GridBounds) -> bool {
+    if bounds.min_cell_x > bounds.max_cell_x || bounds.min_cell_z > bounds.max_cell_z {
+        return false;
+    }
+    let width = i64::from(bounds.max_cell_x) - i64::from(bounds.min_cell_x) + 1;
+    let depth = i64::from(bounds.max_cell_z) - i64::from(bounds.min_cell_z) + 1;
+    width <= MAX_RENDER_GRID_EDGE && depth <= MAX_RENDER_GRID_EDGE
+}
+
+fn render_triangles(bounds: GridBounds, entities: &BTreeMap<EntityId, WorldPoint>) -> Vec<DrawTriangle> {
+    if !visible_grid(bounds) {
+        return Vec::new();
+    }
+
+    let width = i64::from(bounds.max_cell_x) - i64::from(bounds.min_cell_x) + 1;
+    let depth = i64::from(bounds.max_cell_z) - i64::from(bounds.min_cell_z) + 1;
+    let mut triangles = Vec::with_capacity(usize::try_from(width * depth * 2).unwrap_or(0) + entities.len() * 2);
+    for cell_z in bounds.min_cell_z..=bounds.max_cell_z {
+        for cell_x in bounds.min_cell_x..=bounds.max_cell_x {
+            let Some(origin) = cell_origin(CellPosition { cell_x, cell_z }) else {
+                return Vec::new();
+            };
+            let Some(rect) = grid_rect(origin) else {
+                return Vec::new();
+            };
+            let color = if cell_x.wrapping_add(cell_z) & 1 == 0 {
+                GRID_EVEN_COLOR
+            } else {
+                GRID_ODD_COLOR
+            };
+            push_quad(&mut triangles, rect, GRID_Y_METERS, color);
+        }
+    }
+    for point in entities.values() {
+        let Some(rect) = marker_rect(*point) else {
+            continue;
+        };
+        push_quad(&mut triangles, rect, MARKER_Y_METERS, ENTITY_COLOR);
+    }
+    triangles
+}
+
+fn cell_origin(position: CellPosition) -> Option<WorldPoint> {
+    Some(WorldPoint {
+        x_octimeters: position.cell_x.checked_mul(OCTIMETERS_PER_TILE)?,
+        z_octimeters: position.cell_z.checked_mul(OCTIMETERS_PER_TILE)?,
+    })
+}
+
+fn grid_rect(origin: WorldPoint) -> Option<RenderRect> {
+    let far_inset = OCTIMETERS_PER_TILE.checked_sub(GRID_INSET_OCTIMETERS)?;
+    Some(RenderRect {
+        min_x_octimeters: origin.x_octimeters.checked_add(GRID_INSET_OCTIMETERS)?,
+        max_x_octimeters: origin.x_octimeters.checked_add(far_inset)?,
+        min_z_octimeters: origin.z_octimeters.checked_add(GRID_INSET_OCTIMETERS)?,
+        max_z_octimeters: origin.z_octimeters.checked_add(far_inset)?,
+    })
+}
+
+fn marker_rect(point: WorldPoint) -> Option<RenderRect> {
+    Some(RenderRect {
+        min_x_octimeters: point.x_octimeters.checked_sub(MARKER_HALF_EXTENT_OCTIMETERS)?,
+        max_x_octimeters: point.x_octimeters.checked_add(MARKER_HALF_EXTENT_OCTIMETERS)?,
+        min_z_octimeters: point.z_octimeters.checked_sub(MARKER_HALF_EXTENT_OCTIMETERS)?,
+        max_z_octimeters: point.z_octimeters.checked_add(MARKER_HALF_EXTENT_OCTIMETERS)?,
+    })
+}
+
+fn push_quad(out: &mut Vec<DrawTriangle>, rect: RenderRect, y: f32, color: Rgb) {
+    let meters = |octimeters: i32| octimeters as f32 / OCTIMETERS_PER_TILE as f32;
+    let vertex =
+        |x_octimeters: i32, z_octimeters: i32| Vertex { x: meters(x_octimeters), y, z: meters(z_octimeters), color };
+    let north_west = vertex(rect.min_x_octimeters, rect.min_z_octimeters);
+    let north_east = vertex(rect.max_x_octimeters, rect.min_z_octimeters);
+    let south_east = vertex(rect.max_x_octimeters, rect.max_z_octimeters);
+    let south_west = vertex(rect.min_x_octimeters, rect.max_z_octimeters);
+    out.push(DrawTriangle { verts: [north_west, south_east, north_east] });
+    out.push(DrawTriangle { verts: [north_west, south_west, south_east] });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_capabilities::game::{EntityState, StateSummary};
+
+    fn bundle(tick: u64, superseded_through: u64, entities: Vec<EntityState>) -> TickBundle {
+        TickBundle { tick, superseded_through, trajectory: Vec::new(), summary: StateSummary { tick, entities } }
+    }
+
+    fn seeded_scene() -> AuthoritativeScene {
+        let mut scene = AuthoritativeScene::default();
+        assert_eq!(
+            scene.apply(&bundle(4, 4, vec![EntityState { entity_id: 1, cell_x: 0, cell_z: 0 }])),
+            Ok(SceneApply::Committed)
+        );
+        scene
+    }
+
+    #[test]
+    fn stale_bundle_is_ignored_without_mutating_scene() {
+        let mut scene = seeded_scene();
+        let before = scene.clone();
+
+        assert_eq!(
+            scene.apply(&bundle(4, 4, vec![EntityState { entity_id: 2, cell_x: 3, cell_z: 3 }])),
+            Ok(SceneApply::IgnoredStale)
+        );
+        assert_eq!(scene, before);
+    }
+
+    #[test]
+    fn inconsistent_tick_and_impossible_watermark_do_not_mutate_scene() {
+        let mut scene = seeded_scene();
+        let before = scene.clone();
+        let mut mismatched = bundle(5, 5, Vec::new());
+        mismatched.summary.tick = 6;
+
+        assert!(matches!(scene.apply(&mismatched), Err(SceneApplyError::SummaryTickMismatch { .. })));
+        assert_eq!(scene, before);
+        assert!(matches!(scene.apply(&bundle(5, 6, Vec::new())), Err(SceneApplyError::ImpossibleWatermark { .. })));
+        assert_eq!(scene, before);
+    }
+
+    #[test]
+    fn duplicate_id_and_cell_center_overflow_do_not_partially_commit() {
+        let mut scene = seeded_scene();
+        let before = scene.clone();
+        let duplicate = bundle(
+            5,
+            5,
+            vec![
+                EntityState { entity_id: 2, cell_x: 1, cell_z: 1 },
+                EntityState { entity_id: 2, cell_x: 2, cell_z: 2 },
+            ],
+        );
+
+        assert_eq!(scene.apply(&duplicate), Err(SceneApplyError::DuplicateEntity(EntityId { value: 2 })));
+        assert_eq!(scene, before);
+        let overflowing = bundle(5, 5, vec![EntityState { entity_id: 3, cell_x: i32::MAX, cell_z: 0 }]);
+        assert!(matches!(scene.apply(&overflowing), Err(SceneApplyError::CellCenterOverflow { .. })));
+        assert_eq!(scene, before);
+    }
+
+    #[test]
+    fn newer_summary_replaces_the_whole_authoritative_scene() {
+        let mut scene = seeded_scene();
+
+        assert_eq!(
+            scene.apply(&bundle(5, 5, vec![EntityState { entity_id: 2, cell_x: -2, cell_z: 3 }])),
+            Ok(SceneApply::Committed)
+        );
+        assert_eq!(scene.tick, Some(5));
+        assert_eq!(scene.superseded_through, 5);
+        assert_eq!(
+            scene.entities,
+            BTreeMap::from([(EntityId { value: 2 }, WorldPoint { x_octimeters: -384, z_octimeters: 896 })])
+        );
+    }
+
+    #[test]
+    fn retained_session_admission_requires_exact_mailbox_name_and_peer() {
+        let retained =
+            ConnectedSession { name: String::from("conn-7"), id: MailboxId(41), peer: String::from("127.0.0.1:7777") };
+
+        assert!(retained.admits(Some(MailboxId(41)), "conn-7", "127.0.0.1:7777"));
+        assert!(!retained.admits(Some(MailboxId(42)), "conn-7", "127.0.0.1:7777"));
+        assert!(!retained.admits(Some(MailboxId(41)), "conn-8", "127.0.0.1:7777"));
+        assert!(!retained.admits(Some(MailboxId(41)), "conn-7", "127.0.0.1:8888"));
+        assert!(!retained.admits(None, "conn-7", "127.0.0.1:7777"));
+    }
+
+    #[test]
+    fn held_directions_emit_only_one_unopposed_cardinal_direction() {
+        let mut held = HeldDirections::default();
+        held.set(keycode::KEY_W, true);
+        assert_eq!(held.resolved(), Some(MoveDirection::North));
+        held.set(keycode::KEY_S, true);
+        assert_eq!(held.resolved(), None);
+        held.set(keycode::KEY_S, false);
+        held.set(keycode::KEY_D, true);
+        assert_eq!(held.resolved(), None, "diagonal input has no single cardinal resolution");
+    }
+}

--- a/crates/aether-kit/src/client/mod.rs
+++ b/crates/aether-kit/src/client/mod.rs
@@ -57,6 +57,12 @@ enum ConnectionPhase {
     Closed,
 }
 
+impl ConnectionPhase {
+    fn admits_session_mail(self) -> bool {
+        matches!(self, Self::AwaitingHelloAck | Self::Live)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ConnectedSession {
     name: String,
@@ -258,7 +264,7 @@ impl WasmActor for PlayerClient {
 
     #[handler::single]
     fn on_session_data(&mut self, ctx: &mut WasmCtx<'_>, mail: SessionData) {
-        if self.phase == ConnectionPhase::Closed {
+        if !self.phase.admits_session_mail() {
             return;
         }
         if !self.admits_session(ctx.source_mailbox(), &mail.session_name, &mail.peer) {
@@ -281,7 +287,7 @@ impl WasmActor for PlayerClient {
 
     #[handler::single]
     fn on_session_closed(&mut self, ctx: &mut WasmCtx<'_>, mail: SessionClosed) {
-        if self.phase == ConnectionPhase::Closed {
+        if !self.phase.admits_session_mail() {
             return;
         }
         if !self.admits_session(ctx.source_mailbox(), &mail.session_name, &mail.peer) {
@@ -581,6 +587,14 @@ mod tests {
         assert!(!retained.admits(Some(MailboxId(41)), "conn-8", "127.0.0.1:7777"));
         assert!(!retained.admits(Some(MailboxId(41)), "conn-7", "127.0.0.1:8888"));
         assert!(!retained.admits(None, "conn-7", "127.0.0.1:7777"));
+    }
+
+    #[test]
+    fn session_mail_is_admitted_only_after_connect_succeeds() {
+        assert!(!ConnectionPhase::Connecting.admits_session_mail());
+        assert!(ConnectionPhase::AwaitingHelloAck.admits_session_mail());
+        assert!(ConnectionPhase::Live.admits_session_mail());
+        assert!(!ConnectionPhase::Closed.admits_session_mail());
     }
 
     #[test]

--- a/crates/aether-kit/src/client/mod.rs
+++ b/crates/aether-kit/src/client/mod.rs
@@ -36,6 +36,7 @@ use crate::OCTIMETERS_PER_TILE;
 use crate::world::WorldPoint;
 
 const MAX_RENDER_GRID_EDGE: i64 = 32;
+const MAX_RENDER_ENTITIES: usize = 1_024;
 const GRID_INSET_OCTIMETERS: i32 = 8;
 const MARKER_HALF_EXTENT_OCTIMETERS: i32 = 72;
 const GRID_Y_METERS: f32 = 0.0;
@@ -133,6 +134,7 @@ enum SceneApply {
 enum SceneApplyError {
     SummaryTickMismatch { bundle_tick: u64, summary_tick: u64 },
     ImpossibleWatermark { tick: u64, superseded_through: u64 },
+    TooManyEntities { count: usize, maximum: usize },
     DuplicateEntity(EntityId),
     CellCenterOverflow { entity: EntityId, position: CellPosition },
 }
@@ -152,6 +154,12 @@ impl AuthoritativeScene {
             return Err(SceneApplyError::ImpossibleWatermark {
                 tick: bundle.tick,
                 superseded_through: bundle.superseded_through,
+            });
+        }
+        if bundle.summary.entities.len() > MAX_RENDER_ENTITIES {
+            return Err(SceneApplyError::TooManyEntities {
+                count: bundle.summary.entities.len(),
+                maximum: MAX_RENDER_ENTITIES,
             });
         }
 
@@ -558,6 +566,19 @@ mod tests {
         assert_eq!(scene, before);
         let overflowing = bundle(5, 5, vec![EntityState { entity_id: 3, cell_x: i32::MAX, cell_z: 0 }]);
         assert!(matches!(scene.apply(&overflowing), Err(SceneApplyError::CellCenterOverflow { .. })));
+        assert_eq!(scene, before);
+    }
+
+    #[test]
+    fn oversized_summary_does_not_replace_the_scene() {
+        let mut scene = seeded_scene();
+        let before = scene.clone();
+        let entities = vec![EntityState { entity_id: 2, cell_x: 1, cell_z: 1 }; MAX_RENDER_ENTITIES + 1];
+
+        assert_eq!(
+            scene.apply(&bundle(5, 5, entities)),
+            Err(SceneApplyError::TooManyEntities { count: MAX_RENDER_ENTITIES + 1, maximum: MAX_RENDER_ENTITIES })
+        );
         assert_eq!(scene, before);
     }
 

--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -14,7 +14,7 @@
 //!   `aether_kit@aether.kit.camera-controller` export. Its
 //!   `aether.kit.camera-controller.config` init-config lives in
 //!   [`camera::controller`].
-//! - [`client::PlayerClient`] — the outbound player-session and authoritative
+//! - [`PlayerClient`] — the outbound player-session and authoritative
 //!   presentation actor, selected by the `aether_kit@aether.kit.client`
 //!   export. Its `aether.kit.client.config` init-config lives in [`client`].
 //! - [`console::ConsoleOverlay`] — a primitive-rendered developer console

--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -14,6 +14,9 @@
 //!   `aether_kit@aether.kit.camera-controller` export. Its
 //!   `aether.kit.camera-controller.config` init-config lives in
 //!   [`camera::controller`].
+//! - [`client::PlayerClient`] — the outbound player-session and authoritative
+//!   presentation actor, selected by the `aether_kit@aether.kit.client`
+//!   export. Its `aether.kit.client.config` init-config lives in [`client`].
 //! - [`console::ConsoleOverlay`] — a primitive-rendered developer console
 //!   overlay, selected by the `aether_kit@aether.kit.console` export. Its
 //!   config and extension command vocabulary live in [`console`].
@@ -69,6 +72,7 @@
 extern crate alloc;
 
 pub mod camera;
+pub mod client;
 pub mod console;
 pub mod mark;
 pub mod mesh;
@@ -79,6 +83,7 @@ pub mod widget;
 pub mod workbench;
 pub mod world;
 
+pub use client::{PlayerClient, PlayerClientConfig};
 pub use console::{
     ConsoleCommandInvoked, ConsoleCommandOutput, ConsoleConfig, ConsoleTheme, RegisterConsoleCommand,
     UnregisterConsoleCommand,
@@ -151,6 +156,7 @@ aether_actor::export!(
     entry = console::ConsoleOverlay,
     camera::CameraComponent,
     camera::controller::CameraController,
+    PlayerClient,
     mark::MarkBook,
     mesh::MeshViewer,
     terra::TerraEditor,
@@ -182,6 +188,7 @@ aether_actor::export!(
     entry = console::ConsoleOverlay,
     camera::CameraComponent,
     camera::controller::CameraController,
+    PlayerClient,
     mark::MarkBook,
     mesh::MeshViewer,
     terra::TerraEditor,

--- a/crates/aether-kit/tests/client_scenario.rs
+++ b/crates/aether-kit/tests/client_scenario.rs
@@ -1,19 +1,21 @@
 //! Real-TCP player client scenarios through the shipped `aether-kit` wasm.
 
 use std::fs;
+use std::io::Read;
 use std::net::{Ipv4Addr, TcpListener, TcpStream};
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use aether_actor::Addressable;
+use aether_capabilities::ComponentHostCapability;
 use aether_capabilities::GameGatewayConfig;
 use aether_capabilities::component::resolve_embedded;
 use aether_capabilities::game::{GameGatewayCapability, PlayerFrame, PlayerSessionActor, WIRE_VERSION};
 use aether_capabilities::tcp::{ListListeners, ListListenersResult};
 use aether_codec::frame::{read_frame, write_frame};
 use aether_data::{ActorId, Kind, MailboxId, Tag, fold_lineage, with_tag};
-use aether_kinds::{Key, KeyRelease, LoadComponent, LoadResult, keycode};
+use aether_kinds::{DropComponent, DropResult, Key, KeyRelease, LoadComponent, LoadResult, keycode};
 use aether_kit::camera::{CameraSetMode, ModeInit, OrbitParams};
 use aether_kit::{
     EntityState, GridBounds, MoveDirection, MoveIntent, PlayerClientConfig, Poll, PollResult, SimConfig, Spawn,
@@ -43,7 +45,7 @@ enum ControlledEvent {
 enum ControlledCommand {
     StaleSummary,
     NewerSummary,
-    Shutdown,
+    ExpectClientClose,
 }
 
 fn component_address(name: &str) -> String {
@@ -73,6 +75,19 @@ fn load_export(bench: &mut TestBench, wasm: &[u8], export: &str, name: &str, con
             mailbox_id
         }
         LoadResult::Err { error } => panic!("load {export}: {error}"),
+    }
+}
+
+fn drop_component(bench: &mut TestBench, mailbox_id: MailboxId) {
+    let result = bench
+        .execute(vec![(
+            "drop",
+            BenchOp::send_and_await(ComponentHostCapability::NAMESPACE, &DropComponent { mailbox_id }),
+        )])
+        .expect("drop player client");
+    match result.reply::<DropResult>("drop").expect("decode DropResult") {
+        DropResult::Ok => {}
+        DropResult::Err { error } => panic!("drop player client: {error}"),
     }
 }
 
@@ -155,9 +170,11 @@ fn spawn_controlled_peer(
         write_bundle(&mut stream, &controlled_bundle(2, 1));
 
         assert!(matches!(
-            command_rx.recv_timeout(TCP_TIMEOUT).expect("receive shutdown command"),
-            ControlledCommand::Shutdown
+            command_rx.recv_timeout(TCP_TIMEOUT).expect("receive client-close command"),
+            ControlledCommand::ExpectClientClose
         ));
+        let mut trailing = [0_u8; 1];
+        assert_eq!(stream.read(&mut trailing).expect("controlled peer observes client teardown"), 0);
     });
     (event_rx, command_tx, handle)
 }
@@ -257,7 +274,7 @@ fn controlled_peer_proves_framing_input_and_atomic_visual_replacement() {
             ),
         )])
         .expect("configure client camera");
-    load_export(
+    let client_mailbox = load_export(
         &mut bench,
         &wasm,
         "aether.kit.client",
@@ -316,7 +333,8 @@ fn controlled_peer_proves_framing_input_and_atomic_visual_replacement() {
         "newer complete summary must move the marker east: initial={initial:?}, moved={moved:?}"
     );
 
-    command_tx.send(ControlledCommand::Shutdown).expect("stop controlled peer");
+    command_tx.send(ControlledCommand::ExpectClientClose).expect("ask peer to observe client teardown");
+    drop_component(&mut bench, client_mailbox);
     peer.join().expect("controlled peer exits cleanly");
 }
 

--- a/crates/aether-kit/tests/client_scenario.rs
+++ b/crates/aether-kit/tests/client_scenario.rs
@@ -11,10 +11,10 @@ use aether_actor::Addressable;
 use aether_capabilities::ComponentHostCapability;
 use aether_capabilities::GameGatewayConfig;
 use aether_capabilities::component::resolve_embedded;
-use aether_capabilities::game::{GameGatewayCapability, PlayerFrame, PlayerSessionActor, WIRE_VERSION};
+use aether_capabilities::game::{GameGatewayCapability, PlayerFrame, WIRE_VERSION};
 use aether_capabilities::tcp::{ListListeners, ListListenersResult};
 use aether_codec::frame::{read_frame, write_frame};
-use aether_data::{ActorId, Kind, MailboxId, Tag, fold_lineage, with_tag};
+use aether_data::{Kind, MailboxId};
 use aether_kinds::{DropComponent, DropResult, Key, KeyRelease, LoadComponent, LoadResult, keycode};
 use aether_kit::camera::{CameraSetMode, ModeInit, OrbitParams};
 use aether_kit::{
@@ -204,16 +204,6 @@ fn wait_for_authoritative_entity(bench: &mut TestBench, sim_address: &str) -> En
     }
 }
 
-fn expected_player_session_mailbox(session_name: &str) -> MailboxId {
-    MailboxId(with_tag(
-        Tag::Mailbox,
-        fold_lineage(
-            GameGatewayCapability::resolve(0, ()).0,
-            ActorId::instanced(PlayerSessionActor::NAMESPACE, session_name),
-        ),
-    ))
-}
-
 fn gateway_listener_port(bench: &mut TestBench) -> u16 {
     let deadline = Instant::now() + Duration::from_secs(2);
     loop {
@@ -386,7 +376,6 @@ fn active_gateway_turn_sim_loop_spawns_and_moves_the_server_identity() {
 
     let sim_address = component_address(SIM_NAME);
     let spawned = wait_for_authoritative_entity(&mut bench, &sim_address);
-    assert_eq!(spawned.entity_id, expected_player_session_mailbox("conn-0").0);
     assert_eq!((spawned.cell_x, spawned.cell_z), (1, 1));
 
     bench

--- a/crates/aether-kit/tests/client_scenario.rs
+++ b/crates/aether-kit/tests/client_scenario.rs
@@ -11,7 +11,7 @@ use aether_actor::Addressable;
 use aether_capabilities::ComponentHostCapability;
 use aether_capabilities::GameGatewayConfig;
 use aether_capabilities::component::resolve_embedded;
-use aether_capabilities::game::{GameGatewayCapability, PlayerFrame, WIRE_VERSION};
+use aether_capabilities::game::{GameGatewayCapability, PlayerFrame, PlayerSessionActor, WIRE_VERSION};
 use aether_capabilities::tcp::{ListListeners, ListListenersResult};
 use aether_codec::frame::{read_frame, write_frame};
 use aether_data::{Kind, MailboxId};
@@ -376,6 +376,11 @@ fn active_gateway_turn_sim_loop_spawns_and_moves_the_server_identity() {
 
     let sim_address = component_address(SIM_NAME);
     let spawned = wait_for_authoritative_entity(&mut bench, &sim_address);
+    assert_eq!(
+        spawned.entity_id,
+        PlayerSessionActor::resolve(GameGatewayCapability::resolve(0, ()).0, "conn-0").0,
+        "the full client-to-sim loop runs under the server-assigned player-session identity",
+    );
     assert_eq!((spawned.cell_x, spawned.cell_z), (1, 1));
 
     bench

--- a/crates/aether-kit/tests/client_scenario.rs
+++ b/crates/aether-kit/tests/client_scenario.rs
@@ -1,0 +1,392 @@
+//! Real-TCP player client scenarios through the shipped `aether-kit` wasm.
+
+use std::fs;
+use std::net::{Ipv4Addr, TcpListener, TcpStream};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use aether_actor::Addressable;
+use aether_capabilities::GameGatewayConfig;
+use aether_capabilities::component::resolve_embedded;
+use aether_capabilities::game::{GameGatewayCapability, PlayerFrame, PlayerSessionActor, WIRE_VERSION};
+use aether_capabilities::tcp::{ListListeners, ListListenersResult};
+use aether_codec::frame::{read_frame, write_frame};
+use aether_data::{ActorId, Kind, MailboxId, Tag, fold_lineage, with_tag};
+use aether_kinds::{Key, KeyRelease, LoadComponent, LoadResult, keycode};
+use aether_kit::camera::{CameraSetMode, ModeInit, OrbitParams};
+use aether_kit::{
+    EntityState, GridBounds, MoveDirection, MoveIntent, PlayerClientConfig, Poll, PollResult, SimConfig, Spawn,
+    StateSummary, TickBundle,
+};
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
+use aether_substrate_bundle::visual::{ColorRegionStats, decode_png, target_color_stats};
+
+const CAMERA_NAME: &str = "client-camera";
+const CLIENT_NAME: &str = "player-client";
+const SIM_NAME: &str = "client-turn-sim";
+const LISTENER_NAME: &str = "players";
+const INTERVAL_NANOS: u64 = 20_000_000;
+const TCP_TIMEOUT: Duration = Duration::from_secs(10);
+const FRAME_WIDTH: u32 = 192;
+const FRAME_HEIGHT: u32 = 144;
+const ENTITY_SRGB: [u8; 3] = [255, 0, 255];
+const ENTITY_COLOR_TOLERANCE: u8 = 4;
+
+#[derive(Debug)]
+enum ControlledEvent {
+    Handshake { client_name: String, spawn: Spawn },
+    Move(MoveIntent),
+}
+
+#[derive(Debug)]
+enum ControlledCommand {
+    StaleSummary,
+    NewerSummary,
+    Shutdown,
+}
+
+fn component_address(name: &str) -> String {
+    format!("aether.component/{}:{name}", aether_capabilities::WasmTrampoline::NAMESPACE)
+}
+
+fn load_export(bench: &mut TestBench, wasm: &[u8], export: &str, name: &str, config: Vec<u8>) -> MailboxId {
+    let result = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: wasm.to_vec(),
+                    name: Some(name.to_owned()),
+                    config,
+                    export: Some(export.to_owned()),
+                },
+            ),
+        )])
+        .expect("load component sequence")
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult");
+    match result {
+        LoadResult::Ok { mailbox_id, name: loaded_name, .. } => {
+            assert_eq!(loaded_name, component_address(name));
+            mailbox_id
+        }
+        LoadResult::Err { error } => panic!("load {export}: {error}"),
+    }
+}
+
+fn controlled_bundle(tick: u64, cell_x: i32) -> TickBundle {
+    TickBundle {
+        tick,
+        superseded_through: tick,
+        trajectory: Vec::new(),
+        summary: StateSummary { tick, entities: vec![EntityState { entity_id: 77, cell_x, cell_z: 0 }] },
+    }
+}
+
+fn write_bundle(stream: &mut TcpStream, bundle: &TickBundle) {
+    let tick = bundle.tick;
+    write_frame(stream, &PlayerFrame::Fact { kind: TickBundle::ID, payload: bundle.encode_into_bytes() })
+        .expect("controlled peer writes TickBundle fact");
+    write_frame(
+        stream,
+        &PlayerFrame::Beacon { tick, server_nanos: tick * INTERVAL_NANOS, interval_nanos: INTERVAL_NANOS },
+    )
+    .expect("controlled peer writes tick beacon");
+}
+
+#[allow(clippy::disallowed_methods)] // Native loopback peer is test infrastructure outside the actor settlement tree.
+fn spawn_controlled_peer(
+    listener: TcpListener,
+    session_identity: MailboxId,
+) -> (mpsc::Receiver<ControlledEvent>, mpsc::Sender<ControlledCommand>, thread::JoinHandle<()>) {
+    let (event_tx, event_rx) = mpsc::channel();
+    let (command_tx, command_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("controlled peer accepts client");
+        stream.set_read_timeout(Some(TCP_TIMEOUT)).expect("set controlled peer read timeout");
+        stream.set_write_timeout(Some(TCP_TIMEOUT)).expect("set controlled peer write timeout");
+
+        let hello: PlayerFrame = read_frame(&mut stream).expect("controlled peer reads Hello");
+        let PlayerFrame::Hello { wire_version, client_name } = hello else {
+            panic!("expected Hello, got {hello:?}");
+        };
+        assert_eq!(wire_version, WIRE_VERSION);
+        write_frame(
+            &mut stream,
+            &PlayerFrame::HelloAck {
+                wire_version: WIRE_VERSION,
+                session_identity,
+                tick: 0,
+                interval_nanos: INTERVAL_NANOS,
+            },
+        )
+        .expect("controlled peer writes HelloAck");
+
+        let spawn: PlayerFrame = read_frame(&mut stream).expect("controlled peer reads Spawn intent");
+        let PlayerFrame::Intent { kind, payload } = spawn else {
+            panic!("expected Spawn intent, got {spawn:?}");
+        };
+        assert_eq!(kind, Spawn::ID);
+        let spawn = Spawn::decode_from_bytes(&payload).expect("decode controlled Spawn intent");
+        write_bundle(&mut stream, &controlled_bundle(1, 0));
+        event_tx.send(ControlledEvent::Handshake { client_name, spawn }).expect("report controlled handshake");
+
+        let movement: PlayerFrame = read_frame(&mut stream).expect("controlled peer reads MoveIntent");
+        let PlayerFrame::Intent { kind, payload } = movement else {
+            panic!("expected MoveIntent, got {movement:?}");
+        };
+        assert_eq!(kind, MoveIntent::ID);
+        event_tx
+            .send(ControlledEvent::Move(MoveIntent::decode_from_bytes(&payload).expect("decode controlled MoveIntent")))
+            .expect("report controlled movement");
+
+        assert!(matches!(
+            command_rx.recv_timeout(TCP_TIMEOUT).expect("receive stale command"),
+            ControlledCommand::StaleSummary
+        ));
+        write_bundle(&mut stream, &controlled_bundle(1, 1));
+
+        assert!(matches!(
+            command_rx.recv_timeout(TCP_TIMEOUT).expect("receive newer command"),
+            ControlledCommand::NewerSummary
+        ));
+        write_bundle(&mut stream, &controlled_bundle(2, 1));
+
+        assert!(matches!(
+            command_rx.recv_timeout(TCP_TIMEOUT).expect("receive shutdown command"),
+            ControlledCommand::Shutdown
+        ));
+    });
+    (event_rx, command_tx, handle)
+}
+
+fn capture_entity(bench: &mut TestBench, label: &'static str) -> ColorRegionStats {
+    let captured = bench
+        .execute(vec![("settle", BenchOp::advance(3)), (label, BenchOp::capture())])
+        .expect("settle and capture client scene");
+    let image = decode_png(captured.captured(label).expect("capture client frame")).expect("decode client frame");
+    target_color_stats(&image, ENTITY_SRGB, ENTITY_COLOR_TOLERANCE, None)
+}
+
+fn wait_for_authoritative_entity(bench: &mut TestBench, sim_address: &str) -> EntityState {
+    let deadline = Instant::now() + TCP_TIMEOUT;
+    loop {
+        bench.execute(vec![("advance", BenchOp::advance(1))]).expect("advance player loop");
+        let poll = bench
+            .execute(vec![("poll", BenchOp::send_and_await(sim_address, &Poll { since_tick: 0 }))])
+            .expect("poll TurnSim")
+            .reply::<PollResult>("poll")
+            .expect("decode PollResult");
+        if let Some(entity) = poll.bundles.last().and_then(|bundle| bundle.summary.entities.first()).copied() {
+            return entity;
+        }
+        assert!(Instant::now() < deadline, "client Spawn never reached TurnSim");
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn expected_player_session_mailbox(session_name: &str) -> MailboxId {
+    MailboxId(with_tag(
+        Tag::Mailbox,
+        fold_lineage(
+            GameGatewayCapability::resolve(0, ()).0,
+            ActorId::instanced(PlayerSessionActor::NAMESPACE, session_name),
+        ),
+    ))
+}
+
+fn gateway_listener_port(bench: &mut TestBench) -> u16 {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let list = bench
+            .execute(vec![("list-player-listener", BenchOp::send_and_await("aether.tcp", &ListListeners::default()))])
+            .expect("list game gateway listener")
+            .reply::<ListListenersResult>("list-player-listener")
+            .expect("decode game gateway listener list");
+        let matching_listener_count = list.listeners.iter().filter(|listener| listener.name == LISTENER_NAME).count();
+        assert!(
+            matching_listener_count <= 1,
+            "gateway listener did not bind uniquely: expected one {LISTENER_NAME:?} entry, got \
+             {matching_listener_count}: {:?}",
+            list.listeners
+        );
+        if let Some(listener) = list.listeners.iter().find(|listener| listener.name == LISTENER_NAME) {
+            assert!(listener.port > 0, "gateway listener bound an invalid local port");
+            return listener.port;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "gateway listener did not bind within two seconds before loading the player client; live listeners: {:?}",
+            list.listeners
+        );
+        thread::sleep(Duration::from_millis(5));
+    }
+}
+
+#[test]
+fn controlled_peer_proves_framing_input_and_atomic_visual_replacement() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(wasm_path).expect("read aether-kit wasm");
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind controlled loopback peer");
+    let server_addr = listener.local_addr().expect("controlled peer address").to_string();
+    let session_identity = resolve_embedded("controlled-player-session");
+    let (event_rx, command_tx, peer) = spawn_controlled_peer(listener, session_identity);
+    let mut bench = TestBench::start_with_size(FRAME_WIDTH, FRAME_HEIGHT).expect("boot controlled client TestBench");
+
+    load_export(&mut bench, &wasm, "aether.kit.camera", CAMERA_NAME, Vec::new());
+    bench
+        .execute(vec![(
+            "camera",
+            BenchOp::send_mail(
+                component_address(CAMERA_NAME),
+                &CameraSetMode {
+                    name: "main".into(),
+                    mode: ModeInit::Orbit(OrbitParams {
+                        distance: Some(7.0),
+                        pitch: Some(-1.2),
+                        yaw: Some(0.0),
+                        speed: Some(0.0),
+                        fov_y_rad: Some(0.9),
+                        target: Some([1.0, 0.0, 0.5]),
+                    }),
+                },
+            ),
+        )])
+        .expect("configure client camera");
+    load_export(
+        &mut bench,
+        &wasm,
+        "aether.kit.client",
+        CLIENT_NAME,
+        PlayerClientConfig {
+            server_addr,
+            client_name: "controlled".into(),
+            spawn_cell: aether_kit::CellPosition { cell_x: 0, cell_z: 0 },
+            grid_bounds: GridBounds { min_cell_x: -1, max_cell_x: 2, min_cell_z: -1, max_cell_z: 1 },
+        }
+        .encode_into_bytes(),
+    );
+
+    let ControlledEvent::Handshake { client_name, spawn } =
+        event_rx.recv_timeout(TCP_TIMEOUT).expect("controlled handshake completes")
+    else {
+        panic!("controlled peer reported movement before handshake");
+    };
+    assert_eq!(client_name, "controlled");
+    assert_eq!(spawn.entity_id, session_identity.0);
+    assert_eq!((spawn.cell_x, spawn.cell_z), (0, 0));
+    thread::sleep(Duration::from_millis(25));
+    let initial = capture_entity(&mut bench, "initial");
+    assert!(initial.matching > 20, "expected visible magenta marker at initial cell: {initial:?}");
+
+    bench
+        .execute(vec![
+            ("press-east", BenchOp::send_mail("aether.input", &Key { code: keycode::KEY_D })),
+            ("emit-move", BenchOp::advance(1)),
+            ("release-east", BenchOp::send_mail("aether.input", &KeyRelease { code: keycode::KEY_D })),
+        ])
+        .expect("drive held east input through aether.input");
+    let ControlledEvent::Move(intent) = event_rx.recv_timeout(TCP_TIMEOUT).expect("controlled MoveIntent arrives")
+    else {
+        panic!("controlled peer reported a second handshake");
+    };
+    assert_eq!(intent.entity_id, session_identity.0);
+    assert_eq!(intent.direction, MoveDirection::East);
+
+    command_tx.send(ControlledCommand::StaleSummary).expect("ask peer for stale summary");
+    thread::sleep(Duration::from_millis(25));
+    let stale = capture_entity(&mut bench, "stale");
+    let initial_centroid = initial.centroid.expect("initial marker centroid");
+    let stale_centroid = stale.centroid.expect("stale marker centroid");
+    assert!(
+        (stale_centroid.x - initial_centroid.x).abs() <= 2.0 && (stale_centroid.y - initial_centroid.y).abs() <= 2.0,
+        "stale complete summary must not move the marker: initial={initial:?}, stale={stale:?}"
+    );
+
+    command_tx.send(ControlledCommand::NewerSummary).expect("ask peer for newer summary");
+    thread::sleep(Duration::from_millis(25));
+    let moved = capture_entity(&mut bench, "moved");
+    let moved_centroid = moved.centroid.expect("moved marker centroid");
+    assert!(
+        moved_centroid.x > initial_centroid.x + 8.0,
+        "newer complete summary must move the marker east: initial={initial:?}, moved={moved:?}"
+    );
+
+    command_tx.send(ControlledCommand::Shutdown).expect("stop controlled peer");
+    peer.join().expect("controlled peer exits cleanly");
+}
+
+#[test]
+fn active_gateway_turn_sim_loop_spawns_and_moves_the_server_identity() {
+    let Some(wasm_path) = require_runtime("aether_kit") else {
+        return;
+    };
+    let wasm = fs::read(wasm_path).expect("read aether-kit wasm");
+    let sim_mailbox = resolve_embedded(SIM_NAME);
+    let mut bench = TestBench::builder()
+        .size(FRAME_WIDTH, FRAME_HEIGHT)
+        .game_gateway(GameGatewayConfig {
+            listener_addr: Some("127.0.0.1:0".into()),
+            listener_name: LISTENER_NAME.into(),
+            turn_sim_mailbox: Some(sim_mailbox),
+            interval_nanos: INTERVAL_NANOS,
+            max_active_sessions: GameGatewayConfig::DEFAULT_MAX_ACTIVE_SESSIONS,
+            max_pending_live_bundles: GameGatewayConfig::DEFAULT_MAX_PENDING_LIVE_BUNDLES,
+        })
+        .build()
+        .expect("boot active gateway TestBench");
+    let listener_port = gateway_listener_port(&mut bench);
+    load_export(
+        &mut bench,
+        &wasm,
+        "aether.kit.sim",
+        SIM_NAME,
+        SimConfig {
+            fact_sink: Some(GameGatewayCapability::resolve(0, ())),
+            ring_depth: 16,
+            grid_bounds: GridBounds::default(),
+        }
+        .encode_into_bytes(),
+    );
+    load_export(
+        &mut bench,
+        &wasm,
+        "aether.kit.client",
+        CLIENT_NAME,
+        PlayerClientConfig {
+            server_addr: format!("{}:{listener_port}", Ipv4Addr::LOCALHOST),
+            client_name: "gateway-loop".into(),
+            spawn_cell: aether_kit::CellPosition { cell_x: 1, cell_z: 1 },
+            grid_bounds: GridBounds::default(),
+        }
+        .encode_into_bytes(),
+    );
+
+    let sim_address = component_address(SIM_NAME);
+    let spawned = wait_for_authoritative_entity(&mut bench, &sim_address);
+    assert_eq!(spawned.entity_id, expected_player_session_mailbox("conn-0").0);
+    assert_eq!((spawned.cell_x, spawned.cell_z), (1, 1));
+
+    bench
+        .execute(vec![
+            ("press-west", BenchOp::send_mail("aether.input", &Key { code: keycode::KEY_A })),
+            ("emit-west", BenchOp::advance(1)),
+            ("release-west", BenchOp::send_mail("aether.input", &KeyRelease { code: keycode::KEY_A })),
+        ])
+        .expect("drive west input through active gateway");
+
+    let deadline = Instant::now() + TCP_TIMEOUT;
+    loop {
+        let entity = wait_for_authoritative_entity(&mut bench, &sim_address);
+        if (entity.cell_x, entity.cell_z) == (0, 1) {
+            assert_eq!(entity.entity_id, spawned.entity_id);
+            break;
+        }
+        assert!(Instant::now() < deadline, "client MoveIntent never traversed gateway and TurnSim");
+        thread::sleep(Duration::from_millis(10));
+    }
+}

--- a/crates/aether-substrate-bundle/tests/player_gateway.rs
+++ b/crates/aether-substrate-bundle/tests/player_gateway.rs
@@ -13,7 +13,7 @@ use aether_capabilities::component::resolve_embedded;
 use aether_capabilities::game::{GameGatewayCapability, PlayerFrame, PlayerSessionActor, WIRE_VERSION};
 use aether_capabilities::tcp::{ListListeners, ListListenersResult};
 use aether_codec::frame::{read_frame, write_frame};
-use aether_data::{ActorId, Kind, MailboxId, Tag, fold_lineage, with_tag};
+use aether_data::{Kind, MailboxId};
 use aether_kinds::{LoadComponent, LoadResult};
 use aether_kit::{GridBounds, MoveDirection, MoveIntent, Poll, SimConfig, Spawn, TickBundle};
 use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
@@ -51,13 +51,7 @@ fn gateway_listener_port(bench: &mut TestBench) -> u16 {
 }
 
 fn expected_player_session_mailbox(session_name: &str) -> MailboxId {
-    MailboxId(with_tag(
-        Tag::Mailbox,
-        fold_lineage(
-            GameGatewayCapability::resolve(0, ()).0,
-            ActorId::instanced(PlayerSessionActor::NAMESPACE, session_name),
-        ),
-    ))
+    PlayerSessionActor::resolve(GameGatewayCapability::resolve(0, ()).0, session_name)
 }
 
 fn load_turn_sim(bench: &mut TestBench, wasm: Vec<u8>) {


### PR DESCRIPTION
Closes #3050.

## Summary

- add a selector-loaded `aether.kit.client` actor that dials the existing TCP/game-gateway stack and uses canonical player framing
- apply authoritative tick bundles atomically into named octimeter positions, emit allowlisted held-key intents, and render under the existing camera surface
- prove controlled visual replacement and the full client-to-`TurnSim` authority loop through real TCP in TestBench

## Test plan

- `cargo xtask dist --no-bins`
- `cargo test -p aether-kit --lib client::tests`
- `cargo test -p aether-capabilities --features runtime tcp::tests:: -- --nocapture`
- `AETHER_REQUIRE_RUNTIME=1 cargo test -p aether-kit --test client_scenario -- --nocapture`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`

## Generated by

`/implement` — agent execution of [scoped issue #3050](https://github.com/iamacoffeepot/aether/issues/3050).
