### PR TITLE
docs(adr): flip 0137 and 0144 to accepted

### DIFF
--- a/docs/adr/0137-in-cluster-behavior-script-host.md
+++ b/docs/adr/0137-in-cluster-behavior-script-host.md
@@ -1,6 +1,6 @@
 # ADR-0137: In-cluster behavior script host
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — the behavior script host in `crates/aether-behavior` / `crates/aether-behavior-derive`)
 - **Date:** 2026-07-07
 
 ## Context

--- a/docs/adr/0144-tick-native-sim-vocabulary.md
+++ b/docs/adr/0144-tick-native-sim-vocabulary.md
@@ -1,6 +1,6 @@
 # ADR-0144: Tick-native sim intent and fact vocabulary
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — the reference tick vocabulary in `crates/aether-kit/src/sim`)
 - **Date:** 2026-07-10
 
 ## Context


### PR DESCRIPTION
Two ADRs shipped without their status lines catching up. Surfaced by `/sweep adrs`.

- **ADR-0137** (in-cluster behavior script host) — `crates/aether-behavior` and `crates/aether-behavior-derive` both exist, with an integration test (`aether-substrate-bundle/tests/behavior_host.rs`), a fixture crate, and wiring through `aether-actor` and `aether-kit`. 24 source files cite the ADR.
- **ADR-0144** (tick-native sim vocabulary) — `crates/aether-kit/src/sim/mod.rs` declares `TurnSim` as "the fixed-tick toy world implementing ADR-0144's reference vocabulary".

ADR-0143 (terrain proposal/commit) also looks partially shipped — `world/proposal.rs` does the staging and digests, but two call sites describe parts of its surface as deliberately absent. Left alone pending a read; it is not in this PR.