### PR TITLE
feat(workflow): headless skill wrappers and the ask-and-park protocol

### DIFF
--- a/.claude/skills/headless/protocol.md
+++ b/.claude/skills/headless/protocol.md
@@ -1,0 +1,65 @@
+# Headless execution protocol
+
+The shared interaction-surface override for the headless wrapper skills (`/scope-headless`, `/implement-headless`, `/land-headless`). It is a plain doc, not a skill — the `headless/` directory carries no `SKILL.md`, so the loader never surfaces it as a slash command. A wrapper references it by relative path; nothing invokes it directly.
+
+Every wrapper executes its original SKILL.md verbatim for process and judgment. This doc governs only the interaction surface — the points where the interactive original assumes a human at the keyboard. A headless agent runs one-shot on an ephemeral GitHub Actions runner: no keyboard to answer a parked question, no session that survives the job exit, no persistent worktree, no operator to re-run. The overrides below adapt those touchpoints without disturbing the process the original encodes.
+
+## Precedence
+
+For the interaction surface only — waiting on a human, printing to a human, confirmation prompts, worktree creation, session persistence, and commit identity — this protocol governs and overrides the original. For everything else — process order, judgment calls, phase-label mechanics, gates, and CI handling — the original governs unchanged.
+
+Precedence is by enumeration, not by adjective. Each wrapper carries an **Overrides** table that lists the exact original anchors it supersedes, cited by heading. An instruction is overridden if and only if it appears in that table; anything not listed is the original's, verbatim. There is no "which instruction wins" ambiguity to resolve at runtime — the table is the whole answer.
+
+## re-entrancy-first
+
+A crashed or re-dispatched job must re-derive its state from observable facts rather than trusting anything it stored, because it stores nothing — liveness is computed, never persisted. Before any process step, every wrapper runs a re-entrancy guard that reads the current state from GitHub:
+
+- Is the PR already merged? (`gh api repos/iamacoffeepot/aether/pulls/<n> --jq '.merged'`)
+- Does the branch already exist?
+- Which `phase:*` label is present on the issue?
+- Is there already an unanswered `agent:awaiting-answer` label with a parked-question comment on this issue?
+
+An unanswered park means the job is waiting on the owner — end the turn without re-asking. Otherwise post a start-of-work comment carrying the run link, then begin the original's process at the phase the observed state implies. A crash between steps leaves the phase label un-moved, so the next dispatch resumes from the same observable point without a stored cursor.
+
+## ask-and-park
+
+Where the original would ask a human — a scope Define or Design bounce, a scope §Comments self-bounce, a land dirty-conflict or Qodana bail-out, or any value judgment only the owner can make — the headless agent does not stop and wait. It posts a structured question comment in the fixed shape below, applies the `agent:awaiting-answer` label, syncs its session to S3 (see [session-to-S3-sync](#session-to-s3-sync)), and exits 0. The exit is clean: a parked question is a normal terminal state for a headless run, not a failure.
+
+The owner's reply re-dispatches the job, which `claude --resume`s the same session from the S3 pointer recorded in the comment marker, so the answer continues the same reasoning context rather than a cold re-scope. V1's only answerer is the owner — there is no `ask:*` routing vocabulary yet.
+
+The question comment has a fixed, machine-parseable shape so the resume path can find it and its S3 pointer without heuristics. The leading HTML-comment marker is the greppable anchor, carrying `task`, `ref`, `run`, and the S3 `session` URI as key=value pairs; the numbered **Options** list is the parseable choice set:
+
+```markdown
+<!-- aether-agent:awaiting-answer task=<scope|implement|land> ref=<issue-or-pr> run=<run-url> session=<s3-uri> -->
+**Parked on #<N> — need a decision.**
+
+<question in plain language, the load-bearing "why" first>
+
+Options:
+1. <option A> — <consequence>
+2. <option B> — <consequence>
+
+Reply with an option number or free-form; your reply re-dispatches this job, which resumes the same session.
+```
+
+Post the comment over REST (`gh api -X POST repos/iamacoffeepot/aether/issues/<n>/comments -F body=@<file>`, body written to a file first so its backticks and `$` are not shell-expanded) and apply the label over REST (the same `…/labels` endpoints the original's phase reconcile uses). The question carries its load-bearing "why" first, then the options with their consequences, so the owner can decide from the comment alone.
+
+## end-turn-not-wait
+
+The headless agent never sleep-polls or blocks on a human. The original's terminal human-waits — scope's "stops at Plan, awaiting `/approve`", implement's "print to user … tell me to land", land's "wait for one confirmation" — each become: post the terminal state as a comment and end the turn. The dispatch that resumes the flow comes from elsewhere — the owner's reply, or the reconciler or tick of a sibling rung — so there is nothing to wait on in-job.
+
+This targets waits on a human, not waits on CI. An in-job wait the original owns that needs no human — the Refine-loop `scripts/wave-status.sh --wait <pr>` CI poll — is **not** overridden here; it runs exactly as the original specifies. The distinction is the party being waited on: a human wait is replaced by end-turn plus re-dispatch, a CI wait stays.
+
+## checkout-as-isolation
+
+The ephemeral runner is single-purpose and thrown away after the job, so isolation is the job boundary itself, not a nested worktree. The runner's `$GITHUB_WORKSPACE` checkout is the workspace directly. The original's `git worktree add "$main_root/.claude/worktrees/issue-<N>"` and its matching `/land` worktree-sweep tail are no-ops in this environment — the agent works in the checkout as it stands and skips both the add and the sweep.
+
+The checkout copy has its `.claude` interactive-session hooks stripped (the `jq 'del(.hooks)' .claude/settings.json` step the review and dogfood workflows already run) because the SessionStart worktree-rebind hook is actively harmful in CI — it would rebind the session to a worktree that does not exist here.
+
+## bot-identity-assert
+
+Before any commit or merge, assert the `aether-agent` bot git identity (`user.name` / `user.email`) for the checkout. Never author under the owner's identity. This reinforces the standing rule that the owner's real name and personal email never appear in any commit the agent produces.
+
+## session-to-S3-sync
+
+On ask-and-park, sync the Claude session directory to S3 under a per-issue prefix in the RunsOn cache bucket, and record the resulting `s3://…` pointer in the parked-question comment's marker (`session=<s3-uri>`). Resume is `claude --resume` from that pointer, so the owner's answer continues the same reasoning context — the parked run's exploration and design reads carry forward rather than being re-derived from scratch. The comment marker is the only place the pointer lives; nothing else stores it, consistent with computed-liveness.

--- a/.claude/skills/implement-headless/SKILL.md
+++ b/.claude/skills/implement-headless/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: implement-headless
+description: Headless variant of /implement for a one-shot GitHub Actions runner. Executes ../implement/SKILL.md verbatim for the plan execution and CI Refine loop; overrides only the interaction surface — the checkout is the workspace, the terminal hold becomes end-turn, commits assert the bot identity — per ../headless/protocol.md.
+---
+
+# /implement-headless — headless implementation wrapper
+
+This wraps `/implement` for a headless agent running one-shot on an ephemeral GitHub Actions runner. It carries no process of its own.
+
+Execute `../implement/SKILL.md` verbatim — the preconditions, the plan-literal Execute phase, the commit-and-format step, the push, the draft-PR open, the CI Refine loop, the phase-label reconcile, the self-bounce mechanics. Where the original touches the interaction surface, `../headless/protocol.md` governs. An instruction is overridden if and only if it appears in the Overrides table below, cited by the original's anchor; everything else is the original's, unchanged. An improvement to `/implement` is live here the moment it merges, because this wrapper only references it.
+
+Before any process step, run the protocol's [re-entrancy-first](../headless/protocol.md#re-entrancy-first) guard: check whether the PR is already merged, whether the branch already exists, which `phase:*` label is present, and whether an unanswered `agent:awaiting-answer` park is open, then post a start-of-work comment with the run link and begin the original at the phase the observed state implies.
+
+## Overrides
+
+| Original anchor | Interactive behavior | Headless override |
+|-----------------|---------------------|-------------------|
+| [`## Worktree setup`](../implement/SKILL.md#worktree-setup) | `git worktree add "$main_root/.claude/worktrees/issue-<N>"`; the stale-worktree probe surfaces and stops when dirty/ahead/PR-attached | [checkout-as-isolation](../headless/protocol.md#checkout-as-isolation) + [re-entrancy-first](../headless/protocol.md#re-entrancy-first) — the runner's `$GITHUB_WORKSPACE` checkout is the workspace; the worktree add is a no-op, and the re-entrancy guard derives prior-attempt state from GitHub rather than from a stale on-disk worktree |
+| [`## Execute phase`](../implement/SKILL.md#execute-phase) step 3 commit | Commit the work in the current git identity | [bot-identity-assert](../headless/protocol.md#bot-identity-assert) — assert the `aether-agent` bot `user.name` / `user.email` before committing; never author under the owner's identity |
+| [`## Self-bounce mechanics`](../implement/SKILL.md#self-bounce-mechanics) human-addressed bounce comment | Prose bounce comment carrying the reason and attempt history | [ask-and-park](../headless/protocol.md#ask-and-park) — when the bounce needs an owner decision, post the same content in the machine-parseable park shape, apply `agent:awaiting-answer`, sync the session to S3, exit 0 |
+| [`## Done condition`](../implement/SKILL.md#done-condition) "Print to user" and the "hold the draft, tell me to land" terminal | Print the draft-PR summary and wait for the operator to un-draft or say land | [end-turn-not-wait](../headless/protocol.md#end-turn-not-wait) — leave the PR a held green draft at `phase:refine`, post the terminal state as a comment, end the turn; re-dispatch resumes |
+
+**Not overridden — the Refine loop's CI wait.** [`## Refine loop`](../implement/SKILL.md#refine-loop-the-spin-until-green-part)'s `scripts/wave-status.sh --wait <pr>` poll is an in-job wait on CI, not on a human, so [end-turn-not-wait](../headless/protocol.md#end-turn-not-wait) does not touch it — it runs exactly as the original specifies. How the reconciler and the in-job loop divide the building→held stretch is the executor workflow's call, out of scope for this wrapper.
+
+Everything the table does not cite — the preconditions, the plan-literal execution, the commit-and-format discipline, the push, the draft-PR open, the CI classification and flake handling, the phase-label reconcile — is `/implement`'s, verbatim.

--- a/.claude/skills/land-headless/SKILL.md
+++ b/.claude/skills/land-headless/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: land-headless
+description: Headless variant of /land for a one-shot GitHub Actions runner. Executes ../land/SKILL.md verbatim for the gate checks, conflict oracle, Qodana sweep, and landing sequence; overrides only the interaction surface — dirty-conflict and Qodana bail-outs become ask-and-park, the confirmation wait becomes end-turn, the merge asserts the bot identity — per ../headless/protocol.md.
+---
+
+# /land-headless — headless landing wrapper
+
+This wraps `/land` for a headless agent running one-shot on an ephemeral GitHub Actions runner. It carries no process of its own.
+
+Execute `../land/SKILL.md` verbatim — the preconditions and QA-label gate, the conflict prediction oracle, the rebase handling, the Qodana sweep, the un-draft and squash-merge, the phase-label delete. Where the original touches the interaction surface, `../headless/protocol.md` governs. An instruction is overridden if and only if it appears in the Overrides table below, cited by the original's anchor; everything else is the original's, unchanged. An improvement to `/land` is live here the moment it merges, because this wrapper only references it.
+
+Before any process step, run the protocol's [re-entrancy-first](../headless/protocol.md#re-entrancy-first) guard: check whether the PR is already merged (a crashed land job that already merged leaves nothing to redo), whether the closing issue still carries its `phase:*` label, and whether an unanswered `agent:awaiting-answer` park is open, then post a start-of-work comment with the run link and begin the original at the point the observed state implies.
+
+## Overrides
+
+| Original anchor | Interactive behavior | Headless override |
+|-----------------|---------------------|-------------------|
+| [`## Conflict prediction and routing`](../land/SKILL.md#conflict-prediction-and-routing) Dirty conflict handling | Surface the conflicting files to the user and stop | [ask-and-park](../headless/protocol.md#ask-and-park) — post the conflict as the structured park question with the owner's resolve/delegate options, apply `agent:awaiting-answer`, sync the session to S3, exit 0. Never touch the branch contents |
+| [`## Qodana sweep`](../land/SKILL.md#qodana-sweep) "Bail out — surface to the user" | Surface an artifact-missing / outside-the-diff / uncertain Qodana case to the user, do not fix | [ask-and-park](../headless/protocol.md#ask-and-park) — park the bail-out case to the owner rather than auto-suppressing |
+| [`## Sweep land`](../land/SKILL.md#sweep-land) "wait for one confirmation" and the [`## Preconditions`](../land/SKILL.md#preconditions) approved-PR expectation | Print the land plan and wait for the operator's one confirmation before merging | [end-turn-not-wait](../headless/protocol.md#end-turn-not-wait) — the dispatch itself is the authorization; the approval policy is the reconciler gate of a later rung. Post the plan as a comment and end the turn rather than blocking on a prompt |
+| [`## Landing sequence`](../land/SKILL.md#landing-sequence) step 6 squash-merge | Issue the squash merge with `commit_title` in the current git identity | [bot-identity-assert](../headless/protocol.md#bot-identity-assert) — assert the `aether-agent` bot `user.name` / `user.email` before merging; never author the merge under the owner's identity |
+| [`## Landing sequence`](../land/SKILL.md#landing-sequence) step 8 worktree sweep | `git worktree remove` + `git branch -D` for the merged branch | [checkout-as-isolation](../headless/protocol.md#checkout-as-isolation) — a no-op on the ephemeral runner, which is thrown away after the job |
+
+Everything the table does not cite — the gate checks and QA-label gate, the conflict oracle and its `mergeable_state` cross-check, the strict-mode rebase handling, the Qodana fetch-and-fix, the un-draft, the merge-verification poll, the phase-label delete — is `/land`'s, verbatim.

--- a/.claude/skills/scope-headless/SKILL.md
+++ b/.claude/skills/scope-headless/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: scope-headless
+description: Headless variant of /scope for a one-shot GitHub Actions runner. Executes ../scope/SKILL.md verbatim for the Define → Design → Plan process and judgment; overrides only the interaction surface — bounces become ask-and-park, the terminal Plan wait becomes end-turn — per ../headless/protocol.md.
+---
+
+# /scope-headless — headless scoping wrapper
+
+This wraps `/scope` for a headless agent running one-shot on an ephemeral GitHub Actions runner. It carries no process of its own.
+
+Execute `../scope/SKILL.md` verbatim — the full Define → Design → Plan walk, the phase-label reconcile, the body-editing mechanics, the grounding and API-budget discipline, every judgment call. Where the original touches the interaction surface, `../headless/protocol.md` governs. An instruction is overridden if and only if it appears in the Overrides table below, cited by the original's anchor; everything else is the original's, unchanged. An improvement to `/scope` is live here the moment it merges, because this wrapper only references it.
+
+Before any process step, run the protocol's [re-entrancy-first](../headless/protocol.md#re-entrancy-first) guard: read the issue's current `phase:*` label and check for an unanswered `agent:awaiting-answer` park, then post a start-of-work comment with the run link and begin the original at the phase the observed state implies.
+
+## Overrides
+
+| Original anchor | Interactive behavior | Headless override |
+|-----------------|---------------------|-------------------|
+| [`### Define`](../scope/SKILL.md#define) Bounce | Self-bounce with a comment asking the specific clarifying question, then the user re-invokes | [ask-and-park](../headless/protocol.md#ask-and-park) — post the structured question comment, apply `agent:awaiting-answer`, sync the session to S3, exit 0 |
+| [`### Design`](../scope/SKILL.md#design) Bounce | Self-bounce on a tied value-judgment only the user can make | [ask-and-park](../headless/protocol.md#ask-and-park) |
+| [`### Design`](../scope/SKILL.md#design) ADR drafting | Scaffold an ADR on a branch and open a PR; the issue is not `/approve`-eligible until it merges | [ask-and-park](../headless/protocol.md#ask-and-park) — a headless scoper cuts no branch; when the chosen approach is load-bearing, park the ADR decision to the owner rather than drafting it |
+| [`## Comments`](../scope/SKILL.md#comments) self-bounce question/blocker | Prose comment addressed to a human | [ask-and-park](../headless/protocol.md#ask-and-park) — the same content, posted in the machine-parseable park shape |
+| Terminal "Stops at Plan, awaiting `/approve`" and [`## Restart and resume semantics`](../scope/SKILL.md#restart-and-resume-semantics) "the user re-invokes" | Stop at Plan and wait for the operator to re-run | [end-turn-not-wait](../headless/protocol.md#end-turn-not-wait) — leave the issue at `phase:plan`, end the turn; re-dispatch resumes the flow |
+
+Everything the table does not cite — the Define/Design/Plan process, the Grounding, Side findings, Body editing mechanics, Phase label reconcile, GitHub API budget, size and model routing — is `/scope`'s, verbatim. A headless scoper still stamps `size:*` and `model:*` at Plan exactly as the original specifies.

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@
 !.claude/skills/secretary/
 !.claude/skills/sweep/
 !.claude/skills/land/
+!.claude/skills/headless/
+!.claude/skills/scope-headless/
+!.claude/skills/implement-headless/
+!.claude/skills/land-headless/
 # Wish-pass reports — themed use-case ideation runs of `/wish`. Per-run
 # markdown, not part of the source tree. Read locally, file the wishes you
 # like as issues, discard the file.


### PR DESCRIPTION
Closes #3128.

## Summary

The skill pipeline's interactive surface assumes a human at the keyboard: bounces ask and wait, terminal states print "tell me", worktrees and sessions persist. A headless agent on an ephemeral GitHub Actions runner has none of that. This adds the shared headless execution protocol (`.claude/skills/headless/protocol.md`) plus three thin wrapper skills — `scope-headless`, `implement-headless`, `land-headless` — that execute their originals verbatim and override only the interaction surface, each via an explicit Overrides table citing the exact original anchors (precedence by enumeration, no runtime ambiguity).

The protocol's overrides: re-entrancy-first (state re-derived from GitHub facts, nothing stored), ask-and-park (structured machine-parseable question comment + `agent:awaiting-answer` label + session-to-S3 + exit 0; the owner's reply re-dispatches with `claude --resume`), end-turn-not-wait (human waits become end-turn + re-dispatch; CI waits stay), checkout-as-isolation (the runner checkout is the workspace; no nested worktree), bot-identity-assert, and session-to-S3-sync.

Rung 1 groundwork of the cloud-agent arc (ADR-0146); #3129's executor dispatches into these wrappers.

## Test plan

Skill text only — no runtime surface, no Rust. Verified all 14 Overrides-table anchor citations resolve to real headings in the three original SKILL.md files, and protocol self-references resolve to its own heading slugs. CI runs the standard checks; live exercise arrives with #3129's executor.

## Generated by

`/implement` — agent execution of [scoped issue #3128](https://github.com/iamacoffeepot/aether/issues/3128).
