### PR TITLE
feat(ci): agent-chat workflow for owner-gated turns with s3 session resume

### DIFF
--- a/.github/workflows/agent-chat.yml
+++ b/.github/workflows/agent-chat.yml
@@ -1,0 +1,416 @@
+name: Agent chat
+
+# The cloud-agent conversational surface: the one human-in-the-loop turn in an
+# otherwise machine-to-machine arc. Everything else (agent-work, agent-tick, the
+# reconciler) is dispatch and recompute; this rung is where the owner talks to
+# the fleet in the place the work happens — a GitHub issue — and where a parked
+# question gets answered so blocked work can resume. Reply-in-issue is the whole
+# v1 channel surface; Discord and email escalations are deliberately later.
+#
+# The turn fires on a new issue (or PR) comment. issue_comment serves both an
+# issue and a PR conversation (a PR is an issue with a pull_request key), and the
+# owner may converse on either, so v1 keeps both — the owner gate plus per-issue
+# keying already bound it. The issues trigger (issue-opened seeding a session) is
+# reserved, not wired: every filed issue would otherwise wake the agent, and
+# issue creation is already agent-work's dispatch surface.
+#
+# The turn takes one of two branches, decided by whether the issue carries
+# agent:awaiting-answer:
+#   - Parked answer (label present): this comment is the owner answering a
+#     question an agent-work run parked (#3128's ask-and-park). Chat runs NO
+#     Claude turn — it removes the label and re-dispatches the parked work via
+#     agent-work.yml, recovering task + ref from the parked-question comment's
+#     marker. The owner's answer reaches the WORK session (which agent-work
+#     resumes, #3129), not chat's own session. This branch is pure hosted
+#     orchestration and touches no Claude / OAuth / S3 step.
+#   - Plain conversation (label absent): chat runs its own claude --resume turn
+#     on the per-issue chat session and posts the reply inline as a comment.
+#
+# Conversational memory survives a fresh, stateless hosted runner via a per-issue
+# Claude session synced to S3 (agent/chat/issue-<n>/): restore before the turn,
+# claude --resume off the recorded pointer, persist after. A corrupt or missing
+# pointer degrades to a fresh session seeded from the issue's comment thread
+# rather than failing the turn.
+#
+# Cost + runner: a conversation compiles nothing, so this runs on a free hosted
+# runner (ubuntu-latest), NOT the RunsOn ephemeral-EC2 path the cargo-heavy agent
+# work uses. The consequence is S3 reachability: the RunsOn in-VPC instance-
+# profile creds (RUNS_ON_S3_BUCKET_CACHE et al., ci.yml's sccache config) exist
+# only on RunsOn runners, so a hosted runner reaches the session bucket by its
+# own credential path — GitHub OIDC assuming a least-privilege AWS role.
+#
+# Identity and auth follow the arc's two separations:
+#   - GitHub writes (the reply comment, the label removal, the agent-work
+#     dispatch) ride an App INSTALLATION token, not GITHUB_TOKEN. App-created
+#     events trigger downstream workflows where GITHUB_TOKEN-created ones do not
+#     (the documented anti-recursion rule), so a chat that dispatches agent-work
+#     MUST use the App token or the wave never wakes.
+#   - Claude auth is AGENT_CLAUDE_CODE_OAUTH_TOKEN — deliberately distinct from
+#     the QA chain's CLAUDE_CODE_OAUTH_TOKEN so the agent subscription's rate
+#     pool stays isolated from review / dogfood.
+#
+# Security posture — the crown-jewel invariant is the JOB-LEVEL owner gate: a
+# single if: guards the whole job, so no secret-bearing step (App-token mint,
+# AGENT_CLAUDE_CODE_OAUTH_TOKEN, AWS/S3 auth) exists on any path a non-owner can
+# reach. This adapts review.yml / dogfood.yml's same-repo gate (head_repository
+# == this repo, the "not a fork" test) to issue_comment, which carries no
+# head_repository but does carry a sender: the analogue of "code from this repo"
+# is "the actor is the repo owner." A step-level gate is deliberately rejected —
+# it would still let earlier secret-bearing steps exist on a non-owner path. One
+# accepted limit, the same one review.yml documents for its gate: the gate
+# authorizes the owner IDENTITY, so an agent driving the owner's token passes;
+# acceptable because the owner is the arc's sole intended answerer (v1 has no
+# ask:* routing). Chat executes no PR-head branch code (it converses about an
+# issue, owner-gated), so review.yml's read-only/write-scoped JOB SPLIT — which
+# exists to contain untrusted PR-head code — does not transfer; to keep its
+# spirit, Claude writes its reply to a file and a later non-Claude step posts it,
+# so the Claude step itself never holds the write-scoped token.
+#
+# Owner console checklist (maintainer console work, NOT part of this file's
+# merge — the workflow merges without it, degrades cleanly when a prerequisite is
+# absent, and the first owner comment is the acceptance test once it exists):
+#   (a) register + install the aether-agent GitHub App (shared with agent-work);
+#       permissions issues / actions: write; store its id + private key as repo
+#       secrets AGENT_APP_ID / AGENT_APP_PRIVATE_KEY;
+#   (b) mint AGENT_CLAUDE_CODE_OAUTH_TOKEN from the Max 20x subscription
+#       (`claude setup-token`) and `gh secret set` it;
+#   (c) create repo variable AGENT_ENABLED=true (the arc-wide kill switch — a
+#       single flip disables every chat turn) once the arc is meant to be live;
+#   (d) create repo variable AGENT_SESSION_BUCKET naming the S3 bucket that holds
+#       chat sessions. The agent/chat/ prefix is deliberately OUTSIDE cache/,
+#       because cache/ carries the RunsOn bucket's 10-day expiration rule
+#       (ci.yml) and a live conversation must not be GC'd out from under an owner
+#       who replies on day 11. Reusing the RunsOn cache bucket is fine IF its
+#       lifecycle rule is cache/-prefix-scoped; if it is bucket-wide, point this
+#       at a dedicated non-expiring bucket (the arc already runs one, for
+#       dogfood evidence);
+#   (e) create an AWS IAM role assumable via GitHub OIDC from this repo, its
+#       policy scoped to s3:GetObject/PutObject/ListBucket on
+#       arn:aws:s3:::<bucket>/agent/chat/* (+ the bucket ListBucket with an
+#       agent/chat/* prefix condition). Record its ARN as repo variable
+#       AGENT_AWS_ROLE_ARN and the bucket's region as AGENT_AWS_REGION. OIDC is
+#       preferred over static IAM keys-as-secrets — it matches the arc's no-
+#       static-secret posture and needs no rotation; static access keys are the
+#       documented fallback if the OIDC trust policy is out of scope for now.
+# Absent any of these, the run logs the exact remedy and exits without spend.
+
+on:
+  issue_comment:
+    types: [created]
+
+# Queue, not cancel — the deliberate inverse of review.yml / dogfood.yml (which
+# cancel an in-flight run when a newer trigger arrives). A chat turn cancelled
+# mid-`s3 sync` would leave a torn session pointer and corrupt the conversation,
+# so two owner comments on one issue SERIALIZE: each turn reads a consistent
+# session and writes it whole before the next begins. Keyed per issue.
+concurrency:
+  group: chat-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  chat:
+    name: Owner conversational turn
+    runs-on: ubuntu-latest
+    # THE crown-jewel invariant (see the header). A single job-level gate makes
+    # the entire secret-bearing body unreachable to a non-owner, rather than
+    # merely skipped step by step. AGENT_ENABLED (the arc-wide kill switch) is
+    # evaluated first so one repo-variable flip disables every chat turn.
+    # github.repository_owner resolves to the owner login, so the comparison is
+    # symbolic — no hardcoded name.
+    if: >
+      vars.AGENT_ENABLED == 'true' &&
+      github.event.sender.login == github.repository_owner
+    # issues: write covers the reply comment and the label removal; id-token:
+    # write is the OIDC mint for the AWS role; contents: read is the floor. The
+    # agent-work dispatch's actions: write reach rides the App token, NOT this
+    # GITHUB_TOKEN — deliberately kept off the default token.
+    permissions:
+      issues: write
+      id-token: write
+      contents: read
+    env:
+      REPO: ${{ github.repository }}
+      ISSUE: ${{ github.event.issue.number }}
+      # The turn model. A conversation does not need opus; the proven headless
+      # sonnet string (the same one the review / dogfood auth probes use) is the
+      # default.
+      MODEL: claude-sonnet-5
+      # The per-issue chat session lives here; the agent/chat/ prefix is outside
+      # cache/ on purpose (see the header's owner checklist item (d)).
+      SESSION_PREFIX: agent/chat/issue-${{ github.event.issue.number }}
+    steps:
+      # Decide the branch BEFORE any secret-bearing step, from observable board
+      # facts alone (GITHUB_TOKEN reads, no App token yet). A parked answer is an
+      # owner comment on an issue carrying agent:awaiting-answer; task + ref come
+      # from the parked-question comment's marker
+      # (<!-- aether-agent:awaiting-answer task=… ref=… … -->, #3128's fixed
+      # shape). Recover ref from the marker (the authoritative work ref), falling
+      # back to this issue's number if the marker omits it.
+      - name: Route — parked answer or plain conversation
+        id: route
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          labels="$(gh api "repos/${REPO}/issues/${ISSUE}/labels" --jq '.[].name')"
+          if ! grep -qx 'agent:awaiting-answer' <<<"$labels"; then
+            echo "no agent:awaiting-answer on #${ISSUE} — plain conversational turn."
+            echo "parked=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The marker is the greppable anchor the park wrote. Capture then match
+          # with a here-string so grep -q can't SIGPIPE the paginated gh under
+          # pipefail.
+          comments="$(gh api "repos/${REPO}/issues/${ISSUE}/comments" --paginate --jq '.[].body')"
+          marker="$(grep -m1 -oE '<!-- aether-agent:awaiting-answer[^>]*-->' <<<"$comments" || true)"
+          if [ -z "$marker" ]; then
+            # The label is set but no marker comment is present — the pair is torn.
+            # Treat it as a plain turn (reply inline) rather than dispatching a
+            # task we cannot address; the owner sees a normal reply and can retry.
+            echo "agent:awaiting-answer is set but no parked-question marker was found — falling back to a plain turn."
+            echo "parked=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          task="$(grep -oE 'task=[a-z]+' <<<"$marker" | head -n1 | cut -d= -f2 || true)"
+          ref="$(grep -oE 'ref=[0-9]+' <<<"$marker" | head -n1 | cut -d= -f2 || true)"
+          [ -n "$ref" ] || ref="$ISSUE"
+          case "$task" in
+            scope|implement|land) ;;
+            *)
+              echo "parked marker carries an unrecognized task='${task:-}' — falling back to a plain turn."
+              echo "parked=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          echo "parked answer on #${ISSUE}: task=${task} ref=${ref} — will dispatch agent-work."
+          echo "parked=true" >> "$GITHUB_OUTPUT"
+          echo "task=${task}" >> "$GITHUB_OUTPUT"
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
+      # The App-token secrets gate BOTH branches (the parked branch dispatches +
+      # edits a label; the plain branch posts the reply), so require them up
+      # front and fail with the exact remedy rather than letting the mint fail
+      # cryptically. The private key rides step-level env only, never job-wide.
+      - name: Preflight — App token secrets present
+        env:
+          APP_ID: ${{ secrets.AGENT_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          missing=""
+          [ -n "${APP_ID:-}" ] || missing="${missing} AGENT_APP_ID"
+          [ -n "${APP_PRIVATE_KEY:-}" ] || missing="${missing} AGENT_APP_PRIVATE_KEY"
+          if [ -n "$missing" ]; then
+            echo "Required secret(s) not set:${missing}"
+            echo "Owner console setup (see this workflow's header comment):"
+            echo "  - register + install the aether-agent GitHub App and store its"
+            echo "    id + private key as AGENT_APP_ID / AGENT_APP_PRIVATE_KEY"
+            exit 1
+          fi
+          echo "App token secrets present."
+
+      # The identity every write below rides. App-created events trigger
+      # downstream workflows where GITHUB_TOKEN-created ones do not, which is the
+      # whole reason the parked-answer dispatch can wake agent-work.
+      - name: Mint the App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+
+      # Parked-answer branch — pure hosted orchestration, no Claude / S3 step.
+      # Remove the label, then re-dispatch the parked work. The owner's answer
+      # reaches the WORK session because the re-dispatched agent-work run resumes
+      # its own S3 session and reads the triggering owner comment as the answer
+      # (that resume is #3129's concern); chat owns only the label edit + the
+      # dispatch. The dispatch rides the App token so it actually wakes the run
+      # and carries the App's actions: write reach.
+      - name: Clear the parked-answer label and re-dispatch agent-work
+        if: steps.route.outputs.parked == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TASK: ${{ steps.route.outputs.task }}
+          REF: ${{ steps.route.outputs.ref }}
+        run: |
+          set -euo pipefail
+          # DELETE the specific label (leaves every other label untouched, unlike
+          # a PUT of the whole set).
+          gh api -X DELETE "repos/${REPO}/issues/${ISSUE}/labels/agent:awaiting-answer"
+          echo "cleared agent:awaiting-answer on #${ISSUE}."
+          gh workflow run agent-work.yml -f task="$TASK" -f ref="$REF"
+          echo "re-dispatched agent-work: task=${TASK} ref=${REF}."
+
+      # Everything below is the plain-conversation branch only.
+
+      # The plain branch's own prerequisites: the Claude token and the S3 / OIDC
+      # session infra. Degrade cleanly with the exact remedy when any is absent —
+      # a chat that cannot reach its session or the model can do nothing useful.
+      - name: Preflight — conversation prerequisites present
+        if: steps.route.outputs.parked == 'false'
+        env:
+          OAUTH: ${{ secrets.AGENT_CLAUDE_CODE_OAUTH_TOKEN }}
+          BUCKET: ${{ vars.AGENT_SESSION_BUCKET }}
+          ROLE_ARN: ${{ vars.AGENT_AWS_ROLE_ARN }}
+          AWS_REGION_VAR: ${{ vars.AGENT_AWS_REGION }}
+        run: |
+          set -euo pipefail
+          missing=""
+          [ -n "${OAUTH:-}" ] || missing="${missing} secret:AGENT_CLAUDE_CODE_OAUTH_TOKEN"
+          [ -n "${BUCKET:-}" ] || missing="${missing} var:AGENT_SESSION_BUCKET"
+          [ -n "${ROLE_ARN:-}" ] || missing="${missing} var:AGENT_AWS_ROLE_ARN"
+          [ -n "${AWS_REGION_VAR:-}" ] || missing="${missing} var:AGENT_AWS_REGION"
+          if [ -n "$missing" ]; then
+            echo "Conversation prerequisite(s) not set:${missing}"
+            echo "Owner console setup (see this workflow's header comment):"
+            echo "  - mint AGENT_CLAUDE_CODE_OAUTH_TOKEN with 'claude setup-token' and gh secret set it"
+            echo "  - set repo var AGENT_SESSION_BUCKET to the S3 bucket holding chat sessions"
+            echo "  - create the GitHub-OIDC-assumable IAM role scoped to agent/chat/* on that"
+            echo "    bucket, and set repo vars AGENT_AWS_ROLE_ARN + AGENT_AWS_REGION"
+            exit 1
+          fi
+          echo "conversation prerequisites present."
+
+      # Reach S3 from the hosted runner via OIDC — assume the least-privilege
+      # role scoped to agent/chat/* on the session bucket. This replaces the
+      # RunsOn in-VPC instance-profile creds, which do not exist off RunsOn.
+      - name: Configure AWS credentials (OIDC)
+        if: steps.route.outputs.parked == 'false'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AGENT_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AGENT_AWS_REGION }}
+
+      - name: Install Claude Code
+        if: steps.route.outputs.parked == 'false'
+        run: npm install -g @anthropic-ai/claude-code
+
+      # Pre-trust the working directory so settings-based permissions aren't
+      # ignored with a warning under skip-permissions.
+      - name: Pre-trust the workspace for headless Claude
+        if: steps.route.outputs.parked == 'false'
+        run: printf '{"projects":{"%s":{"hasTrustDialogAccepted":true}}}\n' "$PWD" > "$HOME/.claude.json"
+
+      # Auth in isolation before the real turn: a one-line prompt, no tools. If
+      # this fails the AGENT OAuth token itself is the problem, not the turn.
+      # --max-turns 3 (not 1) because the model occasionally spends a turn before
+      # emitting the reply, which a 1-turn cap turns into a spurious auth failure.
+      - name: Auth probe (no tools)
+        if: steps.route.outputs.parked == 'false'
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.AGENT_CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          claude -p "Reply with exactly: AUTH-OK" \
+            --model "$MODEL" \
+            --max-turns 3 | tee /tmp/auth.log
+          grep -q "AUTH-OK" /tmp/auth.log
+
+      # Restore the per-issue session before the turn: sync the session tree into
+      # Claude's project store and read the pointer for the id to resume. A
+      # missing prefix or pointer is not an error — it degrades to the fresh-
+      # session-from-thread fallback in the turn step. The claude session store
+      # is keyed by working directory; every turn for this issue runs from the
+      # same runner path, so the id resumes against the restored tree.
+      - name: Restore the chat session from S3
+        if: steps.route.outputs.parked == 'false'
+        env:
+          BUCKET: ${{ vars.AGENT_SESSION_BUCKET }}
+        run: |
+          set -euo pipefail
+          session_dir="$HOME/.claude/projects"
+          mkdir -p "$session_dir"
+          aws s3 sync "s3://${BUCKET}/${SESSION_PREFIX}/session/" "$session_dir/" || true
+          if aws s3 cp "s3://${BUCKET}/${SESSION_PREFIX}/pointer" /tmp/session-pointer 2>/dev/null; then
+            echo "restored session pointer: $(cat /tmp/session-pointer)"
+          else
+            : > /tmp/session-pointer
+            echo "no session pointer for #${ISSUE} — the turn will seed a fresh session from the thread."
+          fi
+
+      # The turn. Resume the recorded session with the owner's comment as the
+      # turn; on a missing or corrupt pointer (empty / --resume errors) degrade
+      # to a fresh session seeded from the issue's comment thread. Either way,
+      # capture the resulting session id and write the reply text to a file — a
+      # later non-Claude step posts it, so the Claude step never holds the write
+      # token. The owner comment rides step-level env, never inlined into the
+      # prompt string, so its content cannot break the shell.
+      - name: Run the conversational turn
+        if: steps.route.outputs.parked == 'false'
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.AGENT_CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER_COMMENT: ${{ github.event.comment.body }}
+        run: |
+          set -uo pipefail
+          session_id="$(cat /tmp/session-pointer 2>/dev/null || true)"
+
+          out=""
+          resumed=0
+          if [ -n "$session_id" ]; then
+            if out="$(claude --resume "$session_id" -p "$OWNER_COMMENT" \
+                       --model "$MODEL" --output-format json --max-turns 20 2>/tmp/turn.err)" \
+               && [ -n "$(jq -r '.session_id // empty' <<<"$out")" ]; then
+              resumed=1
+              echo "resumed session ${session_id}."
+            else
+              echo "resume of ${session_id} failed — seeding a fresh session from the thread:"
+              cat /tmp/turn.err || true
+            fi
+          fi
+
+          if [ "$resumed" -ne 1 ]; then
+            gh api "repos/${REPO}/issues/${ISSUE}/comments" --paginate \
+              --jq '.[] | "@" + .user.login + ": " + .body' > /tmp/thread.txt || : > /tmp/thread.txt
+            {
+              echo "You are the aether agent replying in GitHub issue #${ISSUE}."
+              echo "The prior thread is below for context, then the owner's new message."
+              echo "Reply concisely, in plain prose, as a single issue comment."
+              echo
+              echo "--- prior thread ---"
+              cat /tmp/thread.txt
+              echo "--- owner's new message ---"
+              printf '%s\n' "$OWNER_COMMENT"
+            } > /tmp/seed-prompt.txt
+            out="$(claude -p "$(cat /tmp/seed-prompt.txt)" \
+                    --model "$MODEL" --output-format json --max-turns 20)"
+          fi
+
+          reply="$(jq -r '.result // empty' <<<"$out")"
+          new_id="$(jq -r '.session_id // empty' <<<"$out")"
+          if [ -z "$reply" ]; then
+            echo "the model produced no reply text — failing the turn."
+            exit 1
+          fi
+          printf '%s\n' "$reply" > /tmp/chat-reply.md
+          printf '%s\n' "$new_id" > /tmp/session-pointer
+          echo "turn produced a reply (session ${new_id})."
+
+      # Persist the session whole before the reply posts, so a torn write can
+      # never leave a half-conversation the next turn resumes from. Sync the
+      # project store back up and rewrite the pointer to the (possibly new) id.
+      - name: Persist the chat session to S3
+        if: steps.route.outputs.parked == 'false'
+        env:
+          BUCKET: ${{ vars.AGENT_SESSION_BUCKET }}
+        run: |
+          set -euo pipefail
+          session_dir="$HOME/.claude/projects"
+          aws s3 sync "$session_dir/" "s3://${BUCKET}/${SESSION_PREFIX}/session/"
+          aws s3 cp /tmp/session-pointer "s3://${BUCKET}/${SESSION_PREFIX}/pointer"
+          echo "persisted session for #${ISSUE}: $(cat /tmp/session-pointer)."
+
+      # Post the reply as an issue comment under the App token, so the reply is
+      # App-authored (aether-agent identity) and the Claude step never held the
+      # write token. Body from a file so its backticks and $ are not shell-
+      # expanded.
+      - name: Post the reply
+        if: steps.route.outputs.parked == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${REPO}/issues/${ISSUE}/comments" -F body=@/tmp/chat-reply.md
+          echo "posted the reply on #${ISSUE}."


### PR DESCRIPTION
Closes #3130.

## Summary

Rung 2 of the cloud-agent arc (ADR-0146): `.github/workflows/agent-chat.yml`, the owner-gated conversational turn. A new issue comment fires the workflow; a single job-level gate — `AGENT_ENABLED` and `sender == repository_owner` — stands before every secret-bearing step, so a non-owner comment never reaches the App token, OAuth token, or S3.

Two branches per turn. When the comment answers a parked question (the #3128 ask-and-park marker + `agent:awaiting-answer` label), the route step recovers `task`/`ref` from the marker, clears the label, and re-dispatches `agent-work.yml` under the App token — resuming the parked pipeline run. Otherwise it is a plain chat turn: GitHub OIDC assumes a least-privilege AWS role, the session restores from `s3://$AGENT_SESSION_BUCKET/agent/chat/issue-<n>/`, `claude --resume` continues the conversation (fresh session from the thread as fallback), and the reply posts App-authored after the session persists — Claude never holds the write token. Hosted runner only (a conversation compiles nothing); concurrency queues per issue rather than cancelling.

Merges inert until the owner console items exist (secrets shared with #3129, plus repo vars `AGENT_ENABLED`, `AGENT_SESSION_BUCKET`, `AGENT_AWS_ROLE_ARN`, `AGENT_AWS_REGION`, and the OIDC-assumable role scoped to `agent/chat/*`); every preflight fails with the exact remedy.

## Test plan

Workflow YAML only — no Rust; CI runs the standard checks. Live acceptance once the console items exist: an owner comment on a scratch issue gets an App-authored reply and a persisted S3 session; a reply to a parked question re-dispatches agent-work; a non-owner comment produces no run with secrets in scope.

## Generated by

`/implement` — agent execution of [scoped issue #3130](https://github.com/iamacoffeepot/aether/issues/3130).
