### PR TITLE
feat(ci): approval policy file with declared-surface enforcement

### DIFF
--- a/.claude/skills/approve/SKILL.md
+++ b/.claude/skills/approve/SKILL.md
@@ -64,14 +64,14 @@ Run all of these. **Refuse** if any fail; list every failure in the refusal outp
 | Problem statement | body has `## Problem statement` and the section is non-empty | "Missing or empty §Problem statement." |
 | Design notes | body has `## Design notes` and is non-empty | "Missing or empty §Design notes." |
 | Implementation plan | body has `## Implementation plan` and is non-empty | "Missing or empty §Implementation plan." |
-| ADR merged | if §Design notes references an ADR PR, that PR's `mergedAt` is non-null | "ADR PR #M is not merged. Merge it or pass `--skip-adr` to override." |
+| ADR merged | if §Design notes references an ADR PR, that PR's `mergedAt` is non-null (see [ADR gate, in detail](#adr-gate-in-detail); an ADR reference *also* forces the `human` tier via the [ADR hard gate](#adr-hard-gate)) | "ADR PR #M is not merged. Merge it or pass `--skip-adr` to override." |
 | Model label | exactly one `model:*` label present (REST: `gh api repos/iamacoffeepot/aether/issues/<n>/labels`) | "Missing model:* label (or more than one). `/scope` stamps model routing at Plan — re-run its Plan step or add the label by hand." |
 | Not blocked | no `blocked` / `wontfix` / `duplicate` label present | "Issue carries label '<label>' which blocks approval." |
 | Freshness | targeted paths exist on `origin/main` and none have churned since scope | "Targets removed on main: <paths>" (hard refuse) / "Targets churned since scope — re-ground before approving: <paths>" (soft surface) |
 | Dependency | every `#N` in `## Depends on` is a closed (Done) issue | "Blocked on unlanded dependency: #N (open)." |
 | Umbrella integrity | if `## Sub-issues` is non-empty, the own `## Implementation plan` describes only coordination/integration, not net-new code the children don't cover | "Malformed umbrella: `## Sub-issues` plus a substantial own plan. Split the residual plan into its own child issue (leaving a pure umbrella), or remove `## Sub-issues` to make it a plain implementable issue." |
 
-If **all** gates pass, proceed.
+If **all** gates pass, decide the approval tier: the [ADR hard gate](#adr-hard-gate) first (an ADR-bearing issue routes to the owner unconditionally), then the [Approval tier](#approval-tier) policy lookup for everything else. The tier decides who approves; the gates above decide whether the issue is approvable at all.
 
 ## Freshness gate
 
@@ -115,6 +115,8 @@ Any dependency whose state is not `closed` is an unlanded blocker. A non-`closed
 
 ## Actions on pass
 
+Runs once the structural gates pass *and* the [approval tier](#approval-tier) has cleared — `auto` clears on its own, `judge` and `human` clear on their approver's decision. The actions themselves are the same whoever approved:
+
 1. Reconcile each approved issue's label to `phase:ready` (a REST `PUT …/labels` per issue, see [Phase label reconcile](#phase-label-reconcile)) — the `phase:ready` label is the canonical phase state and the agent-eligibility signal `/implement` reads. A single-issue `/approve` is the N=1 case — one label swap. When a batch mixes passing and failing issues, swap the label only for the ones that cleared every gate and list the rest in the refusal.
 2. No comment on a plain approve — the `phase:ready` label and the timeline's label event already record it. If `--note` was passed, post the note as prose markdown:
 
@@ -154,9 +156,29 @@ The one-or-the-other invariant means any issue that reaches `/implement` with a 
 
 A future `/release-promote-umbrella <parent>` skill can auto-close the umbrella when all children are Done. Out of scope for v1.
 
+## ADR hard gate
+
+Runs **before any policy lookup**, permanently and unconditionally. An ADR-bearing issue routes to the `human` tier — the owner — before [Approval tier](#approval-tier) is consulted at all. No policy rule, present or future, can auto- or judge-approve it: an ADR is load-bearing by definition. An issue is ADR-bearing when its §Design notes references an ADR — an ADR PR link, a `docs/adr/NNNN-*.md` path, or an `ADR flag:` line (the same references the [ADR merge gate](#adr-gate-in-detail) parses). This rule lives in skill text, above the policy file, so it survives any edit to `.github/approval-policy.yml`; that file's `docs/adr/**` `human` entry is belt-and-suspenders, not the source of the rule. The [Approval tier](#approval-tier) lookup is consulted only for a non-ADR issue.
+
+## Approval tier
+
+For a non-ADR issue (the [ADR hard gate](#adr-hard-gate) has already routed an ADR-bearing one to the owner), resolve the issue's approval tier against `.github/approval-policy.yml` over its `## Declared surface` globs (the machine-readable glob block `/scope` emits at Plan):
+
+1. Read the policy file's `default` tier and its ordered `rules` list of `{glob, tier}` entries; `tier ∈ {auto, judge, human}`.
+2. Each declared path's tier is the **most restrictive** matching rule (`human > judge > auto`), or `default` (`human`) when no rule matches — fail-closed, so an unpoliced surface stops at the owner. Globs are gitwildmatch (gitignore-style `**`), matched exactly as the reconciler's containment step matches them.
+3. The issue's approval tier is the most restrictive tier over every path in its declared surface.
+
+Route by the resulting tier:
+
+- **`auto`** — advance to `phase:ready` with no owner decision (the [Actions on pass](#actions-on-pass) label swap runs unchanged).
+- **`judge`** — route to the LLM approval judge (#3133), shadow-mode first: the judge's verdict is recorded but the owner still confirms until the judge is trusted.
+- **`human`** — hold for the owner's explicit `/approve`, exactly as today.
+
+The tier decision runs *after* the structural [Gate checks](#gate-checks) pass — a failing gate refuses regardless of tier. Relaxing a tier is a one-line, owner-signed diff to `.github/approval-policy.yml`; the file's git history is the delegation-ladder audit trail. The declared surface this tier is resolved over is the same surface the reconciler later enforces the merged diff against, so the thing that ships is the thing that was approved.
+
 ## ADR gate, in detail
 
-Parse §Design notes for a URL or reference matching one of:
+The [ADR hard gate](#adr-hard-gate) decides *routing* — an ADR-bearing issue always goes to the owner. This section is the *merge* check the structural gates run: an ADR the issue depends on must already be merged. Parse §Design notes for a URL or reference matching one of:
 
 - `https://github.com/<owner>/<repo>/pull/<N>`
 - `Closes <owner>/<repo>#<N>` (the cross-repo close form per the user's memory)
@@ -207,5 +229,7 @@ The single `PUT …/labels` replaces the label set with the non-`phase:*` labels
 - Dispatch implementation. Run `/implement <issue>` (or wait for the Phase C orchestrator) after approval.
 - Edit the issue body. Even if a gate fails because a section is missing, /approve doesn't write the missing section — that's `/scope`'s job.
 - Auto-resolve side findings.
+- Edit `.github/approval-policy.yml`. Relaxing a tier is the owner's signed diff, never a side effect of an approval run — an issue that wants a looser tier says so and waits for that diff to land.
+- Enforce the declared surface against a PR's actual diff. `/approve` resolves the tier over the declared globs; the reconciler is what later holds a PR whose diff escapes them.
 - Close umbrella issues when children complete. Future work.
 - Notify anyone. The printed summary (and the `phase:ready` label) is the surface; comments appear only for `--note` / `--skip-adr`.

--- a/.claude/skills/release-init/SKILL.md
+++ b/.claude/skills/release-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-init
-description: Bootstrap a new aether release — ensure the phase / bounce-to / size / model labels exist. Issue phase is carried by phase:* labels (no project board).
+description: Bootstrap a new aether release — ensure the phase / bounce-to / approval / size / model labels exist. Issue phase is carried by phase:* labels (no project board).
 ---
 
 # /release-init — release bootstrap skill
@@ -27,7 +27,7 @@ Bootstraps the label vocabulary + local marker the other release skills depend o
 bash scripts/release-project-init.sh <version> --owner <owner>
 ```
 
-The script ensures every pipeline label exists and is idempotent — a re-run only fills gaps. It covers the phase labels (`phase:define` … `phase:stalled`; Backlog and Done carry none), the `bounce-to:*` resume targets `/bounce` stamps, the `size:*` weights (including `size:xl` = fat), and the `model:*` routing labels. `type:*` labels are stamped by `/sketch` from the title's conventional-commit prefix and `crate:*` labels are created on demand at filing, so this step doesn't touch them.
+The script ensures every pipeline label exists and is idempotent — a re-run only fills gaps. It covers the phase labels (`phase:define` … `phase:stalled`; Backlog and Done carry none), the `bounce-to:*` resume targets `/bounce` stamps, the `approval:surface-exceeded` / `approval:surface-ok` declared-surface labels the reconciler and its owner waiver use, the `size:*` weights (including `size:xl` = fat), and the `model:*` routing labels. `type:*` labels are stamped by `/sketch` from the title's conventional-commit prefix and `crate:*` labels are created on demand at filing, so this step doesn't touch them.
 
 ### 2. Print summary
 

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -144,6 +144,21 @@ For each sub-phase: read inputs, write the corresponding body section, and recon
 
   Lift any "lands after #N" / "depends on #N" language out of plan prose and into `## Depends on` as `- #N — <why>` lines. `/approve` reads this section and refuses to advance the issue to `phase:ready` while any listed dependency is still open.
 
+  And a **declared surface** — the machine-readable glob list bounding what the implementation may touch, emitted on **every** scoped issue at Plan:
+
+  ````
+  ## Declared surface
+
+  ```
+  crates/aether-data/src/wire.rs
+  crates/aether-data/tests/**
+  ```
+  ````
+
+  Derive it from the plan's "files touched" segments and §Affected surfaces, widening each concrete target to the glob that bounds the change — a single edited file to itself, a crate-wide change to `crates/<name>/**`. Globs are gitwildmatch (gitignore-style `**` spans path segments, `*` stays within one). Keep it a plain fenced list of globs, one per line, with no prose or bullets inside the fence: two machines read it. `/approve` resolves the issue's approval tier over these globs against `.github/approval-policy.yml` (most-restrictive-wins, fail-closed to `human`), and the reconciler enforces the PR's actual changed-file set against them — a diff that escapes the declaration is held at `phase:building` for re-approval, because it is no longer the change that was approved.
+
+  Declare the surface the implementation will actually touch. Too narrow and a legitimate growth in the diff costs an owner round-trip; too broad and the guard stops meaning anything. Widening the section later is an owner edit, and the issue timeline records it — that is the intended path when a plan honestly outgrows its declaration.
+
   And a dogfood brief — the consumer-validation task this feature's surface will be trialed with, emitted on **every** scoped issue at Plan:
 
   ```
@@ -223,7 +238,7 @@ Don't pad the comment with summaries of work that completed — the body section
 A body edit replaces the entire body, so to avoid clobbering user-written content:
 
 1. Read the current body and capture the issue's `number`, `title`, and non-managed (user) prose as the scoped baseline — `gh api repos/iamacoffeepot/aether/issues/<n> --jq '{number, title, body}'`. Extract and hold the user prose (everything that is not a scope-managed H2 section) from the captured body as the baseline for the guard below. Also derive a set of distinctive **anchor tokens** from the `title`: strip the conventional-commit `type(scope):` prefix, lowercase, drop stopwords, and keep the remaining content words — held alongside the baseline for the topic-anchor assertion at step 4.
-2. Identify scope-managed sections by their H2 headers: `## Problem statement`, `## Design notes`, `## Implementation plan`, `## Sub-issues`, `## Depends on`, `## Dogfood brief`, `## Side findings`. Everything else is user content; preserve verbatim.
+2. Identify scope-managed sections by their H2 headers: `## Problem statement`, `## Design notes`, `## Implementation plan`, `## Sub-issues`, `## Depends on`, `## Declared surface`, `## Dogfood brief`, `## Side findings`. Everything else is user content; preserve verbatim.
 3. Insert or replace the managed sections, preserving user content above and below them.
 4. **Identity guard — assert before writing.** Re-read `{number, title}` for the same `<n>` — `gh api repos/iamacoffeepot/aether/issues/<n> --jq '{number, title}'`. Assert it equals the baseline captured at step 1; also assert the spliced body about to be written still contains the captured user prose. On any mismatch, abort the PATCH and surface the discrepancy instead of writing — a number or title mismatch means the wrong issue is targeted, and a prose mismatch means user content was accidentally removed during the splice. Then run the **topic-anchor assertion**: derive anchor tokens from the *freshly re-read* title (this re-read is authoritative for `<n>`, not the step-1 baseline, since a concurrent title edit would otherwise be missed) and assert the spliced body's `## Problem statement` section contains at least one of those tokens. On failure, abort the PATCH and surface the discrepancy — this is the signature of a full-body replacement whose managed content was authored for a sibling issue rather than this one. Degrade gracefully: if no distinctive token can be derived (a title that is entirely conventional-commit prefix and stopwords), note that and fall back to the number/title/user-prose asserts above rather than blocking the write — the anchor strengthens the guard, it never weakens the existing floor.
 5. Write back over REST — `gh issue edit --body` is GraphQL-backed, while `PATCH …/issues/<n>` is REST. Write the new body to a file first so its backticks / `$` aren't shell-expanded: `gh api -X PATCH repos/iamacoffeepot/aether/issues/<n> -F body=@/tmp/issue-<n>-body.md`.

--- a/.github/approval-policy.yml
+++ b/.github/approval-policy.yml
@@ -1,0 +1,45 @@
+# Approval policy — the tiered guard the Plan->Ready gate (/approve) consults to
+# decide whether an issue may auto-advance, needs an LLM judge, or stops at the
+# owner's desk. It maps path globs to an approval tier over an issue's declared
+# surface (the `## Declared surface` glob block /scope emits at Plan).
+#
+# Resolution is most-restrictive-match-wins (human > judge > auto): a path's
+# tier is the most restrictive rule that matches it, and a path matched by no
+# rule takes `default` below. The default is `human` — fail-closed — so a brand
+# new, unpoliced surface stops at the owner until a rule relaxes it. An issue's
+# tier is the most restrictive tier over every path in its declared surface;
+# order in the `rules` list does not matter.
+#
+# Globs use gitignore-style ** semantics (gitwildmatch): ** spans path segments,
+# * stays within one segment, ? is one non-slash character — the syntax
+# .gitignore already trains readers to expect. Both consumers evaluate these
+# same globs: the no-Claude reconciler over a stock matcher, and /approve as a
+# Claude reader.
+#
+# Relaxing a tier is a one-line, owner-signed diff to this file, so the file's
+# git history is the delegation ladder's audit trail. `.github/approval-policy.yml`
+# is itself a `human`-tier glob below, so a relaxation can never auto-approve
+# its own relaxation.
+#
+# The ADR hard gate lives ABOVE this file, unconditionally, in /approve's skill
+# text: an ADR-bearing issue routes to `human` before any policy lookup,
+# permanently. The `docs/adr/**` entry below is belt-and-suspenders, not the
+# source of that rule.
+
+default: human
+
+rules:
+  - glob: "docs/guide/**"
+    tier: auto
+  - glob: "crates/aether-kit/**"
+    tier: judge
+  - glob: "crates/aether-data/**"
+    tier: human
+  - glob: ".github/workflows/**"
+    tier: human
+  - glob: ".github/approval-policy.yml"
+    tier: human
+  - glob: ".claude/**"
+    tier: human
+  - glob: "docs/adr/**"
+    tier: human

--- a/.github/workflows/reconciler.yml
+++ b/.github/workflows/reconciler.yml
@@ -82,14 +82,16 @@ jobs:
   reconcile:
     name: Reconcile PR phases
     runs-on: ubuntu-latest
-    # Least privilege: write only the issue label set; everything else is read.
-    # pull-requests: read backs the PR object + the GraphQL reviewThreads /
-    # closingIssuesReferences reads; checks: read backs the head check-runs;
-    # statuses: write backs reading the Review gate status AND posting the
-    # Approval gate status the declared-surface check mirrors its verdict into.
+    # Least privilege. issues: write backs the phase label PUT on the closing
+    # issue. pull-requests: write backs the PR object + the GraphQL reviewThreads
+    # / closingIssuesReferences reads AND the approval:surface-* label and the
+    # diagnostic comment: those ride the issues API but land on a PULL REQUEST, so
+    # GitHub scopes them to the pull-requests permission — issues: write alone
+    # returns 403. checks: read backs the head check-runs; statuses: write backs
+    # reading the Review gate status and posting the Approval gate status.
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
       contents: read
       checks: read
       statuses: write
@@ -427,10 +429,13 @@ jobs:
               # The policy is read from the DEFAULT branch, never the PR head — a
               # PR must not be able to relax the policy it is being judged by. It
               # only annotates each escaping path with the tier it would demand;
-              # the verdict below is containment, which never consults it.
-              gh api "repos/${REPO}/contents/.github/approval-policy.yml" \
-                --jq '.content' 2>/dev/null | base64 -d >"${RUNNER_TEMP}/policy.yml" \
-                || : >"${RUNNER_TEMP}/policy.yml"
+              # the verdict below is containment, which never consults it. Before
+              # this file exists on the default branch the fetch simply misses, and
+              # the tier column honestly reads "?" rather than asserting a tier.
+              if ! gh api "repos/${REPO}/contents/.github/approval-policy.yml" \
+                   --jq '.content' 2>/dev/null | base64 -d >"${RUNNER_TEMP}/policy.yml" 2>/dev/null; then
+                : >"${RUNNER_TEMP}/policy.yml"
+              fi
               escaping="$(python3 "${RUNNER_TEMP}/surface_match.py" \
                 "${RUNNER_TEMP}/globs.txt" "${RUNNER_TEMP}/changed.txt" "${RUNNER_TEMP}/policy.yml")"
 
@@ -474,13 +479,27 @@ jobs:
                 sed 's/^/  escapes: /' <<<"$escaping"
               fi
 
-              # Mirror the verdict into the PR label and the required commit
-              # status. The label write uses GITHUB_TOKEN, whose events do not
-              # trigger workflows, so setting it cannot re-enter this reconciler.
-              # The label is advisory and the commit status is the actual gate, so
-              # a failed label call warns and carries on: this workflow is the sole
-              # writer of every PR's phase, and letting one label error abort the
-              # run under `set -e` would strand the whole fleet's reconciliation.
+              # The commit status IS the gate, so it is written FIRST and alone.
+              # The label and comment below are advisory mirrors of a verdict this
+              # status already carries, and an advisory write that dies under
+              # `set -e` before the status lands would leave the PREVIOUS status
+              # standing — an escaping diff keeping a stale green Approval gate,
+              # the exact hazard this check exists to close. Gate first, then
+              # diagnostics, each guarded: the gate fails closed no matter what
+              # the diagnostics do.
+              gh api -X POST "repos/${REPO}/statuses/${head_sha}" \
+                -f state="$gate_state" \
+                -f context="Approval gate" \
+                -f description="$gate_description" \
+                -f target_url="$RUN_URL" >/dev/null
+              echo "write: Approval gate=${gate_state} (${gate_description})"
+
+              # Mirror the verdict into the PR label. The write uses GITHUB_TOKEN,
+              # whose events do not trigger workflows, so setting it cannot
+              # re-enter this reconciler. A failed label call warns and carries on:
+              # this workflow is the sole writer of every PR's phase and loops over
+              # every open PR on the cron path, so letting one label error abort
+              # the run would strand the whole fleet's reconciliation.
               if [ "$surface_exceeded" -eq 1 ]; then
                 grep -qx 'approval:surface-exceeded' <<<"$pr_labels" \
                   || gh api -X POST "repos/${REPO}/issues/${pr}/labels" -f "labels[]=approval:surface-exceeded" >/dev/null \
@@ -494,14 +513,15 @@ jobs:
               # Diagnostic comment, upserted against a marker so the cron backstop
               # updates one comment instead of spamming a new one every 15 minutes.
               # It clears when the violation does, leaving no stale accusation.
+              # Advisory like the label, and guarded for the same reason.
               comment_id="$(gh api "repos/${REPO}/issues/${pr}/comments" --paginate \
-                --jq '[.[] | select(.body | contains("<!-- aether-approval-gate -->"))] | last | .id // empty')"
+                --jq '[.[] | select(.body | contains("<!-- aether-approval-gate -->"))] | last | .id // empty' || true)"
               if [ "$surface_exceeded" -eq 1 ]; then
                 {
                   echo "<!-- aether-approval-gate -->"
                   echo "**Approval gate: this diff escapes issue #${issue}'s declared surface.**"
                   echo
-                  echo "These changed files are outside the \`## Declared surface\` globs \`/approve\` resolved this issue's approval tier over, so what is about to merge is no longer the change that was approved. The tier column is what each path would demand under \`.github/approval-policy.yml\` (\`?\` = not resolved)."
+                  echo "These changed files are outside the \`## Declared surface\` globs \`/approve\` resolved this issue's approval tier over, so what is about to merge is no longer the change that was approved. The tier column is what each path would demand under \`.github/approval-policy.yml\` (\`?\` = the policy is not on the default branch yet)."
                   echo
                   echo "| escaping path | tier it would demand |"
                   echo "|---|---|"
@@ -511,23 +531,20 @@ jobs:
                 } >"${RUNNER_TEMP}/comment.md"
                 if [ -n "$comment_id" ]; then
                   gh api -X PATCH "repos/${REPO}/issues/comments/${comment_id}" \
-                    -F body=@"${RUNNER_TEMP}/comment.md" >/dev/null
-                  echo "write: updated approval-gate comment ${comment_id}"
+                    -F body=@"${RUNNER_TEMP}/comment.md" >/dev/null \
+                    && echo "write: updated approval-gate comment ${comment_id}" \
+                    || echo "warn: could not update the approval-gate comment"
                 else
                   gh api -X POST "repos/${REPO}/issues/${pr}/comments" \
-                    -F body=@"${RUNNER_TEMP}/comment.md" >/dev/null
-                  echo "write: posted approval-gate comment"
+                    -F body=@"${RUNNER_TEMP}/comment.md" >/dev/null \
+                    && echo "write: posted approval-gate comment" \
+                    || echo "warn: could not post the approval-gate comment"
                 fi
               elif [ -n "$comment_id" ]; then
-                gh api -X DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null
-                echo "write: cleared stale approval-gate comment ${comment_id}"
+                gh api -X DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null \
+                  && echo "write: cleared stale approval-gate comment ${comment_id}" \
+                  || echo "warn: could not clear the stale approval-gate comment"
               fi
-              gh api -X POST "repos/${REPO}/statuses/${head_sha}" \
-                -f state="$gate_state" \
-                -f context="Approval gate" \
-                -f description="$gate_description" \
-                -f target_url="$RUN_URL" >/dev/null
-              echo "write: Approval gate=${gate_state} (${gate_description})"
             fi
 
             # Fact — findings open: either advisory QA flag on the PR, or any

--- a/.github/workflows/reconciler.yml
+++ b/.github/workflows/reconciler.yml
@@ -9,13 +9,27 @@ name: Reconciler
 # whole target from scratch, so a missed event self-heals on the next one, and a
 # forgotten agent step is a liveness hiccup rather than a wrong flag.
 #
+# DECLARED-SURFACE GATE: reaching `held` additionally requires the PR's actual
+# changed-file set to stay a subset of its closing issue's `## Declared surface`
+# globs (what /approve resolved the approval tier over). A diff that escapes the
+# declaration is no longer the change that was approved, so it is pinned at
+# `building` behind a required, failing `Approval gate` commit status — the same
+# owner-gated, label-mirroring shape review.yml uses for `review:unresolved` ->
+# `Review gate`. It self-heals when the owner trims the diff, widens the
+# declaration (an issue-timeline edit), or applies an `approval:surface-ok`
+# waiver. A PR whose issue declares no surface gets no status, so requiring the
+# gate in branch protection is the owner's separate, later call and never wedges
+# a PR from before the mechanism.
+#
 # TRIGGER MODEL (four paths, one pure recompute each):
 #   - pull_request [opened, reopened, synchronize, ready_for_review, labeled,
 #     unlabeled] — the payload carries the PR directly. synchronize is the
 #     push-demotes path (a fresh head with CI not yet green falls back to
 #     building); labeled/unlabeled wakes the reconciler when a QA post job flips
-#     the review:unresolved / dogfood:unresolved PR label. A label event on any
-#     other label exits cleanly.
+#     the review:unresolved / dogfood:unresolved PR label, or when the owner
+#     applies the approval:surface-ok waiver. A label event on any other label
+#     exits cleanly. The reconciler's own approval:surface-exceeded write does
+#     not re-enter it: GITHUB_TOKEN-authored events do not trigger workflows.
 #   - workflow_run on CI only — CI is pull_request-triggered, so a CI run object
 #     carries the real PR branch and resolves exactly as review.yml's resolve
 #     step does. Review and Dogfood are deliberately NOT in this list: those
@@ -71,13 +85,14 @@ jobs:
     # Least privilege: write only the issue label set; everything else is read.
     # pull-requests: read backs the PR object + the GraphQL reviewThreads /
     # closingIssuesReferences reads; checks: read backs the head check-runs;
-    # statuses: read backs the Review gate commit status.
+    # statuses: write backs reading the Review gate status AND posting the
+    # Approval gate status the declared-surface check mirrors its verdict into.
     permissions:
       issues: write
       pull-requests: read
       contents: read
       checks: read
-      statuses: read
+      statuses: write
     # Same-repo only. Dispatch and schedule are always trusted; a pull_request
     # or CI-completion path with a fork head is skipped (its token is read-only
     # and it carries no QA state to reconcile).
@@ -104,8 +119,113 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           DISPATCH_PR: ${{ github.event.inputs.pr }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
+
+          # The declared-surface matcher. Globs are gitwildmatch (gitignore
+          # semantics): ** spans path segments, * stays within one, ? is one
+          # non-slash character, and a pattern naming a directory covers
+          # everything beneath it. Bash has no such matcher and the runner has no
+          # pathspec module, so translate to a regex here — the one place the
+          # semantics the policy file and /scope both promise are actually
+          # decided. Prints the changed paths that escape the declaration; silent
+          # when the diff is contained.
+          cat >"${RUNNER_TEMP}/surface_match.py" <<'PY'
+          import re, sys
+
+
+          def compile_glob(pat):
+              pat = pat.rstrip("/")
+              anchored = "/" in pat
+              out, i, n = [], 0, len(pat)
+              while i < n:
+                  c = pat[i]
+                  if c == "*":
+                      j = i
+                      while j < n and pat[j] == "*":
+                          j += 1
+                      doubled = j - i > 1
+                      at_start = i == 0 or pat[i - 1] == "/"
+                      if doubled and at_start and j < n and pat[j] == "/":
+                          out.append("(?:[^/]+/)*")  # "**/" — zero or more segments
+                          i = j + 1
+                      elif doubled and at_start and j >= n:
+                          out.append(".*")  # trailing "/**" — everything beneath
+                          i = j
+                      else:
+                          out.append("[^/]*")
+                          i = j
+                  elif c == "?":
+                      out.append("[^/]")
+                      i += 1
+                  elif c == "[":
+                      j = i + 1
+                      if j < n and pat[j] in "!^":
+                          j += 1
+                      if j < n and pat[j] == "]":
+                          j += 1
+                      while j < n and pat[j] != "]":
+                          j += 1
+                      if j >= n:
+                          out.append(re.escape("["))
+                          i += 1
+                      else:
+                          cls = pat[i + 1 : j]
+                          out.append("[" + ("^" + cls[1:] if cls.startswith("!") else cls) + "]")
+                          i = j + 1
+                  else:
+                      out.append(re.escape(c))
+                      i += 1
+              body = "".join(out)
+              # An unanchored pattern (no slash) matches at any depth. The trailing
+              # group is the directory rule: naming a directory covers its contents.
+              return re.compile(("^" if anchored else "^(?:.*/)?") + body + "(?:/.*)?$")
+
+
+          RANK = {"auto": 0, "judge": 1, "human": 2}
+
+
+          def read_globs(path):
+              return [
+                  line.strip()
+                  for line in open(path, encoding="utf-8").read().splitlines()
+                  if line.strip() and not line.strip().startswith("#")
+              ]
+
+
+          def load_policy(path):
+              # Annotation only — the gate's verdict is containment, which never
+              # consults the policy. So a runner without PyYAML degrades to an
+              # un-annotated diagnostic rather than failing the gate open OR shut.
+              try:
+                  import yaml
+              except ImportError:
+                  return None
+              doc = yaml.safe_load(open(path, encoding="utf-8")) or {}
+              rules = [
+                  (compile_glob(r["glob"]), r["tier"])
+                  for r in doc.get("rules") or []
+                  if r.get("glob") and r.get("tier") in RANK
+              ]
+              return doc.get("default", "human"), rules
+
+
+          def tier_of(path, policy):
+              if policy is None:
+                  return "?"
+              default, rules = policy
+              matched = [tier for matcher, tier in rules if matcher.match(path)]
+              return max(matched, key=lambda t: RANK[t]) if matched else default
+
+
+          matchers = [compile_glob(g) for g in read_globs(sys.argv[1])]
+          policy = load_policy(sys.argv[3]) if len(sys.argv) > 3 else None
+          for path in open(sys.argv[2], encoding="utf-8").read().splitlines():
+              path = path.strip()
+              if path and not any(m.match(path) for m in matchers):
+                  print(f"{path}\t{tier_of(path, policy)}")
+          PY
 
           # A synchronize (new head push) forces a demotion to building — it
           # applies to the single payload PR, the only PR this event names.
@@ -122,7 +242,7 @@ jobs:
               # own peers make on unrelated labels.
               if [ "$EVENT_ACTION" = "labeled" ] || [ "$EVENT_ACTION" = "unlabeled" ]; then
                 case "$LABEL_NAME" in
-                  review:unresolved|dogfood:unresolved) ;;
+                  review:unresolved|dogfood:unresolved|approval:surface-ok) ;;
                   *) echo "label '${LABEL_NAME}' is not a QA flag — nothing to reconcile."; exit 0 ;;
                 esac
               fi
@@ -264,6 +384,127 @@ jobs:
             fi
             echo "fact dogfood: owed=${dogfood_owed} verdict=${dogfood_verdict:-none} verdict_in=${dogfood_verdict_in}"
 
+            # Fact — declared surface: the closing issue's `## Declared surface`
+            # fenced glob block bounds what the implementation may touch, and the
+            # PR's changed-file set must stay inside it. A diff that escapes the
+            # declaration is no longer the change /approve resolved an approval
+            # tier over, so it pins the issue at building behind a failing
+            # `Approval gate` status until the owner trims the diff, widens the
+            # declaration (an issue-body edit), or waives with approval:surface-ok.
+            # An issue that declares no surface is un-gated and gets no status at
+            # all, so making the gate required in branch protection is the owner's
+            # separate call and never wedges a PR from before the mechanism.
+            surface="$(awk '/^## Declared surface/{f=1; next} /^## /{f=0} f' <<<"$issue_body" \
+              | sed -n '/^[[:space:]]*```/,/^[[:space:]]*```/p' | sed '1d;$d' \
+              | grep -v '^[[:space:]]*$' || true)"
+
+            surface_exceeded=0
+            if [ -z "$surface" ]; then
+              echo "fact declared_surface: none — un-gated, no Approval gate status posted."
+            else
+              printf '%s\n' "$surface" >"${RUNNER_TEMP}/globs.txt"
+              gh api "repos/${REPO}/pulls/${pr}/files" --paginate --jq '.[].filename' \
+                >"${RUNNER_TEMP}/changed.txt"
+              # The policy is read from the DEFAULT branch, never the PR head — a
+              # PR must not be able to relax the policy it is being judged by. It
+              # only annotates each escaping path with the tier it would demand;
+              # the verdict below is containment, which never consults it.
+              gh api "repos/${REPO}/contents/.github/approval-policy.yml" \
+                --jq '.content' 2>/dev/null | base64 -d >"${RUNNER_TEMP}/policy.yml" \
+                || : >"${RUNNER_TEMP}/policy.yml"
+              escaping="$(python3 "${RUNNER_TEMP}/surface_match.py" \
+                "${RUNNER_TEMP}/globs.txt" "${RUNNER_TEMP}/changed.txt" "${RUNNER_TEMP}/policy.yml")"
+
+              # Owner waiver: approval:surface-ok accepts the overreach, but only
+              # when the owner applied it — verified via the timeline actor, the
+              # same shape review.yml's review:skip waiver uses. An agent can set
+              # the label; it just doesn't count.
+              surface_ok=0
+              if grep -qx 'approval:surface-ok' <<<"$pr_labels"; then
+                waiver_actor="$(gh api "repos/${REPO}/issues/${pr}/timeline" --paginate \
+                  --jq '[.[] | select(.event=="labeled" and .label.name=="approval:surface-ok")] | last | .actor.login // empty')"
+                if [ "$waiver_actor" = "$OWNER" ]; then
+                  surface_ok=1
+                fi
+              fi
+
+              escaping_count=0
+              if [ -n "$escaping" ]; then
+                escaping_count="$(wc -l <<<"$escaping" | tr -d ' ')"
+              fi
+
+              if [ "$escaping_count" -eq 0 ]; then
+                gate_state="success"
+                gate_description="diff within the issue's declared surface"
+              elif [ "$surface_ok" -eq 1 ]; then
+                gate_state="success"
+                gate_description="declared-surface overreach waived by owner (approval:surface-ok)"
+              elif grep -qx 'approval:surface-ok' <<<"$pr_labels"; then
+                # Label present but not the owner's — the waiver is the owner's
+                # signoff alone, so it does not count.
+                surface_exceeded=1
+                gate_state="failure"
+                gate_description="approval:surface-ok ignored: applied by '${waiver_actor:-unknown}', not the owner. Owner must re-apply."
+              else
+                surface_exceeded=1
+                gate_state="failure"
+                gate_description="${escaping_count} file(s) escape issue #${issue}'s declared surface — widen it, trim the diff, or waive with approval:surface-ok"
+              fi
+              echo "fact declared_surface: globs=$(wc -l <<<"$surface" | tr -d ' ') escaping=${escaping_count} exceeded=${surface_exceeded}"
+              if [ "$escaping_count" -gt 0 ]; then
+                sed 's/^/  escapes: /' <<<"$escaping"
+              fi
+
+              # Mirror the verdict into the PR label and the required commit
+              # status. The label write uses GITHUB_TOKEN, whose events do not
+              # trigger workflows, so setting it cannot re-enter this reconciler.
+              if [ "$surface_exceeded" -eq 1 ]; then
+                grep -qx 'approval:surface-exceeded' <<<"$pr_labels" || \
+                  gh api -X POST "repos/${REPO}/issues/${pr}/labels" -f "labels[]=approval:surface-exceeded" >/dev/null
+              else
+                ! grep -qx 'approval:surface-exceeded' <<<"$pr_labels" || \
+                  gh api -X DELETE "repos/${REPO}/issues/${pr}/labels/approval:surface-exceeded" >/dev/null
+              fi
+
+              # Diagnostic comment, upserted against a marker so the cron backstop
+              # updates one comment instead of spamming a new one every 15 minutes.
+              # It clears when the violation does, leaving no stale accusation.
+              comment_id="$(gh api "repos/${REPO}/issues/${pr}/comments" --paginate \
+                --jq '[.[] | select(.body | contains("<!-- aether-approval-gate -->"))] | last | .id // empty')"
+              if [ "$surface_exceeded" -eq 1 ]; then
+                {
+                  echo "<!-- aether-approval-gate -->"
+                  echo "**Approval gate: this diff escapes issue #${issue}'s declared surface.**"
+                  echo
+                  echo "These changed files are outside the \`## Declared surface\` globs \`/approve\` resolved this issue's approval tier over, so what is about to merge is no longer the change that was approved. The tier column is what each path would demand under \`.github/approval-policy.yml\` (\`?\` = not resolved)."
+                  echo
+                  echo "| escaping path | tier it would demand |"
+                  echo "|---|---|"
+                  awk -F'\t' '{printf "| `%s` | %s |\n", $1, $2}' <<<"$escaping"
+                  echo
+                  echo "Clear it by trimming the diff back inside the declaration, widening \`## Declared surface\` on #${issue} (an owner edit — the issue timeline records it), or applying \`approval:surface-ok\` (owner only). The next reconcile recomputes from scratch."
+                } >"${RUNNER_TEMP}/comment.md"
+                if [ -n "$comment_id" ]; then
+                  gh api -X PATCH "repos/${REPO}/issues/comments/${comment_id}" \
+                    -F body=@"${RUNNER_TEMP}/comment.md" >/dev/null
+                  echo "write: updated approval-gate comment ${comment_id}"
+                else
+                  gh api -X POST "repos/${REPO}/issues/${pr}/comments" \
+                    -F body=@"${RUNNER_TEMP}/comment.md" >/dev/null
+                  echo "write: posted approval-gate comment"
+                fi
+              elif [ -n "$comment_id" ]; then
+                gh api -X DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null
+                echo "write: cleared stale approval-gate comment ${comment_id}"
+              fi
+              gh api -X POST "repos/${REPO}/statuses/${head_sha}" \
+                -f state="$gate_state" \
+                -f context="Approval gate" \
+                -f description="$gate_description" \
+                -f target_url="$RUN_URL" >/dev/null
+              echo "write: Approval gate=${gate_state} (${gate_description})"
+            fi
+
             # Fact — findings open: either advisory QA flag on the PR, or any
             # unresolved review thread (GraphQL; the only per-thread signal, and
             # the reason the schedule backstop exists — thread resolves have no
@@ -283,8 +524,11 @@ jobs:
             fi
             echo "fact unresolved_threads: ${unresolved_threads:-0} (findings_open=${findings_open})"
 
-            # Compute the target phase, first match wins.
-            if [ "$is_synchronize" = "1" ] || [ "$ci_green" -eq 0 ]; then
+            # Compute the target phase, first match wins. A diff that escaped the
+            # declared surface pins at building alongside the not-green cases: it
+            # owes a re-approval, so it is not a change QA or the owner should be
+            # spending attention on yet.
+            if [ "$surface_exceeded" -eq 1 ] || [ "$is_synchronize" = "1" ] || [ "$ci_green" -eq 0 ]; then
               target="phase:building"
             elif [ "$review_owed" -eq 1 ] || { [ "$dogfood_owed" -eq 1 ] && [ "$dogfood_verdict_in" -eq 0 ]; }; then
               target="phase:qa"

--- a/.github/workflows/reconciler.yml
+++ b/.github/workflows/reconciler.yml
@@ -196,19 +196,38 @@ jobs:
 
           def load_policy(path):
               # Annotation only — the gate's verdict is containment, which never
-              # consults the policy. So a runner without PyYAML degrades to an
-              # un-annotated diagnostic rather than failing the gate open OR shut.
-              try:
-                  import yaml
-              except ImportError:
+              # consults the policy, so a missing policy file costs the tier column
+              # and nothing else. The file's shape is owned by this repo (a
+              # `default` tier plus a list of {glob, tier} rules), so it is parsed
+              # with the standard library rather than PyYAML, which the runner is
+              # not guaranteed to ship: a hand parser keeps the tier column
+              # deterministic instead of silently degrading every row to "?".
+              # Tier resolution is most-restrictive-wins over the matching rules,
+              # falling back to the fail-closed default — the same resolution
+              # /approve applies at the Plan->Ready edge, so the diagnostic quotes
+              # the tier an escaping path would actually cost.
+              text = open(path, encoding="utf-8").read()
+              if not text.strip():
+                  # The fetch failed (no policy on the default branch yet), so the
+                  # tier is honestly unresolved rather than assumed.
                   return None
-              doc = yaml.safe_load(open(path, encoding="utf-8")) or {}
-              rules = [
-                  (compile_glob(r["glob"]), r["tier"])
-                  for r in doc.get("rules") or []
-                  if r.get("glob") and r.get("tier") in RANK
-              ]
-              return doc.get("default", "human"), rules
+              default, rules, pending = "human", [], None
+              for raw in text.splitlines():
+                  line = raw.split("#", 1)[0].rstrip()
+                  m = re.match(r"^default:\s*(\w+)\s*$", line)
+                  if m:
+                      default = m.group(1)
+                      continue
+                  m = re.match(r"""^\s*-\s*glob:\s*["']?(.+?)["']?\s*$""", line)
+                  if m:
+                      pending = m.group(1)
+                      continue
+                  m = re.match(r"""^\s*tier:\s*["']?(\w+)["']?\s*$""", line)
+                  if m and pending is not None:
+                      if m.group(1) in RANK:
+                          rules.append((compile_glob(pending), m.group(1)))
+                      pending = None
+              return default, rules
 
 
           def tier_of(path, policy):
@@ -458,12 +477,18 @@ jobs:
               # Mirror the verdict into the PR label and the required commit
               # status. The label write uses GITHUB_TOKEN, whose events do not
               # trigger workflows, so setting it cannot re-enter this reconciler.
+              # The label is advisory and the commit status is the actual gate, so
+              # a failed label call warns and carries on: this workflow is the sole
+              # writer of every PR's phase, and letting one label error abort the
+              # run under `set -e` would strand the whole fleet's reconciliation.
               if [ "$surface_exceeded" -eq 1 ]; then
-                grep -qx 'approval:surface-exceeded' <<<"$pr_labels" || \
-                  gh api -X POST "repos/${REPO}/issues/${pr}/labels" -f "labels[]=approval:surface-exceeded" >/dev/null
+                grep -qx 'approval:surface-exceeded' <<<"$pr_labels" \
+                  || gh api -X POST "repos/${REPO}/issues/${pr}/labels" -f "labels[]=approval:surface-exceeded" >/dev/null \
+                  || echo "warn: could not set approval:surface-exceeded (is the label bootstrapped?)"
               else
-                ! grep -qx 'approval:surface-exceeded' <<<"$pr_labels" || \
-                  gh api -X DELETE "repos/${REPO}/issues/${pr}/labels/approval:surface-exceeded" >/dev/null
+                ! grep -qx 'approval:surface-exceeded' <<<"$pr_labels" \
+                  || gh api -X DELETE "repos/${REPO}/issues/${pr}/labels/approval:surface-exceeded" >/dev/null \
+                  || echo "warn: could not clear approval:surface-exceeded"
               fi
 
               # Diagnostic comment, upserted against a marker so the cron backstop

--- a/scripts/release-project-init.sh
+++ b/scripts/release-project-init.sh
@@ -2,7 +2,8 @@
 # release-project-init.sh — bootstrap the label vocabulary for aether releases.
 #
 #   release-project-init.sh <version> [--owner <owner>]
-#       Ensure the phase / bounce-to / size / model labels exist on the repo.
+#       Ensure the phase / bounce-to / approval / size / model labels exist on
+#       the repo.
 #       Idempotent — a re-run only fills gaps.
 #
 # Issue phase is carried entirely by phase:* labels: Backlog and Done are
@@ -53,6 +54,14 @@ ensure_label "phase:stalled"   e99695 "env/tooling halt"
 ensure_label "bounce-to:define" c5def5 "/scope resumes from Define"
 ensure_label "bounce-to:design" c5def5 "/scope resumes from Design"
 ensure_label "bounce-to:plan"   c5def5 "/scope resumes from Plan"
+
+# Declared-surface enforcement, carried on the PR (not the issue). The
+# reconciler sets approval:surface-exceeded when a PR's diff escapes its issue's
+# ## Declared surface and mirrors it into the required `Approval gate` commit
+# status; approval:surface-ok is the owner's waiver, honoured only when the
+# owner applied it (timeline actor check), mirroring review:skip.
+ensure_label "approval:surface-exceeded" d93f0b "PR diff escapes the issue's declared surface — re-approval owed"
+ensure_label "approval:surface-ok"       0e8a16 "owner waiver: declared-surface overreach accepted"
 
 # Size (weight) — XL marks a fat issue for /sweep fat (ADR-0110).
 ensure_label "size:s"  bfdadc "single file, single concept"


### PR DESCRIPTION
Tiers the Plan→Ready gate so the owner stops being the bottleneck on changes that are, by their own judgment, safe to auto-advance — and closes the hazard that an agent gets a small change approved and then quietly expands it.

## What landed

**`.github/approval-policy.yml`** maps path globs to an approval tier (`auto` / `judge` / `human`). Resolution is most-restrictive-match-wins and fail-closed: a path no rule matches takes `default: human`, so a new, unpoliced surface stops at the owner until a rule relaxes it. The file is itself a `human` glob, so a relaxation can never auto-approve its own relaxation, and its git history is the delegation ladder's audit trail.

**The ADR hard gate** lives above the file, in `/approve`'s skill text: an ADR-bearing issue routes to the owner *before* any policy lookup, so no policy rule — present or future — can auto- or judge-approve one. The file's `docs/adr/**` entry is belt-and-suspenders, not the source of the rule.

**Declared-surface enforcement.** `/scope` emits a `## Declared surface` glob block at Plan, and the reconciler enforces the PR's actual changed-file set against it. A diff that escapes the declaration is no longer the change that was approved, so it pins at `phase:building` behind a failing `Approval gate` status, an `approval:surface-exceeded` label, and a comment naming each escaping path with the tier it would demand. It self-heals when the diff is trimmed, the declaration widened, or the owner waives with `approval:surface-ok`.

## Design properties worth naming

- **Containment is the whole verdict.** If actual ⊆ declared, the diff's tier cannot exceed the tier already approved, so no second policy evaluation is needed. The policy read only annotates the diagnostic.
- **The gate fails closed.** The commit status is written first and alone; the label and comment are advisory mirrors, each guarded. No diagnostic failure can suppress a failing verdict or leave a stale green one standing.
- **A PR cannot relax the policy judging it** — the policy is read from the default branch, never the PR head.
- **An agent cannot waive its own overreach** — `approval:surface-ok` counts only when the timeline actor is the owner, the same shape `review.yml`'s `review:skip` uses.
- **No PyYAML dependency.** The policy's fixed shape is parsed with the standard library, so the tier column is deterministic rather than degrading to `?` on a runner without the module.
- **No PR from before the mechanism is wedged.** An issue that declares no surface is un-gated and gets no status at all, so making `Approval gate` required in branch protection stays the owner's separate, later call.

## Verification

The glob matcher is gitwildmatch (gitignore semantics) translated to regex, since bash has no such matcher. Unit-exercised against `**` spanning segments, `*` not spanning them, `?`, directory-name patterns covering their contents, unanchored basenames, prefix-bleed (`docs/guidex.md` correctly escapes `docs/guide/**`), sibling dirs (`crates/aether-kit-extra` escapes `crates/aether-kit`), and order-independent most-restrictive-wins.

**This PR gates itself.** #3132 carries a `## Declared surface`, so the reconciler ran the new check against this very PR, and the full lifecycle was exercised live on it:

1. **Contained** → `Approval gate` success.
2. **Declaration temporarily narrowed to one glob** → the gate held: `Approval gate` failure (`5 file(s) escape…`), `approval:surface-exceeded` applied, and a comment naming all five escaping paths.
3. **Declaration restored** → self-healed: status back to success, label cleared, comment deleted.

That live run is what caught the three defects fixed in `bf2a83d4`, none of which a local test could reach: the advisory writes 403'd (labelling a *PR* needs `pull-requests: write`, not `issues: write`), and because they were written *before* the status, the `set -e` abort left the previous **green** status standing on a diff that had just been found to escape — the gate failed open, the exact hazard it exists to close.

Closes #3132
