### PR TITLE
feat(ci): approver judge in shadow mode

### DIFF
--- a/.claude/skills/judge/SKILL.md
+++ b/.claude/skills/judge/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: judge
+description: Shadow-mode approver judge. Reads one `phase:plan` issue's scope artifacts with fresh context and an adversarial "refute readiness" stance, scores them against a four-dimension rubric, and emits a structured `judge-verdict` block plus reasoning. Carries ZERO authority — it writes no label, merges nothing, and never edits this rubric. The label flip stays the owner's.
+---
+
+# /judge — shadow-mode approver judge
+
+The second reader of a Plan-complete issue. `/approve` is the one gate in the phase ladder the wavefront tick deliberately never advances: the owner reads the scope artifacts and decides. This skill adds a reader beside them — a fresh context that tries to *refute* the issue's readiness and records what it found — with no power to act on the answer.
+
+The verdict is a comment. Nothing else. The judge-vs-owner record it accumulates is the evidence a future step consumes before any tier of `.github/approval-policy.yml` is relaxed from `human` toward `judge` or `auto`; it is not itself that relaxation.
+
+## Zero authority
+
+Permanent, in every end state:
+
+- **No label.** The judge never writes, removes, or reconciles a `phase:*` label. It does not advance an issue to `phase:ready`, does not bounce one, and does not touch `agent:*` labels.
+- **No merge.** It never merges a PR, pushes a branch, or edits a file in the repo.
+- **No rubric edit.** This file is human-owned. A judge that finds the rubric wanting says so *in its reasoning* and stops; it does not open a PR against `.claude/skills/judge/`, and it never edits `.github/approval-policy.yml`. Self-modification of the taste being applied is exactly the thing this deployment shape exists to prevent.
+- **No authority claim in prose.** The verdict never reads as an approval or a refusal of approval. It reads as a finding.
+
+## Independence — never judge a plan you authored
+
+Read the issue's scope artifacts before anything else and ask whether you wrote them.
+
+If you recognize the Plan as your own work — you scoped this issue, you drafted these steps, this is a session of yours resumed — **abstain**. Emit the verdict block with every dimension left as `abstain` and say plainly in the reasoning that you authored the plan under judgment and therefore cannot judge it. A self-review is worth nothing to the record, and a self-review that scores itself `no-refutation-found` actively poisons it.
+
+By construction this should not arise: the judge is a distinct workflow that spawns a fresh headless context and never resumes a scope session. The invariant is written here anyway so it survives any future change that would make resumption possible. If you are ever tempted to reason "I remember scoping this, but I can be objective" — that is the failure this line exists to catch. Abstain.
+
+## The adversarial stance
+
+Your task is to **refute readiness**, not to confirm it. Actively look for the strongest available grounds to refuse this issue's advance to Ready, then report whether you found any.
+
+That framing decides the verdict vocabulary:
+
+- **`readiness-refuted`** — you found grounds. Name them.
+- **`no-refutation-found`** — you looked for grounds and could not find any. This is the output of a genuine attempt that failed, never a rubber stamp. A `no-refutation-found` verdict whose reasoning contains no evidence of an attempt is a defect in the verdict, not a clean bill.
+- **`abstain`** — the independence invariant fired, or the artifacts are too incomplete to judge at all (say which).
+
+Score the dimensions honestly under that pressure. A `concern` is a real finding that does not by itself refuse readiness; a `fail` is a finding that does. If every dimension is `pass` you must still be able to say what you tried and why it did not stick.
+
+Do not soften a finding because the plan is well written, because it cites an ADR, or because it was probably authored by an agent doing its best. Do not manufacture a finding to look rigorous either — a padded refutation is as useless to the record as a rubber stamp.
+
+## What you read
+
+1. The issue body — `## Problem statement`, `## Design notes`, `## Implementation plan`, `## Declared surface`, `## Depends on`, and the `size:*` / `model:*` labels.
+2. Every ADR the Design notes cite, read from `docs/adr/` on `origin/main`.
+3. `.github/approval-policy.yml` — the tier table the `risk_class` dimension resolves against.
+4. The code the plan targets, on `origin/main`, when a step's coherence depends on what is actually there.
+
+`/approve`'s own [Gate checks](../approve/SKILL.md#gate-checks) are mechanical — sections present, ADR PR merged, dependencies closed, targets still on `main`. Do not re-run them; they are already automated and they are not taste. Judge what the mechanical gate cannot: whether the plan, read closely, actually holds up.
+
+## The rubric
+
+Four dimensions. Score each `pass` / `concern` / `fail` (except `risk_class`, which reports a tier).
+
+### plan-internal coherence
+
+Do the Plan's steps follow from the Design's chosen approach — or has the plan quietly drifted to a different design than the one argued for? Are edit sites cited by stable anchor (a path, a symbol, a section) rather than a vague gesture? Do the steps, taken together, cover the stated success criteria, with no gap a reader has to fill in and no step that contradicts another?
+
+The refutation to look for: a plan that reads fluently but cannot actually be executed as written — a step whose input no earlier step produces, a success criterion no step reaches, an approach the Design rejected reappearing in the Plan.
+
+### ADR consistency
+
+Does the plan align with the ADRs it cites — not merely name-drop them? Read the cited ADR and check the plan against what it actually decided.
+
+And the harder half: does load-bearing work carry an ADR flag rather than silently skipping one? Public traits, wire formats, lifecycle, dispatch, addressing, and the mail contract are load-bearing by default. A plan that changes one of those with no ADR flag is a refutation candidate even when everything else about it is clean.
+
+### scope-size honesty
+
+Does the stamped `size:*` match the plan's actual reach? A plan whose steps span several crates, several PRs' worth of independent concepts, or an open-ended migration is not an `m` because it was labelled one — the multi-PR split rubric says that issue wants splitting.
+
+Does `model:*` match? The routing is size-asymmetric: a downward misjudgment (opus work stamped for a cheaper tier) is the expensive error, so weigh that direction harder than the reverse.
+
+### risk class
+
+Resolve the issue's `## Declared surface` globs against `.github/approval-policy.yml` and report the resulting tier. The policy file's own rules govern: a path's tier is the **most restrictive** matching rule (`human > judge > auto`), an unmatched path takes the file's `default` (`human`, fail-closed), and the issue's tier is the most restrictive tier over every declared path.
+
+Report the tier as the score — `auto`, `judge`, or `human`. This dimension is a *lookup*, not a judgment: do not editorialize the tier up or down. It exists so the accumulating record can later be filtered to the class where bounded auto-approve would apply.
+
+If the issue has no `## Declared surface`, or its globs match nothing you can resolve, report `human` (the fail-closed default) and say so in the reasoning.
+
+## ADR-bearing issues are advisory-only, permanently
+
+The ADR hard gate sits above the policy file: an ADR-bearing issue routes to the owner before any policy lookup runs, and no tier, present or future, can auto- or judge-approve it.
+
+So stamp `advisory_only: true` whenever the issue is ADR-bearing — its Design notes reference an ADR (a PR link, a `docs/adr/NNNN-*.md` path, or an `ADR flag:` line), or its declared surface touches `docs/adr/**`. Otherwise stamp `advisory_only: false`.
+
+In shadow mode every verdict is advisory, so the flag changes nothing today. It is the forward-looking distinction that survives into a bounded-authority future: it keeps a later promotion step from ever counting an ADR issue toward auto-approve evidence. Stamp it truthfully even though nothing currently reads it.
+
+## Output — the verdict
+
+Write exactly two things, in this order: the fenced `judge-verdict` block, then the reasoning prose. Nothing before the fence.
+
+The block is the machine surface a future disagreement-ledger greps without parsing prose, so its shape is fixed. Emit every key, every time, even when a dimension is uninteresting:
+
+````
+```judge-verdict
+issue: <n>
+verdict: readiness-refuted | no-refutation-found | abstain
+dimensions:
+  plan_coherence:     pass | concern | fail | abstain
+  adr_consistency:    pass | concern | fail | abstain
+  scope_size_honesty: pass | concern | fail | abstain
+  risk_class:         auto | judge | human
+advisory_only:        true | false
+```
+````
+
+Pick exactly one value per key; never emit the pipe-separated menu itself. `verdict` is `readiness-refuted` when any dimension is `fail`, and it may also be `readiness-refuted` on the strength of concerns that compound — say so if that is the call you are making.
+
+Under the fence, the reasoning: the grounds you found for refusing readiness, or — when you found none — what you attacked and why it held. Cite the artifact you are quoting (a step number, an ADR section, a declared glob) so a reader can check you. Keep it to what a reader of the issue needs; this is a finding, not an essay.
+
+The workflow that runs you prepends the `<!-- aether-judge:<n> -->` marker and the shadow-mode header, and upserts the whole thing as one comment — so a re-run refreshes the verdict rather than duplicating it. You emit the block and the reasoning; the marker is not yours to write.
+
+The rendered comment ends up looking like this:
+
+```markdown
+<!-- aether-judge:3133 -->
+**Judge verdict — shadow mode (zero authority; the label flip stays the owner's)**
+
+Adversarial pass: attempted to *refute* the readiness of these Plan artifacts.
+
+<the fenced judge-verdict block>
+
+<the reasoning>
+```
+
+## What `/judge` does NOT do
+
+- Advance, bounce, or otherwise write any `phase:*` label. The Plan→Ready flip is the owner's, and this skill has no path to it.
+- Merge a PR, push a commit, or edit any file in the repo — including this rubric and `.github/approval-policy.yml`.
+- Re-run `/approve`'s mechanical gate checks. Those are automated and they are not taste.
+- Edit the issue body, triage its side findings, or file follow-up issues. A finding worth filing goes in the reasoning; a human decides whether it becomes an issue.
+- Judge anything other than the Plan artifacts of the issue it was handed. The judge reads one issue.

--- a/.github/workflows/agent-judge.yml
+++ b/.github/workflows/agent-judge.yml
@@ -1,0 +1,467 @@
+name: Agent judge
+
+# The shadow-mode approver judge: when an issue reaches phase:plan, a fresh
+# headless Claude reads its scope artifacts with an adversarial "refute
+# readiness" stance and posts a structured verdict comment. ADR-0146 §6.
+#
+# ZERO AUTHORITY, deliberately. The judge writes one comment and nothing else —
+# no phase:* label, no merge, no edit. The Plan->Ready flip stays the owner's
+# (/approve). What accumulates is the judge-vs-owner record: the evidence a
+# future step consumes before any tier of .github/approval-policy.yml is
+# relaxed from `human` toward `judge` or `auto`. Bounded auto-approve authority
+# is explicitly OUT of scope here — shadow mode is the whole of v1, deployed
+# classifier-style (shadow first, authority only once the record earns it).
+#
+# The rubric is human-owned skill text at .claude/skills/judge/SKILL.md, not
+# prompt text buried in this file: the judge applies taste but never edits what
+# the taste is. .claude/** is a `human` tier in the policy file for exactly that
+# reason.
+#
+# TRIGGERS (three paths, one single-issue body):
+#   - issues: [labeled], gated to the moment phase:plan is applied. The primary
+#     path — the judge fires when the plan lands.
+#   - schedule on offset minutes (~every 20) — the MISSED-EVENT BACKSTOP. GitHub
+#     drops `issues` events, so the label trigger needs the same backstop the
+#     tick gives itself (agent-tick.yml). The `scan` job below enumerates open
+#     phase:plan issues that lack a FRESH verdict (one posted after the most
+#     recent phase:plan labeling) and workflow_dispatches this same workflow
+#     once per issue, so the judging body stays single-issue on every path.
+#     workflow_dispatch is the documented exception that a GITHUB_TOKEN-created
+#     event still triggers a workflow, so the fan-out needs no App token.
+#   - workflow_dispatch with a `ref` (issue number) — a manual kick, and the
+#     deliberate re-judge: it bypasses the fresh-verdict check.
+#
+# Self-contained by design: the arc's dependency map lists #3133 -> #3132 only,
+# so the judge must not hard-depend on the tick (#3131) existing. Once the tick
+# is live its board scan is a natural place to ALSO dispatch a missed judge pass
+# — a redundant backstop, never a prerequisite.
+#
+# INDEPENDENCE. The judge never judges a plan it authored. In v1 that is
+# guaranteed by construction: this workflow spawns a FRESH headless context
+# (claude -p, never --resume), and all scoping runs in separate agent-work runs,
+# so no session is ever shared between a scoper and the judge. The rubric skill
+# asserts the invariant in text as well, so it survives a future change that
+# might otherwise try to resume a scope session into a judge pass.
+#
+# SECURITY. Same least-privilege split as review.yml / agent-work.yml: the job
+# that executes code (headless Claude under --dangerously-skip-permissions) is
+# contents: read and holds no write scope; a separate `post` job, which never
+# runs model output as code, holds issues: write to upsert the comment. The
+# verdict is posted as data (-F body=@file), never evaluated. There is no
+# untrusted PR branch here — the judge reads a phase:plan issue's body and
+# origin/main files — but the split is kept for consistency with the arc.
+#
+# The `labeled` path carries no owner gate on the sender: applying a label
+# already requires repo write access, and the primary applier IS the fleet (an
+# agent-work scope run stamps phase:plan through the App), so an owner-only gate
+# would disable the trigger it exists to serve. What the path can reach is
+# bounded accordingly — origin/main code only, a read-only token, one comment.
+#
+# The comment is posted with the aether-agent App installation token, not
+# GITHUB_TOKEN, so the identity is visibly the bot's and the comment event can
+# wake downstream workflows.
+#
+# SECRETS (all SHARED with the rest of the arc — none new to this workflow):
+#   - AGENT_CLAUDE_CODE_OAUTH_TOKEN — the agent subscription, deliberately
+#     distinct from the QA chain's CLAUDE_CODE_OAUTH_TOKEN so the rate pools
+#     stay isolated. ABSENT => the judge steps skip, no verdict artifact is
+#     produced, and `post` no-ops. A judge that is not provisioned is silent,
+#     never red.
+#   - AGENT_APP_ID / AGENT_APP_PRIVATE_KEY — the aether-agent GitHub App.
+#     ABSENT => `post` prints the remedy and no-ops rather than failing the run.
+
+on:
+  issues:
+    types: [labeled]
+  schedule:
+    - cron: "7,27,47 * * * *"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Issue number to judge (forces a re-judge)
+        type: string
+        required: true
+
+# The run's name answers "which issue is this judging?" at a glance; the cron
+# backstop's fan-out run is named for what it is.
+run-name: judge-${{ github.event.issue.number || inputs.ref || 'scan' }}
+
+# One judge pass per issue; a re-label supersedes an in-flight pass rather than
+# racing it to the same comment. Scheduled scans share one group (a newer scan
+# subsumes an older one — it recomputes the same board).
+concurrency:
+  group: agent-judge-${{ github.event.issue.number || inputs.ref || 'scan' }}
+  cancel-in-progress: true
+
+jobs:
+  # The missed-event backstop. No Claude, no checkout — it enumerates the board
+  # and fans out one workflow_dispatch per eligible issue, so every judging run
+  # (label-triggered or cron-recovered) executes the identical single-issue body
+  # below. Degrades to a clean no-op when nothing is stale.
+  scan:
+    name: Scan for unjudged plans
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    # actions: write backs the workflow_dispatch fan-out; issues: read backs the
+    # board enumeration. No write scope on any issue — the scan posts nothing.
+    permissions:
+      actions: write
+      issues: read
+      contents: read
+    env:
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Dispatch a judge pass for every stale phase:plan issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Open, non-PR, phase:plan issues. `has("pull_request")|not` drops PRs,
+          # which share the issues endpoint.
+          gh api "repos/${REPO}/issues?state=open&labels=phase:plan&per_page=100" --paginate \
+            --jq '.[] | select(has("pull_request")|not) | .number' > /tmp/plans.txt
+
+          dispatched=0
+          while IFS= read -r num; do
+            [ -n "$num" ] || continue
+
+            # The agent:dont-touch label blinds the whole fleet, the judge
+            # included (agent-tick.yml's contract).
+            labels="$(gh api "repos/${REPO}/issues/${num}/labels" --jq '.[].name' || true)"
+            if grep -qxF 'agent:dont-touch' <<<"$labels"; then
+              echo "#${num}: agent:dont-touch — skip"
+              continue
+            fi
+
+            # Freshness: a verdict counts only when it was posted AFTER the most
+            # recent phase:plan labeling. A re-scoped issue re-labelled phase:plan
+            # therefore gets re-judged, while a settled one is left alone. The
+            # marker is matched WITHOUT its issue-number suffix so a hand-moved
+            # comment still de-dupes.
+            planned_at="$(gh api "repos/${REPO}/issues/${num}/timeline?per_page=100" --paginate \
+              --jq '[.[] | select(.event=="labeled" and .label.name=="phase:plan") | .created_at] | last // empty' || true)"
+            verdict_at="$(gh api "repos/${REPO}/issues/${num}/comments?per_page=100" --paginate \
+              --jq '[.[] | select(.body | contains("<!-- aether-judge:")) | .updated_at] | last // empty' || true)"
+            if [ -n "$planned_at" ] && [ -n "$verdict_at" ]; then
+              if [ "$(date -u -d "$verdict_at" +%s)" -ge "$(date -u -d "$planned_at" +%s)" ]; then
+                echo "#${num}: verdict is fresh (posted ${verdict_at} >= plan ${planned_at}) — skip"
+                continue
+              fi
+            fi
+
+            gh workflow run agent-judge.yml -f ref="$num"
+            echo "#${num}: dispatched a judge pass"
+            dispatched=$((dispatched + 1))
+          done < /tmp/plans.txt
+
+          echo "backstop scan: dispatched ${dispatched} judge pass(es)." >> "$GITHUB_STEP_SUMMARY"
+
+  judge:
+    name: Judge the plan
+    # The label path fires only on the moment phase:plan is applied; the dispatch
+    # path is always allowed and resolves its own ref. The scheduled path never
+    # lands here — it fans out through `scan` above.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && github.event.label.name == 'phase:plan')
+    # ubuntu-latest, not a RunsOn box: no cargo, no build, no per-file fan-out —
+    # one headless session reading an issue and a handful of files.
+    runs-on: ubuntu-latest
+    # Bring-up leash: a wedged session must not idle toward the 6h default.
+    timeout-minutes: 30
+    # Read-only. This job executes repo code (headless Claude under
+    # --dangerously-skip-permissions), so it holds no write scope — the comment
+    # is `post`'s alone.
+    permissions:
+      contents: read
+    env:
+      # Exposed at job level under the name the Claude Code binary reads, sourced
+      # from the AGENT-isolated secret. Job-level presence is what lets the step
+      # `if: env... != ''` gating work — an absent secret skips the session
+      # cleanly, produces no artifact, and `post` no-ops.
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.AGENT_CLAUDE_CODE_OAUTH_TOKEN }}
+      REPO: ${{ github.repository }}
+    outputs:
+      issue: ${{ steps.resolve.outputs.issue }}
+      verdict_produced: ${{ steps.verdict.outputs.produced }}
+    steps:
+      # Resolve the issue and gate BEFORE any checkout or spend — pure API calls.
+      # proceed=false is a clean no-op, never a failure.
+      - name: Resolve the issue and apply gates
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          LABELED_ISSUE: ${{ github.event.issue.number }}
+          DISPATCH_REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            issue="$DISPATCH_REF"
+          else
+            issue="$LABELED_ISSUE"
+          fi
+          if [ -z "${issue:-}" ]; then
+            echo "no issue resolved — nothing to judge."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "issue=$issue" >> "$GITHUB_OUTPUT"
+
+          # The judge judges Plan artifacts. An issue that has moved off
+          # phase:plan (approved, bounced, re-scoped) has nothing for it to read,
+          # so a stale trigger or a mis-aimed dispatch no-ops rather than posting
+          # a verdict about a plan that is no longer the issue's state. Capture
+          # then match with a here-string so grep's early exit cannot SIGPIPE gh
+          # under pipefail.
+          labels="$(gh api "repos/${REPO}/issues/${issue}/labels" --jq '.[].name')"
+          if ! grep -qxF 'phase:plan' <<<"$labels"; then
+            echo "issue #${issue} is not at phase:plan — nothing to judge."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if grep -qxF 'agent:dont-touch' <<<"$labels"; then
+            echo "issue #${issue} carries agent:dont-touch — the fleet is blind to it, judge included."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      # origin/main only. The judge reads the repo's own ADRs, policy file, and
+      # targeted code as they are on the trunk — never a PR branch, never
+      # untrusted code.
+      - uses: actions/checkout@v4
+        if: steps.resolve.outputs.proceed == 'true'
+        with:
+          ref: main
+
+      # The repo's .claude hooks bind interactive sessions into per-session
+      # worktrees and police edits outside them — actively harmful in CI, where
+      # the SessionStart rebind would move the session out of $GITHUB_WORKSPACE.
+      # The runner is ephemeral and single-purpose, so strip the hooks from this
+      # checkout COPY; the hooks in the repo itself are untouched.
+      - name: Strip interactive-session hooks from the checkout copy
+        if: steps.resolve.outputs.proceed == 'true'
+        run: |
+          jq 'del(.hooks)' .claude/settings.json > /tmp/settings.json
+          mv /tmp/settings.json .claude/settings.json
+
+      - name: Note when the OAuth token secret is absent
+        if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN == ''
+        run: |
+          echo "AGENT_CLAUDE_CODE_OAUTH_TOKEN is not set — the judge pass is skipped and no verdict is posted."
+          echo "Mint one from the agent subscription with 'claude setup-token' and add it:"
+          echo "  gh secret set AGENT_CLAUDE_CODE_OAUTH_TOKEN"
+
+      - name: Install Claude Code
+        if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        run: npm install -g @anthropic-ai/claude-code
+
+      # Pre-trust the checkout so settings.json permissions aren't ignored with a
+      # warning under skip-permissions.
+      - name: Pre-trust the workspace for headless Claude
+        if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        run: printf '{"projects":{"%s":{"hasTrustDialogAccepted":true}}}\n' "$PWD" > "$HOME/.claude.json"
+
+      # Auth in isolation before the real run: a one-line prompt, no tools. If
+      # this fails the AGENT OAuth token itself is the problem, not the harness.
+      # --max-turns 3 (not 1) because the model occasionally spends a turn before
+      # emitting the reply, which a 1-turn cap turns into a spurious auth failure.
+      - name: Auth probe (no tools)
+        if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        run: |
+          claude -p "Reply with exactly: AUTH-OK" \
+            --model claude-sonnet-5 \
+            --max-turns 3 | tee /tmp/auth.log
+          grep -q "AUTH-OK" /tmp/auth.log
+
+      # The judge pass. A FRESH headless context (never --resume: that is the
+      # independence invariant made structural) reads the rubric skill, the
+      # issue, the cited ADRs, and the policy file, then writes the verdict body
+      # to judge-verdict.md. The rubric lives in the skill, NOT in this prompt —
+      # the prompt only points at it, so a rubric change is a skill diff.
+      #
+      # The model writes the fenced block + reasoning ONLY. The marker comment's
+      # header and the <!-- aether-judge:<n> --> marker are the post job's, so
+      # the model can never break comment dedup.
+      #
+      # No backticks in the prompt: it is a double-quoted shell string, where a
+      # backtick would command-substitute.
+      #
+      # `|| true` so a session failure never fails the job — a missing verdict
+      # file is the signal that no comment is posted.
+      - name: Run the judge pass
+        if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ steps.resolve.outputs.issue }}
+        run: |
+          claude -p "You are running headless in CI on a checkout of origin/main.
+          Judge issue #${ISSUE} of ${REPO}, which has just reached phase:plan.
+          Read .claude/skills/judge/SKILL.md and follow it exactly — it is the
+          human-owned rubric, it is normative, and you never edit it.
+          Read the issue with: gh issue view ${ISSUE} --json title,body,labels
+          Then read every ADR its Design notes cite (under docs/adr/), the approval
+          policy at .github/approval-policy.yml, and whatever code on this checkout
+          a plan step's coherence depends on.
+          Take the adversarial stance the skill prescribes: try to REFUTE the
+          readiness of these Plan artifacts, and report what you found.
+          If you recognize this plan as your own authored work, ABSTAIN exactly as
+          the skill's independence invariant requires.
+          Write your output to exactly ${GITHUB_WORKSPACE}/judge-verdict.md — that
+          absolute path — containing the fenced judge-verdict block first, then your
+          reasoning prose, and nothing before the fence. Do NOT write the
+          aether-judge marker or the header: the workflow prepends those.
+          You have ZERO authority: write no label, merge nothing, open no PR, and
+          edit no file in the repo other than that one verdict file.
+          Print exactly JUDGE-DONE when the file is written." \
+            --dangerously-skip-permissions \
+            --model claude-sonnet-5 \
+            --max-turns 40 \
+            --output-format stream-json --verbose \
+            | tee /tmp/judge-session.jsonl \
+            | jq -rj --unbuffered '
+                if .type == "assistant" then
+                  ([.message.content[]? | if .type == "text" then "\n■ " + .text + "\n"
+                    elif .type == "tool_use" then "▸ " + .name + "\n" else empty end] | join(""))
+                elif .type == "result" then "\n== result (\(.subtype)) ==\n" + (.result // "") + "\n"
+                else empty end' \
+            || true
+
+      # Whether a WELL-FORMED verdict was produced gates the post job. A file with
+      # no greppable `verdict:` line is not a verdict — the fenced block is the
+      # ledger substrate, so a session that produced only prose fails loudly rather
+      # than posting an unparseable comment. The quiet-skip path exists only for
+      # the absent-secret case, which never reaches the else branch.
+      - name: Note whether a verdict was produced
+        id: verdict
+        if: always() && steps.resolve.outputs.proceed == 'true'
+        run: |
+          set -uo pipefail
+          if [ -f judge-verdict.md ] && grep -q '^verdict:' judge-verdict.md; then
+            echo "produced=true" >> "$GITHUB_OUTPUT"
+          elif [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+            echo "produced=false" >> "$GITHUB_OUTPUT"
+            echo "the judge ran but produced no well-formed verdict — failing loudly. Session's final events:"
+            if [ -f /tmp/judge-session.jsonl ]; then
+              tail -n 5 /tmp/judge-session.jsonl | cut -c1-2000
+            else
+              echo "(no session transcript)"
+            fi
+            exit 1
+          else
+            echo "produced=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always() && steps.verdict.outputs.produced == 'true'
+        with:
+          name: judge-verdict
+          path: judge-verdict.md
+          if-no-files-found: ignore
+
+      # The full session transcript (stream-json JSONL) — uploaded even on
+      # failure, since a dead run's transcript is exactly what diagnoses it.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: judge-session-transcript
+          path: /tmp/judge-session.jsonl
+          if-no-files-found: ignore
+
+  post:
+    name: Post the verdict
+    needs: judge
+    # No-op when the judge produced no verdict (secret absent, gated out, or the
+    # session failed).
+    if: needs.judge.outputs.verdict_produced == 'true'
+    runs-on: ubuntu-latest
+    # The only job with a write scope, and it never runs model output as code:
+    # the verdict is posted as DATA (-F body=@file), never evaluated. issues:
+    # write is the correct scope — the judge posts on an ISSUE, never on a PR
+    # (a comment or label on a PR would need pull-requests: write instead).
+    permissions:
+      issues: write
+    env:
+      REPO: ${{ github.repository }}
+      ISSUE: ${{ needs.judge.outputs.issue }}
+      APP_ID: ${{ secrets.AGENT_APP_ID }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: judge-verdict
+
+      - name: Note when the App secrets are absent
+        if: env.APP_ID == ''
+        run: |
+          echo "AGENT_APP_ID / AGENT_APP_PRIVATE_KEY are not set — the verdict is not posted."
+          echo "Register the aether-agent GitHub App, install it on ${REPO}, and store its"
+          echo "id + private key as AGENT_APP_ID / AGENT_APP_PRIVATE_KEY (see agent-work.yml's header)."
+          echo "The verdict is still available as this run's judge-verdict artifact."
+
+      # The comment rides the App installation token: the identity is visibly the
+      # bot's, and an App-created comment can wake downstream workflows where a
+      # GITHUB_TOKEN-created one cannot.
+      - name: Mint the App installation token
+        id: app-token
+        if: env.APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+
+      # Compose the comment (marker + shadow-mode header + the model's verdict)
+      # and upsert it: PATCH the existing marker comment if there is one, else
+      # POST a new one — so a re-judge REFRESHES the verdict and never duplicates
+      # it. The marker carries the issue number so a ledger sweep can key on it.
+      #
+      # The ADR advisory-only stamp is asserted here, mechanically, on top of
+      # whatever the model wrote: an ADR-bearing issue is advisory-only in every
+      # end state (the ADR hard gate sits above the policy file, permanently), and
+      # that flag is what keeps a future promotion step from ever counting an ADR
+      # issue toward auto-approve evidence. It is too load-bearing to leave to the
+      # model's memory, so the deterministic check wins.
+      - name: Upsert the verdict comment
+        if: env.APP_ID != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          marker="<!-- aether-judge:${ISSUE} -->"
+
+          # ADR-bearing: the body cites an ADR (a docs/adr path, an ADR-NNNN
+          # reference, or an "ADR flag:" line) or declares docs/adr/** surface.
+          gh api "repos/${REPO}/issues/${ISSUE}" --jq '.body // ""' > /tmp/issue-body.md
+          if grep -qE 'docs/adr/|ADR-[0-9]{4}|ADR flag:' /tmp/issue-body.md; then
+            echo "issue #${ISSUE} is ADR-bearing — asserting advisory_only: true."
+            sed -E 's/^advisory_only:[[:space:]]*.*$/advisory_only:        true/' \
+              judge-verdict.md > /tmp/verdict.md
+            mv /tmp/verdict.md judge-verdict.md
+          fi
+
+          {
+            echo "$marker"
+            echo "**Judge verdict — shadow mode (zero authority; the label flip stays the owner's)**"
+            echo
+            echo "Adversarial pass: attempted to *refute* the readiness of these Plan artifacts."
+            echo
+            cat judge-verdict.md
+          } > /tmp/comment.md
+
+          # Find an existing verdict comment by its marker. Capture first, then
+          # filter — a paginated gh piped into an early-exiting reader can SIGPIPE
+          # under pipefail.
+          comments="$(gh api "repos/${REPO}/issues/${ISSUE}/comments?per_page=100" --paginate)"
+          existing="$(jq -r --arg m "$marker" \
+            '[.[] | select(.body | contains($m)) | .id] | last // empty' <<<"$comments")"
+
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${existing}" -F body=@/tmp/comment.md > /dev/null
+            echo "refreshed the verdict comment on #${ISSUE} (comment ${existing})."
+          else
+            gh api -X POST "repos/${REPO}/issues/${ISSUE}/comments" -F body=@/tmp/comment.md > /dev/null
+            echo "posted a verdict comment on #${ISSUE}."
+          fi
+          grep '^verdict:' judge-verdict.md >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 !.claude/skills/dogfood/
 !.claude/skills/findings/
 !.claude/skills/implement/
+!.claude/skills/judge/
 !.claude/skills/wish/
 !.claude/skills/release-init/
 !.claude/skills/scope/


### PR DESCRIPTION
The last rung of the cloud-agent arc. A hosted Claude pass that reads a `phase:plan` issue's scope artifacts with fresh context and an adversarial "refute readiness" stance, then posts one structured verdict comment carrying **zero authority**.

The label flip stays the owner's. What accumulates is the judge-vs-owner record — the promotion evidence a later step consumes before any tier of `.github/approval-policy.yml` (#3132) is relaxed from `human` toward `judge` or `auto`. Classifier-style deployment: shadow first, authority only once the record earns it. Bounded auto-approve is explicitly out of scope here.

## What landed

**`.claude/skills/judge/SKILL.md`** — the human-owned rubric. Four dimensions (plan-internal coherence, ADR consistency, scope-size honesty, and risk class resolved against the approval policy), the refute-readiness framing, the never-judge-a-plan-you-authored abstention invariant, the permanent ADR advisory-only rule, and the exact `judge-verdict` fenced-block shape. The judge applies the taste but never edits what the taste is — which is precisely why `.claude/**` is a `human` tier in the policy file.

**`.github/workflows/agent-judge.yml`** — fires the moment `phase:plan` is applied, with a cron backstop that re-dispatches any plan lacking a fresh verdict (GitHub drops `issues` events) and a `workflow_dispatch` re-judge. Three jobs, least-privilege: `scan` (schedule-only fan-out, no write scope on any issue), `judge` (`contents: read`, headless `claude -p`, no-ops cleanly when the agent OAuth secret is absent), and `post` (`issues: write` only, mints the App token and upserts the `<!-- aether-judge:<n> -->` marker comment so a re-run refreshes rather than duplicates).

`.gitignore` gains one line: `.claude/skills/*` is ignored behind a per-skill allowlist, so the new skill is invisible to git without it.

## Properties worth naming

- **Zero authority is structural, not just stated.** The `judge` job holds no write scope at all; `post` holds `issues: write` and never runs model output as code. There is no path from the judge to a `phase:*` label.
- **The workflow owns the marker and header; the model writes only the fence and reasoning** — so a model slip cannot break comment dedup.
- **`advisory_only` is asserted mechanically** in the post job on top of whatever the model wrote. The ADR hard gate is permanent and too load-bearing to trust to the model's memory, so the workflow greps the issue for ADR references and forces the ledger line to `true`, overriding the model upward only.
- **A malformed verdict fails loudly** rather than posting an unparseable comment: `post` is gated on a greppable `^verdict:` line. The quiet no-op path exists only for the absent-secret case.

## Verification

Workflow YAML parses; all 11 `run:` blocks pass `bash -n`; `actionlint` + `shellcheck` clean (shellcheck installed first, so actionlint's shell analysis actually ran rather than silently no-opping).

Closes #3133
