### PR TITLE
fix(ci): agent workflows need GH_REPO — bare gh subcommands fail with no checkout

### DIFF
--- a/.github/workflows/agent-chat.yml
+++ b/.github/workflows/agent-chat.yml
@@ -107,6 +107,16 @@ concurrency:
   group: chat-${{ github.event.issue.number }}
   cancel-in-progress: false
 
+# These workflows run no actions/checkout — they are API orchestration, not builds.
+# A bare `gh` subcommand (gh run list / gh workflow run / gh issue …) infers its
+# target repo from the local git remote and dies with "failed to determine base
+# repo" when there isn't one. GH_REPO is the documented way to name the repo
+# without a checkout, and gh honours it for every subcommand, so it is set once
+# here rather than per step. (`gh api` calls are unaffected — they carry the full
+# repos/{owner}/{repo}/… path — which is why this only bit the dispatch paths.)
+env:
+  GH_REPO: ${{ github.repository }}
+
 jobs:
   chat:
     name: Owner conversational turn

--- a/.github/workflows/agent-judge.yml
+++ b/.github/workflows/agent-judge.yml
@@ -93,6 +93,16 @@ concurrency:
   group: agent-judge-${{ github.event.issue.number || inputs.ref || 'scan' }}
   cancel-in-progress: true
 
+# These workflows run no actions/checkout — they are API orchestration, not builds.
+# A bare `gh` subcommand (gh run list / gh workflow run / gh issue …) infers its
+# target repo from the local git remote and dies with "failed to determine base
+# repo" when there isn't one. GH_REPO is the documented way to name the repo
+# without a checkout, and gh honours it for every subcommand, so it is set once
+# here rather than per step. (`gh api` calls are unaffected — they carry the full
+# repos/{owner}/{repo}/… path — which is why this only bit the dispatch paths.)
+env:
+  GH_REPO: ${{ github.repository }}
+
 jobs:
   # The missed-event backstop. No Claude, no checkout — it enumerates the board
   # and fans out one workflow_dispatch per eligible issue, so every judging run

--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -116,6 +116,16 @@ concurrency:
   group: agent-tick
   cancel-in-progress: false
 
+# These workflows run no actions/checkout — they are API orchestration, not builds.
+# A bare `gh` subcommand (gh run list / gh workflow run / gh issue …) infers its
+# target repo from the local git remote and dies with "failed to determine base
+# repo" when there isn't one. GH_REPO is the documented way to name the repo
+# without a checkout, and gh honours it for every subcommand, so it is set once
+# here rather than per step. (`gh api` calls are unaffected — they carry the full
+# repos/{owner}/{repo}/… path — which is why this only bit the dispatch paths.)
+env:
+  GH_REPO: ${{ github.repository }}
+
 jobs:
   tick:
     name: Dispatch a wave


### PR DESCRIPTION
The fleet went live (`AGENT_ENABLED=true`) and the **first tick failed immediately**:

```
failed to determine base repo: failed to run git: fatal: not a git repository
```

`agent-tick.yml` runs no `actions/checkout` — deliberately, it is pure API orchestration — but two of its `gh` calls are subcommands that infer their target repo from the local git remote:

- `gh run list --workflow agent-work.yml` — the single platform read the whole tick computes over (the barrier's live set *and* the governor's gap/budget both derive from it).
- `gh workflow run agent-work.yml` — the actual dispatch.

Both died. So the wavefront dispatcher could neither count live agents nor dispatch work: **the fleet was enabled but inert.**

`agent-chat.yml` carried the same defect in its dispatch step. `agent-judge.yml` uses bare `gh` subcommands too and works only because it happens to check out — the same fragility, one edit away from breaking.

`gh api` calls were never affected: they carry the full `repos/{owner}/{repo}/…` path. That is exactly why every other workflow's API reads worked fine and this stayed invisible until a live dispatch.

## The fix

Set `GH_REPO: ${{ github.repository }}` once at the **workflow level** in all three. `gh` honours it for every subcommand and it needs no checkout, so no future `gh` call in these files can regress the same way.

## Verification

All three workflows parse; `GH_REPO` is asserted present at workflow level in each; all 25 `run:` blocks across the three pass `bash -n`. The real test is the next live tick — it must reach its board scan and print a wave verdict instead of dying on its first `gh` call. I'll dispatch one as soon as this lands.

Closes #3159
