### PR TITLE
fix(ci): agent:dont-touch is honoured only by the dispatcher, not at the point of spend

### DIFF
--- a/.github/workflows/agent-chat.yml
+++ b/.github/workflows/agent-chat.yml
@@ -127,9 +127,21 @@ jobs:
     # evaluated first so one repo-variable flip disables every chat turn.
     # github.repository_owner resolves to the owner login, so the comparison is
     # symbolic — no hardcoded name.
+    # agent:dont-touch is the per-issue kill switch and it is checked HERE, at the
+    # job level, alongside the owner gate. The dispatcher honours the label, but
+    # this workflow re-dispatches agent-work directly on an owner reply, so a chat
+    # turn is a second dispatch path that never passes through the tick — without
+    # this line a benched issue still gets a full turn (App token, AWS role, Claude
+    # resumed) and a fresh agent-work run, and the bench holds only if the model
+    # happens to read the owner's prose as a stand-down. A control that depends on
+    # the model's reading of prose is not a control. The issue_comment payload
+    # carries the labels, so no API call is needed. Job level, not step level, for
+    # the same reason as the owner gate: no secret-bearing step may exist on a path
+    # a benched issue can reach.
     if: >
       vars.AGENT_ENABLED == 'true' &&
-      github.event.sender.login == github.repository_owner
+      github.event.sender.login == github.repository_owner &&
+      !contains(github.event.issue.labels.*.name, 'agent:dont-touch')
     # issues: write covers the reply comment and the label removal; id-token:
     # write is the OIDC mint for the AWS role; contents: read is the floor. The
     # agent-work dispatch's actions: write reach rides the App token, NOT this

--- a/.github/workflows/agent-work.yml
+++ b/.github/workflows/agent-work.yml
@@ -162,6 +162,24 @@ jobs:
           set -euo pipefail
           owner="${REPO%/*}"
           name="${REPO#*/}"
+
+          # agent:dont-touch, checked at the point of spend rather than trusting the
+          # caller. The tick honours the label, but the tick is not the only thing
+          # that dispatches this workflow — agent-chat re-dispatches it on an owner
+          # reply, and anything holding actions: write can dispatch it directly. A
+          # control enforced only in one caller is escaped by every other path, so
+          # the executor refuses the work itself. For a land task REF is a PR, whose
+          # closing issue is where the label lives; the label is read off REF either
+          # way, so a benched PR is honoured too and a benched issue never reaches a
+          # land dispatch (the tick already filters it out of the scan).
+          if gh api "repos/${REPO}/issues/${REF}/labels" --jq '.[].name' 2>/dev/null \
+             | grep -qx 'agent:dont-touch'; then
+            echo "#${REF} carries agent:dont-touch — benched by the owner; refusing ${TASK}."
+            echo "- refused \`${TASK}\` on #${REF}: agent:dont-touch" >> "$GITHUB_STEP_SUMMARY"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           case "$TASK" in
             scope)
               # scope walks Backlog -> phase:plan. A label at or beyond a post-plan

--- a/scripts/release-project-init.sh
+++ b/scripts/release-project-init.sh
@@ -63,6 +63,13 @@ ensure_label "bounce-to:plan"   c5def5 "/scope resumes from Plan"
 ensure_label "approval:surface-exceeded" d93f0b "PR diff escapes the issue's declared surface — re-approval owed"
 ensure_label "approval:surface-ok"       0e8a16 "owner waiver: declared-surface overreach accepted"
 
+# The cloud fleet's control surface (ADR-0146). dont-touch is the per-issue kill
+# switch — the dispatcher, the judge, and the executor all refuse a benched issue.
+# These belong in the bootstrap: a label that does not exist cannot be applied, so
+# without them the kill switch is unusable on a fresh repo.
+ensure_label "agent:dont-touch"      000000 "fleet-blind: the dispatcher, judge, and executor skip this issue. Only the owner removes it."
+ensure_label "agent:awaiting-answer" fbca04 "an agent parked a question here; an owner reply resumes its session"
+
 # Size (weight) — XL marks a fat issue for /sweep fat (ADR-0110).
 ensure_label "size:s"  bfdadc "single file, single concept"
 ensure_label "size:m"  bfdadc "single crate, multiple files"


### PR DESCRIPTION
The per-issue kill switch was enforced in exactly one place — the tick's board scan — and **the tick is not the only thing that dispatches work.** `agent-chat` re-dispatches `agent-work` directly on an owner reply, so a chat turn is a second dispatch path that never passes through the tick.

## What happened

Observed live on the fleet's first day. #3134 was parked awaiting a design decision. The owner applied `agent:dont-touch` **and** commented "let's park this one for now — it's more of a note I wanted to keep for myself."

A full chat turn ran anyway: App token minted, AWS role assumed, S3 session restored, Claude resumed — and it re-dispatched `agent-work` on the benched issue, which ran to completion. The agent happened to read the prose as a stand-down and did no harm.

So the bench held only because the model chose to honour it. **A control that depends on the model's reading of prose is not a control.**

## The fix

**Gate `agent-chat` on the label at job level**, alongside the owner gate, so no secret-bearing step exists on a path a benched issue can reach. The `issue_comment` payload carries `labels`, so this costs no API call. Job-level and not step-level, for the same reason the owner gate is: a step-level check would still let the App-token mint, the Claude OAuth token, and the AWS OIDC mint materialize on a benched issue's path.

**Then refuse the work in `agent-work` itself**, in its re-entrancy guard — before Claude is even installed. The executor is dispatchable by anything holding `actions: write`, so it must not trust its callers to have checked. This is the invariant that actually makes the label mean what it says: a control enforced in one caller is escaped by every other path.

**Bootstrap the `agent:*` labels** in `release-project-init.sh`. Neither `agent:dont-touch` nor `agent:awaiting-answer` existed on the repo until they were hand-created today — a label that cannot be applied is not a kill switch, so this shipped unusable.

## One claim withdrawn

The issue's first draft also asserted the daily budget was bypassed by this path. On closer reading it isn't: the tick counts **every** `agent-work` run since UTC midnight, chat-dispatched ones included, so the spend is charged against the cap even though the reply itself isn't blocked by it — and an owner answering a parked question is exactly the deliberate human action the `workflow_dispatch` override exists to serve. Left in the issue as struck-through rather than deleted, since the first draft called it a hole.

## Verification

Asserted structurally: the `agent-chat` gate is on the **job** (no step carries it, so nothing secret-bearing is reachable) and still carries the kill switch and owner checks; in `agent-work` the guard sits at step 3 while Claude is installed at step 8, so a benched ref is refused before any model runs. Both workflows parse and every `run:` block passes `bash -n`.

Closes #3164
