### PR TITLE
fix(ci): headless agent logs drop every tool argument

### DIFF
--- a/.github/workflows/agent-judge.yml
+++ b/.github/workflows/agent-judge.yml
@@ -332,12 +332,7 @@ jobs:
             --max-turns 40 \
             --output-format stream-json --verbose \
             | tee /tmp/judge-session.jsonl \
-            | jq -rj --unbuffered '
-                if .type == "assistant" then
-                  ([.message.content[]? | if .type == "text" then "\n■ " + .text + "\n"
-                    elif .type == "tool_use" then "▸ " + .name + "\n" else empty end] | join(""))
-                elif .type == "result" then "\n== result (\(.subtype)) ==\n" + (.result // "") + "\n"
-                else empty end' \
+            | python3 scripts/render-agent-stream.py \
             || true
 
       # Whether a WELL-FORMED verdict was produced gates the post job. A file with

--- a/.github/workflows/agent-work.yml
+++ b/.github/workflows/agent-work.yml
@@ -390,12 +390,7 @@ jobs:
             --max-turns ${{ inputs.task == 'implement' && 400 || 200 }} \
             --output-format stream-json --verbose \
             | tee /tmp/agent-work-session.jsonl \
-            | jq -rj --unbuffered '
-                if .type == "assistant" then
-                  ([.message.content[]? | if .type == "text" then "\n■ " + .text + "\n"
-                    elif .type == "tool_use" then "▸ " + .name + "\n" else empty end] | join(""))
-                elif .type == "result" then "\n== result (\(.subtype)) ==\n" + (.result // "") + "\n"
-                else empty end' \
+            | python3 scripts/render-agent-stream.py \
             || true
 
       # The full session transcript (stream-json JSONL) — uploaded even on failure,

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -526,12 +526,7 @@ jobs:
             --max-turns 120 \
             --output-format stream-json --verbose \
             | tee /tmp/dogfood-session.jsonl \
-            | jq -rj --unbuffered '
-                if .type == "assistant" then
-                  ([.message.content[]? | if .type == "text" then "\n■ " + .text + "\n"
-                    elif .type == "tool_use" then "▸ " + .name + "\n" else empty end] | join(""))
-                elif .type == "result" then "\n== result (\(.subtype)) ==\n" + (.result // "") + "\n"
-                else empty end' \
+            | python3 scripts/render-agent-stream.py \
             || true
 
       # Stop + finalize the recording and push it to the evidence bucket, even

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -391,12 +391,7 @@ jobs:
             --max-turns 80 \
             --output-format stream-json --verbose \
             | tee /tmp/review-session.jsonl \
-            | jq -rj --unbuffered '
-                if .type == "assistant" then
-                  ([.message.content[]? | if .type == "text" then "\n■ " + .text + "\n"
-                    elif .type == "tool_use" then "▸ " + .name + "\n" else empty end] | join(""))
-                elif .type == "result" then "\n== result (\(.subtype)) ==\n" + (.result // "") + "\n"
-                else empty end' \
+            | python3 scripts/render-agent-stream.py \
             || true
 
       # Whether the run produced a rollup gates the `post` job. Kept as a

--- a/scripts/render-agent-stream.py
+++ b/scripts/render-agent-stream.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Render a headless Claude stream-json session into a readable CI log.
+
+Reads the stream on stdin, writes a human-legible transcript on stdout, and is a
+pure pass-through in the sense that it never swallows a line it cannot parse. The
+point is the tool ARGUMENTS: a log that says only "ran Bash" fifty times tells a
+reader nothing about what the agent did, which is the whole reason to keep a log.
+"""
+
+import json
+import os
+import sys
+
+# GitHub Actions renders ANSI. Honour NO_COLOR, and drop colour when piped to a
+# file so an artifact isn't littered with escape codes.
+COLOR = os.environ.get("NO_COLOR") is None and (sys.stdout.isatty() or os.environ.get("GITHUB_ACTIONS") == "true")
+
+
+def paint(code, s):
+    return f"\033[{code}m{s}\033[0m" if COLOR else s
+
+
+DIM, BOLD, CYAN, GREEN, RED, YELLOW = "2", "1", "36", "32", "31", "33"
+
+# How to summarise each tool's input: the parameters a reader actually needs to
+# know what happened. Anything not listed falls back to a compact key=value line.
+SUMMARY = {
+    "Bash": lambda i: i.get("command", ""),
+    "Read": lambda i: i.get("file_path", "")
+    + (f":{i['offset']}-{i['offset'] + i.get('limit', 0)}" if i.get("offset") else ""),
+    "Write": lambda i: i.get("file_path", ""),
+    "Edit": lambda i: i.get("file_path", ""),
+    "Glob": lambda i: i.get("pattern", ""),
+    "Grep": lambda i: i.get("pattern", ""),
+    "Skill": lambda i: " ".join(x for x in (i.get("skill"), i.get("args")) if x),
+    "Agent": lambda i: f"[{i.get('subagent_type', '?')}] {i.get('description', '')}",
+    "ToolSearch": lambda i: i.get("query", ""),
+    "TaskCreate": lambda i: i.get("subject", ""),
+    "TaskUpdate": lambda i: f"{i.get('taskId', '')} -> {i.get('status', '')}",
+    "WebFetch": lambda i: i.get("url", ""),
+}
+
+MAX = 220  # a tool line is a summary, not a payload; the artifact has the full text
+
+
+def flat(s, limit=MAX):
+    s = " ".join(str(s).split())
+    return s if len(s) <= limit else s[: limit - 1] + "…"
+
+
+def describe(name, inp):
+    if not isinstance(inp, dict):
+        return flat(inp)
+    if name in SUMMARY:
+        return flat(SUMMARY[name](inp))
+    scalars = {k: v for k, v in inp.items() if isinstance(v, (str, int, float, bool))}
+    return flat(" ".join(f"{k}={v}" for k, v in scalars.items()))
+
+
+def main():
+    tools = {}  # tool_use_id -> name, so a result can be labelled with its call
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            print(line, flush=True)
+            continue
+
+        kind = ev.get("type")
+
+        if kind == "assistant":
+            for block in ev.get("message", {}).get("content", []) or []:
+                if block.get("type") == "text" and block.get("text", "").strip():
+                    print("\n" + paint(BOLD, "● ") + block["text"].strip() + "\n", flush=True)
+                elif block.get("type") == "tool_use":
+                    name = block.get("name", "?")
+                    tools[block.get("id")] = name
+                    print(f"  {paint(CYAN, '▸ ' + name)}  {describe(name, block.get('input', {}))}", flush=True)
+
+        elif kind == "user":
+            # Tool results arrive as user messages. A call whose outcome is invisible
+            # is only half a log — but the useful part of an outcome is tool-specific.
+            # Echoing the head of a file that was just Read by path is pure noise;
+            # the head of a command's OUTPUT is what a reader came for. So only the
+            # tools whose result carries information the call site doesn't already
+            # give away get a body, and everything else gets pass/fail and a size.
+            for block in ev.get("message", {}).get("content", []) or []:
+                if block.get("type") != "tool_result":
+                    continue
+                name = tools.get(block.get("tool_use_id"), "")
+                content = block.get("content")
+                if isinstance(content, list):
+                    content = " ".join(c.get("text", "") for c in content if isinstance(c, dict))
+                content = content or ""
+                err = block.get("is_error")
+
+                if err:
+                    print(f"      {paint(RED, '↳ error')} {flat(content, 200)}", flush=True)
+                elif name in ("Bash", "Grep", "Glob", "ToolSearch"):
+                    print(f"      {paint(GREEN, '↳')} {paint(DIM, flat(content, 160) or '(no output)')}", flush=True)
+                else:
+                    lines = content.count("\n") + 1 if content else 0
+                    print(f"      {paint(GREEN, '↳')} {paint(DIM, f'{lines} lines')}", flush=True)
+
+        elif kind == "result":
+            u = ev.get("usage", {}) or {}
+            ok = not ev.get("is_error")
+            head = paint(GREEN if ok else RED, f"result: {ev.get('subtype', '?')}")
+            print("\n" + paint(BOLD, "── " + head))
+            print(
+                paint(
+                    DIM,
+                    f"   {ev.get('num_turns', 0)} turns · "
+                    f"{ev.get('duration_ms', 0) / 60000:.1f} min · "
+                    f"${ev.get('total_cost_usd', 0):.2f} · "
+                    f"{u.get('output_tokens', 0):,} out / {u.get('cache_read_input_tokens', 0):,} cached",
+                ),
+                flush=True,
+            )
+            if ev.get("result"):
+                print("\n" + str(ev["result"]).strip() + "\n", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The log is the only window into what an autonomous agent did, and it showed almost nothing.

Every headless Claude workflow piped its `stream-json` through the same hand-rolled `jq` renderer, which reduced a tool call to its bare name. A real run reads like this today:

```
▸ Read
▸ Agent
▸ Bash
▸ Bash
▸ Read
▸ Bash
```

Sixteen consecutive calls, and not one says which file was read, what command ran, or whether any of it worked. Tool results were dropped entirely, so outcomes were invisible. And `jq -rj` uses the *join* flag, which suppresses newlines — hence the wall of text.

Every one of those arguments was already in the stream. They were being discarded at render time.

## After

Same run, same section:

```
● ADR-0147 already merged (PR #3144). Let me read all three ADRs plus the affected source files.

  ▸ Read  docs/adr/0147-module-boot-actor-and-default-export-slot.md
      ↳ 140 lines
  ▸ Bash  find crates/aether-actor crates/aether-actor-derive -type f -name "*.rs" | xargs grep -l "entry" -i
      ↳ crates/aether-actor-derive/src/handler_parse.rs crates/aether-actor-derive/src/native_expand.rs …
  ▸ Agent  [Explore] Locate boot/default export slot touch points
      ↳ 6 lines
  ▸ Read  crates/aether-actor/src/wasm/mod.rs:1128-1395
      ↳ 267 lines

── result: success
   30 turns · 5.6 min · $4.85 · 27,251 out / 5,070,769 cached
```

## What changed

`scripts/render-agent-stream.py`, shared by all four workflows. The `jq` was duplicated in `agent-work`, `agent-judge`, `review`, and `dogfood` — byte-identical in at least two — so a fix in one would never have reached the others.

- **Tool calls render with the parameters that identify them**, per tool: a command, a path plus line range, a subagent type and its task. Unlisted tools fall back to a compact `key=value` line, so a new tool degrades rather than vanishing.
- **Results render pass/fail, with a body only where the body carries something the call site doesn't already give away.** A command's output is what a reader came for; echoing the head of a file that was just read *by path* is noise. Errors always show their message.
- **The terminal line reports turns, duration, cost, and tokens** — which incidentally puts every run's spend in its own log, feeding #3166.
- Colour under `GITHUB_ACTIONS` (Actions renders ANSI), honours `NO_COLOR`, and emits no escape codes when redirected to a file.

The `tee` to the session artifact is untouched. Only the rendering moves.

## Verification

Run against a real archived transcript from this morning's fleet run (the before/after above is that run). All four workflows parse and every `run:` block passes `bash -n`. The one invariant worth pinning is checked directly: an unparseable line passes through and the pipe survives — a renderer that dies mid-run takes the log with it.

Closes #3167
