### PR TITLE
fix(ci): the shadow judge cancels itself on every well-formed issue

### DIFF
--- a/.github/workflows/agent-judge.yml
+++ b/.github/workflows/agent-judge.yml
@@ -86,11 +86,21 @@ on:
 # backstop's fan-out run is named for what it is.
 run-name: judge-${{ github.event.issue.number || inputs.ref || 'scan' }}
 
-# One judge pass per issue; a re-label supersedes an in-flight pass rather than
-# racing it to the same comment. Scheduled scans share one group (a newer scan
-# subsumes an older one — it recomputes the same board).
+# One judge pass per issue; a re-label of phase:plan supersedes an in-flight pass
+# rather than racing it to the same comment. Scheduled scans share one group (a
+# newer scan subsumes an older one — it recomputes the same board).
+#
+# A label event that is NOT phase:plan gets a group of its own, and that is the
+# whole point of this expression. GitHub evaluates `concurrency` BEFORE the job's
+# `if`, so a run the gate will skip still joins the group and still cancels what
+# is in flight there. Keyed on the bare issue number, every label event on the
+# judged issue cancelled the judge — and /scope stamps size:* and model:* the
+# instant after phase:plan, so the judge was cancelled two seconds into every
+# correctly-scoped issue. It survived only on an issue whose scoper forgot those
+# labels. Giving the skipped events a unique group makes them cancel nothing,
+# while a genuine phase:plan re-label still supersedes as intended.
 concurrency:
-  group: agent-judge-${{ github.event.issue.number || inputs.ref || 'scan' }}
+  group: agent-judge-${{ (github.event_name == 'issues' && github.event.label.name != 'phase:plan') && github.run_id || github.event.issue.number || inputs.ref || 'scan' }}
   cancel-in-progress: true
 
 # These workflows run no actions/checkout — they are API orchestration, not builds.


### PR DESCRIPTION
The shadow judge has been cancelling itself on every well-formed issue since it went live. It has produced exactly one verdict, and that one survived by accident.

## The bug

**GitHub evaluates `concurrency` before a job's `if`.** A run whose job will be *skipped* still joins the concurrency group, and still cancels whatever is in flight there.

The judge's group was the bare issue number, with `cancel-in-progress: true`. So *every* label event on the judged issue cancelled the judge — including the ones its own gate skips.

`/scope` stamps `size:*` and `model:*` the instant after `phase:plan`. On #3110:

```
08:38:34  +phase:plan    judge fires, gate passes, run starts
08:38:36  +model:opus    judge fires, gate fails, job skipped…
08:38:36  +size:m        …but both joined group agent-judge-3110 and killed it
```

`judge-3110` is `cancelled, cancelled, skipped`. Same for #3166 and #3169. Since every correctly-scoped issue stamps those labels right after `phase:plan`, the judge was being killed two seconds into its run, every time.

**The one verdict that exists, on #3145, survived only because that issue is defective** — its scoper forgot to stamp `size:*`/`model:*`, so no follow-up label event arrived to cancel it. The judge lived exactly once, on the one broken issue, and used that breath to report the very defect that spared it.

## The fix

Give the events the gate skips a concurrency group of their own, so they cancel nothing:

```yaml
group: agent-judge-${{ (github.event_name == 'issues' && github.event.label.name != 'phase:plan') && github.run_id || github.event.issue.number || inputs.ref || 'scan' }}
```

A genuine `phase:plan` re-label still supersedes an in-flight pass — that is what the group was added for — while an unrelated label event now runs, skips, and kills nothing.

## Why it matters beyond the judge

The shadow record was empty in exactly the cases it exists to cover. That record is the promotion evidence the approval-policy ratchet (#3132) depends on before any tier relaxes from `human` toward `judge` or `auto`. It was not accumulating at all, so the delegation ladder had no way to ever move.

## Verification

Expression checked against every trigger: `phase:plan` → the per-issue group (supersedes correctly); `model:opus`/`size:m` → a unique per-run group (cancels nothing); `workflow_dispatch` → the ref; `schedule` → `scan`. The siblings are audited and clean: `agent-tick` and `reconciler` both set `cancel-in-progress: false`, so neither can self-cancel — `agent-judge` was alone in this.

After this lands the missing verdicts want backfilling by dispatching the judge at each `phase:plan` issue that has none (#3110, #3162, #3163, #3166), so the record starts from a complete board rather than a hole.

Closes #3170
