### PR TITLE
fix(workflow): the ADR hard gate fires on citations, making the tier policy dead code

### DIFF
--- a/.claude/skills/approve/SKILL.md
+++ b/.claude/skills/approve/SKILL.md
@@ -158,7 +158,15 @@ A future `/release-promote-umbrella <parent>` skill can auto-close the umbrella 
 
 ## ADR hard gate
 
-Runs **before any policy lookup**, permanently and unconditionally. An ADR-bearing issue routes to the `human` tier — the owner — before [Approval tier](#approval-tier) is consulted at all. No policy rule, present or future, can auto- or judge-approve it: an ADR is load-bearing by definition. An issue is ADR-bearing when its §Design notes references an ADR — an ADR PR link, a `docs/adr/NNNN-*.md` path, or an `ADR flag:` line (the same references the [ADR merge gate](#adr-gate-in-detail) parses). This rule lives in skill text, above the policy file, so it survives any edit to `.github/approval-policy.yml`; that file's `docs/adr/**` `human` entry is belt-and-suspenders, not the source of the rule. The [Approval tier](#approval-tier) lookup is consulted only for a non-ADR issue.
+Runs **before any policy lookup**, permanently and unconditionally. An ADR-bearing issue routes to the `human` tier — the owner — before [Approval tier](#approval-tier) is consulted at all. No policy rule, present or future, can auto- or judge-approve it: an ADR is load-bearing by definition. This rule lives in skill text, above the policy file, so it survives any edit to `.github/approval-policy.yml`; that file's `docs/adr/**` `human` entry is belt-and-suspenders, not the source of the rule. The [Approval tier](#approval-tier) lookup is consulted only for a non-ADR issue.
+
+**An issue is ADR-bearing when it carries an explicit `ADR flag:` line, or its `## Declared surface` includes `docs/adr/`** — that is, when the work *needs* an ADR or *writes* one.
+
+Citing an ADR in prose is **not** the test. `/scope` grounds every design in the ADRs it rests on — a good plan cites several — so a citation-based test routes the entire board to the owner and makes the policy file dead code. That is exactly what happened when this gate first shipped: every issue on the `phase:plan` board carried between three and fifteen ADR citations, none carried an `ADR flag:`, and all of them were short-circuited to `human` without the tier ever being resolved. The gate must separate *this design rests on ADR-0099* from *this work changes the architecture*; only the second is load-bearing.
+
+Do not widen this back to a prose match. The safety property does not need it: anything that adds, changes, or is gated on an ADR still carries an `ADR flag:` (which `/scope` emits precisely for load-bearing work) or declares `docs/adr/` in its surface, and either one routes to the owner permanently.
+
+Note the [ADR merge gate](#adr-gate-in-detail) is a *different* check answering a *different* question — whether an ADR this issue depends on has merged yet — and its citation-based parse is correct there. Routing and merge-readiness are not the same test; do not collapse them.
 
 ## Approval tier
 


### PR DESCRIPTION
The ADR hard gate routed an issue to `human` if its Design notes merely **mentioned** an ADR. But `/scope` grounds every design in the ADRs it rests on — a good plan cites several — so essentially every well-scoped issue in this repo tripped the gate, went to the owner, and **never reached the policy lookup at all**. The entire tier table in `.github/approval-policy.yml` was unreachable code.

Measured on the live `phase:plan` board:

| issue | `ADR flag:` | ADR citations | routed |
|---|---|---|---|
| #3110 | no | 10 | human (false positive) |
| #3162 | no | 14 | human (false positive) |
| #3163 | no | 15 | human (false positive) |
| #3166 | no | 3 | human (false positive) |

Not one is load-bearing in the ADR sense. Every one is grounded in ADRs, as a good plan should be. The gate could not tell *"this design rests on ADR-0099"* from *"this work changes the architecture"*, so it defaulted the whole board to the owner.

That is not a conservative default — it is a false positive that makes the mechanism inert.

## The fix

Test what was actually meant: an issue is ADR-bearing when it carries an explicit **`ADR flag:`** line — which `/scope` emits precisely when work is load-bearing and needs an ADR — **or** declares `docs/adr/` in its `## Declared surface` (it will *write* one).

The safety property is untouched. Anything that adds, changes, or is gated on an ADR still routes to the owner, permanently, before any policy lookup. What changes is that a well-grounded refactor stops being treated as constitutional.

The `## ADR gate, in detail` **merge** check is a different question — has an ADR this issue *depends on* merged yet — and its citation-based parse is correct there. Cross-referenced so a reader doesn't collapse the two.

Closes #3172
