### PR TITLE
feat(ci): auto-approve the auto tier

### DIFF
--- a/.claude/skills/approve-headless/SKILL.md
+++ b/.claude/skills/approve-headless/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: approve-headless
+description: Headless variant of /approve for a one-shot GitHub Actions runner. Executes ../approve/SKILL.md verbatim for the gate checks, the ADR hard gate, and the approval-tier lookup; overrides only the interaction surface — a refusal and any non-auto tier become ask-and-park, the terminal summary becomes end-turn — per ../headless/protocol.md.
+---
+
+# /approve-headless — headless approval wrapper
+
+This wraps `/approve` for a headless agent running one-shot on an ephemeral GitHub Actions runner. It carries no process of its own.
+
+Execute `../approve/SKILL.md` verbatim — every gate check, the freshness gate, the dependency gate, the umbrella-integrity gate, the ADR merge gate, the ADR hard gate, the approval-tier lookup, the `phase:ready` label reconcile, the idempotency rules. Where the original touches the interaction surface, `../headless/protocol.md` governs. An instruction is overridden if and only if it appears in the Overrides table below, cited by the original's anchor; everything else is the original's, unchanged. An improvement to `/approve` is live here the moment it merges, because this wrapper only references it.
+
+Before any process step, run the protocol's [re-entrancy-first](../headless/protocol.md#re-entrancy-first) guard: read the issue's current `phase:*` label (already `phase:ready` means the gate cleared — re-validate and no-op per [`## Idempotency`](../approve/SKILL.md#idempotency)) and check for an unanswered `agent:awaiting-answer` park, then post a start-of-work comment with the run link and begin the original at the point the observed state implies.
+
+## The authority bound
+
+A headless run advances **only an `auto`-tier issue**. Run [`## ADR hard gate`](../approve/SKILL.md#adr-hard-gate) and then [`## Approval tier`](../approve/SKILL.md#approval-tier) exactly as the original specifies, and route on the result:
+
+- **`auto`** — the policy says this surface needs no reader. Apply [`## Actions on pass`](../approve/SKILL.md#actions-on-pass) and flip the issue to `phase:ready`.
+- **`judge`, `human`, or ADR-bearing** — this run has no authority over it. Leave the phase untouched, comment the resolved tier and why, and end the turn. Never flip it.
+
+The dispatcher pre-filters to the `auto` tier so a run is not spent to learn this, but the workflow is dispatchable by anything holding `actions: write`, so the bound is enforced here, at the point of the write, rather than trusting a caller. A tier the wrapper cannot resolve (an unreadable or absent policy file) is not `auto`.
+
+## Overrides
+
+| Original anchor | Interactive behavior | Headless override |
+|-----------------|---------------------|-------------------|
+| [`## Gate checks`](../approve/SKILL.md#gate-checks) refusal, and the hard refusals in [`## Freshness gate`](../approve/SKILL.md#freshness-gate) / [`## Dependency gate`](../approve/SKILL.md#dependency-gate) | Refuse, list every failing gate, and leave the issue for the user to fix or `/bounce` | [ask-and-park](../headless/protocol.md#ask-and-park) — post the same full failure list in the machine-parseable park shape, apply `agent:awaiting-answer`, sync the session to S3, exit 0. The phase label never moves; the issue rests at `phase:plan` |
+| [`## Approval tier`](../approve/SKILL.md#approval-tier) `judge` / `human` routing, and [`## ADR hard gate`](../approve/SKILL.md#adr-hard-gate) | The owner reads the issue and runs `/approve` himself; a `judge`-tier issue goes to the shadow judge and still waits on the owner | [end-turn-not-wait](../headless/protocol.md#end-turn-not-wait) — a headless run holds no such authority (see [The authority bound](#the-authority-bound)). Comment the resolved tier, leave `phase:plan`, end the turn. This is a clean, expected terminal state, not a bounce, so it applies no `agent:awaiting-answer` — the issue is not waiting on an *answer*, it is waiting on its reader |
+| [`## Actions on pass`](../approve/SKILL.md#actions-on-pass) step 3 "Print a summary to the user" | Print the `✓ #N approved / Phase: Plan → Ready / Next: /implement <N>` summary to the operator's terminal | [end-turn-not-wait](../headless/protocol.md#end-turn-not-wait) — the label swap is the durable record and the tick picks the issue up for `implement` on the next wave. Post the same summary as a comment and end the turn; dispatch nothing |
+| [`## Sweep approve`](../approve/SKILL.md#sweep-approve) step 3 "print the approve plan and wait for confirmation" | Enumerate every Plan-complete issue and hold the whole batch behind one operator confirmation | Not reachable — a dispatch names exactly one ref, so a headless run is always the single-issue path. Never enumerate the board and never batch: the dispatcher owns discovery and the wave width, and a self-driven sweep would escape both |
+| [`## Freshness gate`](../approve/SKILL.md#freshness-gate) Tier A `git fetch origin main` and the `git log`/`git cat-file` reads | Run against the operator's local clone | [checkout-as-isolation](../headless/protocol.md#checkout-as-isolation) — the runner's `$GITHUB_WORKSPACE` checkout is the clone; it is on the default branch with full history, so the gate runs unchanged. Cut no branch and no worktree; `/approve` writes no code |
+
+**Not overridden — `--skip-adr`.** It is an emergency override that requires a human's judgment and a mandatory rationale note, and no dispatch can carry one. A headless run never passes it: an unmerged-ADR issue fails the [ADR merge gate](../approve/SKILL.md#adr-gate-in-detail) and parks, exactly like any other failing gate.
+
+Everything the table does not cite — the gate checks themselves, the freshness and dependency and umbrella-integrity logic, the ADR merge gate, the tier resolution, the phase-label reconcile mechanics, the idempotent re-run, the side-findings hands-off rule, and everything under `## What /approve does NOT do` (it dispatches no implementation, edits no issue body, and never edits `.github/approval-policy.yml`) — is `/approve`'s, verbatim.

--- a/.claude/skills/approve/SKILL.md
+++ b/.claude/skills/approve/SKILL.md
@@ -173,7 +173,7 @@ Note the [ADR merge gate](#adr-gate-in-detail) is a *different* check answering 
 For a non-ADR issue (the [ADR hard gate](#adr-hard-gate) has already routed an ADR-bearing one to the owner), resolve the issue's approval tier against `.github/approval-policy.yml` over its `## Declared surface` globs (the machine-readable glob block `/scope` emits at Plan):
 
 1. Read the policy file's `default` tier and its ordered `rules` list of `{glob, tier}` entries; `tier ∈ {auto, judge, human}`.
-2. Each declared path's tier is the **most restrictive** matching rule (`human > judge > auto`), or `default` (`human`) when no rule matches — fail-closed, so an unpoliced surface stops at the owner. Globs are gitwildmatch (gitignore-style `**`), matched exactly as the reconciler's containment step matches them.
+2. Each declared path's tier is the **most restrictive** matching rule (`human > judge > auto`), or the file's `default` when no rule matches — today `judge`, so an unpoliced surface gets a second reader rather than a rubber stamp. Read the tier out of the file; do not assume it. Globs are gitwildmatch (gitignore-style `**`), matched exactly as the reconciler's containment step matches them.
 3. The issue's approval tier is the most restrictive tier over every path in its declared surface.
 
 Route by the resulting tier:

--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -51,14 +51,35 @@ name: Agent tick
 #   no phase:* (Backlog)          -> scope     (framable body; agent-work's scope
 #                                               self-bounces an unframable one)
 #   phase:define / phase:design   -> scope     (resume a crashed scope run)
-#   phase:plan                    -> none       (plan->ready is the /approve gate)
+#   phase:plan                    -> approve    (AUTO TIER ONLY — see below; a
+#                                               judge/human-tier issue rests here
+#                                               for its reader)
 #   phase:ready                   -> implement
 #   phase:building/qa/findings    -> none       (reconciler-owned; #3126)
 #   phase:held                    -> land       (ref is the open closing PR)
 #   phase:bounced/stalled         -> none       (rest until an owner acts)
+#
+# THE APPROVAL TIER (#3176) is what makes `phase:plan -> approve` safe to
+# dispatch unattended. The tick decides WHETHER to dispatch; the executor's
+# /approve run decides whether to APPROVE — so the gate logic keeps exactly one
+# definition (the skill's) and the tick only pre-filters, cheaply, so a Claude
+# run is never spent where it provably cannot advance anything. Per phase:plan
+# issue: the ADR hard gate first (an `ADR flag:` line, or `docs/adr/` in the
+# declared surface, routes to the owner unconditionally, ahead of any policy
+# lookup), then the issue's `## Declared surface` globs resolved against
+# .github/approval-policy.yml by scripts/surface-match.py — the same matcher the
+# reconciler holds a merged diff to, so the tier is resolved over exactly the
+# surface that is later enforced. Most-restrictive-wins (human > judge > auto);
+# an issue that declares NO surface takes the policy default and is never
+# dispatched. Only `auto` dispatches; every other outcome logs a skip line with
+# the resolved tier and rests. This is the one thing in the tick that needs repo
+# code, hence the actions/checkout below — still no Claude and no cargo, so the
+# tick stays free and deterministic.
+#
 # agent:dont-touch items are filtered out of the whole scan first (the label
 # blinds the dispatcher, per its contract). The snapshot is ordered
-# land > question-resume > implement/scope and slots are filled in that order.
+# land > question-resume > approve/implement/scope and slots are filled in that
+# order.
 # `land` BYPASSES THE BARRIER — dispatched every tick regardless of quiescence
 # and excluded from the barrier's live set — because land runs are minutes long,
 # agent-work's merged-check makes re-dispatch idempotent, and landing unblocks
@@ -116,13 +137,14 @@ concurrency:
   group: agent-tick
   cancel-in-progress: false
 
-# These workflows run no actions/checkout — they are API orchestration, not builds.
-# A bare `gh` subcommand (gh run list / gh workflow run / gh issue …) infers its
-# target repo from the local git remote and dies with "failed to determine base
-# repo" when there isn't one. GH_REPO is the documented way to name the repo
-# without a checkout, and gh honours it for every subcommand, so it is set once
-# here rather than per step. (`gh api` calls are unaffected — they carry the full
-# repos/{owner}/{repo}/… path — which is why this only bit the dispatch paths.)
+# The tick's checkout is data, not a build: it brings the approval policy and the
+# shared matcher onto the runner and nothing else compiles or runs from it. A bare
+# `gh` subcommand (gh run list / gh workflow run / gh issue …) infers its target
+# repo from the local git remote, so it would pick the repo up from that checkout
+# anyway — but GH_REPO is the documented way to name it explicitly, it costs
+# nothing, and it keeps the dispatch paths working whatever the checkout does.
+# (`gh api` calls are unaffected — they carry the full repos/{owner}/{repo}/…
+# path — which is why this only ever bit the dispatch paths.)
 env:
   GH_REPO: ${{ github.repository }}
 
@@ -183,6 +205,16 @@ jobs:
         with:
           app-id: ${{ secrets.AGENT_APP_ID }}
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+
+      # The approval policy and the shared matcher, off the default branch — the
+      # two files the tier lookup below needs. Pinned to the default branch for
+      # the same reason the reconciler pins its copy: an issue must not be able to
+      # relax the policy it is being tiered by. Shallow; the tick builds nothing.
+      - uses: actions/checkout@v4
+        if: steps.preflight.outputs.proceed == 'true'
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       # The wave: governor gate, then the computed barrier, board scan, priority,
       # and dispatch — one step so a tick's whole reasoning is legible in one log
@@ -305,10 +337,34 @@ jobs:
             [ "$last" = "$OWNER" ]
           }
 
+          # The approval tier of a phase:plan issue — the pre-filter that decides
+          # whether an auto-approval run is worth dispatching at all. Echoes one
+          # word: `adr` (the ADR hard gate fired), `none` (no declared surface),
+          # or the resolved tier (`auto` / `judge` / `human` / `?` when the policy
+          # is unreadable). Only `auto` dispatches; every other word rests the
+          # issue at phase:plan for its human or judge reader. Fail-safe by
+          # construction — nothing but an explicit `auto` opens the gate.
+          approval_tier() {
+            local body surface
+            body="$(gh api "repos/${REPO}/issues/${1}" --jq '.body // ""')"
+            # ADR hard gate, ahead of the policy lookup, exactly as /approve
+            # states it: work that NEEDS an ADR (the flag line /scope emits) or
+            # WRITES one (docs/adr/ in the surface) is the owner's, permanently.
+            # Merely citing an ADR is not the test — every well-scoped issue does.
+            if grep -qi 'ADR flag:' <<<"$body"; then echo "adr"; return; fi
+            surface="$(awk '/^## Declared surface/{f=1; next} /^## /{f=0} f' <<<"$body" \
+              | sed -n '/^[[:space:]]*```/,/^[[:space:]]*```/p' | sed '1d;$d' \
+              | grep -v '^[[:space:]]*$' || true)"
+            if [ -z "$surface" ]; then echo "none"; return; fi
+            if grep -q '^[[:space:]]*docs/adr/' <<<"$surface"; then echo "adr"; return; fi
+            printf '%s\n' "$surface" > "/tmp/surface-${1}.txt"
+            python3 scripts/surface-match.py --tier "/tmp/surface-${1}.txt" .github/approval-policy.yml
+          }
+
           # Bucket advanceable items by priority tier. land bypasses the barrier
-          # and the slot budget; scope/implement need quiescence; an
-          # awaiting-answer scope/implement item only advances when the owner has
-          # replied (question-resume), else it is left parked.
+          # and the slot budget; approve/scope/implement need quiescence; an
+          # awaiting-answer approve/scope/implement item only advances when the
+          # owner has replied (question-resume), else it is left parked.
           land_items=""
           resume_items=""
           work_items=""
@@ -317,6 +373,15 @@ jobs:
             if [ "$dt" = "dt" ]; then summary "- skip #${num}: agent:dont-touch"; continue; fi
             case "$phase" in
               none|phase:define|phase:design) task="scope"; ref="$num" ;;
+              phase:plan)
+                tier="$(approval_tier "$num")"
+                case "$tier" in
+                  auto) summary "- #${num}: approval tier auto — dispatching approve"; task="approve"; ref="$num" ;;
+                  adr) summary "- skip #${num}: ADR hard gate — the owner approves this one"; continue ;;
+                  none) summary "- skip #${num}: no declared surface — not auto-approvable"; continue ;;
+                  *) summary "- skip #${num}: approval tier ${tier} — awaiting its reader"; continue ;;
+                esac
+                ;;
               phase:ready) task="implement"; ref="$num" ;;
               phase:held) task="land"; ref="" ;;
               *) continue ;;
@@ -372,7 +437,7 @@ jobs:
             done <<< "${resume_items}${work_items}"
             summary "- filled ${filled}/${slots} non-land slot(s)."
           else
-            summary "- not quiescent: ${live_nonland} live scope/implement run(s) — deferring new scope/implement."
+            summary "- not quiescent: ${live_nonland} live non-land run(s) — deferring new approve/scope/implement."
           fi
 
       # Re-notify the owner about stale parked questions. Independent of the wave

--- a/.github/workflows/agent-work.yml
+++ b/.github/workflows/agent-work.yml
@@ -1,13 +1,21 @@
 name: Agent work
 
 # The cloud-agent executor: turn a task request into real engineering work on
-# an ephemeral RunsOn machine. Given task=scope|implement|land and a ref, it
-# forks a runner, drives headless Claude Code through the matching #3128
-# headless-wrapper skill (/scope-headless, /implement-headless, /land-headless),
-# and leaves the durable state — labels, comments, commits, PRs — behind when
-# the runner dies. This is rung ①'s producer half; the QA-chain workflows
-# (review.yml, dogfood.yml) grade LANDED PRs, whereas this one PRODUCES the
-# scope artifacts, the implementation PR, and the merge.
+# an ephemeral RunsOn machine. Given task=scope|approve|implement|land and a ref,
+# it forks a runner, drives headless Claude Code through the matching #3128
+# headless-wrapper skill (/scope-headless, /approve-headless,
+# /implement-headless, /land-headless), and leaves the durable state — labels,
+# comments, commits, PRs — behind when the runner dies. This is rung ①'s producer
+# half; the QA-chain workflows (review.yml, dogfood.yml) grade LANDED PRs,
+# whereas this one PRODUCES the scope artifacts, the implementation PR, and the
+# merge.
+#
+# `approve` is the Plan->Ready gate (#3176), and it is the one task with an
+# authority bound of its own: the wrapper runs the real /approve skill, which
+# resolves the issue's approval tier and advances ONLY an `auto`-tier one. The
+# tick pre-filters to the auto tier so a Claude run is not spent to learn that,
+# but this workflow is dispatchable by anything holding actions: write, so the
+# refusal lives in the skill the executor runs — not in the caller.
 #
 # Manual dispatch only at this rung — no cron, no autonomy. A maintainer runs
 # workflow_dispatch with a task and a ref; every later rung (#3130 chat, #3131
@@ -58,10 +66,11 @@ on:
         required: true
         options:
           - scope
+          - approve
           - implement
           - land
       ref:
-        description: Ref to act on (issue number for scope/implement, PR number for land)
+        description: Ref to act on (issue number for scope/approve/implement, PR number for land)
         type: string
         required: true
 
@@ -82,8 +91,9 @@ jobs:
   work:
     name: Run ${{ inputs.task }} on ${{ inputs.ref }}
     # Per-task runner sizing against the RunsOn label pattern (dogfood.yml uses
-    # the same runs-on=<run_id>/runner=<size> form): scope is API-and-prose work
-    # on a small box; implement builds the workspace and wants s3-cache to warm
+    # the same runs-on=<run_id>/runner=<size> form): scope and approve are
+    # API-and-prose work on a small box (approve's heaviest step is a git-log
+    # freshness read); implement builds the workspace and wants s3-cache to warm
     # sccache across a retrying PR's runs; land is a merge on a non-spot box so a
     # spot reclaim can never interrupt the squash.
     runs-on: runs-on=${{ github.run_id }}/runner=${{ inputs.task == 'implement' && '8cpu-linux-x64/extras=s3-cache' || (inputs.task == 'land' && '2cpu-linux-x64/spot=false' || '2cpu-linux-x64') }}
@@ -191,6 +201,19 @@ jobs:
                 exit 0
               fi
               ;;
+            approve)
+              # approve is the phase:plan -> phase:ready gate. A label at or beyond
+              # a post-plan rung means the gate already cleared, so a re-dispatch (a
+              # crashed run, a duplicate tick, a hand kick) is a clean no-op. An
+              # issue that has not reached phase:plan yet is left to the skill's own
+              # Phase gate, which refuses it and says so.
+              labels="$(gh api "repos/${REPO}/issues/${REF}/labels" --jq '.[].name')"
+              if grep -qxE 'phase:(ready|refine|executing|building|qa|findings|held)' <<<"$labels"; then
+                echo "issue #${REF} is at/past a post-plan rung — approve already complete; nothing to do."
+                echo "proceed=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              ;;
             implement)
               # /implement cuts a PR from the issue. A MERGED PR that closes this
               # issue means the work already landed → clean no-op. An open PR means
@@ -265,12 +288,13 @@ jobs:
           EOF
           gh api -X POST "repos/${REPO}/issues/${REF}/comments" -F body=@/tmp/start-comment.md
 
-      # Assert the aether-agent bot git identity before any commit/merge. scope
-      # writes no commits, so this is gated off for it. The App's canonical commit
-      # identity is <bot-user-id>+<app-slug>[bot]@users.noreply.github.com so
-      # GitHub attributes the commit to the App, never to the owner.
+      # Assert the aether-agent bot git identity before any commit/merge. scope and
+      # approve write no commits (approve reads git for its freshness gate and
+      # writes only a label), so this is gated off for them. The App's canonical
+      # commit identity is <bot-user-id>+<app-slug>[bot]@users.noreply.github.com
+      # so GitHub attributes the commit to the App, never to the owner.
       - name: Assert the bot git identity
-        if: steps.guard.outputs.proceed == 'true' && inputs.task != 'scope'
+        if: steps.guard.outputs.proceed == 'true' && inputs.task != 'scope' && inputs.task != 'approve'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
@@ -290,7 +314,10 @@ jobs:
       # Check out the default branch (the skills live here and the wrapper cuts
       # its own branch from origin/main). The App token is persisted as the git
       # credential so any push the wrapper issues rides the App identity and wakes
-      # downstream workflows. implement/land need full history; scope does not.
+      # downstream workflows. implement/land need full history, and so does
+      # approve — its freshness gate reads `git log origin/main --since=<scoped-at>`
+      # over the plan's targeted paths, which a shallow clone cannot answer. Only
+      # scope is shallow.
       - uses: actions/checkout@v4
         if: steps.guard.outputs.proceed == 'true'
         with:
@@ -331,9 +358,9 @@ jobs:
           grep -q "AUTH-OK" /tmp/auth.log
 
       # Resolve the driving model from the issue's model:* label (scope stamps it
-      # at Plan; /implement and /approve gate on it). scope/implement's ref is the
-      # issue; land's ref is a PR, so resolve its closing issue. Default to the
-      # proven headless sonnet string; upgrade to opus when the label says so.
+      # at Plan; /implement and /approve gate on it). scope/approve/implement's ref
+      # is the issue; land's ref is a PR, so resolve its closing issue. Default to
+      # the proven headless sonnet string; upgrade to opus when the label says so.
       - name: Resolve the driving model
         id: model
         if: steps.guard.outputs.proceed == 'true'
@@ -344,7 +371,7 @@ jobs:
           owner="${REPO%/*}"
           name="${REPO#*/}"
           case "$TASK" in
-            scope|implement) issue="$REF" ;;
+            scope|approve|implement) issue="$REF" ;;
             land)
               issue="$(gh api graphql -f query='
                 query($owner:String!,$name:String!,$number:Int!){

--- a/.github/workflows/reconciler.yml
+++ b/.github/workflows/reconciler.yml
@@ -56,14 +56,23 @@ name: Reconciler
 #     workflow can subscribe to), and the self-heal for any missed poke. Worst-
 #     case staleness for a human thread-resolve is one cron period.
 #
-# SECURITY POSTURE: this workflow runs no branch code and reads the PR head only
-# as data — every fact is a GitHub-API call, and the sole code it executes is
-# scripts/surface-match.py off a checkout PINNED TO THE DEFAULT BRANCH. A PR can
-# no more edit the matcher that judges its diff than it can edit the policy that
-# matcher annotates with (the policy is likewise read from the default branch).
-# The job-level guard drops fork heads (a fork PR gets a read-only token and
-# cannot carry the QA flags this computes over anyway), matching the same-repo
-# posture the Review and Dogfood runners hold.
+# SECURITY POSTURE: this workflow CHECKS NOTHING OUT and reads the PR head only
+# as data. Every fact is a GitHub-API call. The one piece of code it executes,
+# scripts/surface-match.py, is fetched through the contents API with no ref —
+# which always resolves to the default branch — exactly as the policy file is.
+#
+# The checkout is omitted deliberately, not incidentally. `actions/checkout` with
+# `ref:` pinned to the default branch LOOKS equivalent, but it falls back to the
+# TRIGGERING ref whenever that expression is empty, and on a pull_request event
+# the triggering ref is the PR head. A single unset expression would have this
+# job executing branch-authored Python while holding statuses: write and
+# issues: write. The fleet's App can push branches, so that is a live path, not a
+# hypothetical. The API read has no fallback: default branch, or it fails.
+#
+# So a PR can no more edit the matcher that judges its diff than it can edit the
+# policy that matcher annotates with. The job-level guard additionally drops fork
+# heads (a fork PR gets a read-only token and carries no QA flags to compute over
+# anyway), matching the same-repo posture the Review and Dogfood runners hold.
 
 on:
   pull_request:
@@ -118,15 +127,6 @@ jobs:
     steps:
       # The DEFAULT branch, never the PR head — the security posture above says
       # this workflow runs no branch code, and a PR must not be able to edit the
-      # matcher that judges it any more than it can edit the policy that matcher
-      # annotates with. The checkout exists for exactly one file,
-      # scripts/surface-match.py: the declared-surface matcher the tick shares
-      # (#3176). No credential is persisted — this job pushes nothing.
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          persist-credentials: false
-
       # Resolve the PR set for this event, then recompute each one. The fact
       # reads and the compute live in this single step so a run's whole
       # reasoning is legible from its log: one line per fact, one for the
@@ -363,12 +363,24 @@ jobs:
                    --jq '.content' 2>/dev/null | base64 -d >"${RUNNER_TEMP}/policy.yml" 2>/dev/null; then
                 : >"${RUNNER_TEMP}/policy.yml"
               fi
-              # scripts/surface-match.py off the default-branch checkout is the
-              # matcher — the one place gitwildmatch semantics are decided, shared
-              # with the tick's approval-tier lookup (#3176). It prints the changed
-              # paths that escape the declaration, tier-annotated; silent when the
-              # diff is contained.
-              escaping="$(python3 scripts/surface-match.py \
+              # The matcher is fetched the same way the policy is: the contents API
+              # with NO ref, which always resolves to the default branch. This
+              # workflow checks nothing out on purpose. A checkout pinned to the
+              # default branch would look equivalent, but `actions/checkout` falls
+              # back to the TRIGGERING ref when its `ref:` input is empty — and on a
+              # pull_request event that is the PR head. One unset expression and this
+              # job would execute branch-authored Python holding statuses: write and
+              # issues: write. The fleet's App can push branches, so that is not a
+              # hypothetical. The API read has no such fallback: it is default-branch
+              # or it fails. A PR can no more edit the matcher that judges its diff
+              # than the policy that matcher annotates with.
+              gh api "repos/${REPO}/contents/scripts/surface-match.py" \
+                --jq '.content' | base64 -d >"${RUNNER_TEMP}/surface_match.py"
+
+              # The one place gitwildmatch semantics are decided, shared with the
+              # tick's approval-tier lookup (#3176). Prints the changed paths that
+              # escape the declaration, tier-annotated; silent when contained.
+              escaping="$(python3 "${RUNNER_TEMP}/surface_match.py" \
                 "${RUNNER_TEMP}/globs.txt" "${RUNNER_TEMP}/changed.txt" "${RUNNER_TEMP}/policy.yml")"
 
               # Owner waiver: approval:surface-ok accepts the overreach, but only

--- a/.github/workflows/reconciler.yml
+++ b/.github/workflows/reconciler.yml
@@ -374,8 +374,21 @@ jobs:
               # hypothetical. The API read has no such fallback: it is default-branch
               # or it fails. A PR can no more edit the matcher that judges its diff
               # than the policy that matcher annotates with.
-              gh api "repos/${REPO}/contents/scripts/surface-match.py" \
-                --jq '.content' | base64 -d >"${RUNNER_TEMP}/surface_match.py"
+              # A missing matcher must FAIL CLOSED, not fail silent. Dying here
+              # under `set -e` would skip the gate write entirely and leave the
+              # required Approval gate unreported — which GitHub holds as "Expected"
+              # forever, wedging the PR (#3158). So an unreadable matcher posts a
+              # FAILING gate and moves on: the check is red and legible instead of
+              # absent and mysterious. It cannot mean "contained", because with no
+              # matcher containment was never computed.
+              if ! gh api "repos/${REPO}/contents/scripts/surface-match.py" \
+                   --jq '.content' 2>/dev/null | base64 -d >"${RUNNER_TEMP}/surface_match.py" 2>/dev/null \
+                 || ! [ -s "${RUNNER_TEMP}/surface_match.py" ]; then
+                echo "fact declared_surface: matcher unavailable on the default branch."
+                post_gate failure "surface matcher unavailable on the default branch — containment not computed"
+                echo "::endgroup::"
+                return 0
+              fi
 
               # The one place gitwildmatch semantics are decided, shared with the
               # tick's approval-tier lookup (#3176). Prints the changed paths that

--- a/.github/workflows/reconciler.yml
+++ b/.github/workflows/reconciler.yml
@@ -57,10 +57,13 @@ name: Reconciler
 #     case staleness for a human thread-resolve is one cron period.
 #
 # SECURITY POSTURE: this workflow runs no branch code and reads the PR head only
-# as data — every step is a GitHub-API call against the trusted base checkout
-# context. The job-level guard drops fork heads (a fork PR gets a read-only
-# token and cannot carry the QA flags this computes over anyway), matching the
-# same-repo posture the Review and Dogfood runners hold.
+# as data — every fact is a GitHub-API call, and the sole code it executes is
+# scripts/surface-match.py off a checkout PINNED TO THE DEFAULT BRANCH. A PR can
+# no more edit the matcher that judges its diff than it can edit the policy that
+# matcher annotates with (the policy is likewise read from the default branch).
+# The job-level guard drops fork heads (a fork PR gets a read-only token and
+# cannot carry the QA flags this computes over anyway), matching the same-repo
+# posture the Review and Dogfood runners hold.
 
 on:
   pull_request:
@@ -113,6 +116,17 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.head_repository.full_name == github.repository)
     steps:
+      # The DEFAULT branch, never the PR head — the security posture above says
+      # this workflow runs no branch code, and a PR must not be able to edit the
+      # matcher that judges it any more than it can edit the policy that matcher
+      # annotates with. The checkout exists for exactly one file,
+      # scripts/surface-match.py: the declared-surface matcher the tick shares
+      # (#3176). No credential is persisted — this job pushes nothing.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
       # Resolve the PR set for this event, then recompute each one. The fact
       # reads and the compute live in this single step so a run's whole
       # reasoning is legible from its log: one line per fact, one for the
@@ -131,129 +145,6 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-
-          # The declared-surface matcher. Globs are gitwildmatch (gitignore
-          # semantics): ** spans path segments, * stays within one, ? is one
-          # non-slash character, and a pattern naming a directory covers
-          # everything beneath it. Bash has no such matcher and the runner has no
-          # pathspec module, so translate to a regex here — the one place the
-          # semantics the policy file and /scope both promise are actually
-          # decided. Prints the changed paths that escape the declaration; silent
-          # when the diff is contained.
-          cat >"${RUNNER_TEMP}/surface_match.py" <<'PY'
-          import re, sys
-
-
-          def compile_glob(pat):
-              pat = pat.rstrip("/")
-              anchored = "/" in pat
-              out, i, n = [], 0, len(pat)
-              while i < n:
-                  c = pat[i]
-                  if c == "*":
-                      j = i
-                      while j < n and pat[j] == "*":
-                          j += 1
-                      doubled = j - i > 1
-                      at_start = i == 0 or pat[i - 1] == "/"
-                      if doubled and at_start and j < n and pat[j] == "/":
-                          out.append("(?:[^/]+/)*")  # "**/" — zero or more segments
-                          i = j + 1
-                      elif doubled and at_start and j >= n:
-                          out.append(".*")  # trailing "/**" — everything beneath
-                          i = j
-                      else:
-                          out.append("[^/]*")
-                          i = j
-                  elif c == "?":
-                      out.append("[^/]")
-                      i += 1
-                  elif c == "[":
-                      j = i + 1
-                      if j < n and pat[j] in "!^":
-                          j += 1
-                      if j < n and pat[j] == "]":
-                          j += 1
-                      while j < n and pat[j] != "]":
-                          j += 1
-                      if j >= n:
-                          out.append(re.escape("["))
-                          i += 1
-                      else:
-                          cls = pat[i + 1 : j]
-                          out.append("[" + ("^" + cls[1:] if cls.startswith("!") else cls) + "]")
-                          i = j + 1
-                  else:
-                      out.append(re.escape(c))
-                      i += 1
-              body = "".join(out)
-              # An unanchored pattern (no slash) matches at any depth. The trailing
-              # group is the directory rule: naming a directory covers its contents.
-              return re.compile(("^" if anchored else "^(?:.*/)?") + body + "(?:/.*)?$")
-
-
-          RANK = {"auto": 0, "judge": 1, "human": 2}
-
-
-          def read_globs(path):
-              return [
-                  line.strip()
-                  for line in open(path, encoding="utf-8").read().splitlines()
-                  if line.strip() and not line.strip().startswith("#")
-              ]
-
-
-          def load_policy(path):
-              # Annotation only — the gate's verdict is containment, which never
-              # consults the policy, so a missing policy file costs the tier column
-              # and nothing else. The file's shape is owned by this repo (a
-              # `default` tier plus a list of {glob, tier} rules), so it is parsed
-              # with the standard library rather than PyYAML, which the runner is
-              # not guaranteed to ship: a hand parser keeps the tier column
-              # deterministic instead of silently degrading every row to "?".
-              # Tier resolution is most-restrictive-wins over the matching rules,
-              # falling back to the fail-closed default — the same resolution
-              # /approve applies at the Plan->Ready edge, so the diagnostic quotes
-              # the tier an escaping path would actually cost.
-              text = open(path, encoding="utf-8").read()
-              if not text.strip():
-                  # The fetch failed (no policy on the default branch yet), so the
-                  # tier is honestly unresolved rather than assumed.
-                  return None
-              default, rules, pending = "human", [], None
-              for raw in text.splitlines():
-                  line = raw.split("#", 1)[0].rstrip()
-                  m = re.match(r"^default:\s*(\w+)\s*$", line)
-                  if m:
-                      default = m.group(1)
-                      continue
-                  m = re.match(r"""^\s*-\s*glob:\s*["']?(.+?)["']?\s*$""", line)
-                  if m:
-                      pending = m.group(1)
-                      continue
-                  m = re.match(r"""^\s*tier:\s*["']?(\w+)["']?\s*$""", line)
-                  if m and pending is not None:
-                      if m.group(1) in RANK:
-                          rules.append((compile_glob(pending), m.group(1)))
-                      pending = None
-              return default, rules
-
-
-          def tier_of(path, policy):
-              if policy is None:
-                  return "?"
-              default, rules = policy
-              matched = [tier for matcher, tier in rules if matcher.match(path)]
-              return max(matched, key=lambda t: RANK[t]) if matched else default
-
-
-          matchers = [compile_glob(g) for g in read_globs(sys.argv[1])]
-          policy = load_policy(sys.argv[3]) if len(sys.argv) > 3 else None
-          for path in open(sys.argv[2], encoding="utf-8").read().splitlines():
-              path = path.strip()
-              if path and not any(m.match(path) for m in matchers):
-                  print(f"{path}\t{tier_of(path, policy)}")
-          PY
 
           # A synchronize (new head push) forces a demotion to building — it
           # applies to the single payload PR, the only PR this event names.
@@ -472,7 +363,12 @@ jobs:
                    --jq '.content' 2>/dev/null | base64 -d >"${RUNNER_TEMP}/policy.yml" 2>/dev/null; then
                 : >"${RUNNER_TEMP}/policy.yml"
               fi
-              escaping="$(python3 "${RUNNER_TEMP}/surface_match.py" \
+              # scripts/surface-match.py off the default-branch checkout is the
+              # matcher — the one place gitwildmatch semantics are decided, shared
+              # with the tick's approval-tier lookup (#3176). It prints the changed
+              # paths that escape the declaration, tier-annotated; silent when the
+              # diff is contained.
+              escaping="$(python3 scripts/surface-match.py \
                 "${RUNNER_TEMP}/globs.txt" "${RUNNER_TEMP}/changed.txt" "${RUNNER_TEMP}/policy.yml")"
 
               # Owner waiver: approval:surface-ok accepts the overreach, but only

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@
 !.claude/skills/land/
 !.claude/skills/headless/
 !.claude/skills/scope-headless/
+!.claude/skills/approve-headless/
 !.claude/skills/implement-headless/
 !.claude/skills/land-headless/
 # Wish-pass reports — themed use-case ideation runs of `/wish`. Per-run

--- a/scripts/surface-match.py
+++ b/scripts/surface-match.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""The declared-surface matcher — the one place gitwildmatch semantics are decided.
+
+An issue's `## Declared surface` is a block of globs; `.github/approval-policy.yml`
+maps globs to approval tiers. Two consumers need to evaluate those globs with
+identical semantics, and a second copy of the matcher would drift from the first:
+
+  - reconciler.yml — does a merged PR's changed-file set stay inside the surface
+    its closing issue declared? (containment; the policy only annotates each
+    escaping path with the tier it would have cost)
+  - agent-tick.yml — what approval tier does a `phase:plan` issue's declared
+    surface resolve to? (only an `auto` tier is dispatched for auto-approval)
+
+Globs are gitwildmatch (gitignore semantics): `**` spans path segments, `*` stays
+within one, `?` is one non-slash character, and a pattern naming a directory
+covers everything beneath it. Bash has no such matcher and the runner ships no
+pathspec module, so the patterns are translated to regexes here.
+
+Two modes:
+
+    surface-match.py <globs_file> <changed_file> [<policy_file>]
+        Containment. Prints `path\ttier` for every path in <changed_file> that
+        NO glob in <globs_file> matches; silent when the diff is contained. The
+        tier column is annotation only — it reads `?` without a <policy_file>,
+        or when the policy is empty (not on the default branch yet).
+
+    surface-match.py --tier <paths_file> <policy_file>
+        Tier resolution. Prints the single most restrictive tier (human > judge >
+        auto) over every path in <paths_file>, falling back to the policy's
+        `default` for a path no rule matches. An empty <paths_file> prints the
+        default: a surface that declares nothing can never resolve to `auto`.
+"""
+
+import re
+import sys
+
+
+def compile_glob(pat):
+    pat = pat.rstrip("/")
+    anchored = "/" in pat
+    out, i, n = [], 0, len(pat)
+    while i < n:
+        c = pat[i]
+        if c == "*":
+            j = i
+            while j < n and pat[j] == "*":
+                j += 1
+            doubled = j - i > 1
+            at_start = i == 0 or pat[i - 1] == "/"
+            if doubled and at_start and j < n and pat[j] == "/":
+                out.append("(?:[^/]+/)*")  # "**/" — zero or more segments
+                i = j + 1
+            elif doubled and at_start and j >= n:
+                out.append(".*")  # trailing "/**" — everything beneath
+                i = j
+            else:
+                out.append("[^/]*")
+                i = j
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        elif c == "[":
+            j = i + 1
+            if j < n and pat[j] in "!^":
+                j += 1
+            if j < n and pat[j] == "]":
+                j += 1
+            while j < n and pat[j] != "]":
+                j += 1
+            if j >= n:
+                out.append(re.escape("["))
+                i += 1
+            else:
+                cls = pat[i + 1 : j]
+                out.append("[" + ("^" + cls[1:] if cls.startswith("!") else cls) + "]")
+                i = j + 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+    body = "".join(out)
+    # An unanchored pattern (no slash) matches at any depth. The trailing
+    # group is the directory rule: naming a directory covers its contents.
+    return re.compile(("^" if anchored else "^(?:.*/)?") + body + "(?:/.*)?$")
+
+
+RANK = {"auto": 0, "judge": 1, "human": 2}
+
+
+def read_globs(path):
+    return [
+        line.strip()
+        for line in open(path, encoding="utf-8").read().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def load_policy(path):
+    # The file's shape is owned by this repo (a `default` tier plus a list of
+    # {glob, tier} rules), so it is parsed with the standard library rather than
+    # PyYAML, which the runner is not guaranteed to ship: a hand parser keeps the
+    # tier deterministic instead of silently degrading to "?". Tier resolution is
+    # most-restrictive-wins over the matching rules, falling back to the file's
+    # own `default` — the same resolution /approve applies at the Plan->Ready
+    # edge, so both consumers quote the tier a path would actually cost.
+    text = open(path, encoding="utf-8").read()
+    if not text.strip():
+        # The fetch failed (no policy on the default branch yet), so the tier is
+        # honestly unresolved rather than assumed.
+        return None
+    default, rules, pending = "human", [], None
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
+        m = re.match(r"^default:\s*(\w+)\s*$", line)
+        if m:
+            default = m.group(1)
+            continue
+        m = re.match(r"""^\s*-\s*glob:\s*["']?(.+?)["']?\s*$""", line)
+        if m:
+            pending = m.group(1)
+            continue
+        m = re.match(r"""^\s*tier:\s*["']?(\w+)["']?\s*$""", line)
+        if m and pending is not None:
+            if m.group(1) in RANK:
+                rules.append((compile_glob(pending), m.group(1)))
+            pending = None
+    return default, rules
+
+
+def tier_of(path, policy):
+    if policy is None:
+        return "?"
+    default, rules = policy
+    matched = [tier for matcher, tier in rules if matcher.match(path)]
+    return max(matched, key=lambda t: RANK[t]) if matched else default
+
+
+def read_paths(path):
+    return [line.strip() for line in open(path, encoding="utf-8").read().splitlines() if line.strip()]
+
+
+def main(argv):
+    if len(argv) > 1 and argv[1] == "--tier":
+        policy = load_policy(argv[3])
+        if policy is None:
+            print("?")
+            return
+        # Most restrictive over every declared path, and the policy default for a
+        # surface that declares nothing — the fail-safe direction, since `auto` is
+        # the only tier that dispatches an unattended approval.
+        tiers = [tier_of(p, policy) for p in read_globs(argv[2])] or [policy[0]]
+        print(max(tiers, key=lambda t: RANK.get(t, len(RANK))))
+        return
+
+    matchers = [compile_glob(g) for g in read_globs(argv[1])]
+    policy = load_policy(argv[3]) if len(argv) > 3 else None
+    for path in read_paths(argv[2]):
+        if not any(m.match(path) for m in matchers):
+            print(f"{path}\t{tier_of(path, policy)}")
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
Nothing acted on an approval tier. The policy assigned one, `/approve`'s skill text said what each tier meant, and the judge wrote verdicts — but **no workflow ever invoked `/approve`**. `agent-work`'s tasks were `scope | implement | land`; the tick mapped `phase:plan -> none`. An `auto`-tier issue sat at `phase:plan` forever, exactly like a `human`-tier one. The tiering machinery was complete and inert.

## What this adds

**The tick decides *whether to dispatch*; the executor decides *whether to approve*.**

The tick resolves each `phase:plan` issue's tier (declared surface × `.github/approval-policy.yml`, most-restrictive-wins) and dispatches `approve` **only** for `auto`. Everything else is skipped with a logged reason, so no Claude run is spent where it could never advance anything.

The executor is a new `approve` task on `agent-work` that runs the **real `/approve` skill** headlessly. Deliberately not a bash reimplementation of its gates: freshness, umbrella integrity, and the ADR merge check aren't mechanically expressible, and a second copy would drift from the skill text silently. The skill stays the single definition of what approval *means*. On pass it flips `phase:plan -> phase:ready`, and the existing `phase:ready -> implement` map picks it up on the next wave with no extra wiring.

The gitwildmatch matcher moves out of `reconciler.yml`'s heredoc into `scripts/surface-match.py`, shared by both — the same duplication that let four `jq` renderers drift (#3167).

## Fail-safe by construction

- Only the literal string `auto` dispatches. `judge`, `human`, `adr`, an issue with no declared surface, and *any unexpected matcher output* all fall to the wildcard and skip. Authority is granted on an explicit match, never by default.
- The **ADR hard gate is re-applied ahead of the policy lookup**: an `ADR flag:` line or a `docs/adr/` declaration is never dispatched for auto-approval, whatever the policy says.
- **An issue with no declared surface can never auto-approve.** Undeclared means unapproved.

## A security hole this closed

The first implementation gave the reconciler an `actions/checkout` pinned to the default branch. That *looks* equivalent to reading trusted code — but `actions/checkout` falls back to the **triggering ref** when its `ref:` expression is empty, and on a `pull_request` event the triggering ref is the **PR head**. One unset expression and the reconciler would execute branch-authored Python while holding `statuses: write` and `issues: write`. The fleet's App can push branches, so that is a live path, not a hypothetical — a PR could author the matcher that judges its own diff.

`scripts/surface-match.py` is now fetched through the contents API with **no ref**, which always resolves to the default branch and has no fallback — exactly how the policy file is already read. The reconciler checks nothing out again, and its "runs no branch code" posture is intact. The tick keeps its checkout: it has no `pull_request` trigger, so there is no PR head for it to reach.

## Verification

The matcher extraction is proved behaviour-identical against the original heredoc over 12 glob sets × 20 paths × 3 policy modes — zero differences in stdout or exit code. Tier resolution against the real policy: `aether-data` → `human`, `aether-kit` → `auto`, `aether-capabilities` → `judge`, an unpoliced path → `judge`, `Cargo.toml` → `human`, and guide + `aether-actor` → `human` (most-restrictive-wins holds). No prefix bleed: `docs/guidex.md` escapes `docs/guide/**`.

The tick's gate was run against the **live board**: `#3169` skip (ADR flag), `#3166`/`#3163`/`#3162` skip (human — core API and harness), `#3110` skip (judge), `#3145` skip (no surface). **Zero dispatches on today's board** — the correct pre-filter, since today's board is all core-API and fleet work.

All three workflows parse; every `run:` block passes `bash -n`; the reconciler has zero checkouts.

Closes #3176
