### PR TITLE
fix(ci): the fleet scopes machine-filed alerts — gate scope-eligibility on type:*

### DIFF
--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -41,6 +41,12 @@ name: Agent tick
 #   - AGENT_WAVE_WIDTH  — the N-cap (default 2). Free slots = width minus the
 #                         live non-land count.
 #   - AGENT_MIN_WAVE_GAP_MINUTES — minimum gap since the last wave (default 0).
+#   - AGENT_SCOPE_TYPES — comma-separated type:* values the fleet will scope
+#                         (default feat,fix,chore,docs,perf,refactor,flake — the
+#                         closed set). An issue with no type:* label, or a type
+#                         outside this list, is left alone; so is anything tagged
+#                         `alert`. This is the dial for WHICH KINDS of work the
+#                         fleet takes on.
 #   - AGENT_DAILY_WAVE_BUDGET    — daily dispatch cap (0/unset = unlimited).
 #   - AGENT_NUDGE_DAYS  — stale-awaiting-answer nudge threshold in days
 #                         (0/unset = nudge disabled).
@@ -225,6 +231,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           WAVE_WIDTH: ${{ vars.AGENT_WAVE_WIDTH }}
+          SCOPE_TYPES: ${{ vars.AGENT_SCOPE_TYPES }}
           MIN_WAVE_GAP_MINUTES: ${{ vars.AGENT_MIN_WAVE_GAP_MINUTES }}
           DAILY_WAVE_BUDGET: ${{ vars.AGENT_DAILY_WAVE_BUDGET }}
         run: |
@@ -302,13 +309,44 @@ jobs:
 
           # Board scan → advanceable snapshot. Open non-PR issues with labels;
           # `has("pull_request")|not` drops PRs (they share the issues endpoint).
+          # `type` and `alert` back the scope-eligibility gate below.
           gh api "repos/${REPO}/issues?state=open&per_page=100" --paginate \
             --jq '.[] | select(has("pull_request")|not)
               | [ .number,
                   ([.labels[].name | select(startswith("phase:"))] | .[0] // "none"),
                   (if ([.labels[].name] | index("agent:awaiting-answer")) then "await" else "-" end),
-                  (if ([.labels[].name] | index("agent:dont-touch")) then "dt" else "-" end) ]
+                  (if ([.labels[].name] | index("agent:dont-touch")) then "dt" else "-" end),
+                  ([.labels[].name | select(startswith("type:")) | ltrimstr("type:")] | .[0] // "-"),
+                  (if ([.labels[].name] | index("alert")) then "alert" else "-" end) ]
               | @tsv' > /tmp/board.tsv
+
+          # Scope-eligibility. Backlog means "no phase:* label", which is also true
+          # of every machine-filed alert that lands in the repo — and the tick used
+          # to scope those. The context-budget canary and the nightly fuzzer both
+          # file issues with NO labels at all, so the fleet had a standing feed of
+          # alerts it would walk through Define/Design/Plan, each costing a full
+          # Claude run to discover it should not have (#3179 was scoped for seven
+          # minutes before being cancelled by hand).
+          #
+          # Filtering by AUTHOR would be wrong: the fleet's own App files real work
+          # — a scoping agent split the fat #3145 into #3162 and #3163, and those
+          # must be scoped. The signal that separates them is `type:*`. Every real
+          # work item carries one (/sketch stamps it from the conventional-commit
+          # title, and split children inherit it); an alert filed outside the
+          # pipeline carries none.
+          #
+          # AGENT_SCOPE_TYPES is the owner's dial for WHICH KINDS of work the fleet
+          # takes on, alongside the other governors. An issue whose type is not in
+          # the list is left alone, and so is anything tagged `alert`. Fail-safe: an
+          # issue the tick cannot classify is NOT scoped — silence costs a human one
+          # label, the opposite costs a Claude run and a design nobody asked for.
+          scope_types="${SCOPE_TYPES:-feat,fix,chore,docs,perf,refactor,flake}"
+          scopeable() {
+            case ",${scope_types}," in
+              *",$1,"*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
 
           # Resolve the open PR that closes a held issue — land's ref is that PR,
           # not the issue. includeClosedPrs:false already excludes merged/closed.
@@ -368,11 +406,25 @@ jobs:
           land_items=""
           resume_items=""
           work_items=""
-          while IFS=$'\t' read -r num phase await dt; do
+          while IFS=$'	' read -r num phase await dt itype alert; do
             [ -n "$num" ] || continue
             if [ "$dt" = "dt" ]; then summary "- skip #${num}: agent:dont-touch"; continue; fi
+            if [ "$alert" = "alert" ]; then summary "- skip #${num}: alert — machine-filed, not a work item"; continue; fi
             case "$phase" in
-              none|phase:define|phase:design) task="scope"; ref="$num" ;;
+              none|phase:define|phase:design)
+                # The type gate applies to the whole scope arm, not just Backlog: an
+                # issue already at define/design got there through the pipeline and
+                # will carry a type:*, so a missing one still means "not ours".
+                if [ "$itype" = "-" ]; then
+                  summary "- skip #${num}: no type:* label — not a pipeline work item"
+                  continue
+                fi
+                if ! scopeable "$itype"; then
+                  summary "- skip #${num}: type:${itype} not in AGENT_SCOPE_TYPES (${scope_types})"
+                  continue
+                fi
+                task="scope"; ref="$num"
+                ;;
               phase:plan)
                 tier="$(approval_tier "$num")"
                 case "$tier" in

--- a/.github/workflows/context-budget-canary.yml
+++ b/.github/workflows/context-budget-canary.yml
@@ -112,7 +112,10 @@ jobs:
             gh issue comment "$existing" --body-file /tmp/context-budget-issue.md
           else
             echo "Filing context-budget issue."
-            gh issue create --title "$title" --body-file /tmp/context-budget-issue.md
+            # --label alert: a machine-filed alert is not a pipeline work item,
+            # and the fleet's dispatcher skips anything carrying it. Without the
+            # label an unlabelled issue reads as Backlog and gets scoped (#3180).
+            gh issue create --title "$title" --body-file /tmp/context-budget-issue.md --label alert
           fi
 
       - name: Fail on context-budget breach

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -123,5 +123,8 @@ jobs:
             gh issue comment "$existing" --body-file issue_body.md
           else
             echo "Filing new crash issue."
-            gh issue create --title "$title" --body-file issue_body.md
+            # --label alert: a machine-filed alert is not a pipeline work item,
+            # and the fleet's dispatcher skips anything carrying it. Without the
+            # label an unlabelled issue reads as Backlog and gets scoped (#3180).
+            gh issue create --title "$title" --body-file issue_body.md --label alert
           fi

--- a/scripts/release-project-init.sh
+++ b/scripts/release-project-init.sh
@@ -70,6 +70,13 @@ ensure_label "approval:surface-ok"       0e8a16 "owner waiver: declared-surface 
 ensure_label "agent:dont-touch"      000000 "fleet-blind: the dispatcher, judge, and executor skip this issue. Only the owner removes it."
 ensure_label "agent:awaiting-answer" fbca04 "an agent parked a question here; an owner reply resumes its session"
 
+# Machine-filed alerts (the context-budget canary, the nightly fuzzer). They carry
+# no type:* label because they never went through /sketch, so without this tag the
+# dispatcher reads them as Backlog and scopes them. The alert-filing workflows
+# stamp it themselves; it is bootstrapped here because a label that does not exist
+# cannot be applied.
+ensure_label "alert" b60205 "machine-filed alert, not a work item — the fleet never scopes these"
+
 # Size (weight) — XL marks a fat issue for /sweep fat (ADR-0110).
 ensure_label "size:s"  bfdadc "single file, single concept"
 ensure_label "size:m"  bfdadc "single crate, multiple files"


### PR DESCRIPTION
Backlog means "no `phase:*` label" — which is also true of every machine-filed alert that lands in the repo. So the tick scoped those too.

The context-budget canary filed **#3179** (`ci: MCP context-budget canary breach`, no labels) and **seven minutes later the fleet claimed it** and began walking a monitoring alert through Define → Design → Plan. It was cancelled by hand.

Not a one-off: `fuzz-nightly.yml` files a crash issue **every night**. The fleet had a standing feed of alerts it would scope forever, each costing a full Claude run (~$2.42 measured) to discover it shouldn't have.

## Why not filter by author

Because the fleet's own App files *real work*. A scoping agent split the fat #3145 into #3162 and #3163 this morning, and those must be scoped. An author-based filter would have broken the umbrella-split flow that worked.

The signal that actually separates them is **`type:*`**. Every real work item carries one — `/sketch` stamps it from the conventional-commit title, and split children inherit it. An alert filed outside the pipeline carries none.

## What changed

**Scope-eligibility requires a `type:*` in `AGENT_SCOPE_TYPES`** — a repo variable (default: the closed set `feat,fix,chore,docs,perf,refactor,flake`), and the owner's dial for *which kinds of work the fleet takes on*. It lives with the other governors so the control surface stays in one place.

**An `alert` label is skipped outright**, whatever else the issue carries — so a human can bench a whole class of work by tag without touching its type.

**Both alert-filing workflows stamp `alert` at the source.** An alert should be self-identifying, not dependent on somebody labelling it afterwards.

**The label is bootstrapped** in `release-project-init.sh` — a label that doesn't exist can't be applied, which is exactly the trap that left `agent:dont-touch` unusable on the fleet's first day.

## Verified

Against the live board, and across the cases that matter:

```
canary alert (alert, no type) [#3179]      -> SKIP  alert
unlabelled machine issue (no type)         -> SKIP  no type:* label
a human fix issue (type:fix)               -> SCOPE
fleet-filed split child (type:feat)        -> SCOPE      <- author filter would have broken this
human issue TAGGED alert (has type!)       -> SKIP  alert
type outside the allowlist                 -> SKIP  type:security not in allowlist
benched issue                              -> SKIP  agent:dont-touch
```

Fail-safe direction: an issue the tick cannot classify is **not** scoped. Silence costs a human one label; the opposite costs a Claude run and a design document nobody asked for.

## Note

The canary breach itself is a **real signal** — MCP tool responses have grown past their checked-in budgets. #3179 is benched, not resolved; it deserves attention on its own merits, just not by having an agent write a design doc about it.

Closes #3180
