### PR TITLE
feat(ci): an owner tag that pre-approves an issue, except an ADR

### DIFF
--- a/.claude/skills/approve/SKILL.md
+++ b/.claude/skills/approve/SKILL.md
@@ -182,6 +182,18 @@ Route by the resulting tier:
 - **`judge`** — route to the LLM approval judge (#3133), shadow-mode first: the judge's verdict is recorded but the owner still confirms until the judge is trusted.
 - **`human`** — hold for the owner's explicit `/approve`, exactly as today.
 
+### The owner's override — `approval:pre-approved`
+
+An issue carrying `approval:pre-approved` resolves to the **`auto`** tier whatever the policy says. It is the owner's way to say "I have read *this one*, let it go" without widening the policy for a whole surface.
+
+Three constraints, and none of them are negotiable:
+
+**It cannot pass the [ADR hard gate](#adr-hard-gate).** That gate runs *above* the policy lookup and *above* this label. An issue carrying an `ADR flag:` or declaring `docs/adr/` routes to the owner even with the label applied. An ADR is load-bearing by definition — there is no passable gate for one. Check the ADR gate first and refuse before you ever look at this label.
+
+**It must be the owner's label.** Verify against the timeline: the most recent `labeled` event for `approval:pre-approved` must name the repo owner as its actor (the same check `approval:surface-ok` and `review:skip` use — `gh api repos/iamacoffeepot/aether/issues/<n>/timeline`). An agent may apply the label; it does not count, and the refusal says who applied it. Without this check an agent could grant itself unbounded approval authority through a side door, which is the one thing this whole policy exists to prevent. Never treat the label's mere presence as sufficient.
+
+**It waives the tier, not the [gate checks](#gate-checks).** The tier answers *who approves*; the gate checks answer *whether the issue is approvable at all* — sections present, exactly one `model:*`, dependencies closed, targets still on `origin/main`. A pre-approved issue still runs every one of them and still refuses on a failure. A missing `model:*` means `/scope` did not finish, which is a defect to fix rather than something to wave into `implement`.
+
 The tier decision runs *after* the structural [Gate checks](#gate-checks) pass — a failing gate refuses regardless of tier. Relaxing a tier is a one-line, owner-signed diff to `.github/approval-policy.yml`; the file's git history is the delegation-ladder audit trail. The declared surface this tier is resolved over is the same surface the reconciler later enforces the merged diff against, so the thing that ships is the thing that was approved.
 
 ## ADR gate, in detail

--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -82,6 +82,15 @@ name: Agent tick
 # code, hence the actions/checkout below — still no Claude and no cargo, so the
 # tick stays free and deterministic.
 #
+# approval:pre-approved is the owner's per-issue override on that lookup: it
+# resolves the tier to `auto` whatever the policy says. It CANNOT pass the ADR
+# hard gate — an ADR is load-bearing by definition, so there is no passable gate
+# for one — and it counts only when the timeline actor who applied it is the
+# owner, the same verification approval:surface-ok and review:skip use. An agent
+# may apply the label; it does not count. It waives the TIER (who approves), never
+# /approve's gate checks (whether the issue is approvable at all), so a
+# half-scoped plan still refuses rather than advancing into implement.
+#
 # agent:dont-touch items are filtered out of the whole scan first (the label
 # blinds the dispatcher, per its contract). The snapshot is ordered
 # land > question-resume > approve/implement/scope and slots are filled in that
@@ -317,7 +326,8 @@ jobs:
                   (if ([.labels[].name] | index("agent:awaiting-answer")) then "await" else "-" end),
                   (if ([.labels[].name] | index("agent:dont-touch")) then "dt" else "-" end),
                   ([.labels[].name | select(startswith("type:")) | ltrimstr("type:")] | .[0] // "-"),
-                  (if ([.labels[].name] | index("alert")) then "alert" else "-" end) ]
+                  (if ([.labels[].name] | index("alert")) then "alert" else "-" end),
+                  (if ([.labels[].name] | index("approval:pre-approved")) then "pre" else "-" end) ]
               | @tsv' > /tmp/board.tsv
 
           # Scope-eligibility. Backlog means "no phase:* label", which is also true
@@ -406,7 +416,7 @@ jobs:
           land_items=""
           resume_items=""
           work_items=""
-          while IFS=$'	' read -r num phase await dt itype alert; do
+          while IFS=$'	' read -r num phase await dt itype alert preapp; do
             [ -n "$num" ] || continue
             if [ "$dt" = "dt" ]; then summary "- skip #${num}: agent:dont-touch"; continue; fi
             if [ "$alert" = "alert" ]; then summary "- skip #${num}: alert — machine-filed, not a work item"; continue; fi
@@ -427,6 +437,33 @@ jobs:
                 ;;
               phase:plan)
                 tier="$(approval_tier "$num")"
+                # approval:pre-approved is the owner's per-issue override: it
+                # resolves the tier to auto. It sits BELOW the ADR hard gate and
+                # cannot pass it — an ADR is load-bearing by definition, so there is
+                # no passable gate for one, and `adr` is matched first below.
+                #
+                # It must be the OWNER'S label. Verified against the timeline actor
+                # of the most recent `labeled` event, the same shape as
+                # approval:surface-ok and review:skip. An agent may apply the label;
+                # it simply does not count. Without this check an agent could grant
+                # itself unbounded approval authority through a side door, which is
+                # the one thing the whole tier policy exists to prevent.
+                #
+                # It waives the TIER (who approves), never the gate checks (whether
+                # the issue is approvable at all — sections present, one model:*,
+                # dependencies closed, freshness). Those still run in /approve; a
+                # half-scoped plan is a defect to fix, not something to wave into
+                # implement.
+                if [ "$tier" != "adr" ] && [ "$preapp" = "pre" ]; then
+                  actor="$(gh api "repos/${REPO}/issues/${num}/timeline" --paginate \
+                    --jq '[.[] | select(.event=="labeled" and .label.name=="approval:pre-approved")] | last | .actor.login // empty')"
+                  if [ "$actor" = "$OWNER" ]; then
+                    summary "- #${num}: approval:pre-approved by the owner (tier was ${tier}) — dispatching approve"
+                    tier="auto"
+                  else
+                    summary "- #${num}: approval:pre-approved ignored — applied by '${actor:-unknown}', not the owner"
+                  fi
+                fi
                 case "$tier" in
                   auto) summary "- #${num}: approval tier auto — dispatching approve"; task="approve"; ref="$num" ;;
                   adr) summary "- skip #${num}: ADR hard gate — the owner approves this one"; continue ;;

--- a/scripts/release-project-init.sh
+++ b/scripts/release-project-init.sh
@@ -77,6 +77,11 @@ ensure_label "agent:awaiting-answer" fbca04 "an agent parked a question here; an
 # cannot be applied.
 ensure_label "alert" b60205 "machine-filed alert, not a work item — the fleet never scopes these"
 
+# The owner's per-issue approval override. Resolves an issue's approval tier to
+# `auto` whatever the policy says — but it can never pass the ADR hard gate, and
+# it counts only when the OWNER applied it (the tick verifies the timeline actor).
+ensure_label "approval:pre-approved" 0e8a16 "owner: approve this one regardless of tier (never an ADR)"
+
 # Size (weight) — XL marks a fat issue for /sweep fat (ADR-0110).
 ensure_label "size:s"  bfdadc "single file, single concept"
 ensure_label "size:m"  bfdadc "single crate, multiple files"


### PR DESCRIPTION
> I'd like to have a tag which I can add to issues to pre-approve them regardless of what stage they're in the pipeline. THE ONLY EXCEPTION IS ADR HERE. ADR has no passable gate.

Approval routing is decided entirely by the path globs an issue declares. That's the right default — stable and auditable — but it left the owner no way to say *"I've read **this one**, let it go."* His only options were to stand at the gate and run `/approve` by hand at the right moment, or widen the policy for a whole surface because of a single issue.

**`approval:pre-approved`** resolves an issue's tier to `auto` whatever the policy says. Tag it at any stage — Backlog, Define, Design, Plan — and it's honoured when the issue reaches the approval edge.

## Three constraints, none negotiable

**It cannot pass the ADR hard gate.** That gate runs *above* the policy lookup and *above* this label. An issue carrying an `ADR flag:` or declaring `docs/adr/` routes to the owner **even with the label applied**. An ADR is load-bearing by definition — there is no passable gate for one.

**It must be the owner's label.** Verified against the timeline actor of the most recent `labeled` event — the same check `approval:surface-ok` and `review:skip` already use. An agent may apply the label; it does not count, and the skip line names who applied it. Without this, an agent could grant itself unbounded approval authority through a side door — which is the one thing the entire tier policy exists to prevent.

**It waives the tier, not the gate checks.** The tier answers *who approves*. The gate checks answer *whether the issue is approvable at all*: sections present, exactly one `model:*`, dependencies closed, targets still on `origin/main`. A pre-approved issue still runs every one of them and still refuses on a failure — a missing `model:*` means `/scope` didn't finish, which is a defect to fix rather than something to wave into `implement`.

## Verified

```
human tier, no label                     -> SKIP  tier human
human tier + pre-approved BY OWNER       -> DISPATCH approve
human tier + pre-approved by an AGENT    -> SKIP  (ignored: iamakettle)
judge tier + pre-approved by owner       -> DISPATCH approve
ADR-BEARING + pre-approved by owner      -> SKIP  ADR hard gate      <- no passable gate
auto tier, no label                      -> DISPATCH approve
```

Asserted structurally too: the override is guarded by `tier != adr`, so the ADR check is evaluated before the label can ever set `auto`.

## Notes

Read off the existing board scan rather than a per-issue API call, so the tick pays nothing for it. The label is bootstrapped in `release-project-init.sh` — a label that doesn't exist can't be applied, the trap that left `agent:dont-touch` unusable on the fleet's first day. It's already created on the repo, so it's usable the moment this lands.

Closes #3182
