### PR TITLE
fix(workflow): make approval tiers set-safe

### DIFF
--- a/.agents/skills/_shared/github-workflow.md
+++ b/.agents/skills/_shared/github-workflow.md
@@ -67,7 +67,7 @@ Before every label write, re-read the issue identity and current labels. Abort i
 
 - Put markdown in a temporary file using `apply_patch`; do not interpolate it into a shell command.
 - Create or edit with file inputs such as `-F body=@/tmp/aether-issue-<N>.md`.
-- Scope owns these exact H2 sections: `Problem statement`, `Design notes`, `Implementation plan`, `Sub-issues`, `Depends on`, `Dogfood brief`, and `Side findings`.
+- Scope owns these exact H2 sections: `Problem statement`, `Design notes`, `Implementation plan`, `Sub-issues`, `Depends on`, `Declared surface`, `Dogfood brief`, and `Side findings`.
 - Preserve every other section and all user prose byte-for-byte when replacing managed sections.
 - Immediately before a full-body `PATCH`, re-read issue number, title, and body. Abort on a concurrent managed-section edit; merge only non-overlapping user prose changes.
 - Comments exist for human-directed information without a structured home: bounce reasons, explicit overrides, and deliberate declines. Phase progress belongs in labels and artifacts, not progress comments.

--- a/.agents/skills/approve/SKILL.md
+++ b/.agents/skills/approve/SKILL.md
@@ -164,8 +164,11 @@ python3 -I .agents/skills/approve/scripts/resolve_approval_tier.py \
 The resolver loads the policy and tracked paths from the captured ref, uses the
 same matcher as the Reconciler, requires every concrete target to be covered,
 rejects orphan globs, and returns stable JSON with the most restrictive tier and
-path evidence. Treat any resolver, policy, Git, or JSON failure as an approval
-gate failure; never substitute a default from memory.
+path evidence. It refuses a ref that is not reachable from the local
+`refs/remotes/origin/main`, so run it only after the freshness gate's fetch and
+always pass the SHA that fetch captured — never a PR head or any other commit.
+Treat any resolver, policy, Git, or JSON failure as an approval gate failure;
+never substitute a default from memory.
 
 Apply the ADR hard gate before using the returned policy tier. Route to
 `human` when Design notes contain a non-empty line beginning `ADR flag:` or

--- a/.agents/skills/approve/SKILL.md
+++ b/.agents/skills/approve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: approve
-description: "Validate one, several explicitly listed, or every Plan-phase Aether issue and advance eligible issues to Ready. Use for the human Plan-to-Ready gate, including ADR, model, blocked-label, freshness, dependency, umbrella, idempotency, and sweep-confirmation checks; never use it to edit scope or dispatch implementation."
+description: "Validate one, several explicitly listed, or every Plan-phase Aether issue, resolve its declared surface through the auto/judge/human approval policy, and advance authorized issues to Ready. Use for Plan-to-Ready gating, including ADR, model, blocked-label, freshness, dependency, umbrella, idempotency, and sweep-confirmation checks; never use it to edit scope or dispatch implementation."
 ---
 
 # Approve
@@ -21,7 +21,17 @@ $approve <issue-number> --skip-adr --note "<reason>"
 $approve --sweep
 ```
 
-Treat a single issue or explicitly listed batch as authorization to advance each listed issue that clears every gate. Validate the whole explicit set before changing any label, then mutate eligible issues serially. List every failure; never stop gate evaluation at the first one.
+Treat a user-issued single issue or explicitly listed batch as the owner's
+approval decision for each listed issue that clears every gate. Validate the
+whole explicit set before changing any label, then mutate eligible issues
+serially. List every failure; never stop gate evaluation at the first one.
+
+An unattended/headless invocation is not owner authorization merely because its
+prompt names `$approve`. It may advance only an issue whose effective tier is
+`auto`, either from policy or the verified owner override below. A `judge`
+verdict is advisory while the hosted judge remains in shadow mode, and both
+`judge` and `human` must stop at Plan until the owner explicitly invokes the
+issue, confirms an itemized sweep, or validly pre-approves that issue.
 
 Restrict `--note` and `--skip-adr` to one explicitly named issue. Require a non-empty `--note` with `--skip-adr`; never silently bypass the ADR gate. Do not combine issue numbers, `--note`, or `--skip-adr` with `--sweep`.
 
@@ -68,6 +78,7 @@ Parse exact H2 sections. Refuse duplicate managed headers. Require these non-emp
 - `## Problem statement`
 - `## Design notes`
 - `## Implementation plan`
+- `## Declared surface`
 - `## Dogfood brief`
 
 Require Dogfood brief to be either a non-empty `N/A — <specific reason>` or all four fields `medium`, `prompt`, `surfaceUnderTest`, and `expectedArtifact`. Require `medium` to be exactly `drive`, `author`, or `build-layer`.
@@ -80,7 +91,10 @@ Inspect Design notes for ADR references. Treat a same-repository PR URL, an expl
 
 Read every referenced PR over REST and require `.merged == true`. List all unmerged or unreadable ADR PRs. Accept an ADR already present on the captured `origin/main` ref without requiring its historical PR. Refuse Design notes that say a new ADR is required but provide neither a landed ADR nor a draft PR reference.
 
-When `--skip-adr` is validly supplied, bypass only the unmerged-ADR failure. Run every other gate normally.
+When `--skip-adr` is validly supplied, bypass only the unmerged-ADR failure.
+Run every other gate normally. The override never bypasses ADR approval
+routing: work that adds, changes, or is gated on an ADR still requires the
+owner's decision.
 
 ### Model and blocked labels
 
@@ -117,13 +131,86 @@ Parse issue references only from the exact `## Depends on` section. Read every r
 
 When `## Sub-issues` is non-empty, require the parent Implementation plan to contain coordination or integration only. Refuse net-new implementation work not delegated to a listed child. A pure umbrella can advance to Ready, but mark it `umbrella — do not dispatch`; it becomes Done only after its children and integration condition are complete.
 
+## Declared surface and approval routing
+
+For a validated pure umbrella, require `## Declared surface` to contain exactly
+`N/A — pure umbrella; no implementation PR`. Route it to `human`, skip
+path-policy resolution because there is no implementation path, and retain the
+`umbrella — do not dispatch` marker.
+
+For every implementable issue, parse `## Declared surface` as exactly one
+non-empty fenced block with one gitwildmatch glob per line and no prose or
+bullets inside the fence. Reject comments, negation, absolute paths,
+backslashes, control characters, empty/`.`/`..` segments, duplicate globs,
+or an escape-hatch declaration such as bare `**` or `crates/**`. Accept
+only concrete repository paths or a literal directory prefix followed by one
+final `/**`; reject `*`, `?`, and character classes anywhere else so a
+single declaration cannot silently cross approval-policy roots. Declared globs
+are untrusted data: never interpolate them into a shell command or pass them to
+Git as path arguments.
+
+Collect the concrete repository targets already validated by the freshness
+gate, stripping only the explicit `(create)` marker. Put the surface and target
+lists in separate temporary files with `apply_patch`, then run:
+
+```text
+python3 -I .agents/skills/approve/scripts/resolve_approval_tier.py \
+  --repo <absolute-repository-root> \
+  --ref <captured-origin-main-sha> \
+  --surface-file /tmp/aether-approval-surface-<N>.txt \
+  --targets-file /tmp/aether-approval-targets-<N>.txt
+```
+
+The resolver loads the policy and tracked paths from the captured ref, uses the
+same matcher as the Reconciler, requires every concrete target to be covered,
+rejects orphan globs, and returns stable JSON with the most restrictive tier and
+path evidence. Treat any resolver, policy, Git, or JSON failure as an approval
+gate failure; never substitute a default from memory.
+
+Apply the ADR hard gate before using the returned policy tier. Route to
+`human` when Design notes contain a non-empty line beginning `ADR flag:` or
+the declared/target paths touch `docs/adr/`. Ordinary citations to existing
+ADRs do not trigger this routing gate; they remain inputs to the separate ADR
+merge-readiness check above.
+
+For non-ADR work carrying `approval:pre-approved`, page the issue timeline and
+inspect the most recent `labeled` event for that exact label. Treat the override
+as valid only when its actor is the repository owner. A label applied by an
+agent or any other actor grants no authority; report the actor, retain the
+policy tier, and never infer ownership from the label's current presence alone.
+A timeline/API failure makes the override unavailable rather than verified.
+
+A valid owner override changes the effective tier to `auto` but does not alter
+the recorded policy tier and never bypasses a structural, freshness,
+dependency, model, or other gate. The ADR hard gate is evaluated first and has
+no override: ADR-bearing work remains human-routed even when the owner applied
+`approval:pre-approved`.
+
+For non-ADR work without a valid override, use the resolver's
+`auto|judge|human` result:
+
+- `auto`: every passing invocation may advance to Ready. The hosted tick may
+  dispatch only this tier, and the headless approval run must resolve it again
+  before writing Ready rather than trusting the dispatcher.
+- `judge`: a user-issued invocation or confirmed sweep may advance. An
+  unattended run stops at Plan; the current judge is shadow-only, so even a
+  fresh passing verdict is evidence, not mutation authority.
+- `human`: only a user-issued invocation or confirmed sweep may advance.
+
+Record the policy tier, effective tier, ADR override, pre-approval actor/result,
+captured policy SHA, and authority source in every plan and rollup. Tier routing
+happens after all structural gates; no tier or owner override weakens a failed
+gate.
+
 ## Re-read before mutation
 
-Retain each passing issue's validated identity, body, labels, Plan timestamp, and captured `origin/main` SHA. Immediately before a Ready transition:
+Retain each passing issue's validated identity, body, labels, Plan timestamp,
+declared surface, resolved tier/evidence, authority source, and captured
+`origin/main` SHA. Immediately before a Ready transition:
 
 1. Re-read number, title, body, state, and labels.
 2. If identity, body, phase, gate-relevant labels, or dependency state changed, rerun all affected gates. Do not write from the stale snapshot.
-3. Fetch again when the approval run crossed a user-confirmation turn or when remote freshness is uncertain. Re-run Tier A and Tier B against the new SHA.
+3. Fetch again when the approval run crossed a user-confirmation turn or when remote freshness is uncertain. Re-run Tier A, Tier B, declared-surface validation, ADR routing, policy resolution, and any pre-approval timeline verification against the new SHA.
 4. Build the complete label JSON from the fresh labels, preserving every non-`phase:*` label and appending exactly `phase:ready`.
 5. Replace labels in one REST `PUT`. Never perform a remove-then-add phase transition.
 6. Re-read and verify exactly one `phase:ready` label. On an uncertain mutation response, re-read before retrying.
@@ -150,7 +237,10 @@ If the phase transition succeeds and the required comment fails, retry only the 
 
 ## Explicit batches
 
-Validate all named issues before the first mutation. Print passing and failing issues with size, model, umbrella status, and every reason. Apply Ready transitions only to passing issues, serially, with the pre-write re-read.
+Validate all named issues before the first mutation. Print passing and failing
+issues with size, model, policy/effective tier and authority, umbrella status, and every
+reason. Apply Ready transitions only to passing and authorized issues, serially,
+with the pre-write re-read.
 
 If a mutation fails, re-read that issue to determine whether it succeeded. Stop later writes when the failure appears systemic, such as authentication or rate limiting; otherwise continue independent issues and report the exact partial result. Never describe a partially applied batch as wholly approved.
 
@@ -160,7 +250,7 @@ Discover open issues carrying `phase:plan` through the paginated REST issues end
 
 Print:
 
-- every issue proposed for `Plan → Ready`, with title, size, model, and umbrella marker;
+- every issue proposed for `Plan → Ready`, with title, size, model, policy/effective tier, ADR/pre-approval override, and umbrella marker;
 - every dropped issue with all failure reasons;
 - the captured `origin/main` SHA;
 - a plain confirmation request stating that no label write has happened.
@@ -169,6 +259,10 @@ End the turn. On the user's next-message confirmation, rediscover and revalidate
 
 ## Completion
 
-Report each issue's old and final phase, size/model labels, ADR result, dependency result, umbrella status, any override comment, and every skipped or failed mutation. Point eligible non-umbrella issues to `$implement <N>` only as a next action; do not invoke it.
+Report each issue's old and final phase, size/model labels, declared surface,
+policy/effective tier and authority source, ADR/pre-approval result, dependency result, umbrella
+status, any override comment, and every skipped or failed mutation. Point
+eligible non-umbrella issues to `$implement <N>` only as a next action; do not
+invoke it.
 
 Never edit an issue body, repair missing scope artifacts, resolve Side findings, dispatch an agent, create a worktree, open a PR, close an umbrella, notify another person, or merge anything from this skill.

--- a/.agents/skills/approve/scripts/resolve_approval_tier.py
+++ b/.agents/skills/approve/scripts/resolve_approval_tier.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Validate a Plan surface and resolve its tier from one captured Git commit.
+
+Matcher and policy semantics are loaded from scripts/surface-match.py at the
+captured ref. This wrapper adds Codex's Plan-to-Ready validation and evidence;
+it deliberately does not carry a second glob implementation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+
+CANONICAL_PATH = "scripts/surface-match.py"
+POLICY_PATH = ".github/approval-policy.yml"
+FULL_SHA = re.compile(r"(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})\Z")
+SAFE_SURFACE = re.compile(r"[A-Za-z0-9._/*\-]+\Z")
+SAFE_TARGET = re.compile(r"[A-Za-z0-9._/\-]+\Z")
+
+
+class ResolverError(RuntimeError):
+    """A deterministic, user-actionable resolver failure."""
+
+
+def _run_git(repo: Path, arguments: Sequence[str], *, operation: str) -> bytes:
+    # A local replacement ref, alternate object directory, or injected Git
+    # config must not substitute a different tree for the captured origin/main
+    # object we are about to execute. These reads need no Git-specific ambient
+    # state, so strip it all and disable replacement objects redundantly in both
+    # the environment and argv.
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_")
+    }
+    environment["GIT_NO_REPLACE_OBJECTS"] = "1"
+    try:
+        completed = subprocess.run(
+            ["git", "--no-replace-objects", "-C", str(repo), *arguments],
+            check=False,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as error:
+        raise ResolverError(f"cannot run git while {operation}: {error}") from error
+    if completed.returncode:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise ResolverError(
+            f"git failed while {operation} (exit {completed.returncode}): "
+            f"{detail or 'no diagnostic'}"
+        )
+    return completed.stdout
+
+
+def _validate_surface(pattern: str, *, context: str) -> None:
+    if not pattern:
+        raise ResolverError(f"{context}: surface entry is empty")
+    if not pattern.isascii() or SAFE_SURFACE.fullmatch(pattern) is None:
+        raise ResolverError(f"{context}: surface contains unsupported characters: {pattern!r}")
+    if pattern.startswith(("/", "-", "!", "#")) or pattern.endswith("/"):
+        raise ResolverError(f"{context}: surface must be a positive repository-relative pattern: {pattern!r}")
+    if "//" in pattern:
+        raise ResolverError(f"{context}: surface contains an empty path segment: {pattern!r}")
+    if any(segment in {"", ".", ".."} for segment in pattern.split("/")):
+        raise ResolverError(f"{context}: surface contains an unsafe path segment: {pattern!r}")
+    if pattern in {"**", "crates/**"}:
+        raise ResolverError(f"{context}: escape-hatch surface is not allowed: {pattern!r}")
+
+    if "*" not in pattern:
+        return
+    if pattern.endswith("/**") and pattern.count("*") == 2:
+        return
+    raise ResolverError(
+        f"{context}: surface must be a concrete path or a literal directory prefix "
+        f"followed by '/**': {pattern!r}"
+    )
+
+
+def _validate_target(path: str, *, context: str) -> None:
+    if not path:
+        raise ResolverError(f"{context}: target is empty")
+    if not path.isascii() or SAFE_TARGET.fullmatch(path) is None:
+        raise ResolverError(
+            f"{context}: target must contain only ASCII letters, digits, '.', '_', '/', and '-': {path!r}"
+        )
+    if path.startswith(("/", "-")) or path.endswith("/"):
+        raise ResolverError(f"{context}: target must be a concrete repository-relative path: {path!r}")
+    segments = path.split("/")
+    if any(segment in {"", ".", ".."} for segment in segments):
+        raise ResolverError(f"{context}: target contains an unsafe path segment: {path!r}")
+    if segments[0] == ".git":
+        raise ResolverError(f"{context}: target cannot name Git's private directory: {path!r}")
+
+
+def _read_list(path: Path, *, kind: str) -> list[str]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as error:
+        raise ResolverError(f"cannot read {kind} file {path}: {error}") from error
+
+    entries: list[str] = []
+    seen: set[str] = set()
+    for line_number, line in enumerate(lines, start=1):
+        entry = line.strip()
+        if not entry:
+            continue
+        context = f"{path}:{line_number}"
+        if entry.startswith("#"):
+            raise ResolverError(f"{context}: comments are not allowed in {kind} files")
+        if kind == "surface":
+            _validate_surface(entry, context=context)
+        else:
+            _validate_target(entry, context=context)
+        if entry in seen:
+            raise ResolverError(f"{context}: duplicate {kind} entry: {entry!r}")
+        seen.add(entry)
+        entries.append(entry)
+
+    label = "surface patterns" if kind == "surface" else "concrete paths"
+    if not entries:
+        raise ResolverError(f"{kind} file {path} contains no {label}")
+    return entries
+
+
+def _load_snapshot(repo_argument: str, ref_argument: str) -> tuple[str, dict[str, Any], Any, list[str]]:
+    try:
+        repo = Path(repo_argument).expanduser().resolve(strict=True)
+    except OSError as error:
+        raise ResolverError(f"repository path does not exist: {repo_argument!r}: {error}") from error
+    if not repo.is_dir():
+        raise ResolverError(f"repository path is not a directory: {repo}")
+    if FULL_SHA.fullmatch(ref_argument) is None:
+        raise ResolverError("--ref must be a full 40- or 64-character hexadecimal commit SHA")
+
+    ref = ref_argument.lower()
+    if _run_git(repo, ["rev-parse", "--is-inside-work-tree"], operation="validating the repository").strip() != b"true":
+        raise ResolverError(f"path is not a Git worktree: {repo}")
+    resolved = _run_git(
+        repo,
+        ["rev-parse", "--verify", "--end-of-options", f"{ref}^{{commit}}"],
+        operation=f"validating commit {ref}",
+    ).decode("ascii", errors="strict").strip().lower()
+    if resolved != ref:
+        raise ResolverError(f"--ref must identify the commit object itself (resolved {ref} to {resolved})")
+
+    canonical_bytes = _run_git(
+        repo,
+        ["cat-file", "blob", f"{ref}:{CANONICAL_PATH}"],
+        operation=f"reading {CANONICAL_PATH} at {ref}",
+    )
+    policy_bytes = _run_git(
+        repo,
+        ["cat-file", "blob", f"{ref}:{POLICY_PATH}"],
+        operation=f"reading {POLICY_PATH} at {ref}",
+    )
+    try:
+        canonical_source = canonical_bytes.decode("utf-8")
+        policy_text = policy_bytes.decode("utf-8")
+    except UnicodeError as error:
+        raise ResolverError(f"canonical matcher or policy at {ref} is not UTF-8") from error
+
+    namespace: dict[str, Any] = {
+        "__name__": "aether_captured_surface_match",
+        "__file__": f"{ref}:{CANONICAL_PATH}",
+    }
+    try:
+        exec(compile(canonical_source, namespace["__file__"], "exec"), namespace)
+    except Exception as error:
+        raise ResolverError(f"cannot load canonical matcher at {ref}: {error}") from error
+
+    required = {
+        "compile_glob",
+        "compile_surface_glob",
+        "load_policy_text",
+        "tier_of",
+        "tier_of_surface",
+        "rule_intersects_subtree",
+        "rule_covers_subtree",
+    }
+    missing = sorted(name for name in required if not callable(namespace.get(name)))
+    rank = namespace.get("RANK")
+    if missing or rank != {"auto": 0, "judge": 1, "human": 2}:
+        raise ResolverError(
+            f"canonical matcher at {ref} lacks the required resolver API"
+            + (f": {', '.join(missing)}" if missing else "")
+        )
+
+    policy = namespace["load_policy_text"](policy_text)
+    if policy is None:
+        raise ResolverError(f"{POLICY_PATH} at {ref} is empty or malformed")
+
+    tree = _run_git(
+        repo,
+        ["ls-tree", "-r", "-z", "--name-only", ref],
+        operation=f"listing tracked paths at {ref}",
+    )
+    try:
+        tracked = sorted(entry.decode("utf-8") for entry in tree.split(b"\0") if entry)
+    except UnicodeError as error:
+        raise ResolverError(f"the tree at {ref} contains a non-UTF-8 path") from error
+    if not tracked or len(tracked) != len(set(tracked)):
+        raise ResolverError(f"the tree at {ref} is empty or contains duplicate paths")
+
+    return ref, namespace, policy, tracked
+
+
+def resolve(repo: str, ref: str, surface_file: str, targets_file: str) -> dict[str, object]:
+    resolved_ref, canonical, policy, tracked = _load_snapshot(repo, ref)
+    surfaces = _read_list(Path(surface_file), kind="surface")
+    targets = _read_list(Path(targets_file), kind="target")
+    universe = sorted(set(tracked).union(targets))
+    target_set = set(targets)
+    matchers = [(surface, canonical["compile_surface_glob"](surface)) for surface in surfaces]
+
+    for surface, _ in matchers:
+        if "*" not in surface and surface not in universe:
+            raise ResolverError(
+                f"concrete surface path is not tracked or planned at {resolved_ref}: {surface!r}; "
+                "use a literal directory prefix ending in '/**' for a subtree"
+            )
+
+    uncovered = [path for path in targets if not any(matcher.match(path) for _, matcher in matchers)]
+    if uncovered:
+        raise ResolverError("targets are outside the declared surface: " + ", ".join(map(repr, uncovered)))
+
+    default, rules = policy
+    surface_results: list[dict[str, object]] = []
+    allowed_paths: set[str] = set()
+    for surface, matcher in matchers:
+        matched_paths = [path for path in universe if matcher.match(path)]
+        if not matched_paths:
+            raise ResolverError(
+                f"surface pattern matches no tracked or target path at {resolved_ref}: {surface!r}"
+            )
+        allowed_paths.update(matched_paths)
+        tier = canonical["tier_of_surface"](surface, policy)
+
+        prefix = surface if "*" not in surface else surface[:-3].rstrip("/")
+        intersecting = [
+            {"glob": glob, "tier": rule_tier}
+            for glob, _, rule_tier in rules
+            if canonical["rule_intersects_subtree"](glob, prefix)
+        ]
+        default_applies = not any(
+            canonical["rule_covers_subtree"](glob, prefix) for glob, _, _ in rules
+        )
+
+        surface_results.append(
+            {
+                "default_applies": default_applies,
+                "glob": surface,
+                "matched_path_count": len(matched_paths),
+                "matched_policy_rules": sorted(intersecting, key=lambda item: (item["glob"], item["tier"])),
+                "matched_targets": sorted(path for path in matched_paths if path in target_set),
+                "tier": tier,
+            }
+        )
+
+    target_results = []
+    for path in sorted(targets):
+        matches = [
+            {"glob": glob, "tier": rule_tier}
+            for glob, matcher, rule_tier in rules
+            if matcher.match(path)
+        ]
+        target_results.append(
+            {
+                "matched_policy_rules": sorted(matches, key=lambda item: (item["glob"], item["tier"])),
+                "path": path,
+                "surfaces": sorted(surface for surface, matcher in matchers if matcher.match(path)),
+                "tier": canonical["tier_of"](path, policy),
+            }
+        )
+
+    rank = canonical["RANK"]
+    overall = max((entry["tier"] for entry in surface_results), key=lambda tier: rank.get(tier, len(rank)))
+    return {
+        "default": default,
+        "ref": resolved_ref,
+        "surface_path_count": len(allowed_paths),
+        "surfaces": surface_results,
+        "targets": target_results,
+        "tier": overall,
+        "tracked_path_count": len(tracked),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="path to a Git worktree")
+    parser.add_argument("--ref", required=True, help="full hexadecimal commit SHA to inspect")
+    parser.add_argument("--surface-file", required=True, help="newline-delimited declared surface patterns")
+    parser.add_argument("--targets-file", required=True, help="newline-delimited concrete repository targets")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    try:
+        result = resolve(arguments.repo, arguments.ref, arguments.surface_file, arguments.targets_file)
+    except ResolverError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/approve/scripts/resolve_approval_tier.py
+++ b/.agents/skills/approve/scripts/resolve_approval_tier.py
@@ -2,8 +2,11 @@
 """Validate a Plan surface and resolve its tier from one captured Git commit.
 
 Matcher and policy semantics are loaded from scripts/surface-match.py at the
-captured ref. This wrapper adds Codex's Plan-to-Ready validation and evidence;
-it deliberately does not carry a second glob implementation.
+captured ref, which must be reachable from the local refs/remotes/origin/main —
+executing the matcher from an arbitrary fetched commit (a PR head, say) would
+hand the tier decision to that commit's author. This wrapper adds Codex's
+Plan-to-Ready validation and evidence; it deliberately does not carry a second
+glob implementation.
 """
 
 from __future__ import annotations
@@ -29,7 +32,7 @@ class ResolverError(RuntimeError):
     """A deterministic, user-actionable resolver failure."""
 
 
-def _run_git(repo: Path, arguments: Sequence[str], *, operation: str) -> bytes:
+def _git(repo: Path, arguments: Sequence[str], *, operation: str) -> subprocess.CompletedProcess[bytes]:
     # A local replacement ref, alternate object directory, or injected Git
     # config must not substitute a different tree for the captured origin/main
     # object we are about to execute. These reads need no Git-specific ambient
@@ -42,7 +45,7 @@ def _run_git(repo: Path, arguments: Sequence[str], *, operation: str) -> bytes:
     }
     environment["GIT_NO_REPLACE_OBJECTS"] = "1"
     try:
-        completed = subprocess.run(
+        return subprocess.run(
             ["git", "--no-replace-objects", "-C", str(repo), *arguments],
             check=False,
             env=environment,
@@ -51,6 +54,10 @@ def _run_git(repo: Path, arguments: Sequence[str], *, operation: str) -> bytes:
         )
     except OSError as error:
         raise ResolverError(f"cannot run git while {operation}: {error}") from error
+
+
+def _run_git(repo: Path, arguments: Sequence[str], *, operation: str) -> bytes:
+    completed = _git(repo, arguments, operation=operation)
     if completed.returncode:
         detail = completed.stderr.decode("utf-8", errors="replace").strip()
         raise ResolverError(
@@ -58,6 +65,33 @@ def _run_git(repo: Path, arguments: Sequence[str], *, operation: str) -> bytes:
             f"{detail or 'no diagnostic'}"
         )
     return completed.stdout
+
+
+UPSTREAM = "refs/remotes/origin/main"
+
+
+def _require_upstream_ancestry(repo: Path, ref: str) -> None:
+    # The captured commit's own scripts/surface-match.py is about to be
+    # executed, so the commit must be one origin/main actually published. Any
+    # fetched object — a hostile PR head included — passes the commit checks
+    # above; reachability from the remote-tracking ref is what makes it the
+    # owner's code rather than merely present in the object store.
+    _run_git(repo, ["rev-parse", "--verify", "--end-of-options", UPSTREAM], operation=f"resolving {UPSTREAM}")
+    completed = _git(
+        repo,
+        ["merge-base", "--is-ancestor", ref, UPSTREAM],
+        operation=f"checking that {ref} is reachable from {UPSTREAM}",
+    )
+    if completed.returncode == 1:
+        raise ResolverError(
+            f"--ref {ref} is not reachable from {UPSTREAM}; refusing to load its matcher and policy"
+        )
+    if completed.returncode:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise ResolverError(
+            f"git failed while checking ancestry of {ref} (exit {completed.returncode}): "
+            f"{detail or 'no diagnostic'}"
+        )
 
 
 def _validate_surface(pattern: str, *, context: str) -> None:
@@ -150,6 +184,7 @@ def _load_snapshot(repo_argument: str, ref_argument: str) -> tuple[str, dict[str
     ).decode("ascii", errors="strict").strip().lower()
     if resolved != ref:
         raise ResolverError(f"--ref must identify the commit object itself (resolved {ref} to {resolved})")
+    _require_upstream_ancestry(repo, ref)
 
     canonical_bytes = _run_git(
         repo,

--- a/.agents/skills/approve/scripts/test_resolve_approval_tier.py
+++ b/.agents/skills/approve/scripts/test_resolve_approval_tier.py
@@ -69,17 +69,20 @@ class ResolverFixture:
         self._git("add", "--all")
         self._git("commit", "-q", "-m", "fixture")
         self.ref = self._git("rev-parse", "HEAD").stdout.strip()
+        # The resolver only executes a matcher reachable from origin/main.
+        self._git("update-ref", "refs/remotes/origin/main", self.ref)
 
     def close(self) -> None:
         self.temporary.cleanup()
 
-    def install_commit_replacement(self) -> None:
+    def install_commit_replacement(self) -> str:
         matcher = self.repo / "scripts" / "surface-match.py"
         matcher.write_text('raise RuntimeError("replacement matcher executed")\n', encoding="utf-8")
         self._git("add", "scripts/surface-match.py")
         self._git("commit", "-q", "-m", "hostile replacement")
         replacement = self._git("rev-parse", "HEAD").stdout.strip()
         self._git("replace", self.ref, replacement)
+        return replacement
 
     def _git(self, *arguments: str) -> subprocess.CompletedProcess[str]:
         completed = subprocess.run(
@@ -91,7 +94,9 @@ class ResolverFixture:
         self.test.assertEqual(completed.returncode, 0, completed.stderr)
         return completed
 
-    def invoke(self, surfaces: list[str], targets: list[str]) -> subprocess.CompletedProcess[str]:
+    def invoke(
+        self, surfaces: list[str], targets: list[str], ref: str | None = None
+    ) -> subprocess.CompletedProcess[str]:
         surface_file = self.root / "surfaces.txt"
         target_file = self.root / "targets.txt"
         surface_file.write_text("\n".join(surfaces) + ("\n" if surfaces else ""), encoding="utf-8")
@@ -104,7 +109,7 @@ class ResolverFixture:
                 "--repo",
                 str(self.repo),
                 "--ref",
-                self.ref,
+                ref if ref is not None else self.ref,
                 "--surface-file",
                 str(surface_file),
                 "--targets-file",
@@ -223,6 +228,15 @@ class ResolverTests(unittest.TestCase):
         result = self.success(["docs/guide/**"], ["docs/guide/page.md"])
         self.assertEqual(result["ref"], self.fixture.ref)
         self.assertEqual(result["tier"], "auto")
+
+    def test_ref_not_on_origin_main_is_refused(self) -> None:
+        # The hostile commit exists in the object store but origin/main never
+        # published it, so its matcher must not be loaded or executed.
+        hostile = self.fixture.install_commit_replacement()
+        completed = self.fixture.invoke(["docs/guide/**"], ["docs/guide/page.md"], ref=hostile)
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("not reachable from refs/remotes/origin/main", completed.stderr)
+        self.assertNotIn("replacement matcher executed", completed.stderr)
 
     def test_slashless_concrete_surface_is_root_anchored(self) -> None:
         result = self.success(["Cargo.lock"], ["Cargo.lock"])

--- a/.agents/skills/approve/scripts/test_resolve_approval_tier.py
+++ b/.agents/skills/approve/scripts/test_resolve_approval_tier.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Tests for the captured-ref Codex approval-tier resolver."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import resolve_approval_tier as resolver
+
+
+ROOT = Path(resolver.__file__).resolve().parents[4]
+CANONICAL_SOURCE = (ROOT / "scripts" / "surface-match.py").read_text(encoding="utf-8")
+POLICY = """\
+default: judge
+rules:
+  - glob: "/Cargo.toml"
+    tier: human
+  - glob: "crates/*/Cargo.toml"
+    tier: human
+  - glob: "crates/aether-data/**"
+    tier: human
+  - glob: "docs/adr/**"
+    tier: human
+  - glob: ".agents/**"
+    tier: human
+  - glob: "docs/guide/**"
+    tier: auto
+  - glob: "crates/aether-kit/**"
+    tier: auto
+  - glob: "crates/aether-capabilities/**"
+    tier: judge
+"""
+
+
+class ResolverFixture:
+    def __init__(self, test: unittest.TestCase, policy: str = POLICY) -> None:
+        self.test = test
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.repo = self.root / "repo"
+        self.repo.mkdir()
+        self._git("init", "-q")
+        self._git("config", "user.email", "resolver@example.invalid")
+        self._git("config", "user.name", "Resolver Test")
+
+        files = {
+            ".agents/skills/approve/SKILL.md": "approve\n",
+            ".github/approval-policy.yml": policy,
+            "Cargo.toml": "[workspace]\n",
+            "Cargo.lock": "# lock\n",
+            "crates/aether-capabilities/src/lib.rs": "cap\n",
+            "crates/aether-data/src/lib.rs": "data\n",
+            "crates/aether-kit/Cargo.toml": "[package]\n",
+            "crates/aether-kit/src/lib.rs": "kit\n",
+            "docs/adr/0001-example.md": "adr\n",
+            "docs/guide/page.md": "guide\n",
+            "scripts/surface-match.py": CANONICAL_SOURCE,
+            "unclassified.txt": "default\n",
+        }
+        for relative, contents in files.items():
+            path = self.repo / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(contents, encoding="utf-8")
+        self._git("add", "--all")
+        self._git("commit", "-q", "-m", "fixture")
+        self.ref = self._git("rev-parse", "HEAD").stdout.strip()
+
+    def close(self) -> None:
+        self.temporary.cleanup()
+
+    def install_commit_replacement(self) -> None:
+        matcher = self.repo / "scripts" / "surface-match.py"
+        matcher.write_text('raise RuntimeError("replacement matcher executed")\n', encoding="utf-8")
+        self._git("add", "scripts/surface-match.py")
+        self._git("commit", "-q", "-m", "hostile replacement")
+        replacement = self._git("rev-parse", "HEAD").stdout.strip()
+        self._git("replace", self.ref, replacement)
+
+    def _git(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        completed = subprocess.run(
+            ["git", "-C", str(self.repo), *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.test.assertEqual(completed.returncode, 0, completed.stderr)
+        return completed
+
+    def invoke(self, surfaces: list[str], targets: list[str]) -> subprocess.CompletedProcess[str]:
+        surface_file = self.root / "surfaces.txt"
+        target_file = self.root / "targets.txt"
+        surface_file.write_text("\n".join(surfaces) + ("\n" if surfaces else ""), encoding="utf-8")
+        target_file.write_text("\n".join(targets) + ("\n" if targets else ""), encoding="utf-8")
+        return subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                str(Path(resolver.__file__)),
+                "--repo",
+                str(self.repo),
+                "--ref",
+                self.ref,
+                "--surface-file",
+                str(surface_file),
+                "--targets-file",
+                str(target_file),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+
+class ResolverTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = ResolverFixture(self)
+
+    def tearDown(self) -> None:
+        self.fixture.close()
+
+    def success(self, surfaces: list[str], targets: list[str]) -> dict[str, object]:
+        completed = self.fixture.invoke(surfaces, targets)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        return json.loads(completed.stdout)
+
+    def test_auto_judge_human_and_default(self) -> None:
+        cases = [
+            (["docs/guide/**"], ["docs/guide/page.md"], "auto"),
+            (["crates/aether-capabilities/src/**"], ["crates/aether-capabilities/src/lib.rs"], "judge"),
+            ([".agents/skills/approve/SKILL.md"], [".agents/skills/approve/SKILL.md"], "human"),
+            (["unclassified.txt"], ["unclassified.txt"], "judge"),
+        ]
+        for surfaces, targets, expected in cases:
+            with self.subTest(surfaces=surfaces):
+                result = self.success(surfaces, targets)
+                self.assertEqual(result["tier"], expected)
+                self.assertEqual(result["default"], "judge")
+
+    def test_subtree_resolution_is_set_sound(self) -> None:
+        cases = [
+            (["crates/aether-kit/src/**"], ["crates/aether-kit/src/lib.rs"], "auto"),
+            (["crates/aether-kit/**"], ["crates/aether-kit/src/lib.rs"], "human"),
+            (["docs/**"], ["docs/guide/page.md"], "human"),
+            (["new-top/**"], ["new-top/new.txt"], "judge"),
+        ]
+        for surfaces, targets, expected in cases:
+            with self.subTest(surfaces=surfaces):
+                self.assertEqual(self.success(surfaces, targets)["tier"], expected)
+
+    def test_mixed_surface_uses_most_restrictive(self) -> None:
+        result = self.success(
+            ["docs/guide/**", "crates/aether-data/src/lib.rs"],
+            ["docs/guide/new.md", "crates/aether-data/src/lib.rs"],
+        )
+        self.assertEqual(result["tier"], "human")
+        self.assertEqual([surface["tier"] for surface in result["surfaces"]], ["auto", "human"])
+
+    def test_output_carries_canonical_evidence(self) -> None:
+        result = self.success(["crates/aether-kit/**"], ["crates/aether-kit/src/lib.rs"])
+        surface = result["surfaces"][0]
+        self.assertTrue(surface["default_applies"] is False)
+        self.assertIn(
+            {"glob": "crates/*/Cargo.toml", "tier": "human"},
+            surface["matched_policy_rules"],
+        )
+        self.assertEqual(result["targets"][0]["tier"], "auto")
+        self.assertEqual(surface["tier"], "human")
+
+    def test_uncovered_target_and_orphan_surface_fail(self) -> None:
+        completed = self.fixture.invoke(["docs/guide/**"], ["crates/aether-data/src/lib.rs"])
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("outside the declared surface", completed.stderr)
+
+        completed = self.fixture.invoke(
+            ["docs/guide/**", "missing/**"],
+            ["docs/guide/page.md"],
+        )
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("matches no tracked or target path", completed.stderr)
+
+    def test_empty_inputs_and_directory_as_concrete_path_fail(self) -> None:
+        for surfaces, targets, message in [
+            ([], ["docs/guide/page.md"], "contains no surface patterns"),
+            (["docs/guide/**"], [], "contains no concrete paths"),
+            (["docs/guide"], ["docs/guide/page.md"], "not tracked or planned"),
+        ]:
+            with self.subTest(surfaces=surfaces, targets=targets):
+                completed = self.fixture.invoke(surfaces, targets)
+                self.assertEqual(completed.returncode, 2)
+                self.assertIn(message, completed.stderr)
+
+    def test_unsafe_or_cross_root_surface_fails(self) -> None:
+        for surface, message in [
+            ("../**", "unsafe path segment"),
+            ("**", "escape-hatch"),
+            ("crates/**", "escape-hatch"),
+            ("docs/*", "literal directory prefix"),
+            ("crates/aether-*/future/**", "literal directory prefix"),
+            ("# docs/guide/**", "comments are not allowed"),
+        ]:
+            with self.subTest(surface=surface):
+                completed = self.fixture.invoke([surface], ["docs/guide/page.md"])
+                self.assertEqual(completed.returncode, 2)
+                self.assertIn(message, completed.stderr)
+
+    def test_malformed_policy_fails(self) -> None:
+        self.fixture.close()
+        self.fixture = ResolverFixture(
+            self,
+            'default: judge\nrules:\n  - glob: "docs/guide/**"\n    tier: owner\n',
+        )
+        completed = self.fixture.invoke(["docs/guide/**"], ["docs/guide/page.md"])
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("empty or malformed", completed.stderr)
+
+    def test_local_replace_ref_cannot_substitute_captured_commit(self) -> None:
+        self.fixture.install_commit_replacement()
+        result = self.success(["docs/guide/**"], ["docs/guide/page.md"])
+        self.assertEqual(result["ref"], self.fixture.ref)
+        self.assertEqual(result["tier"], "auto")
+
+    def test_slashless_concrete_surface_is_root_anchored(self) -> None:
+        result = self.success(["Cargo.lock"], ["Cargo.lock"])
+        self.assertEqual(result["tier"], "judge")
+
+        completed = self.fixture.invoke(["Cargo.lock"], [".agents/Cargo.lock"])
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("outside the declared surface", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/scope/SKILL.md
+++ b/.agents/skills/scope/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scope
-description: "Walk one Aether issue, an explicit issue set, or the Backlog sweep from Define through Design and Plan. Use to write and safely reconcile scope-managed issue sections, split oversized work, and stamp phase, size, and implementation-model labels without implementing or approving the work."
+description: "Walk one Aether issue, an explicit issue set, or the Backlog sweep from Define through Design and Plan. Use to write and safely reconcile scope-managed issue sections, emit the declared implementation surface, split oversized work, and stamp phase, size, and implementation-model labels without implementing or approving the work."
 ---
 
 # Scope
@@ -57,9 +57,16 @@ Handle eligible states as follows:
 - Backlog: start Define and reconcile to `phase:define` before writing scope artifacts.
 - `phase:define`, `phase:design`, or `phase:plan`: resume at the earliest incomplete phase consistent with the label. Refuse an upstream-section gap hidden by a later label and ask for an explicit earlier `--phase`.
 - `phase:bounced`: require exactly one `bounce-to:define|design|plan`. Use the explicit `--phase` when supplied, otherwise use the bounce target. Before resuming, replace the full label set in one REST `PUT`, excluding every `phase:*` and `bounce-to:*` label and appending the target phase. Note an explicit override of the recorded target.
-- `phase:plan` with all required artifacts, exactly one valid `size:s|m|l`, exactly one valid implementation `model:*`, and no `--phase`: report that the issue is already scoped and make no write. If the body is complete but either routing label is missing or invalid, rerun Plan's routing decision and repair the final label set.
+- `phase:plan` with all required artifacts, a non-empty valid Declared surface (or the exact pure-umbrella exception below), exactly one valid `size:s|m|l`, exactly one valid implementation `model:*`, and no `--phase`: report that the issue is already scoped and make no write. If the body is complete but either routing label is missing or invalid, rerun Plan's routing decision and repair the final label set.
 
 When forcing Define or Design on an issue still within the scope phases, clear stale `size:*` and `model:*` labels while atomically setting the requested phase. Recompute them only after Plan succeeds.
+
+When an explicit Plan rewrite or incomplete-Plan repair starts from
+`phase:plan`, first atomically move the issue to `phase:design` and clear
+stale size/model labels, then write Plan. The final reconcile creates a fresh
+`phase:plan` label event only after every artifact is verified; that event is
+the freshness timestamp and wakes a new hosted judge/auto-approval pass. Do not
+cycle the phase for a body-identical repair of size/model labels alone.
 
 ## Own and preserve body sections
 
@@ -71,11 +78,12 @@ Own exactly these H2 sections:
 ## Implementation plan
 ## Sub-issues
 ## Depends on
+## Declared surface
 ## Dogfood brief
 ## Side findings
 ```
 
-Treat duplicate managed H2 headers as an invalid body and stop. Preserve every other section, comment, and user-authored byte verbatim. Replace an existing managed span in place. Append a missing managed section in the order above. Omit `Sub-issues`, `Depends on`, and `Side findings` when empty; never omit the four required Problem, Design, Implementation, and Dogfood sections at completed Plan.
+Treat duplicate managed H2 headers as an invalid body and stop. Preserve every other section, comment, and user-authored byte verbatim. Replace an existing managed span in place. Append a missing managed section in the order above. Omit `Sub-issues`, `Depends on`, and `Side findings` when empty; never omit the five required Problem, Design, Implementation, Declared surface, and Dogfood sections at completed Plan.
 
 Apply this guard before every full-body `PATCH`:
 
@@ -125,7 +133,18 @@ Treat a new load-bearing decision affecting public traits, wire formats, actor l
 - If a draft ADR PR already exists, link it in Design notes and continue; `$approve` will require it to be merged.
 - If a new ADR must be authored, write the grounded Design notes, remain at `phase:design`, and hand off `$adr <title>`. Resume Design after the ADR is available to cite.
 
-After verifying a complete Design write with no unresolved ADR boundary, atomically reconcile to `phase:plan`.
+When the issue adds or changes an ADR, or implementation is gated on a new
+load-bearing decision, include a non-empty `ADR flag: <reason or ADR path>`
+line in Design notes and preserve it through Plan. Do not emit the flag for an
+ordinary citation to an existing ADR. The flag is approval-routing data:
+`$approve` sends flagged work to the owner before consulting path policy.
+
+After verifying a complete Design write with no unresolved ADR boundary, keep
+the issue at `phase:design` and continue into Plan. The final verified Plan
+body plus atomic phase/size/model label reconcile below is the only
+Design-to-Plan transition. This prevents the hosted judge from observing
+half-written Plan artifacts and makes the Plan label event a trustworthy
+freshness timestamp.
 
 ## Plan
 
@@ -151,6 +170,55 @@ Lift every cross-issue ordering precondition into:
 ```
 
 Do not bury dependency language only in plan prose.
+
+### Declared surface
+
+Emit `## Declared surface` on every completed Plan as one non-empty fenced
+list of gitwildmatch globs:
+
+````text
+## Declared surface
+
+```
+crates/aether-data/src/wire.rs
+crates/aether-data/tests/**
+```
+````
+
+Derive the list from every concrete path in the Implementation plan and Design
+notes. Use the narrowest honest bound: one edited file can name itself, while a
+genuinely crate-wide change can use `crates/<name>/**`. Every concrete target,
+including each `(create)` target, must be covered by at least one declared
+glob, and every glob must cover a concrete target or a tracked path at the
+captured ref.
+
+Keep only globs inside the fence—one per line, with no bullets, comments,
+negation, absolute paths, backslashes, empty/`.`/`..` segments, or control
+characters. To keep approval-tier resolution provable, use either a concrete
+repository path or a literal directory prefix followed by one final `/**`;
+do not put `*`, `?`, or character classes anywhere else. Split a broad
+declaration along the actual planned roots instead of using an escape-hatch
+glob such as `**` or `crates/**`. The same declaration feeds two independent
+guards: `$approve` resolves the most-restrictive `auto|judge|human` tier
+against `.github/approval-policy.yml`, and the Reconciler later holds a PR
+whose changed paths escape it.
+
+Tier resolution covers every path a subtree permits, not only files that happen
+to exist today. For example, `crates/aether-kit/**` also permits its
+`Cargo.toml` and therefore takes the human supply-chain tier; use
+`crates/aether-kit/src/**` only when the Plan genuinely excludes the manifest.
+
+A validated pure umbrella is the one exception because it has no implementation
+path and must never produce a PR. Emit exactly:
+
+```text
+## Declared surface
+
+N/A — pure umbrella; no implementation PR
+```
+
+`$approve` routes that exception to the owner, and `$implement` continues to
+reject the umbrella itself.
 
 ### Dogfood brief
 
@@ -235,12 +303,14 @@ Require each child to return one JSON object:
   "implementation_plan": string | null,
   "sub_issue_drafts": array,
   "depends_on": array,
+  "declared_surface": array | {"na_reason": "pure umbrella; no implementation PR"},
   "dogfood_brief": object | {"na_reason": string} | null,
   "side_findings": array,
   "size": "s" | "m" | "l" | null,
   "model": "haiku" | "sonnet" | "opus" | null,
   "model_reason": string | null,
   "adr": {"status": "covered" | "draft" | "required" | "none", "references": array, "title": string | null},
+  "adr_flag": string | null,
   "bounce_to": "define" | "design" | "plan" | null,
   "message": string
 }
@@ -252,6 +322,6 @@ Roll up every candidate as `plan`, `bounced`, `dropped`, or `failed`, with phase
 
 ## Completion
 
-Stop at `phase:plan`. Report the sections written, size/model labels, dependencies, ADR references, child issues, and side-finding count. Point to `$approve <N>` as the next lifecycle action.
+Stop at `phase:plan`. Report the sections written, declared surface, size/model labels, dependencies, ADR references/flag, child issues, and side-finding count. Point to `$approve <N>` as the next lifecycle action.
 
 Do not write production code, create an implementation worktree, open an implementation PR, approve the issue, dispatch implementation, or file Side findings from this skill.

--- a/.github/approval-policy.yml
+++ b/.github/approval-policy.yml
@@ -95,6 +95,10 @@ rules:
     tier: human
   - glob: "scripts/surface-match.py"
     tier: human
+  # The matcher's tests gate CI, so weakening them is the same conversation
+  # as weakening the matcher.
+  - glob: "scripts/test-surface-match.py"
+    tier: human
 
   # Submitted-and-expected-to-come-back-right. These advance on their own.
   - glob: "docs/guide/**"

--- a/.github/approval-policy.yml
+++ b/.github/approval-policy.yml
@@ -20,10 +20,10 @@
 # every `judge` surface becomes autonomous with no edit to this file.
 #
 # Globs use gitignore-style ** semantics (gitwildmatch): ** spans path segments,
-# * stays within one segment, ? is one non-slash character — the syntax
-# .gitignore already trains readers to expect. Both consumers evaluate these
-# same globs: the no-Claude reconciler over a stock matcher, and /approve as a
-# Claude reader.
+# * stays within one segment, ? is one non-slash character, and a leading /
+# anchors the repository root — the syntax .gitignore already trains readers to
+# expect. Every consumer evaluates these same globs: the no-model reconciler,
+# the Claude approval skill, and Codex's deterministic approval-tier resolver.
 #
 # Relaxing a tier is a one-line, owner-signed diff to this file, so the file's
 # git history is the delegation ladder's audit trail. `.github/approval-policy.yml`
@@ -67,20 +67,33 @@ rules:
   # New systems, and the supply chain. A new crate MUST add one of these, so this
   # is how "adding a new core system" is caught; a dependency change lands here
   # too, which is the same conversation.
-  - glob: "Cargo.toml"
+  - glob: "/Cargo.toml"
     tier: human
   - glob: "crates/*/Cargo.toml"
     tier: human
 
-  # Constitutional, and the harness's own machinery. Self-modification of the
-  # thing that decides what may self-modify is the owner's alone.
+  # Constitutional, and every supported agent harness's own machinery.
+  # Self-modification of the thing that decides what may self-modify is the
+  # owner's alone.
   - glob: "docs/adr/**"
     tier: human
+  - glob: "/AGENTS.md"
+    tier: human
+  - glob: "/CLAUDE.md"
+    tier: human
+  - glob: ".agents/**"
+    tier: human
   - glob: ".claude/**"
+    tier: human
+  - glob: ".codex/**"
+    tier: human
+  - glob: "/.mcp.json"
     tier: human
   - glob: ".github/workflows/**"
     tier: human
   - glob: ".github/approval-policy.yml"
+    tier: human
+  - glob: "scripts/surface-match.py"
     tier: human
 
   # Submitted-and-expected-to-come-back-right. These advance on their own.

--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -406,7 +406,9 @@ jobs:
             if [ -z "$surface" ]; then echo "none"; return; fi
             if grep -q '^[[:space:]]*docs/adr/' <<<"$surface"; then echo "adr"; return; fi
             printf '%s\n' "$surface" > "/tmp/surface-${1}.txt"
-            python3 scripts/surface-match.py --tier "/tmp/surface-${1}.txt" .github/approval-policy.yml
+            # Isolated mode keeps a changed checkout from shadowing stdlib imports
+            # beside this trusted matcher while the App token is in scope.
+            python3 -I scripts/surface-match.py --tier "/tmp/surface-${1}.txt" .github/approval-policy.yml
           }
 
           # Bucket advanceable items by priority tier. land bypasses the barrier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,20 @@ jobs:
           node-version: 22
       - run: node --test scripts/dogfood-token-table.test.mjs scripts/post-dogfood-rollup.test.mjs scripts/dogfood-action-contract.test.mjs
 
+  # The declared-surface matcher and the approval-tier resolver gate what the
+  # unattended fleet may advance, and their strict policy parser fails closed:
+  # a malformed .github/approval-policy.yml would silently stop every auto
+  # dispatch. These suites (which also parse the real policy file) are the loud
+  # version of that failure. Cheap and unconditional, like the dogfood
+  # contracts above.
+  approval-machinery:
+    name: Approval machinery
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 scripts/test-surface-match.py
+      - run: python3 .agents/skills/approve/scripts/test_resolve_approval_tier.py
+
   clippy:
     name: Clippy
     needs: changes
@@ -434,7 +448,7 @@ jobs:
   ci-pass:
     name: CI pass
     if: always()
-    needs: [ changes, fmt, dogfood-token-table, clippy, docs, marker-build, test, desktop, qodana ]
+    needs: [ changes, fmt, dogfood-token-table, approval-machinery, clippy, docs, marker-build, test, desktop, qodana ]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
@@ -442,6 +456,7 @@ jobs:
           echo "changes: ${{ needs.changes.result }}"
           echo "fmt:     ${{ needs.fmt.result }}"
           echo "dogfood-token-table: ${{ needs.dogfood-token-table.result }}"
+          echo "approval-machinery: ${{ needs.approval-machinery.result }}"
           echo "clippy:  ${{ needs.clippy.result }}"
           echo "docs:    ${{ needs.docs.result }}"
           echo "marker-build: ${{ needs.marker-build.result }}"
@@ -452,6 +467,7 @@ jobs:
           [[ "${{ needs.changes.result }}" == "success" ]] || fail=1
           [[ "${{ needs.fmt.result }}"     == "success" ]] || fail=1
           [[ "${{ needs.dogfood-token-table.result }}" == "success" ]] || fail=1
+          [[ "${{ needs.approval-machinery.result }}" == "success" ]] || fail=1
           [[ "${{ needs.clippy.result }}"  == "success" || "${{ needs.clippy.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.docs.result }}"    == "success" || "${{ needs.docs.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.marker-build.result }}" == "success" || "${{ needs.marker-build.result }}" == "skipped" ]] || fail=1

--- a/.github/workflows/reconciler.yml
+++ b/.github/workflows/reconciler.yml
@@ -393,7 +393,7 @@ jobs:
               # The one place gitwildmatch semantics are decided, shared with the
               # tick's approval-tier lookup (#3176). Prints the changed paths that
               # escape the declaration, tier-annotated; silent when contained.
-              escaping="$(python3 "${RUNNER_TEMP}/surface_match.py" \
+              escaping="$(python3 -I "${RUNNER_TEMP}/surface_match.py" \
                 "${RUNNER_TEMP}/globs.txt" "${RUNNER_TEMP}/changed.txt" "${RUNNER_TEMP}/policy.yml")"
 
               # Owner waiver: approval:surface-ok accepts the overreach, but only

--- a/docs/guide/contributing/agent-workflow.md
+++ b/docs/guide/contributing/agent-workflow.md
@@ -77,7 +77,7 @@ choice for an agent to resolve by guessing.
 | Backlog | An open idea not yet scoped | `scope` begins Define |
 | Define | The problem and success criteria are being established | `scope` |
 | Design | The approach, alternatives, affected surfaces, and ADR boundary are being established | `scope` |
-| Plan | An executable file-and-symbol-level plan and routing labels exist | `approve`, the human Plan-to-Ready gate |
+| Plan | An executable plan, declared surface, and routing labels exist | `approve`, the policy-routed Plan-to-Ready gate |
 | Ready | Approved and eligible for implementation | `implement` |
 | Building | A PR exists and its head is new or not CI-green; when the issue carries `## Declared surface`, an escaping diff also stays here | [Reconciler](https://github.com/iamacoffeepot/aether/blob/main/.github/workflows/reconciler.yml) |
 | QA | CI is green but review or dogfood still owes a verdict | Reconciler |
@@ -132,9 +132,38 @@ hosted review after the first green CI head.
 ## Planned implementation
 
 Planned work begins from a scoped GitHub issue. `scope` owns the structured
-Problem statement, Design notes, Implementation plan, dependencies, Dogfood
-brief, and optional side findings. `approve` verifies those artifacts and is
-the explicit Plan-to-Ready gate; it does not repair incomplete scope.
+Problem statement, Design notes, Implementation plan, dependencies, declared
+surface, Dogfood brief, and optional side findings. `approve` verifies those
+artifacts and is the explicit Plan-to-Ready gate; it does not repair incomplete
+scope.
+
+For non-ADR work, `approve` resolves the declared paths against
+`.github/approval-policy.yml` with most-restrictive-wins semantics over every
+path the declaration permits. A crate-wide subtree therefore includes its
+manifest tier even when the planned edit names only source today. `auto` work
+may advance without a new owner decision. `judge` work receives an independent
+verdict, but the judge is currently shadow-only, so the owner still confirms
+it. `human` work always waits for the owner. An explicit `ADR flag:` or a
+declared `docs/adr/**` edit takes the human route before policy lookup;
+ordinary citations to existing ADRs do not.
+
+The hosted tick resolves Plan surfaces with the same canonical matcher and
+dispatches an approval run only when the result is exactly `auto`. The
+headless gate resolves the tier again before writing Ready. `judge`, `human`,
+ADR-bearing, missing-surface, and unresolved-policy outcomes remain at Plan for
+their reader.
+
+The owner can pre-authorize one non-ADR issue at any earlier phase with
+`approval:pre-approved`. The approval gate verifies the actor of the latest
+matching label event, then treats a genuinely owner-applied label as an
+effective `auto` tier. It still runs every scope, freshness, dependency, and
+model gate; the label waives who must approve, not whether the Plan is valid.
+It never overrides the ADR hard gate, and an agent-applied copy of the label
+grants no authority.
+
+A pure umbrella has no implementation path or PR. It uses the exact
+`N/A — pure umbrella; no implementation PR` declaration, stays human-routed,
+and remains ineligible for `implement`.
 
 `implement` accepts Ready work, creates or adopts the one issue worktree
 described on [Worktrees and safety](worktrees-and-safety.md), follows the

--- a/docs/release/schema.md
+++ b/docs/release/schema.md
@@ -11,7 +11,7 @@ The lifecycle vocabulary is the `phase:*` label set, the canonical phase state f
 | Backlog   | *(no label)*      | Not yet picked up for this release                 | User             |
 | Define    | `phase:define`    | Problem framing in progress                        | User + `/scope`  |
 | Design    | `phase:design`    | Tradeoffs / options / ADR drafting                 | User + `/scope`  |
-| Plan      | `phase:plan`      | Sequencing, dependencies, sub-issues               | User + `/scope`  |
+| Plan      | `phase:plan`      | Sequencing, dependencies, declared surface          | User + `/scope`  |
 | Ready     | `phase:ready`     | Agent-ready; awaiting dispatch                     | Gate: `/approve` |
 | Building  | `phase:building`  | PR open; head unproven, CI not green, or declared-surface gate red | Reconciler |
 | QA        | `phase:qa`        | CI green; review/dogfood verdict owed              | Reconciler       |
@@ -36,6 +36,21 @@ Phase and every other axis ride labels — durable, REST-cheap, and the signal t
 | Bounce target | `bounce-to:plan\|design\|define` label  | `/bounce` (or a self-bouncing skill) | Present only while `phase:bounced`; `/scope` reads it to resume, then clears it |
 
 The ADR link lives in the issue's `## Design notes` section; per-issue auth budgets aren't persisted in v1 (a breach is noted in the self-bounce comment).
+
+At Plan, `/scope` emits a fenced `## Declared surface` glob list. `/approve`
+validates that it covers the planned targets and resolves the most restrictive
+`auto|judge|human` tier from `.github/approval-policy.yml` over every path
+each declaration can permit, including higher-tier files inside a declared
+subtree. An explicit `ADR flag:` or declared ADR edit is always human-routed.
+The hosted judge is currently shadow-only, so `judge` still requires owner
+confirmation; `auto` does not. The hosted tick dispatches an approval run only
+for an exact `auto` result, and the headless gate resolves the tier again
+before writing Ready. A verified owner-applied `approval:pre-approved` label
+makes a non-ADR issue's effective tier `auto` without bypassing any other gate;
+an agent-applied label has no authority, and ADR work has no override. The same
+declared surface later bounds the implementation diff. A validated pure umbrella instead carries the exact
+`N/A — pure umbrella; no implementation PR` declaration and routes to human
+approval; it never produces an implementation PR.
 
 `Approval gate` is a required status, so the reconciler posts it on every PR
 path. A PR with no closing issue, an issue outside the reconciler phase domain,

--- a/scripts/surface-match.py
+++ b/scripts/surface-match.py
@@ -20,6 +20,14 @@ but are repository-relative, so even a slashless concrete path is root-anchored.
 Bash has no such matcher and the runner ships no pathspec module, so the
 patterns are translated to regexes here.
 
+Declared surfaces come from issue bodies, so both modes hold every declared
+pattern to the validated grammar (a concrete path, or a literal directory
+prefix followed by one final `/**`). A pattern outside the grammar never
+reaches the regex engine: containment ignores it with a stderr note (so the
+paths it claimed to cover escape), and tier mode resolves it `human`. This
+also keeps an adversarial pattern such as a run of `**/` segments from
+backtracking the regex engine for hours.
+
 Two modes:
 
     surface-match.py <globs_file> <changed_file> [<policy_file>]
@@ -98,6 +106,29 @@ def compile_surface_glob(pattern):
     """Compile a repository-relative declared-surface pattern."""
 
     return compile_glob(pattern if pattern.startswith("/") else "/" + pattern)
+
+
+SURFACE_SAFE = re.compile(r"[A-Za-z0-9._/*\-]+\Z")
+
+
+def valid_surface_glob(pattern):
+    """Whether a declared-surface pattern is inside the validated grammar.
+
+    The same shape /approve's resolver accepts: a concrete repository-relative
+    path, or a literal directory prefix followed by one final `/**`. Declared
+    surfaces are untrusted issue-body text, so anything outside this grammar is
+    refused before it can reach the regex engine.
+    """
+
+    if SURFACE_SAFE.fullmatch(pattern) is None:
+        return False
+    if pattern.startswith(("/", "-", "!", "#")) or pattern.endswith("/"):
+        return False
+    if any(segment in {"", ".", ".."} for segment in pattern.split("/")):
+        return False
+    if "*" not in pattern:
+        return True
+    return pattern.endswith("/**") and pattern.count("*") == 2
 
 
 RANK = {"auto": 0, "judge": 1, "human": 2}
@@ -332,13 +363,23 @@ def main(argv):
             print("?")
             return
         # Most restrictive over every path each declaration permits. The policy
-        # default covers an empty surface, and unsafe wildcard shapes resolve
-        # human — only a proved `auto` result may dispatch unattended approval.
-        tiers = [tier_of_surface(p, policy) for p in read_globs(argv[2])] or [policy[0]]
+        # default covers an empty surface, and any declaration outside the
+        # validated grammar resolves human — only a proved `auto` result may
+        # dispatch unattended approval.
+        tiers = [
+            tier_of_surface(p, policy) if valid_surface_glob(p) else "human" for p in read_globs(argv[2])
+        ] or [policy[0]]
         print(max(tiers, key=lambda t: RANK.get(t, len(RANK))))
         return
 
-    matchers = [compile_surface_glob(g) for g in read_globs(argv[1])]
+    matchers = []
+    for glob in read_globs(argv[1]):
+        if valid_surface_glob(glob):
+            matchers.append(compile_surface_glob(glob))
+        else:
+            # Fail toward escape: the paths this pattern claimed to cover are
+            # reported as outside the surface rather than silently contained.
+            print(f"ignored out-of-grammar surface glob: {glob}", file=sys.stderr)
     policy = load_policy(argv[3]) if len(argv) > 3 else None
     for path in read_paths(argv[2]):
         if not any(m.match(path) for m in matchers):

--- a/scripts/surface-match.py
+++ b/scripts/surface-match.py
@@ -2,7 +2,7 @@
 """The declared-surface matcher — the one place gitwildmatch semantics are decided.
 
 An issue's `## Declared surface` is a block of globs; `.github/approval-policy.yml`
-maps globs to approval tiers. Two consumers need to evaluate those globs with
+maps globs to approval tiers. Three consumers need to evaluate those globs with
 identical semantics, and a second copy of the matcher would drift from the first:
 
   - reconciler.yml — does a merged PR's changed-file set stay inside the surface
@@ -10,11 +10,15 @@ identical semantics, and a second copy of the matcher would drift from the first
     escaping path with the tier it would have cost)
   - agent-tick.yml — what approval tier does a `phase:plan` issue's declared
     surface resolve to? (only an `auto` tier is dispatched for auto-approval)
+  - Codex approve — validate planned targets and independently re-resolve the
+    tier at the captured `origin/main` commit before writing Ready
 
-Globs are gitwildmatch (gitignore semantics): `**` spans path segments, `*` stays
-within one, `?` is one non-slash character, and a pattern naming a directory
-covers everything beneath it. Bash has no such matcher and the runner ships no
-pathspec module, so the patterns are translated to regexes here.
+Policy globs are gitwildmatch (gitignore semantics): `**` spans path segments,
+`*` stays within one, `?` is one non-slash character, and a pattern naming a
+directory covers everything beneath it. Declared surfaces use the same grammar
+but are repository-relative, so even a slashless concrete path is root-anchored.
+Bash has no such matcher and the runner ships no pathspec module, so the
+patterns are translated to regexes here.
 
 Two modes:
 
@@ -24,11 +28,15 @@ Two modes:
         tier column is annotation only — it reads `?` without a <policy_file>,
         or when the policy is empty (not on the default branch yet).
 
-    surface-match.py --tier <paths_file> <policy_file>
-        Tier resolution. Prints the single most restrictive tier (human > judge >
-        auto) over every path in <paths_file>, falling back to the policy's
-        `default` for a path no rule matches. An empty <paths_file> prints the
-        default: a surface that declares nothing can never resolve to `auto`.
+    surface-match.py --tier <surface_file> <policy_file>
+        Set-sound tier resolution over declared surface patterns. Exact paths and
+        literal subtrees ending in /** include every policy rule that can match
+        the path or anything beneath it, plus the policy default unless one rule
+        covers the entire set. This mirrors containment's directory-tail
+        semantics even for a planned path that does not exist yet. More complex
+        wildcard declarations fail closed to human. Prints the single most
+        restrictive result (human > judge > auto). An empty file prints the
+        policy default.
 """
 
 import re
@@ -37,7 +45,10 @@ import sys
 
 def compile_glob(pat):
     pat = pat.rstrip("/")
-    anchored = "/" in pat
+    root_anchored = pat.startswith("/")
+    if root_anchored:
+        pat = pat[1:]
+    anchored = root_anchored or "/" in pat
     out, i, n = [], 0, len(pat)
     while i < n:
         c = pat[i]
@@ -83,6 +94,12 @@ def compile_glob(pat):
     return re.compile(("^" if anchored else "^(?:.*/)?") + body + "(?:/.*)?$")
 
 
+def compile_surface_glob(pattern):
+    """Compile a repository-relative declared-surface pattern."""
+
+    return compile_glob(pattern if pattern.startswith("/") else "/" + pattern)
+
+
 RANK = {"auto": 0, "judge": 1, "human": 2}
 
 
@@ -94,7 +111,20 @@ def read_globs(path):
     ]
 
 
-def load_policy(path):
+def _parse_policy_scalar(raw):
+    raw = raw.strip()
+    if not raw:
+        return None
+    if raw[0] in "\"'":
+        if len(raw) < 2 or raw[-1] != raw[0] or raw[0] in raw[1:-1]:
+            return None
+        return raw[1:-1] or None
+    if "\"" in raw or "'" in raw:
+        return None
+    return raw
+
+
+def load_policy_text(text):
     # The file's shape is owned by this repo (a `default` tier plus a list of
     # {glob, tier} rules), so it is parsed with the standard library rather than
     # PyYAML, which the runner is not guaranteed to ship: a hand parser keeps the
@@ -102,36 +132,193 @@ def load_policy(path):
     # most-restrictive-wins over the matching rules, falling back to the file's
     # own `default` — the same resolution /approve applies at the Plan->Ready
     # edge, so both consumers quote the tier a path would actually cost.
-    text = open(path, encoding="utf-8").read()
     if not text.strip():
         # The fetch failed (no policy on the default branch yet), so the tier is
         # honestly unresolved rather than assumed.
         return None
-    default, rules, pending = "human", [], None
+    default, rules, pending, saw_rules = None, [], None, False
     for raw in text.splitlines():
         line = raw.split("#", 1)[0].rstrip()
-        m = re.match(r"^default:\s*(\w+)\s*$", line)
-        if m:
-            default = m.group(1)
+        if not line.strip():
             continue
-        m = re.match(r"""^\s*-\s*glob:\s*["']?(.+?)["']?\s*$""", line)
+        m = re.match(r"^default:\s*(.*?)\s*$", line)
         if m:
-            pending = m.group(1)
+            tier = _parse_policy_scalar(m.group(1))
+            if default is not None or tier not in RANK:
+                return None
+            default = tier
             continue
-        m = re.match(r"""^\s*tier:\s*["']?(\w+)["']?\s*$""", line)
+        if re.match(r"^rules:\s*$", line):
+            if saw_rules:
+                return None
+            saw_rules = True
+            continue
+        # This parser owns one intentionally small YAML shape. Exact indentation
+        # keeps a missing nested field from consuming an unrelated top-level key.
+        m = re.match(r"^  - glob:\s*(.*?)\s*$", line)
+        if m:
+            if not saw_rules or pending is not None:
+                return None
+            pending = _parse_policy_scalar(m.group(1))
+            if pending is None:
+                return None
+            continue
+        m = re.match(r"^    tier:\s*(.*?)\s*$", line)
         if m and pending is not None:
-            if m.group(1) in RANK:
-                rules.append((compile_glob(pending), m.group(1)))
+            tier = _parse_policy_scalar(m.group(1))
+            if tier not in RANK:
+                return None
+            if not valid_policy_glob(pending):
+                return None
+            try:
+                matcher = compile_glob(pending)
+            except re.error:
+                return None
+            rules.append((pending, matcher, tier))
             pending = None
+            continue
+        return None
+    if default is None or not saw_rules or pending is not None or not rules:
+        return None
     return default, rules
+
+
+def valid_policy_glob(pattern):
+    """Whether a policy glob is inside the canonical, provable grammar."""
+
+    if not pattern or not pattern.isascii() or pattern.startswith(("!", "#", "-")):
+        return False
+    if "\\" in pattern or any(ord(character) < 32 for character in pattern):
+        return False
+
+    body = pattern[1:] if pattern.startswith("/") else pattern
+    if not body or body.endswith("/") or "//" in body:
+        return False
+    segments = body.split("/")
+    if any(segment in {"", ".", ".."} for segment in segments):
+        return False
+    # `**` has recursive meaning only as a complete path segment. Rejecting
+    # ambiguous star runs keeps the subtree intersection proof aligned with the
+    # regex compiler instead of accepting a pattern the two could normalize
+    # differently.
+    return not any("**" in segment and segment != "**" for segment in segments)
+
+
+def load_policy(path):
+    return load_policy_text(open(path, encoding="utf-8").read())
 
 
 def tier_of(path, policy):
     if policy is None:
         return "?"
     default, rules = policy
-    matched = [tier for matcher, tier in rules if matcher.match(path)]
+    matched = [tier for _, matcher, tier in rules if matcher.match(path)]
     return max(matched, key=lambda t: RANK[t]) if matched else default
+
+
+META = "*?["
+
+
+def _segment_matches(pattern, literal):
+    # Prefixing with / selects compile_glob's repository-anchored form. A segment
+    # contains no slash, so the directory-tail suffix cannot create a false match.
+    return compile_glob("/" + pattern).match(literal) is not None
+
+
+def _normalise_pattern(pattern):
+    pattern = pattern.rstrip("/")
+    root_anchored = pattern.startswith("/")
+    if root_anchored:
+        pattern = pattern[1:]
+    return pattern, root_anchored
+
+
+def rule_intersects_subtree(rule_glob, surface_prefix):
+    """Whether a policy rule can match any path at/below a literal prefix.
+
+    This is exact for the matcher grammar at path-segment level. Once the fixed
+    surface prefix is consumed, arbitrary descendant segments may be chosen.
+    Once the policy pattern is consumed, compile_glob's directory-tail rule
+    covers any remaining fixed surface segments.
+    """
+
+    pattern, root_anchored = _normalise_pattern(rule_glob)
+    anchored = root_anchored or "/" in pattern
+    if not anchored:
+        # A slashless gitignore pattern can match a segment at any depth.
+        return True
+
+    policy_segments = pattern.split("/") if pattern else []
+    surface_segments = surface_prefix.split("/") if surface_prefix else []
+    seen = set()
+
+    def intersects(policy_index, surface_index):
+        state = (policy_index, surface_index)
+        if state in seen:
+            return False
+        seen.add(state)
+        if policy_index == len(policy_segments):
+            return True
+        if surface_index == len(surface_segments):
+            # Every validated remaining glob segment has at least one witness,
+            # which can be appended below the fixed surface prefix.
+            return True
+
+        segment = policy_segments[policy_index]
+        if segment == "**":
+            return intersects(policy_index + 1, surface_index) or intersects(policy_index, surface_index + 1)
+        return _segment_matches(segment, surface_segments[surface_index]) and intersects(
+            policy_index + 1, surface_index + 1
+        )
+
+    return intersects(0, 0)
+
+
+def rule_covers_subtree(rule_glob, surface_prefix):
+    """Conservatively prove that one policy rule covers the whole subtree."""
+
+    pattern, root_anchored = _normalise_pattern(rule_glob)
+    if not (root_anchored or "/" in pattern):
+        return False
+
+    if pattern.endswith("/**"):
+        rule_prefix = pattern[:-3].rstrip("/")
+    elif not any(character in pattern for character in META):
+        # A literal directory pattern covers descendants under compile_glob.
+        rule_prefix = pattern
+    else:
+        return False
+
+    if any(character in rule_prefix for character in META):
+        return False
+    return surface_prefix == rule_prefix or surface_prefix.startswith(rule_prefix + "/")
+
+
+def tier_of_surface(surface, policy):
+    """Resolve the maximum tier of every concrete path a declaration permits."""
+
+    if policy is None:
+        return "?"
+
+    surface = surface.rstrip("/")
+    if not any(character in surface for character in META):
+        prefix = surface.lstrip("/")
+    else:
+        if not surface.endswith("/**"):
+            return "human"
+        prefix = surface[:-3].rstrip("/").lstrip("/")
+        if not prefix or any(character in prefix for character in META):
+            return "human"
+
+    default, rules = policy
+    tiers = [
+        tier
+        for glob, _, tier in rules
+        if rule_intersects_subtree(glob, prefix)
+    ]
+    if not any(rule_covers_subtree(glob, prefix) for glob, _, _ in rules):
+        tiers.append(default)
+    return max(tiers, key=lambda tier: RANK.get(tier, len(RANK))) if tiers else default
 
 
 def read_paths(path):
@@ -144,14 +331,14 @@ def main(argv):
         if policy is None:
             print("?")
             return
-        # Most restrictive over every declared path, and the policy default for a
-        # surface that declares nothing — the fail-safe direction, since `auto` is
-        # the only tier that dispatches an unattended approval.
-        tiers = [tier_of(p, policy) for p in read_globs(argv[2])] or [policy[0]]
+        # Most restrictive over every path each declaration permits. The policy
+        # default covers an empty surface, and unsafe wildcard shapes resolve
+        # human — only a proved `auto` result may dispatch unattended approval.
+        tiers = [tier_of_surface(p, policy) for p in read_globs(argv[2])] or [policy[0]]
         print(max(tiers, key=lambda t: RANK.get(t, len(RANK))))
         return
 
-    matchers = [compile_glob(g) for g in read_globs(argv[1])]
+    matchers = [compile_surface_glob(g) for g in read_globs(argv[1])]
     policy = load_policy(argv[3]) if len(argv) > 3 else None
     for path in read_paths(argv[2]):
         if not any(m.match(path) for m in matchers):

--- a/scripts/test-surface-match.py
+++ b/scripts/test-surface-match.py
@@ -110,6 +110,87 @@ class MatcherTests(unittest.TestCase):
             "human",
         )
 
+    def test_surface_grammar(self) -> None:
+        for pattern in ["Cargo.lock", "docs/guide/page.md", "docs/guide/**", "crates/aether-kit/src/**"]:
+            with self.subTest(pattern=pattern):
+                self.assertTrue(surface_match.valid_surface_glob(pattern))
+        rejected = [
+            "",
+            "/Cargo.toml",
+            "docs/",
+            "docs//guide",
+            "../escape",
+            "docs/guide/../adr/x.md",
+            "docs/*",
+            "docs/**/x.md",
+            "a/**/**",
+            "**",
+            "docs/[ag]uide/**",
+            "docs/guide/page?.md",
+            "docs\\guide",
+        ]
+        for pattern in rejected:
+            with self.subTest(pattern=pattern):
+                self.assertFalse(surface_match.valid_surface_glob(pattern))
+
+    def test_repository_policy_file_parses_and_guards_itself(self) -> None:
+        # Tripwire: the strict parser fails closed, so a malformed edit to the
+        # real policy file would silently stop every auto dispatch — this is the
+        # one place that failure is loud. The guarded paths pin the
+        # constitutional carve-outs against an accidental policy edit.
+        policy = surface_match.load_policy(str(SCRIPT.parent.parent / ".github" / "approval-policy.yml"))
+        self.assertIsNotNone(policy)
+        for guarded in [
+            "scripts/surface-match.py",
+            "scripts/test-surface-match.py",
+            ".github/approval-policy.yml",
+            ".github/workflows/ci.yml",
+            ".agents/skills/approve/scripts/resolve_approval_tier.py",
+            ".claude/hooks/check-no-divider-comments.sh",
+        ]:
+            with self.subTest(guarded=guarded):
+                self.assertEqual(surface_match.tier_of(guarded, policy), "human")
+
+    def test_out_of_grammar_surface_resolves_human_in_tier_mode(self) -> None:
+        for surface in ["docs/guide/../adr/0001-x.md", "/docs/guide/page.md", "docs//guide/page.md"]:
+            with self.subTest(surface=surface), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                surfaces = root / "surface.txt"
+                policy = root / "policy.yml"
+                surfaces.write_text(surface + "\n", encoding="utf-8")
+                policy.write_text(POLICY, encoding="utf-8")
+                completed = subprocess.run(
+                    [sys.executable, "-I", str(SCRIPT), "--tier", str(surfaces), str(policy)],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+                self.assertEqual(completed.stdout, "human\n")
+
+    def test_containment_ignores_out_of_grammar_globs_without_backtracking(self) -> None:
+        # Tripwire: the hostile glob compiles to nested unbounded regex groups;
+        # without the grammar gate this match backtracks effectively forever.
+        hostile = "**/" * 12 + "a"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            globs = root / "globs.txt"
+            paths = root / "paths.txt"
+            policy = root / "policy.yml"
+            globs.write_text(hostile + "\ndocs/guide/**\n", encoding="utf-8")
+            paths.write_text("b/" * 40 + "c\ndocs/guide/page.md\n", encoding="utf-8")
+            policy.write_text(POLICY, encoding="utf-8")
+            completed = subprocess.run(
+                [sys.executable, "-I", str(SCRIPT), str(globs), str(paths), str(policy)],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(completed.stdout, "b/" * 40 + "c\tjudge\n")
+            self.assertIn("ignored out-of-grammar surface glob", completed.stderr)
+
     def test_most_restrictive_across_surface_file(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/scripts/test-surface-match.py
+++ b/scripts/test-surface-match.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Regression tests for the canonical declared-surface matcher."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("surface-match.py")
+SPEC = importlib.util.spec_from_file_location("surface_match", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+surface_match = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(surface_match)
+
+
+POLICY = """\
+default: judge
+rules:
+  - glob: "/Cargo.toml"
+    tier: human
+  - glob: "crates/*/Cargo.toml"
+    tier: human
+  - glob: "crates/aether-data/**"
+    tier: human
+  - glob: "docs/adr/**"
+    tier: human
+  - glob: ".agents/**"
+    tier: human
+  - glob: "docs/guide/**"
+    tier: auto
+  - glob: "crates/aether-kit/**"
+    tier: auto
+  - glob: "crates/aether-capabilities/**"
+    tier: judge
+  - glob: "scripts/surface-match.py"
+    tier: human
+"""
+
+
+class MatcherTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = surface_match.load_policy_text(POLICY)
+
+    def test_root_anchor(self) -> None:
+        matcher = surface_match.compile_glob("/Cargo.toml")
+        self.assertIsNotNone(matcher.match("Cargo.toml"))
+        self.assertIsNone(matcher.match("nested/Cargo.toml"))
+
+    def test_slashless_concrete_surface_is_root_anchored(self) -> None:
+        matcher = surface_match.compile_surface_glob("Cargo.lock")
+        self.assertIsNotNone(matcher.match("Cargo.lock"))
+        self.assertIsNone(matcher.match(".agents/Cargo.lock"))
+
+    def test_existing_matcher_semantics_remain(self) -> None:
+        matcher = surface_match.compile_glob("docs/**/index?.md")
+        self.assertIsNotNone(matcher.match("docs/index1.md"))
+        self.assertIsNotNone(matcher.match("docs/a/b/indexz.md"))
+        self.assertIsNone(matcher.match("docs/index.md"))
+        self.assertIsNone(matcher.match("other/docs/index1.md"))
+
+    def test_exact_paths(self) -> None:
+        self.assertEqual(surface_match.tier_of_surface("docs/guide/page.md", self.policy), "auto")
+        self.assertEqual(surface_match.tier_of_surface("Cargo.toml", self.policy), "human")
+        self.assertEqual(surface_match.tier_of_surface("new-top/file.txt", self.policy), "judge")
+
+    def test_exact_path_respects_directory_tail_semantics(self) -> None:
+        self.assertEqual(surface_match.tier_of_surface("crates/aether-kit", self.policy), "human")
+
+    def test_literal_subtrees_are_set_sound(self) -> None:
+        cases = {
+            "docs/guide/**": "auto",
+            "crates/aether-kit/src/**": "auto",
+            "crates/aether-kit/**": "human",
+            "docs/**": "human",
+            "crates/aether-capabilities/new/**": "judge",
+            "new-top/**": "judge",
+        }
+        for surface, expected in cases.items():
+            with self.subTest(surface=surface):
+                self.assertEqual(surface_match.tier_of_surface(surface, self.policy), expected)
+
+    def test_complex_surface_wildcards_fail_closed(self) -> None:
+        for surface in ["**", "docs/*", "crates/aether-*/future/**", "docs/[ag]uide/**"]:
+            with self.subTest(surface=surface):
+                self.assertEqual(surface_match.tier_of_surface(surface, self.policy), "human")
+
+    def test_malformed_policy_fails_closed(self) -> None:
+        malformed = [
+            'default: judge\nrules:\n  - glob: "docs/**"\n    tier: owner\n',
+            'default: judge\nrules:\n  - glob: "docs//**"\n    tier: auto\n',
+            'default: judge\nrules:\n  - glob: "docs***"\n    tier: auto\n',
+            'default: judge\nrules:\n  - glob: "../**"\n    tier: auto\n',
+            'default: judge\nrules:\n  - glob: "docs/guide/**\n    tier: auto\n',
+            'default: judge\nrules:\n  - glob: docs/guide/**"\n    tier: auto\n',
+            'default: judge\nrules:\n- glob: docs/guide/**\ntier: auto\n',
+            'default: judge\nrules:\n  - glob: docs/guide/**\n  tier: auto\n',
+        ]
+        for policy in malformed:
+            with self.subTest(policy=policy):
+                self.assertIsNone(surface_match.load_policy_text(policy))
+
+    def test_matcher_implementation_is_human(self) -> None:
+        self.assertEqual(
+            surface_match.tier_of_surface("scripts/surface-match.py", self.policy),
+            "human",
+        )
+
+    def test_most_restrictive_across_surface_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            surfaces = root / "surface.txt"
+            policy = root / "policy.yml"
+            surfaces.write_text("docs/guide/**\ncrates/aether-data/src/lib.rs\n", encoding="utf-8")
+            policy.write_text(POLICY, encoding="utf-8")
+            completed = subprocess.run(
+                [sys.executable, "-I", str(SCRIPT), "--tier", str(surfaces), str(policy)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(completed.stdout, "human\n")
+
+    def test_containment_cli_and_root_anchor(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            globs = root / "globs.txt"
+            paths = root / "paths.txt"
+            policy = root / "policy.yml"
+            globs.write_text("Cargo.toml\nCargo.lock\ndocs/guide/**\n", encoding="utf-8")
+            paths.write_text(
+                "Cargo.toml\nnested/Cargo.toml\nCargo.lock\n.agents/Cargo.lock\ndocs/guide/page.md\n",
+                encoding="utf-8",
+            )
+            policy.write_text(POLICY, encoding="utf-8")
+            completed = subprocess.run(
+                [sys.executable, "-I", str(SCRIPT), str(globs), str(paths), str(policy)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(
+                completed.stdout,
+                "nested/Cargo.toml\tjudge\n.agents/Cargo.lock\thuman\n",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make declared-surface containment repository-rooted and approval-tier resolution sound over every path a declaration permits
- add a deterministic Codex resolver that validates Plan targets against a captured `origin/main` commit while ignoring Git replacement/environment tricks
- fail closed on malformed approval policy syntax, protect the matcher itself, and isolate Python imports in privileged workflow invocations
- teach the Codex `scope` and `approve` skills to emit/validate declared surfaces, apply ADR and owner pre-approval routing, and report policy evidence
- align the contributor guide and release schema with the executable approval contract

## Amendment (Claude review follow-up)

- hold declared surfaces to the validated grammar in both matcher modes, so an untrusted issue-body glob never reaches the regex engine: containment ignores an out-of-grammar pattern (its paths escape, with a stderr note) and tier mode resolves it `human` — a run of `**/` segments could otherwise backtrack containment effectively forever
- refuse a resolver `--ref` that is not reachable from the local `refs/remotes/origin/main`; any fetched commit passes the object checks, and executing a PR head's matcher would hand the tier decision to its author
- run both approval-machinery suites as a required CI job (`Approval machinery`, wired into `ci-pass`), with a new tripwire that the real `.github/approval-policy.yml` parses under the fail-closed parser — a malformed edit would otherwise silently stop every auto dispatch — and that the constitutional carve-outs stay `human`
- pin `scripts/test-surface-match.py` to the human tier alongside the matcher it now gates

## Validation

- `python3 scripts/test-surface-match.py` (15 tests)
- `python3 .agents/skills/approve/scripts/test_resolve_approval_tier.py` (11 tests)
- Python byte-compilation for all four matcher/resolver files
- Codex skill validation for `approve` and `scope`
- `mdbook build docs --dest-dir /tmp/aether-approval-guide-book`
- `cargo fmt --all -- --check`
- YAML parse for the two changed workflows and `ci.yml`
- `git diff --check` and conflict-marker scan

No Rust runtime code changes.
