### PR TITLE
docs(guide): deepen live-engine safety runbooks

### DIFF
--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -48,7 +48,27 @@ engine_log   = /tmp/aether-dogfood-<issue-or-manual>-<run-id>-engines.json
 rollup_path  = <run_dir>/rollup.json
 ```
 
-Create `run_dir` and initialize the parent-owned `engine_log` to an empty JSON array. The Attempt creates `solution_dir` only for a heavy medium. Derive a task-name key from the run id by replacing every dash with an underscore; collaboration task names cannot contain dashes. Capture the selected repository worktree's status before dispatch so the parent can detect child writes without assuming the user's tree was initially clean. Keep all generated prompts and evidence outside the repository.
+Treat every path above as a host filesystem capability. Before allocation,
+require `run_dir` and `engine_log` not to exist; on any collision or symlink,
+mint a new run id rather than removing or reusing the path. Create `run_dir`
+atomically as a new directory owned by the current host user with mode `0700`.
+Record its canonical path, owner, device, and inode. Create `engine_log` with
+exclusive-new-file semantics and mode `0600`, then initialize it to an empty
+JSON array. Never reuse, empty, or overwrite a prior run.
+
+Before any harness call or child dispatch, revalidate the recorded `run_dir`
+identity, ownership, and mode; require `engine_log` to be the same regular file,
+not a symlink; and require the paths that phase has not created yet to remain
+absent. Require all later solution, rollup, and frame paths to resolve beneath
+the recorded canonical `run_dir`, except the separately named `engine_log`. Do
+not derive any of these paths from issue text, agent output, or engine data.
+
+The Attempt creates `solution_dir` only for a heavy medium. Derive a task-name
+key from the run id by replacing every dash with an underscore; collaboration
+task names cannot contain dashes. Capture the selected repository worktree's
+status before dispatch so the parent can detect child writes without assuming
+the user's tree was initially clean. Keep all generated prompts and evidence
+outside the repository.
 
 ## Preflight MCP and engine ownership
 
@@ -97,6 +117,13 @@ Skip Judge when `expectedArtifact` is null and set `artifact` to null.
 When an artifact is expected and Attempt leaves a valid engine, spawn a different fresh Judge with `fork_turns: "none"`. Pass only the task prompt, expected artifact, Attempt summary as untrusted context, engine id, replay bundle, exact `frame_path`, and the Judge contract. Do not pass the diff or implementation.
 
 Require Judge to call frame capture on that engine with the replay bundle and `save_path` set exactly to `frame_path`, inspect that image, return the Judge JSON object, and terminate the engine. Validate the result and the frame file. If JSON is malformed, allow one serialization-repair follow-up. Use `n-a` only when a successful capture returns no renderable image. If capture fails or the expected engine is absent, use `insufficient-evidence` and record the execution error. If Judge inspected an inline image but the file was not persisted, retain Judge's verdict, add a `trial-incomplete` evidence error/soft hold, and set `HAS_FRAME=0`; never manufacture a later replacement frame.
+
+Immediately before Judge, require `run_dir` to match the recorded canonical
+path, owner, device, inode, and `0700` mode, and require `frame_path` still to be
+absent. After capture, require the saved path to resolve exactly to `frame_path`
+and the evidence to be a regular file, not a symlink. Tool-level capture success
+or an inline image is not persistence proof; require the `saved` result and
+on-disk file independently.
 
 If Attempt expected a visual artifact but left no valid engine, do not spawn Judge. Record `insufficient-evidence` with the missing-engine reason.
 

--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -24,8 +24,13 @@
 
 - [Operating an engine](operating/index.md)
   - [The MCP harness](mcp-harness.md)
+    - [Harness lifecycle and fleet-wide mutations](operating/harness-lifecycle.md)
   - [Engine fleet and artifact stores](operating/engine-fleet.md)
+  - [Host paths, artifact trust, and evidence files](operating/host-paths-and-artifacts.md)
+    - [Artifact trust and provenance](operating/artifacts/trust-and-provenance.md)
+    - [Host evidence files and capture destinations](operating/evidence/host-files.md)
   - [Component registry and replacement](operating/component-registry.md)
+    - [Replacement failure states](operating/components/replacement-failure-states.md)
   - [Inspection and debugging](operating/inspect-and-debug.md)
   - [Recovery runbook](operating/recovery.md)
 

--- a/docs/guide/mcp-harness.md
+++ b/docs/guide/mcp-harness.md
@@ -47,11 +47,13 @@ connection even for a healthy engine, and the hub learns of death only when the
 connection closes. The fleet row does not expose whether heartbeats are enabled,
 so confirm hub configuration before using its age as a diagnosis.
 
-To restart the hub
-after a rebuild *without* losing your session, hit the tunnel's admin endpoint
-(`POST /admin/restart-hub`); the tunnel re-forks the hub and aether-mcp re-dials
-it on your next call. Restarting aether-mcp itself does drop the session, so prefer
-restarting the hub.
+To restart the hub after a rebuild *without* losing your session, hit the
+tunnel's admin endpoint (`POST /admin/restart-hub`); the tunnel re-forks the hub
+and aether-mcp re-dials it on your next call. This is a fleet-wide destructive
+operation, not a harmless reconnect: use it only with authority over the whole
+fleet and one coordinated request. Restarting aether-mcp itself does drop the
+session. Read [Harness lifecycle and fleet-wide mutations](operating/harness-lifecycle.md)
+before cycling either process.
 
 ## Bringing it up
 
@@ -237,7 +239,8 @@ one handler.
   [Mail, kinds & scheduling](systems/mail-and-kinds.md).
 - **Paths, not bytes.** `upload_component` takes the fleet-host filesystem path;
   `load_component` and `replace_component` take registry selectors. Tool JSON
-  never carries the wasm buffer itself.
+  never carries the wasm buffer itself. Host paths are not sandboxed task paths;
+  see [Host paths and artifacts](operating/host-paths-and-artifacts.md).
 - **Wire ids are tagged strings.** Mailbox, kind, and handle ids come back as
   `mbx-…`, `knd-…`, `hdl-…` — hand them back verbatim, don't reformat or parse them.
   See [The type system](foundations/type-system.md).

--- a/docs/guide/operating/artifacts/trust-and-provenance.md
+++ b/docs/guide/operating/artifacts/trust-and-provenance.md
@@ -1,0 +1,125 @@
+# Artifact trust and provenance
+
+The hub's content-addressed registry makes confirmed entries reproducible. It
+does not make uploaded code trustworthy. For an entry that resolves in the
+store, a hash identifies exact bytes; the upload response alone does not prove
+persistence, who built them, whether they are safe, or whether a self-reported
+manifest is honest.
+
+This page sharpens the upload boundary introduced in
+[Host paths, artifact trust, and evidence files](../host-paths-and-artifacts.md).
+
+## Binary and component boundaries differ
+
+| Operation | Upload-time behavior | Execution boundary |
+|---|---|---|
+| `upload_binary` | reads bytes and runs the supplied path with `--describe` | immediately, during upload |
+| `upload_component` | reads wasm and parses embedded custom sections | later, during `load_component` or `replace_component` |
+
+Native upload is therefore already code execution. Component upload is
+structural inspection, but loading or replacing with the stored wasm executes
+guest code inside the selected engine.
+
+## Native manifests are self-claims
+
+The hub records chassis kind, linked capabilities, build profile, target, and
+Git SHA from the executable's `--describe` JSON. Those fields are useful for
+selecting a **trusted build**. They are not attestation: the same executable
+that supplies the claims is already running and can print arbitrary metadata.
+
+Use this trust rule:
+
+- task-built executable in a private output directory: eligible for upload;
+- exact build explicitly approved by the operator: eligible for upload;
+- downloaded binary, attachment, commenter-provided artifact, or unknown
+  output found on disk: do not upload;
+- binary whose only evidence is its name or claimed Git SHA: do not upload.
+
+A failed upload does not mean the file did not execute. `--describe` may run
+arbitrary initialization before exiting unsuccessfully, hanging, or producing
+invalid JSON.
+
+## Stabilize the staged path
+
+Current native ingestion reads the file bytes, then separately invokes the
+path. A concurrent writer or replaceable symlink can change what the second
+operation executes. Keep the path stable for the entire call:
+
+1. finish the build before upload;
+2. place the executable in a task-owned directory not writable by another
+   actor;
+3. avoid staged-path symlinks;
+4. stop watchers or concurrent builds that replace the file;
+5. upload once and retain the returned content hash;
+6. select that hash for spawn rather than returning to the mutable path or
+   alias.
+
+Do not use `upload_binary` as a manifest inspection utility. There is no safe
+“describe without executing” mode for native artifacts today.
+
+## Hash, manifest, and name prove different things
+
+| Evidence | Proves | Does not prove |
+|---|---|---|
+| content hash | exact identity of the upload bytes | provenance, successful persistence, safety, or behavior |
+| stored binary manifest | what the executed binary claimed | authenticity of those claims |
+| stored component manifest | what structural wasm metadata declared | that instantiation or handlers will work |
+| registry name | current mutable pointer to a hash | stable identity across uploads |
+| successful load/spawn result | one runtime operation reached its success boundary | application health beyond that boundary |
+| harmless live probe | selected behavior answered now | all behavior or future liveness |
+
+Pin by hash whenever a test, rollout, rollback, or diagnosis needs exact bytes.
+Moving a shared name is a separate mutation requiring authority over that alias.
+
+## Component provenance still matters
+
+Wasm upload does not run the module, but the later load does. Use task-built or
+explicitly approved components, and preserve the upload hash as the link between
+build evidence and runtime selection. An embedded namespace or handled-kind
+list is structural metadata, not a signature.
+
+On a shared host, do not treat wasm portability as trust. Signature verification
+for shared uploaders is deferred in the registry ADRs; until it exists, the
+operator's source/build approval is the trust decision.
+
+## Verify after selection
+
+For a binary:
+
+1. require the upload result, then confirm its exact hash resolves in the store;
+2. spawn by hash;
+3. verify the returned engine appears in the current fleet;
+4. inspect the live native handler surface and issue a bounded harmless probe.
+
+For a component:
+
+1. require the upload result, then confirm the stored manifest and exact hash;
+2. load or replace by hash;
+3. require the explicit success result;
+4. retain the returned lineage and mailbox id;
+5. verify a behavior the selected component is expected to provide.
+
+Do not substitute registry listing for runtime verification: stored, running,
+and loaded are different states.
+
+## Current trust assumptions
+
+[ADR-0115](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0115-hub-binary-registry.md)
+deliberately starts with a single-user local host and defers native signature
+verification. [ADR-0116](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0116-component-registry.md)
+inherits the content-addressed store and also defers a shared-uploader keyring.
+
+If the host, uploader set, or artifact source is broader than that assumption,
+stop. Do not improvise trust from content addressing.
+
+## Source routes
+
+- Native/component ingestion:
+  `crates/aether-capabilities/src/engine/server/artifacts.rs`
+- Stored manifests, hashes, aliases, and eviction:
+  `crates/aether-capabilities/src/engine/store/`
+- Native spawn realization:
+  `crates/aether-capabilities/src/engine/server/runtime.rs`
+- Component load and replacement:
+  `crates/aether-capabilities/src/component/` and
+  `crates/aether-capabilities/src/trampoline/runtime/replace.rs`

--- a/docs/guide/operating/component-registry.md
+++ b/docs/guide/operating/component-registry.md
@@ -187,7 +187,11 @@ deadline. Require an explicit successful result, then re-run
 validation preserves the old guest; an instantiation failure after the old
 guest is taken can leave the trampoline empty; a rehydrate failure installs the
 new guest but still returns `Err`. Observe live behavior before deciding whether
-to retry or roll forward.
+to retry or roll forward. After a post-splice error, both MCP's cache and the
+substrate capability registry can describe the old handler set even when the
+slot is empty or the new guest remains installed. Use
+[Replacement failure states](components/replacement-failure-states.md) rather
+than treating `describe_component` as rollback proof.
 
 ## Component cleanup
 

--- a/docs/guide/operating/components/replacement-failure-states.md
+++ b/docs/guide/operating/components/replacement-failure-states.md
@@ -1,0 +1,105 @@
+# Replacement failure states
+
+`replace_component` preserves a trampoline mailbox on success, but an error is
+not a universal rollback signal. The old guest, an empty slot, or the new guest
+can remain depending on which phase failed. Introspection can also describe a
+retained capability snapshot rather than the guest that is actually installed.
+
+Read [Component registry](../component-registry.md) first for normal load,
+replace, and drop behavior.
+
+## Phase-dependent residue
+
+| Failure phase | Guest left behind | Capability/introspection risk |
+|---|---|---|
+| new wasm compile, manifest parse, or export selection | prior slot is unchanged: old guest or an already-empty post-drop slot | existing descriptions still reflect the prior registry snapshot, not a new guest |
+| `save_state` host-call rejection during dehydrate | old guest object is restored after its unwire/dehydrate hooks already ran | old description remains the best snapshot, but the guest may have changed its own lifecycle state |
+| new guest instantiation failure after old guest was taken | trampoline can be empty | old capability registry and MCP cache can remain even though no guest is live |
+| new guest rehydrate failure | new guest remains installed despite `Err` | capability re-registration has not run; old substrate and MCP descriptions can remain |
+| successful replacement | new guest remains and new capabilities are registered | MCP refreshes its cache from the success result |
+
+The exact phase matters more than the generic `Err` shape. Do not say
+“replacement rolled back” unless a current behavioral observation proves the
+old guest still serves the mailbox.
+
+An `unwire` or `on_dehydrate` guest trap is different: those traps are logged
+and contained rather than returned as `ReplaceResult::Err`, and replacement
+continues. Only a rejected `save_state` host call is surfaced at that phase. If
+the later replacement succeeds, do not mistake an earlier hook-trap log for a
+rolled-back splice.
+
+## Why `describe_component` can mislead
+
+There are two description layers:
+
+1. `aether-mcp` returns a process-local cache hit immediately. It refreshes that
+   cache on successful load/replace, but retains the prior entry on replace
+   error.
+2. On a cache miss addressed by lineage name, the substrate returns its
+   capability registry entry. Some post-splice failures happen before that
+   entry is removed or replaced.
+
+After a failed replacement, restarting only `aether-mcp` can bypass its cache
+and still obtain a stale substrate registry entry. Kind presence and cost rows
+can likewise outlive or disagree with the currently installed guest. Treat all
+of them as snapshots, not liveness or binary-identity proof.
+
+## Recovery protocol
+
+After any replace error:
+
+1. Stop further lifecycle mutation on that mailbox.
+2. Record the exact selector/hash, export, config, mailbox id, error, logs, and
+   pre-replace capabilities.
+3. Call `describe_component` by lineage only as supporting evidence; label a
+   cache hit or live-registry reply as potentially stale.
+4. Use one known side-effect-free application query that distinguishes the old
+   and new build when such a query exists.
+5. If no safe discriminating probe exists, classify the slot as indeterminate.
+6. On a task-owned engine, prefer terminating and recreating the engine from
+   known hashes over repeated splice attempts.
+7. On a shared engine, stop and report the indeterminate mailbox to its owner.
+   Do not drop, refill, or retry by guess.
+
+A roll-forward by known-good hash is appropriate only after the owner accepts
+the current state and the mailbox is still safe to mutate. `drain_timeout_ms`
+is currently ignored and cannot repair a failed splice.
+
+## Designing a discriminating probe
+
+A useful probe:
+
+- is documented as read-only or idempotent;
+- has a bounded reply;
+- is handled differently by the candidate builds or proves required state;
+- does not depend on a kind that may itself be stale only in the MCP encode
+  cache;
+- records its exact request and reply as evidence.
+
+If the only available operation mutates application state, do not use it merely
+to answer “which guest is installed?” Recreate an owned engine or escalate a
+shared one instead.
+
+## Success verification
+
+Even after `ReplaceResult::Ok`:
+
+- retain the exact content hash used;
+- compare returned capabilities with the expected actor export;
+- run a harmless live probe;
+- confirm downstream senders still address the stable lineage;
+- treat a mutable registry name only as provenance context, not selected-byte
+  identity.
+
+## Source routes
+
+- Phase transitions and capability registration:
+  `crates/aether-capabilities/src/trampoline/runtime/replace.rs`
+- Substrate live component description:
+  `crates/aether-capabilities/src/component/runtime/mod.rs`
+- MCP replace result and cache update:
+  `crates/aether-mcp/src/tools/components.rs`
+- MCP description cache and live fallback:
+  `crates/aether-mcp/src/tools/describe.rs`
+- Live kind cache contract:
+  [ADR-0091](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0091-live-kind-schemas-on-the-inventory-cap.md)

--- a/docs/guide/operating/engine-fleet.md
+++ b/docs/guide/operating/engine-fleet.md
@@ -71,6 +71,14 @@ surface to capture its manifest. Re-uploading identical bytes deduplicates to
 the same hash. A name is a movable pointer; a hash pins the spawn request to
 exact content.
 
+Running `--describe` is immediate native code execution, not passive manifest
+inspection. Upload only a task-built executable in a stable private path or an
+exact build the operator approved. Never upload a download, attachment, or
+unknown executable to discover what it is, and do not treat its self-reported
+manifest as attestation. Follow
+[Artifact trust and provenance](artifacts/trust-and-provenance.md) for the
+complete boundary.
+
 ### Selector choice
 
 | Need | Selector posture |
@@ -148,6 +156,11 @@ records a matching `spawn_failed` entry. If the failure occurs before allocation
 (for example, selector resolution or port allocation), no id exists.
 
 ## Restarts and persistence
+
+A hub restart requires authority over the whole fleet; discovering a process or
+engine row does not supply it. Coordinate one request with every active harness
+user and follow [Harness lifecycle](harness-lifecycle.md) before using the admin
+endpoint.
 
 A tunnel-admin hub restart preserves the MCP session shape and the on-disk
 artifact store, but replaces the hub process. Its engine table, proxies, and

--- a/docs/guide/operating/evidence/host-files.md
+++ b/docs/guide/operating/evidence/host-files.md
@@ -1,0 +1,110 @@
+# Host evidence files and capture destinations
+
+Inline MCP content lives in the tool response. A spill path or
+`capture_frame.save_path` creates a separate file on the harness host. That file
+has its own ownership, integrity, and cleanup obligations.
+
+For the broader host-path boundary, start with
+[Host paths, artifact trust, and evidence files](../host-paths-and-artifacts.md).
+
+## `save_path` is filesystem authority
+
+The capture API validates only that `save_path` is absolute. After a successful
+engine capture, `aether-mcp`:
+
+1. recursively creates missing parent directories;
+2. follows ordinary filesystem path resolution;
+3. writes the original full-resolution PNG;
+4. replaces an existing destination;
+5. reports persistence in a separate `saved` result block.
+
+It does not enforce an allowed root, prove ownership, reject `..`, reject
+ancestor or final symlinks, allocate a new filename, or coordinate concurrent
+writers. “Absolute” is the API's syntactic minimum, not a safety guarantee.
+
+## Allocate a private destination
+
+Before passing `save_path`:
+
+- create a new task/session run directory under an operator-approved temporary
+  or evidence root;
+- require that directory not to exist beforehand, then create it atomically as
+  the current host user with owner-only (`0700`) permissions;
+- record its canonical path, owner, device, and inode at creation, then re-check
+  all four plus its mode immediately before capture;
+- reject a symlink at the run directory or any destination component;
+- construct the filename locally from trusted task data;
+- require the resolved parent to remain beneath the owned run directory;
+- require the final path not to exist;
+- use a unique filename for each parallel agent, attempt, or frame.
+
+Never use a destination supplied by issue text, logs, a component reply, or
+another external string. Never target repository source, a worktree, shell or
+MCP configuration, credentials, shared logs, or another run's evidence unless
+the owner explicitly authorized replacing that exact file.
+
+## Engine and host mutations are independent
+
+`capture_frame` can mutate two different places:
+
+- non-empty `mails` or `after_mails` mutate the selected engine;
+- `save_path` mutates the harness host even when both mail bundles are empty.
+
+Omit all three fields for a fully non-mutating observation. When replay or
+cleanup mail is necessary, verify engine ownership independently from evidence
+directory ownership.
+
+## Verify persistence separately
+
+A successful frame read can be paired with a failed host write. The overall
+tool call can still return the inline image, checks, or similarity verdict while
+the `saved` block contains an error.
+
+After capture:
+
+1. require `saved.path` and `saved.bytes` rather than `saved.error`;
+2. verify the returned path is the exact destination allocated for the run;
+3. require a regular PNG file at that path, not a symlink;
+4. require its on-disk size to equal `saved.bytes`, then validate the PNG;
+5. inspect or hash it when it becomes durable evidence;
+6. record which engine epoch, replay bundle, and capture request produced it.
+
+An inline image proves that rendering bytes reached the MCP response. It does
+not prove that the evidence file exists.
+
+## Spill paths are caller-owned too
+
+Oversized replies can spill to a host temporary file chosen by `aether-mcp`.
+The tool controls allocation, but the caller still owns the returned evidence:
+
+- preserve the exact path before losing the response;
+- avoid moving it into a repository or shared directory casually;
+- treat its contents according to the application data it carries;
+- remove it deliberately when no longer needed.
+
+The spill uses a unique name in the process temporary directory, not the
+task-owned capture directory. Do not assume it has evidence-store retention or
+confidentiality guarantees. Capture files and spills can contain private state;
+move sensitive evidence into an approved private store when required, and do
+not widen permissions merely to make inspection convenient.
+
+## Cleanup
+
+At handoff, report every evidence path and one disposition:
+
+- preserved as part of the incident/trial record;
+- transferred to an explicitly named owner;
+- removed after its evidence value was exhausted;
+- retained unintentionally because cleanup failed.
+
+Do not claim a clean run while untracked host evidence or an owned live engine
+remains.
+
+## Source routes
+
+- Capture path validation and persistence:
+  `crates/aether-mcp/src/tools/capture.rs`
+- Capture argument contract: `crates/aether-mcp/src/args.rs`
+- Reply spill allocation: `crates/aether-mcp/src/tools/bytes.rs`
+- Engine-side capture and checks:
+  `crates/aether-capabilities/src/render/`

--- a/docs/guide/operating/harness-lifecycle.md
+++ b/docs/guide/operating/harness-lifecycle.md
@@ -1,0 +1,152 @@
+# Harness lifecycle and fleet-wide mutations
+
+A hub restart is not a transport refresh. It replaces the process that owns the
+fleet and therefore destroys live engine state. Use this page before restarting
+the hub, restarting `aether-mcp`, stopping the tunnel, or treating one of those
+actions as recovery.
+
+For ordinary engine ownership and termination, see
+[Engine fleet](engine-fleet.md). For symptom-first recovery, see
+[Recovery](recovery.md).
+
+## Bootstrap is not restart
+
+These surfaces operate at different scopes:
+
+| Surface | Scope | Mutation |
+|---|---|---|
+| `scripts/ensure-tunnel.sh` while `:8890` answers | harness discovery | none; it exits without replacing the live stack |
+| `scripts/ensure-tunnel.sh` on a cold host | host process stack | builds and starts the tunnel, hub, and `aether-mcp` |
+| `GET /admin/status` | tunnel observation | none; reports child liveness, PIDs, and ports |
+| `terminate_substrate(engine_id)` | one supervised engine | force-stops that engine |
+| `POST /admin/restart-hub` | entire supervised fleet | terminates and replaces the hub process |
+| graceful tunnel shutdown by `SIGINT` or `SIGTERM` | entire harness | asks the tunnel to terminate the hub, `aether-mcp`, and supervised fleet |
+
+The tunnel's admin endpoint is loopback control, not an ownership system. It
+does not authenticate a task or establish which session may restart the fleet.
+Likewise, `/admin/status` and `list_engines` expose no owner or hub epoch. A
+reachable endpoint, PID, port, or fleet row is evidence of existence—not
+authority to destroy it.
+
+## Authority boundary
+
+Treat the tunnel as shared host state. It can outlive the session that started
+it, and several agents or humans can drive the same hub.
+
+- Terminate one engine only when your task spawned that exact current-epoch
+  `engine_id`, ownership was explicitly handed to you, or the user authorized
+  that engine's termination.
+- Restart the hub only with explicit authority over the whole fleet and after
+  coordinating with other active harness users.
+- Stop the tunnel only when you own the complete harness or the operator has
+  authorized a full shutdown.
+- An empty fleet is not proof that another session has no in-flight spawn,
+  upload, or other hub operation.
+
+If one owned engine is unhealthy, terminate that engine. Do not use a hub
+restart as per-engine cleanup.
+
+## Blast radius
+
+| Action | Destroyed | Preserved |
+|---|---|---|
+| `terminate_substrate(engine_id)` | that engine's live actors, components, scheduler, and in-memory state | other engines, tunnel, MCP session, stored artifacts |
+| `POST /admin/restart-hub` | hub process, fleet table, proxies, all hub-spawned engines, loaded components, and recently-dead memory | tunnel, `aether-mcp`, MCP session shape, on-disk artifact stores |
+| restart `aether-mcp` | MCP backend process, client session, and its local caches | hub, fleet, tunnel, stored artifacts |
+| graceful tunnel shutdown | tunnel, hub, `aether-mcp`, MCP session, and supervised fleet | only separately persisted host state |
+
+The hub process owns engine proxies. Proxy teardown force-kills and reaps the
+child substrate it spawned, so replacing the hub also removes its supervised
+children. This is intentionally stronger than reconnecting a socket.
+
+Do not force-kill the tunnel and call that fleet cleanup. `SIGKILL`, a crash, or
+another unorderly exit bypasses its shutdown path and can leave separately
+spawned child process groups alive. Use the orderly `SIGINT`/`SIGTERM` path;
+after an abnormal exit, reconcile process ownership explicitly before starting
+another stack.
+
+A hub-only restart leaves `aether-mcp` alive. Its caches have no hub-epoch key,
+while a new hub can reuse old `engine_id` text. A cached kind or component
+description can therefore refer to the prior epoch.
+
+## Before a hub restart
+
+1. Select one coordinator and stop new mutations.
+2. Take a fresh `list_engines(show: "alive")` snapshot.
+3. Identify the owner of every engine. If any owner is unknown or another
+   harness user may still be active, stop and ask.
+4. Preserve logs, traces, frames, recently-dead details, and application-owned
+   state that will be needed afterward.
+5. Resolve interrupted operations. A lost reply does not prove that the
+   mutation never landed.
+6. Decide whether terminating one owned engine is sufficient.
+
+Do not infer permission from a quiet fleet, an unhealthy heartbeat, or the fact
+that your session originally started the tunnel.
+
+## Issue one restart
+
+Use one coordinator and send one `POST /admin/restart-hub`. Do not issue
+concurrent restart requests, and do not blindly retry an uncertain response.
+The admin route does not carry an idempotency key or task lease; reconcile the
+observable process and fleet state before deciding whether another request is
+necessary.
+
+This operator discipline does not make restart transactional. The admin route
+and the tunnel's automatic supervisor do not share a restart lease, so even one
+request can race a hub death detected by the supervisor. Avoid an admin restart
+while the hub is flapping or status is unstable. A race can hang the request or
+leave child tracking ambiguous; stop and reconcile process ownership instead of
+sending another restart.
+
+A successful admin response proves that its replacement fork returned. It does
+not prove exclusive child tracking, that hub RPC is already ready, that an
+engine was restored, or that the old application state survived.
+
+If the call fails or its reply is lost:
+
+1. read `/admin/status` once;
+2. wait for a read-only `list_engines` call to succeed;
+3. treat the result as a new epoch if the hub was replaced;
+4. escalate rather than repeatedly cycling an ambiguous shared stack.
+
+## Begin the new epoch
+
+After a restart:
+
+- discard every pre-restart `engine_id`, mailbox id, loaded-component handle,
+  heartbeat age, and recently-dead assumption;
+- reacquire the fleet with `list_engines`;
+- re-list stored binaries and components, using exact hashes where identity
+  matters;
+- spawn replacement engines explicitly;
+- rebuild live state only from known inputs or an application persistence
+  contract;
+- treat cached descriptions as hints until a harmless live probe confirms the
+  new engine;
+- restart and reconnect `aether-mcp` only when a clean cache boundary is worth
+  losing the current MCP session.
+
+Transport reconnection is not state recovery. Do not describe a re-dialed hub
+or a reused identifier as the same engine.
+
+## Per-engine termination remains forceful
+
+`terminate_substrate` is narrower than a hub restart, but it is still not an
+application shutdown handshake. Preserve evidence and application state first.
+The tool removes the fleet row and asks the proxy to shut down; proxy teardown
+then force-kills and reaps its owned child. Verify the row disappears, but do
+not interpret the response timestamp as proof that every OS teardown side
+effect was already visible at that instant.
+
+## Source routes
+
+- Tunnel topology and lifecycle decision:
+  [ADR-0089](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0089-mcp-hub-lifecycle-tunnel.md)
+- Tunnel supervisor and admin routes:
+  `crates/aether-mcp/src/bin/aether-tunnel.rs`
+- Fleet table and logical termination:
+  `crates/aether-capabilities/src/engine/server/runtime.rs`
+- Proxy child ownership and forceful teardown:
+  `crates/aether-capabilities/src/engine/proxy/runtime.rs`
+- MCP fleet orchestration: `crates/aether-mcp/src/tools/engine.rs`

--- a/docs/guide/operating/host-paths-and-artifacts.md
+++ b/docs/guide/operating/host-paths-and-artifacts.md
@@ -1,0 +1,102 @@
+# Host paths, artifact trust, and evidence files
+
+Several MCP arguments are paths on the **harness host**. They are not paths in
+the guest's `save://` namespace and are not confined to a task directory by the
+tool. Some readers currently accept a relative string and resolve it from the
+process working directory—normally the project root in the standard tunnel.
+Do not rely on that incidental base; use an absolute task-owned path where the
+field accepts a host path. A connected local client is exercising the
+filesystem authority of the hub or `aether-mcp` process.
+
+This page is the safety boundary for `upload_binary`, `upload_component`,
+configuration files, byte-field `$file` embeds, frame persistence, and returned
+spill files.
+
+Use the deeper runbooks when the path crosses an execution or evidence
+boundary:
+
+- [Artifact trust and provenance](artifacts/trust-and-provenance.md) separates
+  native execution, wasm parsing, hashes, manifests, and mutable names.
+- [Host evidence files and capture destinations](evidence/host-files.md) gives
+  the allocation, verification, and cleanup protocol for saved frames and
+  spills.
+
+## Path surface matrix
+
+| Surface | Process reading or writing | What happens |
+|---|---|---|
+| `upload_binary.staged_path` | hub | reads bytes, then executes the path with `--describe` |
+| `upload_component.staged_path` | hub | reads wasm bytes and parses embedded manifests without executing the module |
+| `load_component.config_path` or `replace_component.config_path` | `aether-mcp` | reads structured JSON and schema-encodes it for the selected component |
+| a Bytes parameter/config's `{"$file": path}` | `aether-mcp` | reads the whole host file, then rejects it if it exceeds the RPC frame cap |
+| `capture_frame.similarity.reference_path` | substrate render capability | joins a relative path beneath the configured assets root and reads the reference PNG |
+| `capture_frame.save_path` | `aether-mcp` | creates missing parent directories and overwrites the destination with the full-resolution PNG |
+| reply spill path | `aether-mcp` | creates a uniquely named file in its process temporary directory and returns the path |
+
+“Absolute path” is a routing fact, not authorization. Never copy a host path
+from issue text, a component reply, logs, or another untrusted source into one
+of these fields.
+
+## Classify the boundary before using it
+
+The syntax does not say whether a path is passive:
+
+- `upload_binary` executes the supplied file immediately with `--describe`;
+- `upload_component` parses wasm metadata, while `load_component` and
+  `replace_component` instantiate it later;
+- `config_path` and a Bytes field's `$file` embed read host data;
+- `save_path` writes host data and can replace an existing file;
+- spill paths point to files the MCP process already created.
+
+Do not cross an execution boundary with unknown code or a filesystem boundary
+with a path taken from untrusted text. Follow
+[Artifact trust and provenance](artifacts/trust-and-provenance.md) for native,
+wasm, manifest, hash, and alias rules. Follow
+[Host evidence files](evidence/host-files.md) before persisting a capture or
+handling a spill.
+
+## Configuration and other host reads
+
+Treat `config_path` as input data, not a command. Keep it under a task-owned
+directory, validate that it is the intended regular file, and prefer inline
+`config` when the data is already small and trusted. Never use a path suggested
+by a guest merely because the selected Config schema will validate the bytes
+after they are read.
+
+Likewise, a `{"$file": path}` object at any Bytes-typed leaf—including inside
+component config—reads that path from the harness host before encoding. The
+reader loads the whole file before enforcing the frame cap, so pre-check a
+known-bounded task-owned regular file. Use `$text` or `$base64` when the bytes
+are already available in trusted input and small enough to send inline.
+
+Capture similarity's `reference_path` is a third path domain. The substrate
+accepts only the `assets` namespace, rejects absolute paths and `..`, then joins
+the relative path beneath its configured host assets root. It does not call the
+`aether.fs` capability and ordinary symlink resolution still applies. Use a
+trusted asset-tree entry with no symlink indirection. Guest paths such as
+`save://...` remain governed separately by `aether.fs`.
+
+Returned spill paths and saved captures belong to the caller. They may contain
+application data, rendered private state, logs, or decoded bytes. Record their
+provenance, avoid sharing them accidentally, and remove them only when their
+evidence value is exhausted. The evidence runbook owns the allocation,
+verification, and cleanup procedure.
+
+## Names and hashes carry different authority
+
+A content hash names exact bytes; it does not prove provenance, successful
+persistence, or runtime health. A registry name is a mutable pointer in shared
+hub state. Use hashes for reproducible selection, and move a name only with
+authority over that alias. The artifact runbook defines the verification chain.
+
+## Source routes
+
+- Native/component ingestion and `--describe` execution:
+  `crates/aether-capabilities/src/engine/server/artifacts.rs`
+- Hub artifact store: `crates/aether-capabilities/src/engine/store/`
+- MCP component orchestration: `crates/aether-mcp/src/tools/components.rs`
+- Bytes-field host reads and reply spills: `crates/aether-mcp/src/tools/bytes.rs`
+- Capture validation and host write: `crates/aether-mcp/src/tools/capture.rs`
+- Engine-side similarity reference read:
+  `crates/aether-capabilities/src/render/runtime/capture.rs`
+- Public path arguments: `crates/aether-mcp/src/args.rs`

--- a/docs/guide/operating/index.md
+++ b/docs/guide/operating/index.md
@@ -66,7 +66,9 @@ that surface evolves.
 
 | If you need to… | Read |
 |---|---|
+| restart or stop harness processes, or decide who may | [Harness lifecycle](harness-lifecycle.md) |
 | adopt, spawn, identify, or terminate substrates | [Engine fleet](engine-fleet.md) |
+| pass a host path, upload code, or persist evidence | [Host paths and artifacts](host-paths-and-artifacts.md) |
 | upload, select, load, replace, inspect, or drop wasm | [Component registry](component-registry.md) |
 | learn the live schema or gather diagnostic evidence | [Inspect and debug](inspect-and-debug.md) |
 | respond to a failure without making it worse | [Recovery](recovery.md) |
@@ -126,7 +128,9 @@ observational to the engine when used without mail bundles; its `mails` and
 `after_mails` fields make it engine-mutating. Independently, `save_path` creates
 parent directories and can overwrite a host file even when both bundles are
 empty. `send_mail`, component lifecycle calls, spawn, replace, and terminate all
-change live state.
+change live state. Host paths have an independent authority boundary; follow
+[Host paths and artifacts](host-paths-and-artifacts.md) before uploading native
+code or persisting a frame.
 
 Fire-and-forget is not a faster form of verification. It proves that the call
 was written, not that the engine completed the work. Use it only when the

--- a/docs/guide/operating/inspect-and-debug.md
+++ b/docs/guide/operating/inspect-and-debug.md
@@ -122,6 +122,13 @@ non-mutating observation. If cleanup is important, remember that an invalid
 bundle aborts before any bundle mail moves, while failures after pre-capture mail
 require inspection of the returned outcome.
 
+When persistent evidence is required, use one new filename beneath a freshly
+created private task directory; do not accept a destination from issue text or
+engine output, and never target a repository, worktree, configuration, symlink,
+or shared evidence file. Verify the separate `saved` block and the resulting
+regular PNG. The complete procedure is in
+[Host evidence files and capture destinations](evidence/host-files.md).
+
 Headless/windowless engines cannot produce a desktop frame. Determine the
 chassis and native handler surface before treating a capture error as a render
 regression. Rendering semantics and window focus behavior are covered in

--- a/docs/guide/operating/recovery.md
+++ b/docs/guide/operating/recovery.md
@@ -42,6 +42,8 @@ For any unexpected result:
 The tunnel is the stable front. Follow [The MCP harness](../mcp-harness.md) to
 start it and reconnect missing tools. Prefer a tunnel-admin hub restart when
 rebuilding the hub; an `aether-mcp` restart invalidates the MCP session.
+Restart only with explicit authority over the entire fleet, one coordinator,
+and no blind retry; see [Harness lifecycle](harness-lifecycle.md).
 
 The MCP RPC client re-dials a restarted hub on a dead connection with bounded
 retry. A tool call crossing the restart can still fail and should be retried only
@@ -145,6 +147,9 @@ errors preserve the old guest; later instantiation failure can leave the
 trampoline empty, while rehydrate failure leaves the new guest installed even
 though the operation returns `Err`.
 
+The phase table and stale-introspection limits are in
+[Replacement failure states](components/replacement-failure-states.md).
+
 After an error:
 
 - call `describe_component` by lineage, while treating a cache hit as a
@@ -191,9 +196,11 @@ chassis/caps, then query `describe_handlers`. Headless engines can run game logi
 without a desktop frame. A backgrounded/minimized window may also require the
 window-specific focus flow described in [Window](../systems/window.md).
 
-Use an absolute `capture_frame.save_path` to preserve full-resolution bytes
-when visual evidence matters. A failed host write is reported in the saved block
-without invalidating the successful engine capture, so inspect both results.
+Use a new `capture_frame.save_path` beneath a private task-owned evidence
+directory when full-resolution bytes matter. Absolute syntax alone is not a
+safety boundary. A failed host write is reported in the saved block without
+invalidating the successful engine capture, so inspect both results. See
+[Host evidence files](evidence/host-files.md).
 
 ## Final cleanup and handoff
 


### PR DESCRIPTION
## Summary

- add nested runbooks for hub/tunnel lifecycle authority, host-path artifact trust, evidence files, and phase-dependent component replacement residue
- cross-link the operating guide so agents can route from a task to the exact safety boundary, including restart races, native `--describe` execution, recursive `$file` reads, and stale introspection
- harden dogfood evidence allocation with exclusive private paths, recorded directory identity, and pre-capture revalidation

## Test plan

- [x] `mdbook build docs --dest-dir /tmp/aether-operations-safety-book`
- [x] dogfood skill `quick_validate.py`
- [x] `cargo fmt --all -- --check`
- [x] all relative links under `docs/guide/` resolve
- [x] forward tests reject a pre-existing symlink and a same-path directory identity swap before capture
