### PR TITLE
perf(test): reduce repeated wasm scenario work

### DIFF
--- a/crates/aether-capabilities/src/component/runtime/config.rs
+++ b/crates/aether-capabilities/src/component/runtime/config.rs
@@ -16,4 +16,7 @@ pub struct ComponentHostConfig {
     pub engine: Arc<Engine>,
     pub linker: Arc<Linker<ComponentCtx>>,
     pub hub_outbound: Arc<HubOutbound>,
+    /// Reuse compiled modules with identical wasm bytes for the lifetime of
+    /// this component host. Intended for test harness chassis only.
+    pub cache_modules: bool,
 }

--- a/crates/aether-capabilities/src/component/runtime/load.rs
+++ b/crates/aether-capabilities/src/component/runtime/load.rs
@@ -89,7 +89,11 @@ impl ComponentHostCapabilityState {
             };
 
         // 3. Compile module.
-        let module = match Module::new(&self.engine, &payload.wasm) {
+        let module = match self
+            .module_cache
+            .as_ref()
+            .map_or_else(|| Module::new(&self.engine, &payload.wasm), |cache| cache.compile(&payload.wasm))
+        {
             Ok(m) => m,
             Err(e) => {
                 return LoadResult::Err { error: format!("invalid wasm module: {e}") };
@@ -124,6 +128,7 @@ impl ComponentHostCapabilityState {
         let trampoline_config = WasmTrampolineConfig {
             engine: Arc::clone(&self.engine),
             linker: Arc::clone(&self.linker),
+            module_cache: self.module_cache.as_ref().map(Arc::clone),
             module,
             registry: Arc::clone(&self.registry),
             outbound: Arc::clone(&self.outbound),

--- a/crates/aether-capabilities/src/component/runtime/mod.rs
+++ b/crates/aether-capabilities/src/component/runtime/mod.rs
@@ -35,6 +35,7 @@ use aether_kinds::{
 // Crate-local wiring the `#[runtime] impl` handler bodies name (sibling caps it
 // mails, the unsubscribe kind, the `Kind` / `MailboxCategory` vocabulary), the
 // state struct, and `forward_to_trampoline` — all used within this module.
+use crate::WasmModuleCache;
 use crate::http::HttpServerCapability;
 use crate::http::kinds::UnregisterRoutesAll;
 use crate::input::{InputCapability, UnsubscribeAll};
@@ -74,6 +75,7 @@ use aether_substrate::mail::{KindId, MailboxId};
 pub struct ComponentHostCapabilityState {
     pub engine: Arc<Engine>,
     pub linker: Arc<Linker<ComponentCtx>>,
+    pub module_cache: Option<Arc<WasmModuleCache>>,
     pub registry: Arc<Registry>,
     pub mailer: Arc<Mailer>,
     pub outbound: Arc<HubOutbound>,
@@ -122,9 +124,11 @@ impl NativeActor for ComponentHostCapability {
     ) -> Result<ComponentHostCapabilityState, BootError> {
         let mailer = ctx.mailer();
         let registry = Arc::clone(mailer.registry());
+        let module_cache = config.cache_modules.then(|| Arc::new(WasmModuleCache::new(Arc::clone(&config.engine))));
         Ok(ComponentHostCapabilityState {
             engine: config.engine,
             linker: config.linker,
+            module_cache,
             registry,
             mailer,
             outbound: config.hub_outbound,

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -85,7 +85,13 @@ pub mod test_bench;
 pub mod text;
 pub mod trace;
 pub mod trampoline;
+#[cfg(feature = "runtime")]
+mod wasm_module_cache;
 pub mod window;
+
+#[cfg(feature = "runtime")]
+#[doc(hidden)]
+pub use wasm_module_cache::WasmModuleCache;
 
 #[cfg(feature = "audio")]
 pub use audio::AudioCapability;

--- a/crates/aether-capabilities/src/trampoline/runtime/config.rs
+++ b/crates/aether-capabilities/src/trampoline/runtime/config.rs
@@ -9,6 +9,8 @@ use aether_substrate::mail::outbound::HubOutbound;
 use aether_substrate::mail::registry::Registry;
 use wasmtime::{Engine, Linker, Module};
 
+use crate::WasmModuleCache;
+
 /// Configuration handed to [`Lifecycle::init`](aether_actor::Lifecycle::init) by the spawn
 /// path. Carries the wasmtime engine / linker plus the parsed
 /// module bytes; `init` instantiates the `Component` against the
@@ -16,6 +18,8 @@ use wasmtime::{Engine, Linker, Module};
 pub struct WasmTrampolineConfig {
     pub engine: Arc<Engine>,
     pub linker: Arc<Linker<ComponentCtx>>,
+    #[doc(hidden)]
+    pub module_cache: Option<Arc<WasmModuleCache>>,
     pub module: Module,
     pub registry: Arc<Registry>,
     pub outbound: Arc<HubOutbound>,

--- a/crates/aether-capabilities/src/trampoline/runtime/mod.rs
+++ b/crates/aether-capabilities/src/trampoline/runtime/mod.rs
@@ -105,6 +105,7 @@ impl NativeActor for WasmTrampoline {
             component: Some(component),
             engine: config.engine,
             linker: config.linker,
+            module_cache: config.module_cache,
             registry: config.registry,
             mailer,
             outbound: config.outbound,

--- a/crates/aether-capabilities/src/trampoline/runtime/replace.rs
+++ b/crates/aether-capabilities/src/trampoline/runtime/replace.rs
@@ -43,6 +43,7 @@ impl WasmTrampolineState {
         let config = WasmTrampolineConfig {
             engine: Arc::clone(&self.engine),
             linker: Arc::clone(&self.linker),
+            module_cache: self.module_cache.as_ref().map(Arc::clone),
             module: self.module.clone(),
             registry: Arc::clone(&self.registry),
             outbound: Arc::clone(&self.outbound),
@@ -122,7 +123,11 @@ impl WasmTrampolineState {
         // this mail to us, so the field is informational).
         let _ = payload.mailbox_id;
 
-        let module = match Module::new(&self.engine, &payload.wasm) {
+        let module = match self
+            .module_cache
+            .as_ref()
+            .map_or_else(|| Module::new(&self.engine, &payload.wasm), |cache| cache.compile(&payload.wasm))
+        {
             Ok(m) => m,
             Err(e) => {
                 return ReplaceResult::Err { error: format!("invalid wasm module: {e}") };

--- a/crates/aether-capabilities/src/trampoline/runtime/state.rs
+++ b/crates/aether-capabilities/src/trampoline/runtime/state.rs
@@ -8,6 +8,8 @@ use aether_substrate::mail::outbound::HubOutbound;
 use aether_substrate::mail::registry::Registry;
 use wasmtime::{Engine, Linker, Module};
 
+use crate::WasmModuleCache;
+
 /// Per-component trampoline **runtime state** (ADR-0122 identity/runtime
 /// split — the addressing identity is the distinct ZST
 /// [`WasmTrampoline`](crate::trampoline::WasmTrampoline)). Holds the wasm
@@ -29,6 +31,7 @@ pub struct WasmTrampolineState {
     /// is reachable from the handler.
     pub engine: Arc<Engine>,
     pub linker: Arc<Linker<ComponentCtx>>,
+    pub module_cache: Option<Arc<WasmModuleCache>>,
     pub registry: Arc<Registry>,
     pub mailer: Arc<Mailer>,
     pub outbound: Arc<HubOutbound>,

--- a/crates/aether-capabilities/src/wasm_module_cache.rs
+++ b/crates/aether-capabilities/src/wasm_module_cache.rs
@@ -1,0 +1,67 @@
+//! Per-chassis cache of compiled Wasmtime modules.
+//!
+//! Repeated-load `TestBench` scenarios opt into this cache so identical wasm
+//! bytes reuse Wasmtime's compiled code. Each chassis boot owns a fresh
+//! instance; component stores and actor state are never shared.
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use wasmtime::{Engine, Module};
+
+struct CachedModule {
+    wasm: Box<[u8]>,
+    module: Module,
+}
+
+/// A thread-safe, exact-byte-keyed collection of compiled Wasmtime modules.
+///
+/// Test scenarios load only a handful of distinct modules, while their wasm
+/// binaries can be tens of megabytes. Keeping one byte copy and comparing it
+/// directly avoids running an unoptimized cryptographic hash over every load;
+/// exact equality also makes collisions impossible.
+pub struct WasmModuleCache {
+    engine: Arc<Engine>,
+    modules: Mutex<Vec<CachedModule>>,
+}
+
+impl WasmModuleCache {
+    /// Create an empty cache whose modules all belong to `engine`.
+    #[must_use]
+    pub fn new(engine: Arc<Engine>) -> Self {
+        Self { engine, modules: Mutex::new(Vec::new()) }
+    }
+
+    /// Return the cached module for `wasm`, compiling and retaining it on the
+    /// first request.
+    pub fn compile(&self, wasm: &[u8]) -> wasmtime::Result<Module> {
+        let mut modules = self.modules.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(cached) = modules.iter().find(|cached| cached.wasm.as_ref() == wasm) {
+            return Ok(cached.module.clone());
+        }
+
+        let module = Module::new(&self.engine, wasm)?;
+        modules.push(CachedModule { wasm: wasm.into(), module: module.clone() });
+        drop(modules);
+        Ok(module)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, PoisonError};
+
+    use wasmtime::Engine;
+
+    use super::WasmModuleCache;
+
+    #[test]
+    fn identical_bytes_occupy_one_entry() {
+        let cache = WasmModuleCache::new(Arc::new(Engine::default()));
+        let wasm = b"\0asm\x01\0\0\0";
+
+        cache.compile(wasm).expect("compile first module");
+        cache.compile(wasm).expect("reuse first module");
+
+        assert_eq!(cache.modules.lock().unwrap_or_else(PoisonError::into_inner).len(), 1);
+    }
+}

--- a/crates/aether-kit/tests/camera_scenario.rs
+++ b/crates/aether-kit/tests/camera_scenario.rs
@@ -1,4 +1,4 @@
-//! Camera scenario tests. Each test boots a `TestBench`, loads
+//! Camera component lifecycle scenario. It boots a `TestBench`, loads
 //! `aether-kit`'s wasm artifact (built separately for
 //! `wasm32-unknown-unknown`) selecting the non-entry `camera` export
 //! (ADR-0096), drives the `CameraComponent` through its
@@ -39,11 +39,8 @@ use aether_kit as _;
 use std::fs;
 use std::path::Path;
 
-/// Component name passed to `LoadComponent`. The full mailbox address
-/// the substrate registers is `aether.embedded:cam`
-/// (issue 634 Phase 4 PR 1) — bare `"cam"` is not addressable. Camera
-/// tests don't currently send any mail to the loaded trampoline by
-/// address, so only the load-time name matters here.
+/// Component name passed to `LoadComponent`; [`component_address`]
+/// derives the loaded trampoline's full address from it.
 const COMPONENT_NAME: &str = "cam";
 
 /// The `/`-rendered lineage a loaded component registers at (ADR-0099
@@ -90,86 +87,34 @@ fn camera_component_lifecycle() {
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     load_camera(&mut bench, &wasm_path);
 
-    // A few ticks lets the component finish init, run on_tick, and
-    // let the renderer cycle.
-    let result =
-        bench.execute(vec![("advance", BenchOp::advance(5)), ("snap", BenchOp::capture())]).expect("advance + capture");
-    let png = result.captured("snap").expect("snap step ran");
-    let img = decode_png(png).expect("decode capture png");
-    not_all_black(&img).expect("camera scene should not be all black");
-}
-
-/// Smoke test: the default camera (a frozen orbit, `speed: 0.0`) still
-/// publishes `aether.view_projection` to the chassis render mailbox every tick
-/// even though the eye does not move. This is the load-bearing flow for
-/// camera matrices reaching the GPU; if it regresses, every scene goes
-/// back to identity-projection until someone notices visually.
-/// `count_observed` queries the bench's chassis-cap observation log for
-/// the kind name.
-#[test]
-fn camera_default_static_publishes_view_proj() {
-    let Some(wasm_path) = require_runtime("aether_kit") else {
-        return;
-    };
-
-    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
-    load_camera(&mut bench, &wasm_path);
-
-    // Five ticks: enough for init + a handful of publishes to surface
-    // on the camera sink. The component publishes on every tick after
-    // init, so any non-zero count proves the path is alive.
+    // The frozen default camera still publishes after initialization.
     bench.execute(vec![("advance", BenchOp::advance(5))]).expect("advance");
-
-    let observed = bench.count_observed(ViewProjection::NAME);
+    let initialized = bench.count_observed(ViewProjection::NAME);
     assert!(
-        observed >= 1,
-        "expected ≥1 aether.view_projection observed; got {observed}; observed kinds: {:?}",
-        bench.observed_kinds(),
-    );
-}
-
-/// Destroy the active default camera ("main") and confirm the
-/// substrate stays alive — frame still draws the chassis clear, no
-/// panic, no `fatal_abort`. The component pauses publishing (no further
-/// `aether.view_projection` mail) per its docstring; `count_observed` is
-/// cumulative since boot so we can't assert "no further publishes"
-/// directly with the current vocabulary, but the survivability half
-/// is the load-bearing assertion: a destroy of the active camera
-/// shouldn't take down the chassis.
-#[test]
-fn camera_destroy_main_keeps_substrate_alive() {
-    let Some(wasm_path) = require_runtime("aether_kit") else {
-        return;
-    };
-
-    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
-    load_camera(&mut bench, &wasm_path);
-
-    bench.execute(vec![("pre", BenchOp::advance(2))]).expect("pre-destroy advance");
-    // Baseline: default orbit was publishing before destroy.
-    let pre_destroy = bench.count_observed(ViewProjection::NAME);
-    assert!(
-        pre_destroy >= 1,
-        "expected ≥1 aether.view_projection before destroy; got {pre_destroy}; observed kinds: {:?}",
+        initialized >= 1,
+        "expected ≥1 aether.view_projection after initialization; got {initialized}; observed kinds: {:?}",
         bench.observed_kinds(),
     );
 
-    // Drop the only camera the component was bootstrapped with (agents
-    // address loaded components at the trampoline's full name,
-    // `aether.embedded:NAME`, per issue 634 Phase 4), then
-    // advance and capture.
-    //
-    // Survivability: the chassis still renders its clear pass after
-    // the active camera was removed. If the component panicked or the
-    // substrate wedged, capture would fail or the frame would be
-    // all-black.
-    let result = bench
+    // Let destruction and any already in-flight publication settle before
+    // taking the cumulative observation baseline.
+    bench
         .execute(vec![
             ("destroy", BenchOp::send_mail(component_address(), &CameraDestroy { name: "main".to_owned() })),
-            ("post", BenchOp::advance(5)),
-            ("snap", BenchOp::capture()),
+            ("settle", BenchOp::advance(2)),
         ])
-        .expect("destroy + advance + capture");
+        .expect("destroy + settle");
+    let post_destroy = bench.count_observed(ViewProjection::NAME);
+
+    let result = bench
+        .execute(vec![("post_destroy", BenchOp::advance(5)), ("snap", BenchOp::capture())])
+        .expect("post-destroy advance + capture");
+    let after_window = bench.count_observed(ViewProjection::NAME);
+    assert_eq!(
+        after_window, post_destroy,
+        "aether.view_projection count increased after destroying main: baseline {post_destroy}, after window {after_window}",
+    );
+
     let png = result.captured("snap").expect("snap step ran");
     let img = decode_png(png).expect("decode capture png");
     not_all_black(&img).expect("frame should not be all black after camera destroy");

--- a/crates/aether-kit/tests/terrain_workbench_scenario.rs
+++ b/crates/aether-kit/tests/terrain_workbench_scenario.rs
@@ -191,7 +191,7 @@ fn terrain_annotation_workbench_runs_the_full_raw_input_proposal_loop() {
     let Some(wasm_path) = require_runtime("aether_kit") else {
         return;
     };
-    let mut bench = TestBench::start_with_size(WIDTH, HEIGHT).expect("boot TestBench");
+    let mut bench = TestBench::builder().size(WIDTH, HEIGHT).reuse_compiled_modules().build().expect("boot TestBench");
     let mark_book_mailbox = load_export(&mut bench, &wasm_path, "aether.kit.mark", MARK_COMPONENT_NAME, Vec::new());
     let world_mailbox = load_export(&mut bench, &wasm_path, "aether.kit.world", WORLD_COMPONENT_NAME, Vec::new());
     let terra_mailbox = load_export(

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -70,6 +70,7 @@ fn main() -> anyhow::Result<()> {
         // the `0 → wait forever` sentinel) — the same knob the settlement
         // gates read.
         teardown_cap: resolve_teardown_cap(),
+        cache_modules: false,
     };
 
     let TestBenchBuild { passive, boot, render_handles, kind_tick } = TestBenchChassis::build_passive(env)?;

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -418,6 +418,7 @@ impl DesktopChassis {
             engine: Arc::clone(&boot.engine),
             linker: Arc::clone(&boot.linker),
             hub_outbound: Arc::clone(&boot.outbound),
+            cache_modules: false,
         };
         let input_config = InputConfig::default();
         // Capture handoff lives on `RenderCapability` post-issue-603

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -284,6 +284,7 @@ impl HeadlessChassis {
             engine: Arc::clone(&boot.engine),
             linker: Arc::clone(&boot.linker),
             hub_outbound: Arc::clone(&boot.outbound),
+            cache_modules: false,
         };
         let input_config = InputConfig::default();
 

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -241,6 +241,7 @@ pub struct TestBenchBuilder {
     trace_ring_capacity: Option<usize>,
     trace_ring_max_capacity: Option<usize>,
     settlement_cap: Option<Duration>,
+    cache_modules: bool,
     clipboard_mode: TestBenchClipboardMode,
     game_gateway: GameGatewayConfig,
 }
@@ -256,6 +257,7 @@ impl Default for TestBenchBuilder {
             trace_ring_capacity: None,
             trace_ring_max_capacity: None,
             settlement_cap: None,
+            cache_modules: false,
             clipboard_mode: TestBenchClipboardMode::default(),
             game_gateway: GameGatewayConfig::default(),
         }
@@ -340,6 +342,16 @@ impl TestBenchBuilder {
         self
     }
 
+    /// Reuse compiled Wasmtime modules when this bench loads identical wasm
+    /// bytes more than once. Disabled by default because the cache retains one
+    /// byte copy of each distinct module until bench teardown; repeated-load
+    /// scenarios opt in when avoiding recompilation outweighs that memory.
+    #[must_use]
+    pub fn reuse_compiled_modules(mut self) -> Self {
+        self.cache_modules = true;
+        self
+    }
+
     /// Select the clipboard actor composed into this bench. The default is
     /// deterministic in-memory storage; `Unavailable` composes the fail-fast
     /// companion for negative-path scenarios.
@@ -386,6 +398,7 @@ impl TestBenchBuilder {
             self.pool_workers,
             ring_caps,
             settlement_cap,
+            self.cache_modules,
             self.clipboard_mode,
             self.game_gateway,
         )
@@ -416,6 +429,7 @@ impl TestBench {
             None,
             RingCapacities::default(),
             SettlementConfig::from_env().to_cap(),
+            false,
             TestBenchClipboardMode::default(),
             GameGatewayConfig::default(),
         )
@@ -432,6 +446,7 @@ impl TestBench {
         pool_workers: Option<usize>,
         ring_caps: RingCapacities,
         settlement_cap: Duration,
+        cache_modules: bool,
         clipboard_mode: TestBenchClipboardMode,
         game_gateway: GameGatewayConfig,
     ) -> Result<Self, TestBenchError> {
@@ -459,6 +474,7 @@ impl TestBench {
             namespace_roots,
             clipboard_mode,
             game_gateway,
+            cache_modules,
             // Issue #2509: the teardown gate honors the same resolved cap
             // (env knob or programmatic override) as the settlement-await
             // loops the bench stores this value for.

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -163,6 +163,10 @@ pub struct TestBenchEnv {
     /// `TestBench::settlement_cap` override), so a scenario's teardown
     /// gate uses the same patience as its settlement gates.
     pub teardown_cap: Duration,
+    /// Whether this bench reuses compiled modules for identical wasm bytes.
+    /// The in-process builder enables it only for repeated-load scenarios;
+    /// ordinary benches and the standalone binary leave it disabled.
+    pub cache_modules: bool,
 }
 
 /// Output of [`TestBenchChassis::build_passive`]. Bundles the
@@ -224,6 +228,7 @@ impl TestBenchChassis {
             clipboard_mode,
             game_gateway,
             teardown_cap,
+            cache_modules,
         } = env;
 
         let boot = SubstrateBoot::builder(&name, &version).build()?;
@@ -232,6 +237,7 @@ impl TestBenchChassis {
             engine: Arc::clone(&boot.engine),
             linker: Arc::clone(&boot.linker),
             hub_outbound: Arc::clone(&boot.outbound),
+            cache_modules,
         };
 
         let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -66,7 +66,6 @@ use aether_substrate::mail::mailer::Mailer;
 use aether_substrate::mail::outbound::HubOutbound;
 use aether_substrate::mail::registry::Registry;
 use aether_substrate::testing::TestChassis;
-use serde::Serialize;
 
 /// Re-arm interval for the client→hub socket read: how often a blocked
 /// `read_frame` wakes to log a slow-gate line and re-check its cumulative
@@ -684,10 +683,12 @@ impl FleetBench {
     /// Route a mail to a recipient on a forked substrate and return the
     /// reply envelopes (one per `ReplyEvent`). `recipient` is a mailbox
     /// path — a chassis cap (`aether.fs`) or a loaded component's
-    /// lineage address (`aether.component/aether.embedded:<name>`).
+    /// lineage address (`aether.component/aether.embedded:<name>`). Encoding
+    /// goes through [`Kind::encode_into_bytes`], so cast-shaped kinds such as
+    /// `Tick` do not need an unrelated serde `Serialize` implementation.
     pub fn send<K>(&mut self, engine: EngineId, recipient: &str, mail: &K) -> Vec<MailEnvelope>
     where
-        K: Kind + Serialize,
+        K: Kind,
     {
         self.call(Some(engine), recipient, mail)
     }
@@ -703,7 +704,7 @@ impl FleetBench {
     /// gate (issue 2064).
     fn call<K>(&mut self, engine: Option<EngineId>, mailbox: &str, request: &K) -> Vec<MailEnvelope>
     where
-        K: Kind + Serialize,
+        K: Kind,
     {
         self.call_with_budget(engine, mailbox, request, reply_cap(), "reply")
     }
@@ -725,7 +726,7 @@ impl FleetBench {
         gate: &str,
     ) -> Vec<MailEnvelope>
     where
-        K: Kind + Serialize,
+        K: Kind,
     {
         let cid = self.next_cid;
         self.next_cid += 1;
@@ -847,7 +848,7 @@ impl FleetBench {
     /// carrier the empty-config [`load`](Self::load) sends.
     pub fn load_with_config<C>(&mut self, engine: EngineId, stem: &str, config: &C) -> String
     where
-        C: Kind + Serialize,
+        C: Kind,
     {
         let wasm = read_component_wasm(stem);
         let replies = self.call(
@@ -870,7 +871,7 @@ impl FleetBench {
     /// module's entry type. Returns the registered ADR-0099 lineage address.
     pub fn load_with_config_export<C>(&mut self, engine: EngineId, stem: &str, config: &C, export: &str) -> String
     where
-        C: Kind + Serialize,
+        C: Kind,
     {
         let wasm = read_component_wasm(stem);
         let replies = self.call(
@@ -906,7 +907,7 @@ impl FleetBench {
     /// `Err`/undecodable ack, mirroring [`single_reply`].
     pub fn send_traced<K>(&mut self, engine: EngineId, recipient: &str, mail: &K) -> (MailId, Vec<MailEnvelope>)
     where
-        K: Kind + Serialize,
+        K: Kind,
     {
         let batch = DispatchTraced {
             mails: vec![NamedMail {

--- a/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
@@ -17,7 +17,7 @@ mod tests {
 
     use aether_actor::Addressable;
     use aether_capabilities::WasmTrampoline;
-    use aether_data::{Kind, Schema, SchemaType, wire};
+    use aether_data::{EngineId, Kind, Schema, SchemaType, wire};
     use aether_kinds::{
         ComponentSelector, ListComponentBinaries, LogTailResult, ResolveComponentResult, Tick, UploadComponentResult,
     };
@@ -30,6 +30,10 @@ mod tests {
     /// The probe fixture's declared `Addressable::NAMESPACE` (distinct from the
     /// `probe` wasm stem).
     const PROBE_NAMESPACE: &str = "test.probe";
+    /// `info` in the `0 = trace .. 4 = error` log-level mapping.
+    const LEVEL_INFO: u8 = 2;
+    /// One-shot log emitted by each fresh probe instance on its first tick.
+    const PROBE_FIRST_TICK_LOG: &str = "typed_send_alive";
 
     /// The probe's registered ADR-0099 lineage address.
     fn probe_lineage_addr() -> String {
@@ -43,6 +47,47 @@ mod tests {
             ResolveComponentResult::Ok { hash, .. } => hash,
             ResolveComponentResult::Err { error } => panic!("resolve failed: {error}"),
         }
+    }
+
+    /// Poll one probe lineage ring from `since` until a fresh instance's
+    /// one-shot first-tick entry appears. Returns the entry sequence and the
+    /// ring cursor so a caller can require the next lifecycle observation to
+    /// be strictly newer.
+    fn poll_probe_first_tick(
+        bench: &mut FleetBench,
+        engine: EngineId,
+        addr: &str,
+        since: Option<u64>,
+        lifecycle: &str,
+    ) -> (u64, u64) {
+        let mut last_reply = None;
+        let mut found = None;
+        poll_until(|| {
+            let reply = bench.log_tail(engine, addr, since, Some(PROBE_FIRST_TICK_LOG.to_owned()));
+            if let LogTailResult::Ok { entries, .. } = &reply {
+                assert!(
+                    entries.iter().all(|entry| entry.message.contains(PROBE_FIRST_TICK_LOG)),
+                    "the substrate-side contains filter should remove non-matching entries: {entries:?}",
+                );
+            }
+            if let LogTailResult::Ok { entries, next_since, .. } = &reply
+                && let Some(entry) =
+                    entries.iter().find(|entry| entry.message == PROBE_FIRST_TICK_LOG && entry.level == LEVEL_INFO)
+            {
+                found = Some((entry.sequence, *next_since));
+                true
+            } else {
+                last_reply = Some(reply);
+                false
+            }
+        });
+
+        found.unwrap_or_else(|| {
+            panic!(
+                "probe's `{PROBE_FIRST_TICK_LOG}` entry never appeared after {lifecycle} within the poll budget; \
+                 last reply: {last_reply:?}",
+            )
+        })
     }
 
     /// Upload the probe by staged path and assert the store ingested it
@@ -205,7 +250,10 @@ mod tests {
     /// Upload the probe component by staged path, then assert the store
     /// ingested it content-addressed with a manifest read from the wasm,
     /// resolves + loads it by name / hash / handled-kind, dedups an
-    /// identical re-upload, and replaces by hash.
+    /// identical re-upload, and replaces by hash. The replacement must
+    /// initialize a fresh probe instance: its one-shot first-tick log must
+    /// appear again after the pre-replace log cursor at the same lineage
+    /// address, so a same-hash no-op cannot satisfy the test.
     #[test]
     fn fleetbench_uploads_resolves_loads_and_replaces_a_component() {
         if !dist_component_available("aether_test_fixtures_bundle") {
@@ -279,17 +327,37 @@ mod tests {
         let expected = probe_lineage_addr();
         let loaded = bench.load_by_selector(engine, "probe");
         assert_eq!(loaded.addr, expected, "load by selector registers at the lineage addr");
-        match bench.log_tail(engine, &expected, None, None) {
-            LogTailResult::Ok { .. } => {}
-            LogTailResult::Err { error } => {
-                panic!("the loaded probe should answer LogTail, got Err: {error}")
-            }
-        }
+        assert!(
+            bench.send(engine, &expected, &Tick).is_empty(),
+            "a direct Tick used to observe the initial guest lifecycle should not reply",
+        );
+        let (first_tick_sequence, first_tick_cursor) =
+            poll_probe_first_tick(&mut bench, engine, &expected, None, "initial load");
 
         // Replace the loaded component by hash (ADR-0022 in-place swap,
-        // ADR-0116 selector). The trampoline keeps its lineage address.
+        // ADR-0116 exact-hash selector). The trampoline keeps its lineage
+        // address, while the new probe instance resets its tick counter and
+        // therefore emits the one-shot first-tick log again. A resolver or
+        // trampoline optimization that treats the same hash as a no-op would
+        // retain the old nonzero counter and fail this lifecycle oracle.
         let caps = bench.replace_by_selector(engine, loaded.mailbox_id, &hash);
         assert!(caps.handlers.iter().any(|h| h.id == Tick::ID), "the replaced probe still advertises its Tick handler");
+        assert!(
+            bench.send(engine, &expected, &Tick).is_empty(),
+            "a direct Tick used to observe the replacement lifecycle should not reply",
+        );
+        let (replacement_tick_sequence, _) =
+            poll_probe_first_tick(&mut bench, engine, &expected, Some(first_tick_cursor), "same-hash replacement");
+        assert!(
+            replacement_tick_sequence > first_tick_sequence,
+            "the replacement's first-tick entry should be newer than the original (first={first_tick_sequence}, \
+             replacement={replacement_tick_sequence})",
+        );
+        let registered = bench.list_components(engine);
+        assert!(
+            registered.iter().any(|addr| addr == &expected),
+            "the replacement should remain registered at its original lineage address {expected}: {registered:?}",
+        );
     }
 
     /// A `spawn_substrate` boot manifest written in component selectors

--- a/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
@@ -1,9 +1,9 @@
 //! `FleetBench` `replace_component` proof (issue 1459, Tier-A): load the
 //! `probe` fixture into a forked substrate, then atomically swap it for
-//! `aether-kit`'s `aether.kit.camera` export (selector `aether_kit@aether.kit.camera`) at the
-//! same trampoline mailbox id (ADR-0022) and assert the returned
-//! capability set reflects the new binary while the lineage address
-//! stays put.
+//! the standalone stateful fixture's entry actor at the
+//! same trampoline mailbox id (ADR-0022). Assert the returned capability
+//! set reflects the cross-module swap, the lineage address stays put,
+//! and mail reaches the replacement guest.
 
 mod fleetbench;
 
@@ -11,26 +11,25 @@ mod tests {
     use aether_actor::Addressable;
     use aether_capabilities::WasmTrampoline;
     use aether_data::Kind;
-    use aether_kinds::{ComponentCapabilities, LogTailResult, Ping, Tick};
-    use aether_kit::camera::CameraCreate;
-    use aether_test_fixtures_kinds::SetRender;
+    use aether_kinds::{ComponentCapabilities, LogTailResult, Ping};
+    use aether_test_fixtures_kinds::{Bump, CountQuery, CountReport, SetRender};
 
     use crate::fleetbench::{FleetBench, dist_component_available};
 
-    /// Load `probe` (handlers `SetRender` + `Tick`), then `replace`
-    /// it with `aether-kit`'s non-entry `aether.camera` export (selector
-    /// `aether_kit@aether.kit.camera`; handlers `CameraCreate` + `Tick` + the
-    /// camera-driver kinds) targeting the captured trampoline
-    /// `mailbox_id` — exercising `ReplaceComponent.export` (#2027)
-    /// end-to-end over the wire. The returned
-    /// `ReplaceResult::Ok.capabilities` must carry the camera
-    /// handler set and not the probe's, with `Tick` surviving the
-    /// swap; the lineage address — unchanged by construction, since
-    /// the trampoline keeps its load-time name — must still route to
-    /// the live mailbox afterward.
+    /// Load the bundled `probe` (handler `SetRender`), then replace it
+    /// with the standalone `aether_test_fixtures_stateful_typed` module's
+    /// entry actor (handlers `Bump` + `CountQuery`) at the
+    /// captured trampoline `mailbox_id`. This exercises the
+    /// cross-module `ReplaceComponent` path over the real wire. The returned
+    /// capabilities must flip to the stateful handler set, while a `Bump`
+    /// followed by `CountQuery` at the probe's unchanged load-time lineage
+    /// address must report `count = 1`. The neighboring test covers a named
+    /// non-entry export replacement separately.
     #[test]
-    fn fleetbench_replaces_probe_with_camera_at_a_stable_address() {
-        if !dist_component_available("aether_test_fixtures_bundle") {
+    fn fleetbench_replaces_probe_with_stateful_actor_at_a_stable_address() {
+        if !dist_component_available("aether_test_fixtures_bundle")
+            || !dist_component_available("aether_test_fixtures_stateful_typed")
+        {
             return;
         }
         let mut bench = FleetBench::start();
@@ -39,45 +38,55 @@ mod tests {
 
         let has = |caps: &ComponentCapabilities, id| caps.handlers.iter().any(|h| h.id == id);
 
-        // Pre-replace sanity: the probe declares SetRender, not the
-        // camera's create kind, and registers at its ADR-0099 lineage
-        // address.
+        // Pre-replace sanity: the bundled probe declares SetRender, not
+        // the standalone stateful actor's driver/query kinds, and
+        // registers at its ADR-0099 lineage address.
         assert!(
             has(&loaded.capabilities, SetRender::ID),
             "probe should declare a SetRender handler: {:?}",
             loaded.capabilities.handlers,
         );
         assert!(
-            !has(&loaded.capabilities, CameraCreate::ID),
-            "probe should not declare a CameraCreate handler: {:?}",
+            !has(&loaded.capabilities, Bump::ID),
+            "probe should not declare a Bump handler: {:?}",
+            loaded.capabilities.handlers,
+        );
+        assert!(
+            !has(&loaded.capabilities, CountQuery::ID),
+            "probe should not declare a CountQuery handler: {:?}",
             loaded.capabilities.handlers,
         );
         let expected = format!("aether.component/{}:test.probe", WasmTrampoline::NAMESPACE);
         assert_eq!(loaded.addr, expected, "probe should load at its ADR-0099 lineage address");
 
-        let caps = bench.replace_export(engine, loaded.mailbox_id, "aether_kit", "aether.kit.camera");
+        let caps = bench.replace(engine, loaded.mailbox_id, "aether_test_fixtures_stateful_typed");
 
-        // Post-replace: the camera handler set is active, the probe's
-        // is gone, and Tick (declared by both) survives the swap.
-        assert!(
-            has(&caps, CameraCreate::ID),
-            "post-replace should declare a CameraCreate handler: {:?}",
-            caps.handlers,
-        );
+        // Post-replace: the standalone stateful actor's handlers are
+        // active and the bundled probe's distinguishing handler is gone.
+        assert!(has(&caps, Bump::ID), "post-replace should declare a Bump handler: {:?}", caps.handlers);
+        assert!(has(&caps, CountQuery::ID), "post-replace should declare a CountQuery handler: {:?}", caps.handlers);
         assert!(
             !has(&caps, SetRender::ID),
             "post-replace should not declare the probe's SetRender handler: {:?}",
             caps.handlers,
         );
-        assert!(
-            has(&caps, Tick::ID),
-            "Tick is declared by both components and should survive the swap: {:?}",
-            caps.handlers,
-        );
 
-        // The lineage address still resolves to the live mailbox: a
-        // LogTail routed to the rendered path is answered Ok, proving
-        // the same mailbox was swapped in place.
+        // Drive replacement-only guest behavior through the probe's
+        // load-time lineage address. A decoded count of one proves both
+        // mails reached the stateful module at the same trampoline path.
+        let bump_replies = bench.send(engine, &loaded.addr, &Bump);
+        assert!(bump_replies.is_empty(), "Bump should not reply, got {bump_replies:?}");
+        let replies = bench.send(engine, &loaded.addr, &CountQuery);
+        let reply = match replies.as_slice() {
+            [one] => one,
+            other => panic!("CountQuery should get exactly one reply, got {}", other.len()),
+        };
+        assert_eq!(reply.kind, CountReport::ID, "the replacement should reply with CountReport");
+        let report = CountReport::decode_from_bytes(&reply.payload).expect("the CountReport reply should decode");
+        assert_eq!(report.count, 1, "one Bump at the stable lineage address should advance the replacement state");
+
+        // The framework-owned LogTail handler remains another direct
+        // liveness check through that unchanged address.
         assert!(
             matches!(bench.log_tail(engine, &loaded.addr, None, None), LogTailResult::Ok { .. },),
             "the lineage address should still route to the live mailbox after replace",


### PR DESCRIPTION
## Summary

- add an explicit `TestBench` builder opt-in that reuses immutable compiled Wasmtime modules only within repeated-load scenarios; stores, actors, ordinary benches, and production chassis remain fresh and uncached
- consolidate the camera publication/destruction/survival checks into one stronger lifecycle scenario
- replace the FleetBench probe-to-camera swap with a smaller stateful fixture and prove mail reaches the replacement guest at the stable lineage
- make same-hash component replacement prove a fresh guest lifecycle, so a future no-op optimization cannot satisfy the test

## Measured locally

| Scenario | Before/control | After | Change |
| --- | ---: | ---: | ---: |
| Terrain repeated-load scenario | 22.2s | 18.9s | ~15% faster |
| FleetBench cross-module replacement | 36.3s | 17.0s | ~53% faster |
| Camera scenario suite | 3 tests at ~4.8-5.5s each | 1 test at 5.0s | ~65-70% less aggregate runtime |
| Same-hash component-store scenario | 43.0s | 43.0s | unchanged, with a stronger oracle |

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p aether-capabilities --all-features wasm_module_cache::tests::identical_bytes_occupy_one_entry`
- [x] `AETHER_REQUIRE_RUNTIME=1 cargo nextest run --all-features -p aether-kit --test camera_scenario --test-threads 1`
- [x] `AETHER_REQUIRE_RUNTIME=1 cargo nextest run --all-features -p aether-kit --test terrain_workbench_scenario --test-threads 1`
- [x] `AETHER_REQUIRE_RUNTIME=1 cargo nextest run --all-features -p aether-substrate-bundle --test fleetbench_replace -E 'test(fleetbench_replaces_probe_with_stateful_actor_at_a_stable_address)' --test-threads 1`
- [x] `AETHER_REQUIRE_RUNTIME=1 cargo nextest run --all-features -p aether-substrate-bundle --test fleetbench_component_store -E 'test(fleetbench_uploads_resolves_loads_and_replaces_a_component)' --test-threads 1`

CI is intentionally not being used as the completion gate while the repository pipeline is under development.

Generated by Codex from direct owner-authorized implementation work.
