### PR TITLE
fix(ci): the tick must not dispatch implement on a pure umbrella at phase:ready

### DIFF
--- a/.claude/skills/approve/SKILL.md
+++ b/.claude/skills/approve/SKILL.md
@@ -154,7 +154,7 @@ An issue carrying a non-empty `## Sub-issues` section is either a **pure umbrell
 
 The one-or-the-other invariant means any issue that reaches `/implement` with a non-empty `## Sub-issues` is a pure umbrella and is correct to drop.
 
-A future `/release-promote-umbrella <parent>` skill can auto-close the umbrella when all children are Done. Out of scope for v1.
+The agent tick owns the umbrella's end of life (#3212): its `phase:ready` arm never dispatches `implement` for a non-empty `## Sub-issues` issue — the umbrella rests until every listed child is closed, then the tick deletes its phase label and closes it as completed.
 
 ## ADR hard gate
 
@@ -251,5 +251,5 @@ The single `PUT …/labels` replaces the label set with the non-`phase:*` labels
 - Auto-resolve side findings.
 - Edit `.github/approval-policy.yml`. Relaxing a tier is the owner's signed diff, never a side effect of an approval run — an issue that wants a looser tier says so and waits for that diff to land.
 - Enforce the declared surface against a PR's actual diff. `/approve` resolves the tier over the declared globs; the reconciler is what later holds a PR whose diff escapes them.
-- Close umbrella issues when children complete. Future work.
+- Close umbrella issues when children complete. The agent tick's `phase:ready` arm owns that (#3212).
 - Notify anyone. The printed summary (and the `phase:ready` label) is the surface; comments appear only for `--note` / `--skip-adr`.

--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -569,7 +569,41 @@ jobs:
                     continue ;;
                 esac
                 ;;
-              phase:ready) task="implement"; ref="$num" ;;
+              phase:ready)
+                # A pure umbrella never dispatches implement (#3212): /implement
+                # refuses any non-empty ## Sub-issues issue, so a dispatch is a
+                # box-burn loop. When every listed child is closed the umbrella
+                # itself is done — the tick closes it here, because an umbrella
+                # never gets a PR and so is structurally unreachable by the
+                # PR-driven reconciler. Otherwise it rests. A parse failure
+                # (no child references found) rests rather than closes.
+                sub_issues="$(gh api "repos/${REPO}/issues/${num}" --jq '.body // ""' \
+                  | awk '/^## Sub-issues/{f=1; next} /^## /{f=0} f' \
+                  | grep -v '^[[:space:]]*$' || true)"
+                if [ -n "$sub_issues" ]; then
+                  children="$(grep -oE '^[[:space:]]*-[[:space:]]+#[0-9]+' <<<"$sub_issues" \
+                    | grep -oE '[0-9]+' | sort -u || true)"
+                  found=0 open_children=0
+                  for child in $children; do
+                    found=$((found + 1))
+                    child_state="$(gh api "repos/${REPO}/issues/${child}" --jq '.state' || echo unknown)"
+                    [ "$child_state" = "closed" ] || open_children=$((open_children + 1))
+                  done
+                  if [ "$found" -ge 1 ] && [ "$open_children" -eq 0 ]; then
+                    gh api -X DELETE "repos/${REPO}/issues/${num}/labels/phase:ready" >/dev/null \
+                      || summary "- warn #${num}: umbrella close could not delete phase:ready"
+                    gh api -X PATCH "repos/${REPO}/issues/${num}" -f state=closed -f state_reason=completed >/dev/null \
+                      || summary "- warn #${num}: umbrella close PATCH failed"
+                    printf 'Pure umbrella auto-closed by the tick: all %s listed children are closed (#3212).\n' "$found" > /tmp/umbrella-close.md
+                    gh api -X POST "repos/${REPO}/issues/${num}/comments" -F body=@/tmp/umbrella-close.md >/dev/null \
+                      || summary "- warn #${num}: umbrella close comment failed"
+                    summary "- closed #${num}: pure umbrella, all ${found} children closed"
+                  else
+                    summary "- skip #${num}: pure umbrella, ${open_children}/${found} children still open — resting at phase:ready"
+                  fi
+                  continue
+                fi
+                task="implement"; ref="$num" ;;
               phase:held) task="land"; ref="" ;;
               *) continue ;;
             esac


### PR DESCRIPTION
Closes #3212.

## Summary

Implements the approved plan: the tick's `phase:ready` arm reads the issue body and tests `## Sub-issues` with the same predicate `/implement` and `/approve` share. Non-empty means pure umbrella (the malformed shape is refused upstream), so the arm never dispatches `implement`. All listed children closed (and at least one parsed) moves the umbrella to Done — `phase:ready` label deleted, issue closed `completed`, one-line timeline comment. Any open child, or zero parsed children, rests with a summary skip line. Writes are warn-and-continue so one failure never aborts the wave. The two stale future-work notes in `.claude/skills/approve/SKILL.md` now point at the tick.

## Provenance

Pushed by the owner session: the fleet's App token lacks the `workflows` permission and cannot push a workflow file (the implement box parked on exactly this — see the issue thread). The diff is the box's approved plan re-derived in an owner worktree.

## Verification

First live tick after merge; then #3145 comes off the bench and should rest ("2/2 children still open") instead of burning a box, and auto-close once #3162/#3163 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
