### PR TITLE
fix(ci): review and dogfood run on the fleet CI key, not the owner subscription token

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -297,7 +297,7 @@ jobs:
       AETHER_AUDIO_DISABLE: "1"
       # Job level so step-level `if: env... != ''` gating works. Absent secret =>
       # the CC steps skip cleanly and no rollup is produced, so `post` no-ops.
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.AGENT_CLAUDE_CODE_OAUTH_TOKEN }}
       # <github.run_id>-<attempt> — the evidence path segment for this attempt.
       DOGFOOD_RUN_ID: ${{ github.run_id }}-${{ needs.resolve.outputs.attempt }}
       EXPECTED_ARTIFACT: ${{ needs.resolve.outputs.expected_artifact }}
@@ -399,8 +399,8 @@ jobs:
       - name: Note when the OAuth token secret is absent
         if: env.CLAUDE_CODE_OAUTH_TOKEN == ''
         run: |
-          echo "CLAUDE_CODE_OAUTH_TOKEN secret is not set — the trial is skipped."
-          echo "Mint one with 'claude setup-token' and add it: gh secret set CLAUDE_CODE_OAUTH_TOKEN"
+          echo "AGENT_CLAUDE_CODE_OAUTH_TOKEN secret is not set — the trial is skipped."
+          echo "Mint one with 'claude setup-token' and add it: gh secret set AGENT_CLAUDE_CODE_OAUTH_TOKEN"
 
       # Pre-trust the checkout so settings.json permissions aren't ignored with
       # a warning under skip-permissions.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -27,8 +27,8 @@ name: Review
 # FAILS the gate closed until the owner waives or dispatches a full review.
 # `workflow_dispatch` bypasses both — the deliberate "review it anyway".
 #
-# Same security posture as the dogfood runner: subscription OAuth token
-# (CLAUDE_CODE_OAUTH_TOKEN), same-repo head only, and a least-privilege
+# Same security posture as the dogfood runner: fleet CI OAuth token
+# (AGENT_CLAUDE_CODE_OAUTH_TOKEN), same-repo head only, and a least-privilege
 # split — the code-executing `review` job is read-only on the repo, and
 # only the `post` job (which never runs branch code) holds write scopes.
 
@@ -87,7 +87,7 @@ jobs:
       # Present at job level so step-level `if: env... != ''` gating works
       # (mirrors the dogfood runner). Absent secret => the CC steps skip
       # cleanly and no rollup artifact is produced, so `post` no-ops.
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.AGENT_CLAUDE_CODE_OAUTH_TOKEN }}
     outputs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       # head_sha + touches_rust feed the `gate` job's per-SHA status post,
@@ -313,8 +313,8 @@ jobs:
       - name: Note when the OAuth token secret is absent
         if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN == ''
         run: |
-          echo "CLAUDE_CODE_OAUTH_TOKEN secret is not set — the review is skipped."
-          echo "Mint one with 'claude setup-token' and add it: gh secret set CLAUDE_CODE_OAUTH_TOKEN"
+          echo "AGENT_CLAUDE_CODE_OAUTH_TOKEN secret is not set — the review is skipped."
+          echo "Mint one with 'claude setup-token' and add it: gh secret set AGENT_CLAUDE_CODE_OAUTH_TOKEN"
 
       - name: Install Claude Code
         if: steps.resolve.outputs.proceed == 'true' && env.CLAUDE_CODE_OAUTH_TOKEN != ''


### PR DESCRIPTION
The fleet workflows (agent-work, agent-chat, agent-judge) all authenticate Claude with `secrets.AGENT_CLAUDE_CODE_OAUTH_TOKEN` — the dedicated CI account key. `review.yml` and `dogfood.yml` predate that split and still read `secrets.CLAUDE_CODE_OAUTH_TOKEN`, the owner's personal subscription token, so every review and dogfood run on every PR push drained the owner's subscription quota.

This points both workflows' job-level `CLAUDE_CODE_OAUTH_TOKEN` env at the CI key, updates the two skip-path help messages to name the new secret, and fixes the review.yml header comment that described the token as the subscription one. The in-workflow env var name stays `CLAUDE_CODE_OAUTH_TOKEN` (it is what the Claude CLI reads), so every `env.CLAUDE_CODE_OAUTH_TOKEN` guard is untouched — only the secret source changes.

Closes #3227

🤖 Generated with [Claude Code](https://claude.com/claude-code)